### PR TITLE
Drop test dependency on bc

### DIFF
--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -20,7 +20,7 @@ TEST_CASE("evaluate_backticks replaces command in backticks with its output",
 				== "hello world");
 		REQUIRE(configparser::evaluate_backticks("xxx`echo yyy`zzz")
 				== "xxxyyyzzz");
-		REQUIRE(configparser::evaluate_backticks("`echo 3 \\* 4 | bc`") == "12");
+		REQUIRE(configparser::evaluate_backticks("`seq 10 | tail -1`") == "10");
 	}
 
 	SECTION("backticks can be escaped with backslash") {


### PR DESCRIPTION
While 'bc' is a very common piece of software a lot of distributions,
like Debian, do not include it by default. I don't see a reason to have
it as a test dependency when bash can serve the exact same purpose.