### PR TITLE
Fail if DSV files are malformed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ clean: clean-newsboat clean-podboat clean-libboat clean-libfilter clean-doc clea
 distclean: clean clean-mo test-clean profclean
 	$(RM) core *.core core.* config.mk
 
-doc: doc/xhtml/newsboat.html doc/xhtml/faq.html doc/newsboat.1 doc/podboat.1
+doc: doc/newsboat.1 doc/podboat.1 doc/xhtml/newsboat.html doc/xhtml/faq.html
 
 doc/xhtml/newsboat.html: doc/newsboat.txt doc/chapter-firststeps.txt doc/configcommands-linked.dsv \
 		doc/keycmds-linked.dsv doc/chapter-tagging.txt doc/chapter-snownews.txt \
@@ -204,7 +204,7 @@ doc/podboat-cmds-linked.dsv: doc/podboat-cmds.dsv
 	sed -r 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/podboat-cmds.dsv > doc/podboat-cmds-linked.dsv
 
 doc/keycmds-linked.dsv: doc/keycmds.dsv
-	sed -r 's/^([^:]+)/[[\1]]<<\1,`\1`>>/' doc/keycmds.dsv > doc/keycmds-linked.dsv
+	sed -r 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/keycmds.dsv > doc/keycmds-linked.dsv
 
 fmt:
 	astyle --suffix=none --style=java --indent=tab --indent-classes *.cpp include/*.h src/*.cpp rss/*.{cpp,h} test/*.cpp

--- a/doc/generate.cpp
+++ b/doc/generate.cpp
@@ -17,7 +17,9 @@ int main(int argc, char *argv[])
 
 	const std::string linkprefix = argc == 3 ? argv[2] : "";
 
+	int lineno = 0;
 	for (std::string line; std::getline(input, line); ) {
+		++lineno;
 		const std::vector<std::string> matches = split(line, "||");
 		if (matches.size() == 5) {
 			const std::string option = matches[0];
@@ -31,6 +33,10 @@ int main(int argc, char *argv[])
 			std::cout << "default value: '" << defaultparam << "')::\n";
 			std::cout << "         " << desc;
 			std::cout << " (example: " << example <<  ")\n\n";
+		} else {
+			std::cerr << "expected exactly 5 cells in " << argv[1] << ":" << lineno;
+			std::cerr << ", but got " << matches.size() << " instead\n";
+			return 1;
 		}
 	}
 

--- a/doc/generate2.cpp
+++ b/doc/generate2.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
-#include <regex>
 #include <fstream>
+#include "split.h"
 
 int main(int argc, char *argv[])
 {
@@ -15,21 +15,22 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	int lineno = 0;
 	for (std::string line; std::getline(input, line); ) {
-		const std::regex rgx(
-				"([^:]*):([^:]*):(.*)",
-				std::regex_constants::awk);
-		std::smatch matches;
-		if (std::regex_match(line, matches, rgx)) {
-			if (matches.size() == 4) {
-				const std::string cmd = matches[1].str();
-				const std::string key = matches[2].str();
-				const std::string desc = matches[3].str();
+		++lineno;
+		const std::vector<std::string> matches = split(line, "||");
+		if (matches.size() == 3) {
+			const std::string cmd = matches[0];
+			const std::string key = matches[1];
+			const std::string desc = matches[2];
 
-				std::cout <<  "'" << cmd << "' ";
-				std::cout << "(default key: '" << key << "')::\n";
-				std::cout << "         " << desc << "\n\n";
-			}
+			std::cout << "'" << cmd << "' ";
+			std::cout << "(default key: '" << key << "')::\n";
+			std::cout << "         " << desc << "\n\n";
+		} else {
+			std::cerr << "expected exactly 3 cells in " << argv[1] << ":" << lineno;
+			std::cerr << ", but got " << matches.size() << " instead\n";
+			return 1;
 		}
 	}
 

--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -1,55 +1,55 @@
-open:ENTER:Open the currently selected feed or article.
-quit:q:Quit the program or return to the previous dialog (depending on the context).
-hard-quit:Q:Quit the program without confirmation.
-reload:r:Reload the currently selected feed.
-reload-all:R:Reload all feeds.
-mark-feed-read:A:Mark all articles in the currently selected feed read.
-mark-all-feeds-read:C:Mark articles in all feeds read.
-save:s:Save the currently selected article to a file.
-next-unread:n:Jump to the next unread article.
-prev-unread:p:Jump to the previous unread article.
-next:J:Jump to next article.
-prev:K:Jump to previous article.
-random-unread:^K:Jump to a random unread article.
-open-in-browser:o:Opens the URL associated with the current article.
-open-in-browser-and-mark-read:O:Opens the URL associated with the current article and marks the article as read.
-open-all-unread-in-browser:n/a:Opens all the unread URLs in the current feed.
-open-all-unread-in-browser-and-mark-read:n/a:Opens all the unread URLs in the current feed and marks them as read.
-help:?:Runs the help screen.
-toggle-source-view:^U:Toggles between the HTML view and the source view in the article view.
-toggle-article-read:N:Toggle the read flag for the currently selected article, and clears delete flag if set.
-toggle-show-read-feeds:l:Toggle whether read feeds should be shown in the feed list.
-show-urls:u:Show all URLs in the article in a list (similar to urlview).
-clear-tag:^T:Clear current tag.
-set-tag:t:Select tag.
-open-search:/:Opens the search dialog. When a search is done in the article list, then the search operation only applies to the articles of the current feed, otherwise to all articles.
-goto-url:#:Open the URL dialog and then opens specified URL.
-enqueue:e:Add the podcast download URL of the current article (if any is found) to the podcast download queue (see the respective section in the documentation for more information on podcast support).
-edit-urls:E:Edit the list of subscribed URLs. newsboat will start the editor configured through the $VISUAL environment variable (if unset, $EDITOR is used; fallback\: "vi"). When editing is finished, newsboat will reload the URLs file.
-reload-urls:^R:Reload the URLs configuration file.
-redraw:^L:Redraw the screen.
-cmdline:<colon>:Open the command line.
-set-filter:F:Set a filter.
-select-filter:f:Select a predefined filter.
-clear-filter:^F:Clear currently set filter.
-bookmark:^B:Bookmark currently selected article or URL.
-edit-flags:^E:Edit the flags of the currently selected article.
-next-unread-feed:^N:Go to the next feed with unread articles. This only works from the article list.
-prev-unread-feed:^P:Go to the previous feed with unread articles. This only works from the article list.
-next-feed:j:Go to the next feed. This only works from the article list.
-prev-feed:k:Go to the previous feed. This only works from the article list.
-delete-article:D:Delete the currently selected article.
-purge-deleted:$:Purge all article that are marked as deleted from the article list.
-view-dialogs:v:View list of open dialogs.
-close-dialog:^X:Close currently selected dialog.
-next-dialog:^V:Go to next dialog.
-prev-dialog:^G:Go to previous dialog.
-pipe-to:|:Pipe article to command.
-sort:g:Sort feeds/articles by interactively choosing the sort method.
-revsort:G:Sort feeds/articles by interactively choosing the sort method (reversed).
-up:UP:Goes up one item in the list.
-down:DOWN:Goes down one item in the list.
-pageup:PPAGE:Goes up one page in the list.
-pagedown:NPAGE:Goes down one page in the list.
-home:HOME:Goes to the first item in the list.
-end:END:Goes to the last item in the list.
+open||ENTER||Open the currently selected feed or article.
+quit||q||Quit the program or return to the previous dialog (depending on the context).
+hard-quit||Q||Quit the program without confirmation.
+reload||r||Reload the currently selected feed.
+reload-all||R||Reload all feeds.
+mark-feed-read||A||Mark all articles in the currently selected feed read.
+mark-all-feeds-read||C||Mark articles in all feeds read.
+save||s||Save the currently selected article to a file.
+next-unread||n||Jump to the next unread article.
+prev-unread||p||Jump to the previous unread article.
+next||J||Jump to next article.
+prev||K||Jump to previous article.
+random-unread||^K||Jump to a random unread article.
+open-in-browser||o||Opens the URL associated with the current article.
+open-in-browser-and-mark-read||O||Opens the URL associated with the current article and marks the article as read.
+open-all-unread-in-browser||n/a||Opens all the unread URLs in the current feed.
+open-all-unread-in-browser-and-mark-read||n/a||Opens all the unread URLs in the current feed and marks them as read.
+help||?||Runs the help screen.
+toggle-source-view||^U||Toggles between the HTML view and the source view in the article view.
+toggle-article-read||N||Toggle the read flag for the currently selected article, and clears delete flag if set.
+toggle-show-read-feeds||l||Toggle whether read feeds should be shown in the feed list.
+show-urls||u||Show all URLs in the article in a list (similar to urlview).
+clear-tag||^T||Clear current tag.
+set-tag||t||Select tag.
+open-search||/||Opens the search dialog. When a search is done in the article list, then the search operation only applies to the articles of the current feed, otherwise to all articles.
+goto-url||#||Open the URL dialog and then opens specified URL.
+enqueue||e||Add the podcast download URL of the current article (if any is found) to the podcast download queue (see the respective section in the documentation for more information on podcast support).
+edit-urls||E||Edit the list of subscribed URLs. newsboat will start the editor configured through the $VISUAL environment variable (if unset, $EDITOR is used; fallback: "vi"). When editing is finished, newsboat will reload the URLs file.
+reload-urls||^R||Reload the URLs configuration file.
+redraw||^L||Redraw the screen.
+cmdline||<colon>||Open the command line.
+set-filter||F||Set a filter.
+select-filter||f||Select a predefined filter.
+clear-filter||^F||Clear currently set filter.
+bookmark||^B||Bookmark currently selected article or URL.
+edit-flags||^E||Edit the flags of the currently selected article.
+next-unread-feed||^N||Go to the next feed with unread articles. This only works from the article list.
+prev-unread-feed||^P||Go to the previous feed with unread articles. This only works from the article list.
+next-feed||j||Go to the next feed. This only works from the article list.
+prev-feed||k||Go to the previous feed. This only works from the article list.
+delete-article||D||Delete the currently selected article.
+purge-deleted||$||Purge all article that are marked as deleted from the article list.
+view-dialogs||v||View list of open dialogs.
+close-dialog||^X||Close currently selected dialog.
+next-dialog||^V||Go to next dialog.
+prev-dialog||^G||Go to previous dialog.
+pipe-to|||||Pipe article to command.
+sort||g||Sort feeds/articles by interactively choosing the sort method.
+revsort||G||Sort feeds/articles by interactively choosing the sort method (reversed).
+up||UP||Goes up one item in the list.
+down||DOWN||Goes down one item in the list.
+pageup||PPAGE||Goes up one page in the list.
+pagedown||NPAGE||Goes down one page in the list.
+home||HOME||Goes to the first item in the list.
+end||END||Goes to the last item in the list.

--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -94,9 +94,9 @@ include::configcommands-linked.dsv[]
 |======================================================================================================
 
 .[[available-operations,Available Operations]]<<available-operations>>
-[frame="all", grid="all", format="dsv", options="header", cols="20,20,60"]
+[frame="all", grid="all", format="dsv", separator="\|\||\n", options="header", cols="20,20,60"]
 |=========================================================================
-Operation:Default key:Description
+Operation||Default key||Description
 include::keycmds-linked.dsv[]
 |=========================================================================
 


### PR DESCRIPTION
If the DSV input files are broken regarding their number of columns in a
row (missing some or defining too many), this will now fail the build.
Reordering the dependencies for the 'doc' target will cause the
doc/generate{,2} binaries to be executed prior to creating the HTML
documentation. Previously the HTML build failed with a meaningless
xmllint error. In order to aid fixing the problem a bit faster, the DSV
error will now be presented instead. See also #30.