### PR TITLE
Use more portable __linux__ define

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -300,7 +300,7 @@ std::string utils::convert_text(const std::string& text, const std::string& toco
 	 * of all the Unix-like systems around there, only Linux/glibc seems to
 	 * come with a SuSv3-conforming iconv implementation.
 	 */
-#if !(__linux) && !defined(__GLIBC__) && !defined(__APPLE__) \
+#if !defined(__linux__) && !defined(__GLIBC__) && !defined(__APPLE__) \
 	&& !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
 	const char * inbufp;
 #else


### PR DESCRIPTION
This is the last patch to upstream from Alpine Linux before they can build without any downstream patches. Once this is accepted I'll maintain the patches in the Alpine tree till the next version ships then remove them.

----

This fixes an Alpine Linux has building newsbeuter because the distro
uses MUSL instead of glibc. To quote the original patch author:

"If you try to compile newsbeuter without -fpermissive, as ppc64le, it
will not build due to a wrong argument type.

It is wrong because it sets the proper argument if you have Linux with
Glibc. Since we use MUSL, it use the wrong argument.

This patch assure that both musl and glibc uses the same argument type."