### PR TITLE
Bugfix: Set CURLOPT_COOKIEJAR after reset of curlhandle

### DIFF
--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -156,6 +156,9 @@ feed parser::parse_url(const std::string& url, time_t lastmodified, const std::s
 	CURLcode infoOk = curl_easy_getinfo(easyhandle, CURLINFO_RESPONSE_CODE, &status);
 
 	curl_easy_reset(easyhandle);
+	if (cookie_cache != "") {
+		curl_easy_setopt(easyhandle, CURLOPT_COOKIEJAR, cookie_cache.c_str());
+	}
 
 	if (!ehandle)
 		curl_easy_cleanup(easyhandle);


### PR DESCRIPTION
This is a bugfix for a bug reported by Håkan Jerning on IRC on 4th November 2017, who reported that the cookie-cache option did not work as expected. According to the reporter, the bug is fixed by this patch.

## Summary

When resetting a curlhandle, this also discards the `CURLOPT_COOKIEJAR` option, which means that no cookies get persisted even though the "cookie-cache" config option is enabled.

## Details
In the url-parser, we reset the curl_handle after each request, which according to the libcurl documentation "[r]e-initializes all options previously set on a specified CURL handle to the default values" and seems like a good idea to not leak old settings into new connections.
Some handle-data, like cookies remain untouched by this operation, which is important, because we (optionally) use those cookies to speed up future connections by reusing already established sessions, etc. The required serialisation of curl's cookies is controlled by `CURLOPT_COOKIEJAR`, which is also discarded by `curl_easy_reset`, therefore, no cache is written.
This patch ensures that this particular setting remains intact over resets.

## Acknowledgements
Testers: Håkan Jerning