### PR TITLE
Allow ncurses6

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -108,7 +108,8 @@ if [ `uname -s` = "Darwin" ]; then
 	check_custom "ncurses5.4" "ncurses5.4-config" || fail "ncurses5.4"
 elif [ `uname -s` != "OpenBSD" ]; then
 	check_pkg "ncursesw" || \
-	check_custom "ncursesw5" "ncursesw5-config" ||  fail "ncursesw"
+	check_custom "ncursesw5" "ncursesw5-config" || \
+		check_custom "ncursesw6" "ncursesw6-config" || fail "ncursesw"
 fi
 check_ssl_implementation
 all_aboard_the_fail_boat


### PR DESCRIPTION
Alpine Linux has a downstream patch for [newsbeuter](https://github.com/alpinelinux/aports/blob/master/main/newsbeuter/newsbeuter-2.9-ncurses6.patch) and hopefully soon for [newsboat](https://github.com/alpinelinux/aports/pull/2937/files#diff-66b0ab3ce7ee080e38cf45115524a1fc) to allow building with ncurses 6. I've tested that this approach works on Alpine Linux and would like to integrate it into newsboat so Alpine can remove their patch.