### PR TITLE
Add basic evernote bookmark plugin

### DIFF
--- a/contrib/bookmark-evernote.sh
+++ b/contrib/bookmark-evernote.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#basic newsboat bookmark plugin for evernote using geeknote: https://github.com/pipakin/geeknote
+
+url="$1"
+title="$2"
+description="$3"
+feed_title="$4"
+
+content="${url}"$'\n'"${description}"$'\n'${feed_title}
+
+geeknote create --title "${title}" --content "${content}"

--- a/contrib/bookmark-evernote.sh
+++ b/contrib/bookmark-evernote.sh
@@ -6,6 +6,6 @@ title="$2"
 description="$3"
 feed_title="$4"
 
-content="${url}"$'\n'"${description}"$'\n'${feed_title}
+content="${url}"$'\n'"${description}"$'\n'$"{feed_title}"
 
 geeknote create --title "${title}" --content "${content}"

--- a/contrib/bookmark-evernote.sh
+++ b/contrib/bookmark-evernote.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #basic newsboat bookmark plugin for evernote using geeknote: https://github.com/pipakin/geeknote
 
 url="$1"

--- a/contrib/bookmark-evernote.sh
+++ b/contrib/bookmark-evernote.sh
@@ -6,6 +6,6 @@ title="$2"
 description="$3"
 feed_title="$4"
 
-content="${url}"$'\n'"${description}"$'\n'$"{feed_title}"
+content="${url}"$'\n'"${description}"$'\n'"${feed_title}"
 
 geeknote create --title "${title}" --content "${content}"


### PR DESCRIPTION
This adds a bookmark plugin for Evernote to contrib using the geeknote command line tool.

It could use some cleanup so that it doesn't end with an output as a save error in Newsboat even though the bookmark is successfully added to Evernote. 