### PR TITLE
Use conditional assignment for RANLIB and AR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ MKDIR=mkdir -p
 INSTALL=install
 A2X=a2x
 MSGFMT=msgfmt
-RANLIB=ranlib
-AR=ar
+RANLIB?=ranlib
+AR?=ar
 CHMOD=chmod
 
 STFLHDRS:=$(patsubst %.stfl,%.h,$(wildcard stfl/*.stfl))


### PR DESCRIPTION
Using the conditional variable assignment for RANLIB and AR allows cross compilation to work by overriding these variables.