### PR TITLE
Makefile: install docs as non-executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,13 +222,13 @@ install-newsboat: $(NEWSBOAT) doc/$(NEWSBOAT).1
 	$(MKDIR) $(DESTDIR)$(prefix)/bin
 	$(INSTALL) $(NEWSBOAT) $(DESTDIR)$(prefix)/bin
 	$(MKDIR) $(DESTDIR)$(mandir)/man1
-	$(INSTALL) doc/$(NEWSBOAT).1 $(DESTDIR)$(mandir)/man1 || true
+	$(INSTALL) -m 644 doc/$(NEWSBOAT).1 $(DESTDIR)$(mandir)/man1 || true
 
 install-podboat: $(PODBOAT) doc/$(PODBOAT).1
 	$(MKDIR) $(DESTDIR)$(prefix)/bin
 	$(INSTALL) $(PODBOAT) $(DESTDIR)$(prefix)/bin
 	$(MKDIR) $(DESTDIR)$(mandir)/man1
-	$(INSTALL) doc/$(PODBOAT).1 $(DESTDIR)$(mandir)/man1 || true
+	$(INSTALL) -m 644 doc/$(PODBOAT).1 $(DESTDIR)$(mandir)/man1 || true
 
 install-docs: doc
 	$(MKDIR) $(DESTDIR)$(docdir)


### PR DESCRIPTION
This removes the executable bits from the man pages. The `644` permissions are properly being applied to other docs already, but it was missed for the two man pages.

----

You can see the openSUSE package details with this patch here:

https://build.opensuse.org/package/show/network:utilities/newsboat
https://build.opensuse.org/request/show/560213