### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,14 +197,14 @@ doc/example-config: doc/gen-example-config doc/configcommands.dsv
 
 # add hyperlinks for every configuration command
 doc/configcommands-linked.dsv: doc/configcommands.dsv
-	sed -r 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/configcommands.dsv > doc/configcommands-linked.dsv
+	sed -E 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/configcommands.dsv > doc/configcommands-linked.dsv
 
 # add hyperlinks for every configuration command
 doc/podboat-cmds-linked.dsv: doc/podboat-cmds.dsv
-	sed -r 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/podboat-cmds.dsv > doc/podboat-cmds-linked.dsv
+	sed -E 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/podboat-cmds.dsv > doc/podboat-cmds-linked.dsv
 
 doc/keycmds-linked.dsv: doc/keycmds.dsv
-	sed -r 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/keycmds.dsv > doc/keycmds-linked.dsv
+	sed -E 's/^([^|]+)/[[\1]]<<\1,`\1`>>/' doc/keycmds.dsv > doc/keycmds-linked.dsv
 
 fmt:
 	astyle --suffix=none --style=java --indent=tab --indent-classes *.cpp include/*.h src/*.cpp rss/*.{cpp,h} test/*.cpp


### PR DESCRIPTION
BSD sed (found on macOS) doesn't have the `-r` flag, but both GNU and BSD sed support `-E`