### PR TITLE
Add support for $CURL_CA_BUNDLE

### DIFF
--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -118,6 +118,9 @@ feed parser::parse_url(const std::string& url, time_t lastmodified, const std::s
 
 	curl_easy_setopt(easyhandle, CURLOPT_PROXYTYPE, prxtype);
 
+	if (getenv ("CURL_CA_BUNDLE") != NULL)
+		curl_easy_setopt(easyhandle, CURLOPT_CAINFO, getenv("CURL_CA_BUNDLE"));
+
 	header_values hdrs;
 	curl_easy_setopt(easyhandle, CURLOPT_HEADERDATA, &hdrs);
 	curl_easy_setopt(easyhandle, CURLOPT_HEADERFUNCTION, handle_headers);


### PR DESCRIPTION
Hello!

On some distributions, libcurl is built without useful TLS certificate information.  This patch allows end users to override the libcurl builtin.