### PR TITLE
Implement mutt-like movement in the feedlist and itemlist

### DIFF
--- a/include/formaction.h
+++ b/include/formaction.h
@@ -43,7 +43,7 @@ class formaction {
 
 		virtual void finished_qna(operation op);
 
-		void start_cmdline();
+		void start_cmdline(std::string default_value = "");
 
 		virtual void recalculate_form();
 

--- a/include/list_formaction.h
+++ b/include/list_formaction.h
@@ -9,6 +9,7 @@ class list_formaction : public formaction {
 	public:
 		list_formaction(view *, std::string formstr);
 	protected:
+		void process_operation(operation op, bool automatic = false, std::vector<std::string> * args = nullptr) override;
 		void open_unread_items_in_browser(std::shared_ptr<rss_feed> feed , bool markread);
 
 };

--- a/src/feedlist_formaction.cpp
+++ b/src/feedlist_formaction.cpp
@@ -387,6 +387,7 @@ REDO:
 		v->push_help();
 		break;
 	default:
+		list_formaction::process_operation(op, automatic, args);
 		break;
 	}
 	if (quit) {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -69,9 +69,9 @@ std::string formaction::get_value(const std::string& value) {
 }
 
 
-void formaction::start_cmdline() {
+void formaction::start_cmdline(std::string default_value) {
 	std::vector<qna_pair> qna;
-	qna.push_back(qna_pair(":", ""));
+	qna.push_back(qna_pair(":", default_value));
 	v->inside_cmdline(true);
 	this->start_qna(qna, OP_INT_END_CMDLINE, &formaction::cmdlinehistory);
 }

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -502,6 +502,7 @@ void itemlist_formaction::process_operation(operation op, bool automatic, std::v
 		invalidate(InvalidationMode::COMPLETE);
 		break;
 	default:
+		list_formaction::process_operation(op, automatic, args);
 		break;
 	}
 	if (hardquit) {

--- a/src/list_formaction.cpp
+++ b/src/list_formaction.cpp
@@ -7,6 +7,40 @@ list_formaction::list_formaction(view * v, std::string formstr)
 :formaction(v, formstr)
 {}
 
+void list_formaction::process_operation(operation op, bool, std::vector<std::string> *) {
+	switch (op) {
+	case OP_1:
+		formaction::start_cmdline("1");
+		break;
+	case OP_2:
+		formaction::start_cmdline("2");
+		break;
+	case OP_3:
+		formaction::start_cmdline("3");
+		break;
+	case OP_4:
+		formaction::start_cmdline("4");
+		break;
+	case OP_5:
+		formaction::start_cmdline("5");
+		break;
+	case OP_6:
+		formaction::start_cmdline("6");
+		break;
+	case OP_7:
+		formaction::start_cmdline("7");
+		break;
+	case OP_8:
+		formaction::start_cmdline("8");
+		break;
+	case OP_9:
+		formaction::start_cmdline("9");
+		break;
+	default:
+		break;
+	}
+}
+
 void list_formaction::open_unread_items_in_browser(std::shared_ptr<rss_feed> feed , bool markread){
 	int tabcount = 0;
 	for (auto item : feed->items()) {


### PR DESCRIPTION
Currently the best way to move in lists is to use the goto operation byopening the cmdline, typing the number then pressing enter.

In my opinion that's one key too many (especially with the default cmdline which requires to press shift). This commit implements movement in a similar way to mutt i.e. the cmdline is automatically opened when a number is pressed.