### PR TITLE
Add snapcraft support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,47 @@
+name: newsboat
+version: git
+summary: An RSS/Atom feed reader for text terminals
+description: |
+  Newsboat is a fork of Newsbeuter, an RSS/Atom feed reader for the text 
+  console. The only difference is that Newsboat is actively maintained 
+  while Newsbeuter isn't.
+grade: stable
+confinement: strict
+
+apps:
+  newsboat:
+    command: usr/local/bin/newsboat
+    environment:
+      LOCPATH: "$SNAP/usr/lib/locale"
+    plugs:
+      - network
+      - home
+  podboat:
+    command: usr/local/bin/podboat
+    aliases: [podboat]
+    environment:
+      LOCPATH: "$SNAP/usr/lib/locale"
+    plugs:
+      - network
+      - home
+
+parts:
+  newsboat:
+    plugin: make
+    source: .
+    build-packages: 
+      - pkg-config
+      - libsqlite3-dev
+      - libcurl4-openssl-dev
+      - libxml2-dev
+      - libstfl-dev
+      - libjson-c-dev
+      - libncursesw5-dev
+      - asciidoc
+      - libssl-dev
+      - gettext
+    stage-packages:
+      - libxml2
+      - librtmp1
+      - locales-all
+      - libcurl3


### PR DESCRIPTION
This pull request adds support to build newboat as a snap.

newboat is already [available](https://snapcraft.io/newboat/) in the snap store via the yaml in the [snapcrafter](https://github.com/snapcrafters/newboat) repo.

This PR is to upstream the snapcraft.yaml which creates the snap which is in the store. If the PR is accepted, we can transfer ownership of the newboat snap to you, the upstream developer. Once done you could use the free build.snapcraft.io service to automatically build new releases of newboat and push directly to the store. 

If accepted, I'm happy to walk you through the next steps. 