### PR TITLE
Reuse handle when bulk-reloading

### DIFF
--- a/include/ttrss_api.h
+++ b/include/ttrss_api.h
@@ -16,7 +16,7 @@ class ttrss_api : public remote_api {
 		bool authenticate() override;
 		virtual nlohmann::json run_op(
 				const std::string& op, const std::map<std::string,
-				std::string>& args, bool try_login = true);
+				std::string>& args, bool try_login = true, CURL *cached_handle = nullptr);
 		std::vector<tagged_feedurl> get_subscribed_urls() override;
 		void add_custom_headers(curl_slist** custom_headers) override;
 		bool mark_all_read(const std::string& feedurl) override;
@@ -24,7 +24,7 @@ class ttrss_api : public remote_api {
 		bool update_article_flags(
 				const std::string& oldflags, const std::string& newflags,
 				const std::string& guid) override;
-		rsspp::feed fetch_feed(const std::string& id);
+		rsspp::feed fetch_feed(const std::string& id, CURL* cached_handle);
 		bool update_article(const std::string& guid, int mode, int field);
 	private:
 		void fetch_feeds_per_category(

--- a/include/utils.h
+++ b/include/utils.h
@@ -55,7 +55,8 @@ class utils {
 				const std::string& url,
 				configcontainer * cfgcont = nullptr,
 				const std::string& authinfo = "",
-				const std::string* postdata = nullptr);
+				const std::string* postdata = nullptr,
+				CURL* easyhandle = nullptr);
 		static void run_command(const std::string& cmd, const std::string& param); // used for notifications only
 		static std::string run_program(char * argv[], const std::string& input);
 

--- a/src/rss_parser.cpp
+++ b/src/rss_parser.cpp
@@ -471,7 +471,7 @@ bool rss_parser::is_html_type(const std::string& type) {
 void rss_parser::fetch_ttrss(const std::string& feed_id) {
 	ttrss_api * tapi = dynamic_cast<ttrss_api *>(api);
 	if (tapi) {
-		f = tapi->fetch_feed(feed_id);
+		f = tapi->fetch_feed(feed_id, easyhandle ? easyhandle->ptr() : nullptr);
 		is_valid = true;
 	}
 	LOG(level::DEBUG, "rss_parser::fetch_ttrss: f.items.size = %u", f.items.size());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -379,11 +379,17 @@ std::string utils::retrieve_url(
 		const std::string& url,
 		configcontainer * cfgcont,
 		const std::string& authinfo,
-		const std::string* postdata)
+		const std::string* postdata,
+		CURL* cached_handle)
 {
 	std::string buf;
 
-	CURL * easyhandle = curl_easy_init();
+	CURL* easyhandle;
+	if (cached_handle) {
+		easyhandle = cached_handle;
+	} else {
+		easyhandle = curl_easy_init();
+	}
 	set_common_curl_options(easyhandle, cfgcont);
 	curl_easy_setopt(easyhandle, CURLOPT_URL, url.c_str());
 	curl_easy_setopt(easyhandle, CURLOPT_WRITEFUNCTION, my_write_data);
@@ -401,7 +407,9 @@ std::string utils::retrieve_url(
 	}
 
 	curl_easy_perform(easyhandle);
-	curl_easy_cleanup(easyhandle);
+	if (!cached_handle) {
+		curl_easy_cleanup(easyhandle);
+	}
 
 	if (postdata != nullptr) {
 		LOG(level::DEBUG, "utils::retrieve_url(%s)[%s]: %s", url, postdata, buf);


### PR DESCRIPTION
As all feed updates target the same host when an remote API is used, they can benefit from cURL-handle and therefore connection reuse. This is implemented by this commit.

At a cursory glance, it seems to pay off, even though the total payoff is not as siginificant as I've hoped (most of the time seems to be spend waiting for the network, even though the measurements were taken between servers with two symmetric gigabit links. So we save on CPU time, but without ostendable speedups in the actual operation):
```
Old:
for i in $(seq 0 7); do time ./newsboat -x reload; done
./newsboat -x reload  15.29s user 1.32s system 93% cpu 17.766 total
./newsboat -x reload  15.65s user 1.44s system 96% cpu 17.772 total
./newsboat -x reload  15.40s user 1.37s system 59% cpu 27.970 total
./newsboat -x reload  15.64s user 1.39s system 98% cpu 17.305 total
./newsboat -x reload  15.50s user 1.31s system 89% cpu 18.747 total
./newsboat -x reload  15.08s user 1.34s system 87% cpu 18.796 total
./newsboat -x reload  15.45s user 1.24s system 91% cpu 18.328 total
./newsboat -x reload  15.54s user 1.32s system 89% cpu 18.753 total

New:
for i in $(seq 0 7); do time ./newsboat -x reload; done
./newsboat -x reload  8.77s user 1.24s system 73% cpu 13.630 total
./newsboat -x reload  9.42s user 1.39s system 71% cpu 15.130 total
./newsboat -x reload  8.77s user 1.32s system 75% cpu 13.405 total
./newsboat -x reload  8.42s user 1.31s system 68% cpu 14.257 total
./newsboat -x reload  8.49s user 1.37s system 63% cpu 15.611 total
./newsboat -x reload  8.76s user 1.38s system 68% cpu 14.798 total
./newsboat -x reload  8.34s user 1.34s system 55% cpu 17.419 total
./newsboat -x reload  8.61s user 1.33s system 70% cpu 14.000 total
```