### PR TITLE
Add missing newsboat namespace

### DIFF
--- a/rss/atom_parser.cpp
+++ b/rss/atom_parser.cpp
@@ -103,7 +103,7 @@ item atom_parser::parse_entry(xmlNode * entryNode) {
 				it.link = newsboat::utils::absolute_url(base, get_prop(node, "href"));
 			} else if (rel == "enclosure") {
 				const std::string type = get_prop(node, "type");
-				if (utils::is_valid_podcast_type(type)) {
+				if (newsboat::utils::is_valid_podcast_type(type)) {
 					it.enclosure_url = get_prop(node, "href");
 					it.enclosure_type = std::move(type);
 				}


### PR DESCRIPTION
Fix compilation issue:
```cpp
g++ -std=c++11 -ggdb -Iinclude -Istfl -Ifilter -I. -Irss -Werror -Wall -Wextra -Wunreachable-code -DLOCALEDIR=\"/usr/local/share/locale\" -DGIT_HASH=\"r2.10-74-g7901\" -I/usr/include/x86_64-linux-gnu -I/usr/include/libxml2 -I/usr/include/json-c -D_GNU_SOURCE -D_DEFAULT_SOURCE -I/usr/include/ncursesw -o src/download.o -c src/download.cpp
rss/atom_parser.cpp: In member function ‘rsspp::item rsspp::atom_parser::parse_entry(xmlNode*)’:
rss/atom_parser.cpp:106:9: error: ‘utils’ has not been declared
     if (utils::is_valid_podcast_type(type)) {
         ^~~~~
```
introduced in ef929a9c3bda2f58ce300ac2e9d5e4a4159026c9