### PR TITLE
Fix exit

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -103,7 +103,7 @@ class controller {
 
 		unsigned int get_feed_count_per_tag(const std::string& tag);
 	private:
-		int usage(char * argv0);
+		void print_usage(char * argv0);
 		bool setup_dirs_xdg(const std::string& env_home);
 		void setup_dirs(const std::string& env_home);
 		void migrate_data_from_newsbeuter(
@@ -112,7 +112,7 @@ class controller {
 				const std::string& env_home, bool silent);
 		bool migrate_data_from_newsbeuter_simple(
 				const std::string& env_home, bool silent);
-		int version_information(const char * argv0, unsigned int level);
+		void print_version_information(const char * argv0, unsigned int level);
 		void import_opml(const std::string& filename);
 		void export_opml();
 		void rec_find_rss_outlines(xmlNode * node, std::string tag);

--- a/include/pb_controller.h
+++ b/include/pb_controller.h
@@ -34,8 +34,6 @@ class pb_controller {
 			return downloads_;
 		}
 
-		int usage(const char * argv0);
-
 		std::string get_dlpath();
 
 		unsigned int downloads_in_progress();
@@ -56,6 +54,7 @@ class pb_controller {
 		}
 
 	private:
+		void print_usage(const char * argv0);
 		bool setup_dirs_xdg(const char *env_home);
 
 		pb_view * v;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -405,15 +405,6 @@ int controller::run(int argc, char * argv[]) {
 		{0                 , 0                , 0,  0 }
 	};
 
-	/* First of all, let's check for options that imply silencing of the
-	 * output: import, export, command execution and, well, quiet mode */
-	while ((c = ::getopt_long(argc, argv, getopt_str, longopts, nullptr)) != -1) {
-		if (strchr("iexq", c) != nullptr) {
-			silent = true;
-			break;
-		}
-	}
-
 	const char * env_home;
 	if (!(env_home = ::getenv("HOME"))) {
 		struct passwd * spw = ::getpwuid(::getuid());
@@ -452,6 +443,9 @@ int controller::run(int argc, char * argv[]) {
 			refresh_on_start = true;
 			break;
 		case 'e':
+			// disable logging of newsboat's startup progress to stdout, because the
+			// OPML export will be printed to stdout
+			silent = true;
 			if (do_import) {
 				print_usage(argv[0]);
 				return EXIT_FAILURE;
@@ -483,9 +477,13 @@ int controller::run(int argc, char * argv[]) {
 			show_version++;
 			break;
 		case 'x':
+			// disable logging of newsboat's startup progress to stdout, because the
+			// command execution result will be printed to stdout
+			silent = true;
 			execute_cmds = true;
 			break;
 		case 'q':
+			silent = true;
 			break;
 		case 'd':
 			logger::getInstance().set_logfile(optarg);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -438,11 +438,13 @@ int controller::run(int argc, char * argv[]) {
 		switch (c) {
 		case ':': /* fall-through */
 		case '?': /* missing option */
-			usage(argv[0]);
-			break;
+			print_usage(argv[0]);
+			return EXIT_FAILURE;
 		case 'i':
-			if (do_export)
-				usage(argv[0]);
+			if (do_export) {
+				print_usage(argv[0]);
+				return EXIT_FAILURE;
+			}
 			do_import = true;
 			importfile = optarg;
 			break;
@@ -450,13 +452,15 @@ int controller::run(int argc, char * argv[]) {
 			refresh_on_start = true;
 			break;
 		case 'e':
-			if (do_import)
-				usage(argv[0]);
+			if (do_import) {
+				print_usage(argv[0]);
+				return EXIT_FAILURE;
+			}
 			do_export = true;
 			break;
 		case 'h':
-			usage(argv[0]);
-			break;
+			print_usage(argv[0]);
+			return EXIT_SUCCESS;
 		case 'u':
 			url_file = optarg;
 			using_nonstandard_configs = true;
@@ -497,27 +501,32 @@ int controller::run(int argc, char * argv[]) {
 		}
 		break;
 		case 'I':
-			if (do_read_export)
-				usage(argv[0]);
+			if (do_read_export) {
+				print_usage(argv[0]);
+				return EXIT_FAILURE;
+			}
 			do_read_import = true;
 			readinfofile = optarg;
 			break;
 		case 'E':
-			if (do_read_import)
-				usage(argv[0]);
+			if (do_read_import) {
+				print_usage(argv[0]);
+				return EXIT_FAILURE;
+			}
 			do_read_export = true;
 			readinfofile = optarg;
 			break;
 		default:
 			std::cout << strprintf::fmt(_("%s: unknown option - %c"), argv[0], static_cast<char>(c)) << std::endl;
-			usage(argv[0]);
-			break;
+			print_usage(argv[0]);
+			return EXIT_FAILURE;
 		}
 	};
 
 
 	if (show_version) {
-		return version_information(argv[0], show_version);
+		print_version_information(argv[0], show_version);
+		return EXIT_SUCCESS;
 	}
 
 	if (do_import) {
@@ -687,7 +696,8 @@ int controller::run(int argc, char * argv[]) {
 			assert(0); // shouldn't happen
 		}
 		std::cout << msg << std::endl << std::endl;
-		return usage(argv[0]);
+		print_usage(argv[0]);
+		return EXIT_FAILURE;
 	}
 
 	if (!do_export && !do_vacuum && !silent)
@@ -1138,7 +1148,7 @@ void controller::start_reload_all_thread(std::vector<int> * indexes) {
 	t.detach();
 }
 
-int controller::version_information(const char * argv0, unsigned int level) {
+void controller::print_version_information(const char * argv0, unsigned int level) {
 	if (level<=1) {
 		std::cout << PROGRAM_NAME << " " << PROGRAM_VERSION << " - " << PROGRAM_URL << std::endl;
 		std::cout << "Copyright (C) 2006-2015 Andreas Krennmair" << std::endl;
@@ -1164,11 +1174,9 @@ int controller::version_information(const char * argv0, unsigned int level) {
 	} else {
 		std::cout << LICENSE_str << std::endl;
 	}
-
-	return EXIT_SUCCESS;
 }
 
-int controller::usage(char * argv0) {
+void controller::print_usage(char * argv0) {
 	auto msg =
 	    strprintf::fmt(_("%s %s\nusage: %s [-i <file>|-e] [-u <urlfile>] "
 	    "[-c <cachefile>] [-x <command> ...] [-h]\n"),
@@ -1213,8 +1221,6 @@ int controller::usage(char * argv0) {
 		}
 		std::cout << a.desc << std::endl;
 	}
-
-	return EXIT_FAILURE;
 }
 
 void controller::import_opml(const std::string& filename) {

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -172,8 +172,8 @@ int pb_controller::run(int argc, char * argv[]) {
 		switch (c) {
 		case ':':
 		case '?':
-			usage(argv[0]);
-			break;
+			print_usage(argv[0]);
+			return EXIT_FAILURE;
 		case 'C':
 			config_file = optarg;
 			break;
@@ -197,12 +197,12 @@ int pb_controller::run(int argc, char * argv[]) {
 			}
 			break;
 		case 'h':
-			usage(argv[0]);
-			break;
+			print_usage(argv[0]);
+			return EXIT_SUCCESS;
 		default:
 			std::cout << strprintf::fmt(_("%s: unknown option - %c"), argv[0], static_cast<char>(c)) << std::endl;
-			usage(argv[0]);
-			break;
+			print_usage(argv[0]);
+			return EXIT_FAILURE;
 		}
 	};
 
@@ -274,7 +274,7 @@ int pb_controller::run(int argc, char * argv[]) {
 	return EXIT_SUCCESS;
 }
 
-int pb_controller::usage(const char * argv0) {
+void pb_controller::print_usage(const char * argv0) {
 	auto msg =
 	    strprintf::fmt(_("%s %s\nusage %s [-C <file>] [-q <file>] [-h]\n"),
 	    "podboat",
@@ -309,8 +309,6 @@ int pb_controller::usage(const char * argv0) {
 		}
 		std::cout << a.desc << std::endl;
 	}
-
-	return EXIT_FAILURE;
 }
 
 std::string pb_controller::get_dlpath() {


### PR DESCRIPTION
Fix exiting newsboat/podboat if `--help` is given

Commit a0cc1ae755386a2db342659c0a9d1fe9794f84ed introduced a bug where
supplying the `--help` option did not exit the softwares immediately as
they were supposed to do, but actually started them after showing the 
help text. This commit fixes that.

Also rename the methods to indicate more clearly what they do and let 
the exit code handling be done by the callers. This way we can also
return exit code 0 when `--help` was requested as most other programs do
as well. Previously, always exit code 1 was returned when the usage was 
involved, even when passing `--help`.

Thanks to qgTG in IRC for reporting this bug!

Also when working on this I noticed a problem with unknown options. Newsboat prints the error message twice. So I refactored the getopt handling a tiny bit. This probably should have been a separate merge request, but hey. :-)