### PR TITLE
Support line wrapping for CJK languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - When used with Newsblur, Newsboat will check on startup if cookie-cache exists
   or can be created, because integration doesn't work without cookies (#13)
+- CJK text is wrapped at correct code-point boundaries (#71)
 
 ## 2.10.1 - 2017-09-22
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -77,6 +77,8 @@ class utils {
 		static size_t strwidth_stfl(const std::string& str);
 		static size_t wcswidth_stfl(const std::wstring& str, size_t size);
 
+		static std::string substr_with_width(const std::string& str, const size_t max_width);
+
 		static unsigned int max(unsigned int a, unsigned int b) {
 			return (a > b) ? a : b;
 		}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <cstdarg>
 #include <cstdio>
+#include <cmath>
 #include <algorithm>
 #include <regex>
 
@@ -736,6 +737,64 @@ size_t utils::wcswidth_stfl(const std::wstring& str, size_t size) {
 	}
 
 	return width - reduce_count;
+}
+
+std::string utils::substr_with_width(
+		const std::string& str,
+		const size_t max_width)
+{
+	// Returns a longest substring fits to the given width.
+	// Returns an empty string if `str` is an empty string or `max_width` is zero,
+	//
+	// Each chararacter width is calculated with wcwidth(3). If wcwidth() returns < 1,
+	// the character width is treated as 0. A STFL tag (e.g. `<b>`, `<foobar>`, `</>`)
+	// width is treated as 0, but escaped less-than (`<>`) width is treated as 1.
+
+	if (str.empty() || max_width == 0) {
+		return std::string("");
+	}
+
+	const std::wstring wstr = utils::str2wstr(str);
+	size_t total_width = 0;
+	bool in_bracket = false;
+	std::wstring result;
+	std::wstring tagbuf;
+
+	for (auto wc : wstr) {
+		if (in_bracket) {
+			tagbuf += wc;
+			if (wc == L'>') {  // tagbuf is escaped less-than or tag
+				in_bracket = false;
+				if (tagbuf == L"<>") {
+					if (total_width + 1 > max_width) {
+						break;
+					}
+					result += L"<>";  // escaped less-than
+					tagbuf.clear();
+					total_width++;
+				} else {
+					result += tagbuf;
+					tagbuf.clear();
+				}
+			}
+		} else {
+			if (wc == L'<') {
+				in_bracket = true;
+				tagbuf += wc;
+			} else {
+				int w = wcwidth(wc);
+				if (w < 1) {
+					w = 0;
+				}
+				if (total_width + w > max_width) {
+					break;
+				}
+				total_width += w;
+				result += wc;
+			}
+		}
+	}
+	return utils::wstr2str(result);
 }
 
 std::string utils::join(const std::vector<std::string>& strings, const std::string& separator) {

--- a/test/textformatter.cpp
+++ b/test/textformatter.cpp
@@ -47,6 +47,40 @@ TEST_CASE("lines marked as `wrappable` are wrapped to fit width",
 	}
 }
 
+TEST_CASE("line wrapping works for non-space-separeted text",
+          "[textformatter]") {
+
+	textformatter fmt;
+
+	fmt.add_lines(
+		{
+			std::make_pair(LineType::wrappable,
+					"    つれづれなるままに、ひぐらしすずりにむかいて、")
+		});
+
+
+	SECTION("preserve indent and doesn't return broken UTF-8") {
+		const std::string expected = (
+				"    つれづれなるまま\n"
+				"    に、ひぐらしすず\n"
+				"    りにむかいて、\n");
+		REQUIRE(fmt.format_text_plain(20) == expected);
+		// +1 is not enough to store single wide-width char
+		REQUIRE(fmt.format_text_plain(20+1) == expected);
+	}
+
+	SECTION("truncate indent if given window width is too narrow") {
+		REQUIRE(fmt.format_text_plain(1) == (" \n \n"));
+		REQUIRE(fmt.format_text_plain(2) == ("  \n  \n"));
+		REQUIRE(fmt.format_text_plain(3) == ("   \n   \n"));
+	}
+
+	SECTION("discard a current word if no enough space to put single char is available") {
+		REQUIRE(fmt.format_text_plain(4) == ("    \n    \n"));
+		REQUIRE(fmt.format_text_plain(5) == ("    \n    \n"));
+	}
+}
+
 TEST_CASE("regex manager is used by format_text_to_list if one is passed",
           "[textformatter]") {
 	textformatter fmt;


### PR DESCRIPTION
This PR fixes #71 

CJK (Chinese, Japanese and Korean) don't use a space for
specifying word boundaries in a general. This commit
wraps such text at a screen border at a correct code-point boundary.

Note that this commit doesn't support grapheme clusters;
single grapheme cluster may be split into multiple code points
at a screen border.