### PR TITLE
Added apt stmt to README to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ newsboat can be compiled.
 
 Debian unstable comes with ready-to-use packages for these dependencies.
 
+Ubuntu can install the dependecies with:
+
+    apt install libsqlite3-dev libcurl4-openssl-dev libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev libkrb5-dev
+
 Installation
 ------------
 


### PR DESCRIPTION
I added the apt statement that's needed in Ubuntu to install all of the dependencies, if that's something you're looking for in the README.