### PR TITLE
Fix building of docs on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,14 +196,14 @@ doc/example-config: doc/gen-example-config doc/configcommands.dsv
 
 # add hyperlinks for every configuration command
 doc/configcommands-linked.dsv: doc/configcommands.dsv
-	sed -e 's/^\([^|]\+\)/[[\1]]<<\1,`\1`>>/' doc/configcommands.dsv > doc/configcommands-linked.dsv
+	sed -r 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/configcommands.dsv > doc/configcommands-linked.dsv
 
 # add hyperlinks for every configuration command
 doc/podboat-cmds-linked.dsv: doc/podboat-cmds.dsv
-	sed -e 's/^\([^|]\+\)/[[\1]]<<\1,`\1`>>/' doc/podboat-cmds.dsv > doc/podboat-cmds-linked.dsv
+	sed -r 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/podboat-cmds.dsv > doc/podboat-cmds-linked.dsv
 
 doc/keycmds-linked.dsv: doc/keycmds.dsv
-	sed -e 's/^\([^:]\+\)/[[\1]]<<\1,`\1`>>/' doc/keycmds.dsv > doc/keycmds-linked.dsv
+	sed -r 's/^([^:]+)/[[\1]]<<\1,`\1`>>/' doc/keycmds.dsv > doc/keycmds-linked.dsv
 
 fmt:
 	astyle --suffix=none --style=java --indent=tab --indent-classes *.cpp include/*.h src/*.cpp rss/*.{cpp,h} test/*.cpp


### PR DESCRIPTION
These sed commands fail on FreeBSD as they're interpreted as extended
regular expressions. At least, that's what the error message suggests to
me. As it turns out using the -e option was wrong in the first place as
I thought this switch enables extended regex, which it doesn't. Correct
is either -r (GNU sed) or -E (BSD sed). Both implementations support the
other's flag as well, so it shouldn't matter which we actually use.

* https://www.freebsd.org/cgi/man.cgi?query=sed&sektion=&n=1
* https://stackoverflow.com/a/3139925

Thanks to imm_ on IRC for reporting this and confirming the fix!