### PR TITLE
Add an option for a clean debug build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ config.mk
 po/*.mo
 stfl/*.h
 newsboat
+newsboat-dbg
 podboat
+podboat-dbg
 test/test
 test/test-rss
 test/testlog.txt
@@ -27,3 +29,5 @@ doc/keycmds-linked.dsv
 *.gcno
 *.gcda
 *.sw?
+build
+build-dbg

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ WARNFLAGS=-Werror -Wall -Wextra -Wunreachable-code
 INCLUDES=-Iinclude -Istfl -Ifilter -I. -Irss
 BARE_CXXFLAGS=-std=c++11 -O2 -ggdb $(INCLUDES)
 LDFLAGS+=-L.
+OBJDIR=./build
 
 PACKAGE=newsboat
 
@@ -34,34 +35,42 @@ BARE_CXXFLAGS+=-O0 -fprofile-arcs -ftest-coverage
 LDFLAGS+=-fprofile-arcs -ftest-coverage
 endif
 
+OBJDIR_DBG=./build-dbg
 ifeq ($(DEBUG),1)
 BARE_CXXFLAGS+=-O0 -ggdb
+OBJDIR=$(OBJDIR_DBG)
 endif
 
 CXXFLAGS:=$(BARE_CXXFLAGS) $(WARNFLAGS) $(DEFINES) $(CXXFLAGS)
 
 LIB_SOURCES:=$(shell cat mk/libboat.deps)
-LIB_OBJS:=$(patsubst %.cpp,%.o,$(LIB_SOURCES))
-LIB_OUTPUT=libboat.a
+LIB_OBJS:=$(patsubst %.cpp,$(OBJDIR)/%.o,$(LIB_SOURCES))
+LIB_OUTPUT=$(OBJDIR)/libboat.a
 
 FILTERLIB_SOURCES=filter/Scanner.cpp filter/Parser.cpp filter/FilterParser.cpp
-FILTERLIB_OBJS:=$(patsubst %.cpp,%.o,$(FILTERLIB_SOURCES))
-FILTERLIB_OUTPUT=libfilter.a
+FILTERLIB_OBJS:=$(patsubst %.cpp,$(OBJDIR)/%.o,$(FILTERLIB_SOURCES))
+FILTERLIB_OUTPUT=$(OBJDIR)/libfilter.a
 
 NEWSBOAT=newsboat
 NEWSBOAT_SOURCES:=$(shell cat mk/newsboat.deps)
-NEWSBOAT_OBJS:=$(patsubst %.cpp,%.o,$(NEWSBOAT_SOURCES))
-NEWSBOAT_LIBS=-lboat -lfilter -lpthread -lrsspp
+NEWSBOAT_OBJS:=$(patsubst %.cpp,$(OBJDIR)/%.o,$(NEWSBOAT_SOURCES))
+NEWSBOAT_LIBS=-L"$(OBJDIR)" -lboat -lfilter -lpthread -lrsspp
 
 RSSPPLIB_SOURCES=$(sort $(wildcard rss/*.cpp))
-RSSPPLIB_OBJS=$(patsubst rss/%.cpp,rss/%.o,$(RSSPPLIB_SOURCES))
-RSSPPLIB_OUTPUT=librsspp.a
+RSSPPLIB_OBJS=$(patsubst rss/%.cpp,$(OBJDIR)/rss/%.o,$(RSSPPLIB_SOURCES))
+RSSPPLIB_OUTPUT=$(OBJDIR)/librsspp.a
 
 
 PODBOAT=podboat
 PODBOAT_SOURCES:=$(shell cat mk/podboat.deps)
-PODBOAT_OBJS:=$(patsubst %.cpp,%.o,$(PODBOAT_SOURCES))
-PODBOAT_LIBS=-lboat -lpthread
+PODBOAT_OBJS:=$(patsubst %.cpp,$(OBJDIR)/%.o,$(PODBOAT_SOURCES))
+PODBOAT_LIBS=-L"$(OBJDIR)" -lboat -lpthread
+
+ifeq ($(DEBUG),1)
+NEWSBOAT=newsboat-dbg
+PODBOAT=podboat-dbg
+endif
+
 
 ifeq (, $(filter Linux GNU GNU/%, $(shell uname -s)))
 NEWSBOAT_LIBS+=-liconv -lintl
@@ -114,7 +123,8 @@ regenerate-parser:
 	$(RM) filter/Scanner.cpp filter/Parser.cpp filter/Scanner.h filter/Parser.h
 	cococpp -frames filter filter/filter.atg
 
-%.o: %.cpp
+$(OBJDIR)/%.o: %.cpp
+	@$(MKDIR) "$(dir $@)"
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
 %.h: %.stfl
@@ -136,13 +146,14 @@ clean-libfilter:
 	$(RM) $(FILTERLIB_OUTPUT) $(FILTERLIB_OBJS)
 
 clean-doc:
-	$(RM) -r doc/xhtml 
+	$(RM) -r doc/xhtml
 	$(RM) doc/*.xml doc/*.1 doc/newsboat-cfgcmds.txt doc/podboat-cfgcmds.txt \
 		doc/newsboat-keycmds.txt doc/configcommands-linked.dsv \
 		doc/podboat-cmds-linked.dsv doc/keycmds-linked.dsv \
 		doc/gen-example-config doc/example-config doc/generate doc/generate2
 
 clean: clean-newsboat clean-podboat clean-libboat clean-libfilter clean-doc clean-librsspp
+	$(RM) -r "$(OBJDIR)"
 	$(RM) $(STFLHDRS) xlicense.h
 
 debug:
@@ -306,9 +317,9 @@ uninstall-mo:
 test: test/test
 
 TEST_SRCS:=$(shell ls test/*.cpp)
-TEST_OBJS:=$(patsubst %.cpp,%.o,$(TEST_SRCS))
+TEST_OBJS:=$(patsubst %.cpp,$(OBJDIR)/%.o,$(TEST_SRCS))
 test/test: $(LIB_OUTPUT) $(NEWSBOAT_OBJS) $(FILTERLIB_OUTPUT) $(RSSPPLIB_OUTPUT) $(TEST_OBJS) test/test-helpers.h
-	$(CXX) $(CXXFLAGS) -o test/test $(TEST_OBJS) src/*.o $(NEWSBOAT_LIBS) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -o test/test $(TEST_OBJS) $(OBJDIR)/src/*.o $(NEWSBOAT_LIBS) $(LDFLAGS)
 
 test-clean:
 	$(RM) test/test test/*.o
@@ -331,12 +342,14 @@ ALL_SRCS:=$(shell ls filter/*.cpp rss/*.cpp src/*.cpp test/*.cpp)
 ALL_HDRS:=$(shell ls filter/*.h rss/*.h test/*.h test/*.hpp) $(STFLHDRS) xlicense.h
 depslist: $(ALL_SRCS) $(ALL_HDRS)
 	> mk/mk.deps
-	for dir in filter rss src test ; do \
-		for file in $$dir/*.cpp ; do \
-			target=`echo $$file | sed 's/cpp$$/o/'`; \
-			$(CXX) $(BARE_CXXFLAGS) -MM -MG -MQ $$target $$file >> mk/mk.deps ; \
-			echo $$file ; \
-		done; \
+	for builddir in "$(OBJDIR)" "$(OBJDIR_DBG)"; do \
+		for dir in filter rss src test ; do \
+			for file in "$$dir"/*.cpp ; do \
+				target=`echo "$$builddir/$$file" | sed 's/cpp$$/o/'`; \
+				$(CXX) $(BARE_CXXFLAGS) -MM -MG -MQ "$$target" "$$file" >> mk/mk.deps ; \
+				echo "$$file" ; \
+			done; \
+		done \
 	done
 
 include mk/mk.deps

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ BARE_CXXFLAGS+=-O0 -fprofile-arcs -ftest-coverage
 LDFLAGS+=-fprofile-arcs -ftest-coverage
 endif
 
+ifeq ($(DEBUG),1)
+BARE_CXXFLAGS+=-O0 -ggdb
+endif
+
 CXXFLAGS:=$(BARE_CXXFLAGS) $(WARNFLAGS) $(DEFINES) $(CXXFLAGS)
 
 LIB_SOURCES:=$(shell cat mk/libboat.deps)
@@ -140,6 +144,9 @@ clean-doc:
 
 clean: clean-newsboat clean-podboat clean-libboat clean-libfilter clean-doc clean-librsspp
 	$(RM) $(STFLHDRS) xlicense.h
+
+debug:
+	$(MAKE) DEBUG=1
 
 distclean: clean clean-mo test-clean profclean
 	$(RM) core *.core core.* config.mk

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -1,38 +1,40 @@
-filter/FilterParser.o: filter/FilterParser.cpp include/logger.h config.h \
- include/strprintf.h filter/FilterParser.h filter/Parser.h \
+build/filter/FilterParser.o: filter/FilterParser.cpp include/logger.h \
+ config.h include/strprintf.h filter/FilterParser.h filter/Parser.h \
  filter/Scanner.h include/utils.h include/configcontainer.h \
  include/configparser.h
-filter/Parser.o: filter/Parser.cpp filter/Parser.h filter/FilterParser.h \
- filter/Scanner.h
-filter/Scanner.o: filter/Scanner.cpp filter/Scanner.h
-rss/atom_parser.o: rss/atom_parser.cpp config.h rss/rsspp_internal.h \
- rss/rsspp.h include/remote_api.h include/configcontainer.h \
- include/configparser.h include/utils.h include/logger.h \
- include/strprintf.h
-rss/exception.o: rss/exception.cpp rss/rsspp.h include/remote_api.h \
- include/configcontainer.h include/configparser.h config.h
-rss/parser.o: rss/parser.cpp config.h rss/rsspp.h include/remote_api.h \
- include/configcontainer.h include/configparser.h rss/rsspp_internal.h \
- include/logger.h include/strprintf.h include/utils.h
-rss/parser_factory.o: rss/parser_factory.cpp config.h \
- rss/rsspp_internal.h rss/rsspp.h include/remote_api.h \
- include/configcontainer.h include/configparser.h
-rss/rss_09x_parser.o: rss/rss_09x_parser.cpp config.h \
+build/filter/Parser.o: filter/Parser.cpp filter/Parser.h \
+ filter/FilterParser.h filter/Scanner.h
+build/filter/Scanner.o: filter/Scanner.cpp filter/Scanner.h
+build/rss/atom_parser.o: rss/atom_parser.cpp config.h \
  rss/rsspp_internal.h rss/rsspp.h include/remote_api.h \
  include/configcontainer.h include/configparser.h include/utils.h \
  include/logger.h include/strprintf.h
-rss/rss_10_parser.o: rss/rss_10_parser.cpp config.h rss/rsspp_internal.h \
+build/rss/exception.o: rss/exception.cpp rss/rsspp.h include/remote_api.h \
+ include/configcontainer.h include/configparser.h config.h
+build/rss/parser.o: rss/parser.cpp config.h rss/rsspp.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ rss/rsspp_internal.h include/logger.h include/strprintf.h \
+ include/utils.h
+build/rss/parser_factory.o: rss/parser_factory.cpp config.h \
+ rss/rsspp_internal.h rss/rsspp.h include/remote_api.h \
+ include/configcontainer.h include/configparser.h
+build/rss/rss_09x_parser.o: rss/rss_09x_parser.cpp config.h \
+ rss/rsspp_internal.h rss/rsspp.h include/remote_api.h \
+ include/configcontainer.h include/configparser.h include/utils.h \
+ include/logger.h include/strprintf.h
+build/rss/rss_10_parser.o: rss/rss_10_parser.cpp config.h \
+ rss/rsspp_internal.h rss/rsspp.h include/remote_api.h \
+ include/configcontainer.h include/configparser.h
+build/rss/rss_parser.o: rss/rss_parser.cpp rss/rsspp_internal.h \
  rss/rsspp.h include/remote_api.h include/configcontainer.h \
  include/configparser.h
-rss/rss_parser.o: rss/rss_parser.cpp rss/rsspp_internal.h rss/rsspp.h \
- include/remote_api.h include/configcontainer.h include/configparser.h
-src/cache.o: src/cache.cpp include/controller.h include/urlreader.h \
+build/src/cache.o: src/cache.cpp include/controller.h include/urlreader.h \
  include/configcontainer.h include/configparser.h include/rss.h \
  include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
  config.h include/strprintf.h include/cache.h include/filtercontainer.h \
  include/colormanager.h include/regexmanager.h include/remote_api.h \
  include/fslock.h include/exceptions.h
-src/colormanager.o: src/colormanager.cpp include/logger.h config.h \
+build/src/colormanager.o: src/colormanager.cpp include/logger.h config.h \
  include/strprintf.h include/colormanager.h include/configparser.h \
  include/utils.h include/configcontainer.h include/pb_view.h \
  include/keymap.h include/stflpp.h include/feedlist_formaction.h \
@@ -46,13 +48,13 @@ src/colormanager.o: src/colormanager.cpp include/logger.h config.h \
  include/listformatter.h include/itemview_formaction.h \
  include/help_formaction.h include/urlview_formaction.h \
  include/select_formaction.h include/exceptions.h
-src/configcontainer.o: src/configcontainer.cpp config.h \
+build/src/configcontainer.o: src/configcontainer.cpp config.h \
  include/configcontainer.h include/configparser.h include/exceptions.h \
  include/logger.h include/strprintf.h include/utils.h
-src/configparser.o: src/configparser.cpp include/configparser.h \
+build/src/configparser.o: src/configparser.cpp include/configparser.h \
  include/tagsouppullparser.h include/exceptions.h include/utils.h \
  include/logger.h config.h include/strprintf.h include/configcontainer.h
-src/controller.o: src/controller.cpp config.h include/view.h \
+build/src/controller.o: src/controller.cpp config.h include/view.h \
  include/controller.h include/urlreader.h include/configcontainer.h \
  include/configparser.h include/rss.h include/matcher.h \
  filter/FilterParser.h include/utils.h include/logger.h \
@@ -64,9 +66,9 @@ src/controller.o: src/controller.cpp config.h include/view.h \
  include/exceptions.h include/downloadthread.h include/exception.h \
  include/formatstring.h include/rss_parser.h rss/rsspp.h \
  include/oldreader_api.h include/feedhq_api.h include/ttrss_api.h \
- include/newsblur_api.h include/ocnews_api.h include/inoreader_api.h \
- xlicense.h
-src/dialogs_formaction.o: src/dialogs_formaction.cpp config.h \
+ include/json.hpp include/newsblur_api.h include/ocnews_api.h \
+ include/inoreader_api.h xlicense.h
+build/src/dialogs_formaction.o: src/dialogs_formaction.cpp config.h \
  include/view.h include/controller.h include/urlreader.h \
  include/configcontainer.h include/configparser.h include/rss.h \
  include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
@@ -77,30 +79,30 @@ src/dialogs_formaction.o: src/dialogs_formaction.cpp config.h \
  include/filebrowser_formaction.h include/formaction.h include/history.h \
  include/dialogs_formaction.h include/listformatter.h \
  include/formatstring.h
-src/download.o: src/download.cpp include/download.h \
+build/src/download.o: src/download.cpp include/download.h \
  include/pb_controller.h include/configcontainer.h include/configparser.h \
  include/queueloader.h include/fslock.h config.h
-src/downloadthread.o: src/downloadthread.cpp include/downloadthread.h \
- include/controller.h include/urlreader.h include/configcontainer.h \
- include/configparser.h include/rss.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/cache.h include/filtercontainer.h \
+build/src/downloadthread.o: src/downloadthread.cpp \
+ include/downloadthread.h include/controller.h include/urlreader.h \
+ include/configcontainer.h include/configparser.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/cache.h include/filtercontainer.h \
  include/colormanager.h include/regexmanager.h include/remote_api.h \
  include/fslock.h
-src/exception.o: src/exception.cpp include/exception.h \
+build/src/exception.o: src/exception.cpp include/exception.h \
  include/exceptions.h include/configparser.h config.h include/utils.h \
  include/logger.h include/strprintf.h include/configcontainer.h
-src/feedhq_api.o: src/feedhq_api.cpp include/feedhq_api.h \
+build/src/feedhq_api.o: src/feedhq_api.cpp include/feedhq_api.h \
  include/remote_api.h include/configcontainer.h include/configparser.h \
  include/urlreader.h include/cache.h include/rss.h include/matcher.h \
  filter/FilterParser.h include/utils.h include/logger.h config.h \
  include/strprintf.h
-src/feedhq_urlreader.o: src/feedhq_urlreader.cpp include/feedhq_api.h \
- include/remote_api.h include/configcontainer.h include/configparser.h \
- include/urlreader.h include/cache.h include/rss.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h
-src/feedlist_formaction.o: src/feedlist_formaction.cpp \
+build/src/feedhq_urlreader.o: src/feedhq_urlreader.cpp \
+ include/feedhq_api.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h include/urlreader.h include/cache.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h
+build/src/feedlist_formaction.o: src/feedlist_formaction.cpp \
  include/feedlist_formaction.h include/list_formaction.h \
  include/formaction.h include/stflpp.h include/keymap.h \
  include/configparser.h include/rss.h include/configcontainer.h \
@@ -112,7 +114,7 @@ src/feedlist_formaction.o: src/feedlist_formaction.cpp \
  include/filebrowser_formaction.h include/formaction.h \
  include/reloadthread.h include/exceptions.h include/formatstring.h \
  include/listformatter.h
-src/filebrowser_formaction.o: src/filebrowser_formaction.cpp \
+build/src/filebrowser_formaction.o: src/filebrowser_formaction.cpp \
  include/filebrowser_formaction.h include/formaction.h include/stflpp.h \
  include/keymap.h include/configparser.h include/rss.h \
  include/configcontainer.h include/matcher.h filter/FilterParser.h \
@@ -122,11 +124,11 @@ src/filebrowser_formaction.o: src/filebrowser_formaction.cpp \
  include/filtercontainer.h include/colormanager.h include/regexmanager.h \
  include/remote_api.h include/fslock.h include/htmlrenderer.h \
  include/textformatter.h
-src/filtercontainer.o: src/filtercontainer.cpp include/filtercontainer.h \
- include/configparser.h include/exceptions.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/configcontainer.h
-src/formaction.o: src/formaction.cpp include/formaction.h \
+build/src/filtercontainer.o: src/filtercontainer.cpp \
+ include/filtercontainer.h include/configparser.h include/exceptions.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/configcontainer.h
+build/src/formaction.o: src/formaction.cpp include/formaction.h \
  include/stflpp.h include/keymap.h include/configparser.h include/rss.h \
  include/configcontainer.h include/matcher.h filter/FilterParser.h \
  include/utils.h include/logger.h config.h include/strprintf.h \
@@ -135,12 +137,12 @@ src/formaction.o: src/formaction.cpp include/formaction.h \
  include/colormanager.h include/regexmanager.h include/remote_api.h \
  include/fslock.h include/htmlrenderer.h include/textformatter.h \
  include/filebrowser_formaction.h include/exceptions.h
-src/formatstring.o: src/formatstring.cpp include/formatstring.h \
+build/src/formatstring.o: src/formatstring.cpp include/formatstring.h \
  include/utils.h include/logger.h config.h include/strprintf.h \
  include/configcontainer.h include/configparser.h
-src/fslock.o: src/fslock.cpp include/fslock.h include/logger.h config.h \
- include/strprintf.h
-src/help_formaction.o: src/help_formaction.cpp config.h \
+build/src/fslock.o: src/fslock.cpp include/fslock.h include/logger.h \
+ config.h include/strprintf.h
+build/src/help_formaction.o: src/help_formaction.cpp config.h \
  include/help_formaction.h include/formaction.h include/stflpp.h \
  include/keymap.h include/configparser.h include/rss.h \
  include/configcontainer.h include/matcher.h filter/FilterParser.h \
@@ -150,23 +152,23 @@ src/help_formaction.o: src/help_formaction.cpp config.h \
  include/colormanager.h include/regexmanager.h include/remote_api.h \
  include/fslock.h include/htmlrenderer.h include/textformatter.h \
  include/filebrowser_formaction.h include/listformatter.h
-src/history.o: src/history.cpp include/history.h
-src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
+build/src/history.o: src/history.cpp include/history.h
+build/src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
  include/textformatter.h include/regexmanager.h include/configparser.h \
  include/matcher.h filter/FilterParser.h include/tagsouppullparser.h \
  include/utils.h include/logger.h config.h include/strprintf.h \
  include/configcontainer.h
-src/inoreader_api.o: src/inoreader_api.cpp include/inoreader_api.h \
+build/src/inoreader_api.o: src/inoreader_api.cpp include/inoreader_api.h \
  include/remote_api.h include/configcontainer.h include/configparser.h \
  include/urlreader.h include/cache.h include/rss.h include/matcher.h \
  filter/FilterParser.h include/utils.h include/logger.h config.h \
  include/strprintf.h
-src/inoreader_urlreader.o: src/inoreader_urlreader.cpp \
+build/src/inoreader_urlreader.o: src/inoreader_urlreader.cpp \
  include/inoreader_api.h include/remote_api.h include/configcontainer.h \
  include/configparser.h include/urlreader.h include/cache.h include/rss.h \
  include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
  config.h include/strprintf.h
-src/itemlist_formaction.o: src/itemlist_formaction.cpp \
+build/src/itemlist_formaction.o: src/itemlist_formaction.cpp \
  include/controller.h include/urlreader.h include/configcontainer.h \
  include/configparser.h include/rss.h include/matcher.h \
  filter/FilterParser.h include/utils.h include/logger.h config.h \
@@ -177,7 +179,7 @@ src/itemlist_formaction.o: src/itemlist_formaction.cpp \
  include/view.h include/htmlrenderer.h include/textformatter.h \
  include/filebrowser_formaction.h include/formaction.h \
  include/listformatter.h include/exceptions.h include/formatstring.h
-src/itemview_formaction.o: src/itemview_formaction.cpp \
+build/src/itemview_formaction.o: src/itemview_formaction.cpp \
  include/itemview_formaction.h include/formaction.h include/stflpp.h \
  include/keymap.h include/configparser.h include/rss.h \
  include/configcontainer.h include/matcher.h filter/FilterParser.h \
@@ -188,100 +190,102 @@ src/itemview_formaction.o: src/itemview_formaction.cpp \
  include/colormanager.h include/remote_api.h include/fslock.h \
  include/filebrowser_formaction.h include/exceptions.h \
  include/formatstring.h
-src/keymap.o: src/keymap.cpp include/keymap.h include/configparser.h \
- include/logger.h config.h include/strprintf.h include/exceptions.h \
- include/utils.h include/configcontainer.h
-src/list_formaction.o: src/list_formaction.cpp include/list_formaction.h \
- include/formaction.h include/stflpp.h include/keymap.h \
- include/configparser.h include/rss.h include/configcontainer.h \
- include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
- config.h include/strprintf.h include/history.h include/view.h \
- include/controller.h include/urlreader.h include/cache.h \
- include/filtercontainer.h include/colormanager.h include/regexmanager.h \
- include/remote_api.h include/fslock.h include/htmlrenderer.h \
- include/textformatter.h include/filebrowser_formaction.h \
- include/formaction.h
-src/listformatter.o: src/listformatter.cpp include/listformatter.h \
+build/src/keymap.o: src/keymap.cpp include/keymap.h \
+ include/configparser.h include/logger.h config.h include/strprintf.h \
+ include/exceptions.h include/utils.h include/configcontainer.h
+build/src/list_formaction.o: src/list_formaction.cpp \
+ include/list_formaction.h include/formaction.h include/stflpp.h \
+ include/keymap.h include/configparser.h include/rss.h \
+ include/configcontainer.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/history.h include/view.h include/controller.h \
+ include/urlreader.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/formaction.h
+build/src/listformatter.o: src/listformatter.cpp include/listformatter.h \
  include/regexmanager.h include/configparser.h include/matcher.h \
  filter/FilterParser.h include/utils.h include/logger.h config.h \
  include/strprintf.h include/configcontainer.h include/stflpp.h
-src/logger.o: src/logger.cpp include/logger.h config.h \
+build/src/logger.o: src/logger.cpp include/logger.h config.h \
  include/strprintf.h include/exception.h
-src/matcher.o: src/matcher.cpp include/matcher.h filter/FilterParser.h \
- include/logger.h config.h include/strprintf.h include/utils.h \
- include/configcontainer.h include/configparser.h include/exceptions.h
-src/newsblur_api.o: src/newsblur_api.cpp rss/rsspp.h include/remote_api.h \
- include/configcontainer.h include/configparser.h include/utils.h \
- include/logger.h config.h include/strprintf.h include/newsblur_api.h \
- include/urlreader.h
-src/newsblur_urlreader.o: src/newsblur_urlreader.cpp \
+build/src/matcher.o: src/matcher.cpp include/matcher.h \
+ filter/FilterParser.h include/logger.h config.h include/strprintf.h \
+ include/utils.h include/configcontainer.h include/configparser.h \
+ include/exceptions.h
+build/src/newsblur_api.o: src/newsblur_api.cpp rss/rsspp.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/newsblur_api.h include/urlreader.h
+build/src/newsblur_urlreader.o: src/newsblur_urlreader.cpp \
  include/newsblur_api.h include/remote_api.h include/configcontainer.h \
  include/configparser.h include/urlreader.h rss/rsspp.h include/logger.h \
  config.h include/strprintf.h
-src/ocnews_api.o: src/ocnews_api.cpp include/ocnews_api.h \
+build/src/ocnews_api.o: src/ocnews_api.cpp include/ocnews_api.h \
  include/remote_api.h include/configcontainer.h include/configparser.h \
  include/urlreader.h rss/rsspp.h include/utils.h include/logger.h \
  config.h include/strprintf.h
-src/ocnews_urlreader.o: src/ocnews_urlreader.cpp include/ocnews_api.h \
- include/remote_api.h include/configcontainer.h include/configparser.h \
- include/urlreader.h rss/rsspp.h include/logger.h config.h \
- include/strprintf.h
-src/oldreader_api.o: src/oldreader_api.cpp include/oldreader_api.h \
+build/src/ocnews_urlreader.o: src/ocnews_urlreader.cpp \
+ include/ocnews_api.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h include/urlreader.h rss/rsspp.h include/logger.h \
+ config.h include/strprintf.h
+build/src/oldreader_api.o: src/oldreader_api.cpp include/oldreader_api.h \
  include/remote_api.h include/configcontainer.h include/configparser.h \
  include/urlreader.h include/cache.h include/rss.h include/matcher.h \
  filter/FilterParser.h include/utils.h include/logger.h config.h \
  include/strprintf.h
-src/oldreader_urlreader.o: src/oldreader_urlreader.cpp \
+build/src/oldreader_urlreader.o: src/oldreader_urlreader.cpp \
  include/oldreader_api.h include/remote_api.h include/configcontainer.h \
  include/configparser.h include/urlreader.h include/cache.h include/rss.h \
  include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
  config.h include/strprintf.h
-src/pb_controller.o: src/pb_controller.cpp include/pb_controller.h \
+build/src/pb_controller.o: src/pb_controller.cpp include/pb_controller.h \
  include/configcontainer.h include/configparser.h include/download.h \
  include/queueloader.h include/fslock.h include/pb_view.h \
  include/keymap.h include/stflpp.h include/colormanager.h \
  include/poddlthread.h config.h include/utils.h include/logger.h \
  include/strprintf.h include/exceptions.h
-src/pb_view.o: src/pb_view.cpp include/pb_view.h include/keymap.h \
+build/src/pb_view.o: src/pb_view.cpp include/pb_view.h include/keymap.h \
  include/configparser.h include/stflpp.h include/colormanager.h \
  include/pb_controller.h include/configcontainer.h include/download.h \
  include/queueloader.h include/fslock.h include/poddlthread.h config.h \
  include/logger.h include/strprintf.h stfl/dllist.h stfl/help.h \
  include/utils.h
-src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
+build/src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
  include/download.h include/configcontainer.h include/configparser.h \
  include/logger.h config.h include/strprintf.h include/utils.h
-src/queueloader.o: src/queueloader.cpp include/stflpp.h include/utils.h \
- include/logger.h config.h include/strprintf.h include/configcontainer.h \
- include/configparser.h include/queueloader.h include/download.h \
- include/pb_controller.h include/fslock.h
-src/regexmanager.o: src/regexmanager.cpp include/regexmanager.h \
+build/src/queueloader.o: src/queueloader.cpp include/stflpp.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/configcontainer.h include/configparser.h include/queueloader.h \
+ include/download.h include/pb_controller.h include/fslock.h
+build/src/regexmanager.o: src/regexmanager.cpp include/regexmanager.h \
  include/configparser.h include/matcher.h filter/FilterParser.h \
  include/logger.h config.h include/strprintf.h include/utils.h \
  include/configcontainer.h include/exceptions.h
-src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
+build/src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
  include/controller.h include/urlreader.h include/configcontainer.h \
  include/configparser.h include/rss.h include/matcher.h \
  filter/FilterParser.h include/utils.h include/logger.h config.h \
  include/strprintf.h include/cache.h include/filtercontainer.h \
  include/colormanager.h include/regexmanager.h include/remote_api.h \
  include/fslock.h
-src/remote_api.o: src/remote_api.cpp include/remote_api.h \
+build/src/remote_api.o: src/remote_api.cpp include/remote_api.h \
  include/configcontainer.h include/configparser.h include/utils.h \
  include/logger.h config.h include/strprintf.h
-src/rss.o: src/rss.cpp include/rss.h include/configcontainer.h \
+build/src/rss.o: src/rss.cpp include/rss.h include/configcontainer.h \
  include/configparser.h include/matcher.h filter/FilterParser.h \
  include/utils.h include/logger.h config.h include/strprintf.h \
  include/cache.h include/tagsouppullparser.h include/exceptions.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h
-src/rss_parser.o: src/rss_parser.cpp rss/rsspp.h include/remote_api.h \
- include/configcontainer.h include/configparser.h rss/rsspp_internal.h \
- include/rss_parser.h include/rss.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/cache.h include/htmlrenderer.h \
+build/src/rss_parser.o: src/rss_parser.cpp rss/rsspp.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ rss/rsspp_internal.h include/rss_parser.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/cache.h include/htmlrenderer.h \
  include/textformatter.h include/regexmanager.h include/ttrss_api.h \
- include/urlreader.h include/newsblur_api.h include/ocnews_api.h
-src/select_formaction.o: src/select_formaction.cpp \
+ include/urlreader.h include/json.hpp include/newsblur_api.h \
+ include/ocnews_api.h
+build/src/select_formaction.o: src/select_formaction.cpp \
  include/select_formaction.h include/formaction.h include/stflpp.h \
  include/keymap.h include/configparser.h include/rss.h \
  include/configcontainer.h include/matcher.h filter/FilterParser.h \
@@ -291,33 +295,33 @@ src/select_formaction.o: src/select_formaction.cpp \
  include/colormanager.h include/regexmanager.h include/remote_api.h \
  include/fslock.h include/htmlrenderer.h include/textformatter.h \
  include/filebrowser_formaction.h include/listformatter.h
-src/stflpp.o: src/stflpp.cpp include/stflpp.h include/logger.h config.h \
- include/strprintf.h include/exception.h include/utils.h \
+build/src/stflpp.o: src/stflpp.cpp include/stflpp.h include/logger.h \
+ config.h include/strprintf.h include/exception.h include/utils.h \
  include/configcontainer.h include/configparser.h
-src/strprintf.o: src/strprintf.cpp include/strprintf.h
-src/tagsouppullparser.o: src/tagsouppullparser.cpp \
+build/src/strprintf.o: src/strprintf.cpp include/strprintf.h
+build/src/tagsouppullparser.o: src/tagsouppullparser.cpp \
  include/tagsouppullparser.h include/exceptions.h include/configparser.h \
  include/utils.h include/logger.h config.h include/strprintf.h \
  include/configcontainer.h
-src/textformatter.o: src/textformatter.cpp include/textformatter.h \
+build/src/textformatter.o: src/textformatter.cpp include/textformatter.h \
  include/regexmanager.h include/configparser.h include/matcher.h \
  filter/FilterParser.h include/utils.h include/logger.h config.h \
  include/strprintf.h include/configcontainer.h include/htmlrenderer.h \
  include/stflpp.h
-src/ttrss_api.o: src/ttrss_api.cpp include/remote_api.h \
- include/configcontainer.h include/configparser.h include/ttrss_api.h \
- rss/rsspp.h include/urlreader.h include/cache.h include/rss.h \
- include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
- config.h include/strprintf.h
-src/ttrss_urlreader.o: src/ttrss_urlreader.cpp include/ttrss_api.h \
+build/src/ttrss_api.o: src/ttrss_api.cpp include/json.hpp \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ include/ttrss_api.h rss/rsspp.h include/urlreader.h include/cache.h \
+ include/rss.h include/matcher.h filter/FilterParser.h include/utils.h \
+ include/logger.h config.h include/strprintf.h
+build/src/ttrss_urlreader.o: src/ttrss_urlreader.cpp include/ttrss_api.h \
  rss/rsspp.h include/remote_api.h include/configcontainer.h \
  include/configparser.h include/urlreader.h include/cache.h include/rss.h \
  include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
- config.h include/strprintf.h
-src/urlreader.o: src/urlreader.cpp include/urlreader.h \
+ config.h include/strprintf.h include/json.hpp
+build/src/urlreader.o: src/urlreader.cpp include/urlreader.h \
  include/configcontainer.h include/configparser.h include/utils.h \
  include/logger.h config.h include/strprintf.h
-src/urlview_formaction.o: src/urlview_formaction.cpp \
+build/src/urlview_formaction.o: src/urlview_formaction.cpp \
  include/urlview_formaction.h include/formaction.h include/stflpp.h \
  include/keymap.h include/configparser.h include/rss.h \
  include/configcontainer.h include/matcher.h filter/FilterParser.h \
@@ -328,17 +332,19 @@ src/urlview_formaction.o: src/urlview_formaction.cpp \
  include/filtercontainer.h include/colormanager.h include/remote_api.h \
  include/fslock.h include/filebrowser_formaction.h \
  include/listformatter.h
-src/utils.o: src/utils.cpp include/utils.h include/logger.h config.h \
- include/strprintf.h include/configcontainer.h include/configparser.h
-src/view.o: src/view.cpp stfl/itemlist.h stfl/itemview.h stfl/help.h \
- stfl/filebrowser.h stfl/urlview.h stfl/selecttag.h stfl/feedlist.h \
- stfl/dialogs.h include/formatstring.h include/formaction.h \
- include/stflpp.h include/keymap.h include/configparser.h include/rss.h \
- include/configcontainer.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/logger.h config.h include/strprintf.h \
- include/history.h include/feedlist_formaction.h \
- include/list_formaction.h include/formaction.h include/regexmanager.h \
- include/view.h include/controller.h include/urlreader.h include/cache.h \
+build/src/utils.o: src/utils.cpp include/utils.h include/logger.h \
+ config.h include/strprintf.h include/configcontainer.h \
+ include/configparser.h
+build/src/view.o: src/view.cpp stfl/itemlist.h stfl/itemview.h \
+ stfl/help.h stfl/filebrowser.h stfl/urlview.h stfl/selecttag.h \
+ stfl/feedlist.h stfl/dialogs.h include/formatstring.h \
+ include/formaction.h include/stflpp.h include/keymap.h \
+ include/configparser.h include/rss.h include/configcontainer.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/history.h \
+ include/feedlist_formaction.h include/list_formaction.h \
+ include/formaction.h include/regexmanager.h include/view.h \
+ include/controller.h include/urlreader.h include/cache.h \
  include/filtercontainer.h include/colormanager.h include/remote_api.h \
  include/fslock.h include/htmlrenderer.h include/textformatter.h \
  include/filebrowser_formaction.h include/itemlist_formaction.h \
@@ -346,27 +352,28 @@ src/view.o: src/view.cpp stfl/itemlist.h stfl/itemview.h stfl/help.h \
  include/help_formaction.h include/urlview_formaction.h \
  include/select_formaction.h include/dialogs_formaction.h \
  include/reloadthread.h include/exception.h include/exceptions.h
-test/cache.o: test/cache.cpp test/catch.hpp test/test-helpers.h \
+build/test/cache.o: test/cache.cpp test/catch.hpp test/test-helpers.h \
  include/cache.h include/rss.h include/configcontainer.h \
  include/configparser.h include/matcher.h filter/FilterParser.h \
  include/utils.h include/logger.h config.h include/strprintf.h \
  include/rss_parser.h rss/rsspp.h include/remote_api.h
-test/configcontainer.o: test/configcontainer.cpp test/catch.hpp \
- include/configcontainer.h include/configparser.h include/keymap.h
-test/configparser.o: test/configparser.cpp test/catch.hpp \
+build/test/configcontainer.o: test/configcontainer.cpp test/catch.hpp \
+ include/configcontainer.h include/configparser.h include/keymap.h \
+ include/exceptions.h
+build/test/configparser.o: test/configparser.cpp test/catch.hpp \
  include/configparser.h
-test/filterparser.o: test/filterparser.cpp test/catch.hpp \
+build/test/filterparser.o: test/filterparser.cpp test/catch.hpp \
  filter/FilterParser.h
-test/formatstring.o: test/formatstring.cpp test/catch.hpp \
+build/test/formatstring.o: test/formatstring.cpp test/catch.hpp \
  include/formatstring.h
-test/history.o: test/history.cpp test/catch.hpp include/history.h
-test/htmlrenderer.o: test/htmlrenderer.cpp test/catch.hpp \
+build/test/history.o: test/history.cpp test/catch.hpp include/history.h
+build/test/htmlrenderer.o: test/htmlrenderer.cpp test/catch.hpp \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
  include/configparser.h include/matcher.h filter/FilterParser.h \
  include/utils.h include/logger.h config.h include/strprintf.h \
  include/configcontainer.h
-test/itemlist_formaction.o: test/itemlist_formaction.cpp test/catch.hpp \
- test/test-helpers.h include/cache.h include/rss.h \
+build/test/itemlist_formaction.o: test/itemlist_formaction.cpp \
+ test/catch.hpp test/test-helpers.h include/cache.h include/rss.h \
  include/configcontainer.h include/configparser.h include/matcher.h \
  filter/FilterParser.h include/utils.h include/logger.h config.h \
  include/strprintf.h include/itemlist_formaction.h \
@@ -378,33 +385,457 @@ test/itemlist_formaction.o: test/itemlist_formaction.cpp test/catch.hpp \
  include/filebrowser_formaction.h include/formaction.h \
  include/listformatter.h include/feedlist_formaction.h stfl/itemlist.h \
  stfl/feedlist.h
-test/keymap.o: test/keymap.cpp test/catch.hpp include/keymap.h \
+build/test/keymap.o: test/keymap.cpp test/catch.hpp include/keymap.h \
  include/configparser.h include/exceptions.h
-test/listformatter.o: test/listformatter.cpp test/catch.hpp \
+build/test/listformatter.o: test/listformatter.cpp test/catch.hpp \
  include/listformatter.h include/regexmanager.h include/configparser.h \
  include/matcher.h filter/FilterParser.h
-test/matcher.o: test/matcher.cpp test/catch.hpp include/matcher.h \
+build/test/matcher.o: test/matcher.cpp test/catch.hpp include/matcher.h \
  filter/FilterParser.h include/exceptions.h include/configparser.h
-test/regexmanager.o: test/regexmanager.cpp test/catch.hpp \
+build/test/regexmanager.o: test/regexmanager.cpp test/catch.hpp \
  include/regexmanager.h include/configparser.h include/matcher.h \
  filter/FilterParser.h include/exceptions.h
-test/remote_api.o: test/remote_api.cpp test/catch.hpp \
+build/test/remote_api.o: test/remote_api.cpp test/catch.hpp \
  include/remote_api.h include/configcontainer.h include/configparser.h
-test/rss.o: test/rss.cpp test/catch.hpp rss/rsspp.h include/remote_api.h \
- include/configcontainer.h include/configparser.h rss/rsspp_internal.h \
- include/rss.h include/matcher.h filter/FilterParser.h include/utils.h \
- include/logger.h config.h include/strprintf.h include/rss_parser.h \
- include/cache.h
-test/strprintf.o: test/strprintf.cpp test/catch.hpp include/strprintf.h
-test/tagsouppullparser.o: test/tagsouppullparser.cpp test/catch.hpp \
- include/tagsouppullparser.h
-test/test.o: test/test.cpp test/catch.hpp include/logger.h config.h \
+build/test/rss.o: test/rss.cpp test/catch.hpp rss/rsspp.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ rss/rsspp_internal.h include/rss.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h include/rss_parser.h include/cache.h
+build/test/strprintf.o: test/strprintf.cpp test/catch.hpp \
  include/strprintf.h
-test/textformatter.o: test/textformatter.cpp test/catch.hpp \
+build/test/tagsouppullparser.o: test/tagsouppullparser.cpp test/catch.hpp \
+ include/tagsouppullparser.h
+build/test/test.o: test/test.cpp test/catch.hpp include/logger.h config.h \
+ include/strprintf.h
+build/test/textformatter.o: test/textformatter.cpp test/catch.hpp \
  include/textformatter.h include/regexmanager.h include/configparser.h \
  include/matcher.h filter/FilterParser.h
-test/urlreader.o: test/urlreader.cpp test/catch.hpp include/urlreader.h \
+build/test/urlreader.o: test/urlreader.cpp test/catch.hpp \
+ include/urlreader.h include/configcontainer.h include/configparser.h
+build/test/utils.o: test/utils.cpp test/catch.hpp include/utils.h \
+ include/logger.h config.h include/strprintf.h include/configcontainer.h \
+ include/configparser.h
+build-dbg/filter/FilterParser.o: filter/FilterParser.cpp include/logger.h \
+ config.h include/strprintf.h filter/FilterParser.h filter/Parser.h \
+ filter/Scanner.h include/utils.h include/configcontainer.h \
+ include/configparser.h
+build-dbg/filter/Parser.o: filter/Parser.cpp filter/Parser.h \
+ filter/FilterParser.h filter/Scanner.h
+build-dbg/filter/Scanner.o: filter/Scanner.cpp filter/Scanner.h
+build-dbg/rss/atom_parser.o: rss/atom_parser.cpp config.h \
+ rss/rsspp_internal.h rss/rsspp.h include/remote_api.h \
+ include/configcontainer.h include/configparser.h include/utils.h \
+ include/logger.h include/strprintf.h
+build-dbg/rss/exception.o: rss/exception.cpp rss/rsspp.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ config.h
+build-dbg/rss/parser.o: rss/parser.cpp config.h rss/rsspp.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ rss/rsspp_internal.h include/logger.h include/strprintf.h \
+ include/utils.h
+build-dbg/rss/parser_factory.o: rss/parser_factory.cpp config.h \
+ rss/rsspp_internal.h rss/rsspp.h include/remote_api.h \
  include/configcontainer.h include/configparser.h
-test/utils.o: test/utils.cpp test/catch.hpp include/utils.h \
+build-dbg/rss/rss_09x_parser.o: rss/rss_09x_parser.cpp config.h \
+ rss/rsspp_internal.h rss/rsspp.h include/remote_api.h \
+ include/configcontainer.h include/configparser.h include/utils.h \
+ include/logger.h include/strprintf.h
+build-dbg/rss/rss_10_parser.o: rss/rss_10_parser.cpp config.h \
+ rss/rsspp_internal.h rss/rsspp.h include/remote_api.h \
+ include/configcontainer.h include/configparser.h
+build-dbg/rss/rss_parser.o: rss/rss_parser.cpp rss/rsspp_internal.h \
+ rss/rsspp.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h
+build-dbg/src/cache.o: src/cache.cpp include/controller.h \
+ include/urlreader.h include/configcontainer.h include/configparser.h \
+ include/rss.h include/matcher.h filter/FilterParser.h include/utils.h \
+ include/logger.h config.h include/strprintf.h include/cache.h \
+ include/filtercontainer.h include/colormanager.h include/regexmanager.h \
+ include/remote_api.h include/fslock.h include/exceptions.h
+build-dbg/src/colormanager.o: src/colormanager.cpp include/logger.h \
+ config.h include/strprintf.h include/colormanager.h \
+ include/configparser.h include/utils.h include/configcontainer.h \
+ include/pb_view.h include/keymap.h include/stflpp.h \
+ include/feedlist_formaction.h include/list_formaction.h \
+ include/formaction.h include/rss.h include/matcher.h \
+ filter/FilterParser.h include/history.h include/regexmanager.h \
+ include/view.h include/controller.h include/urlreader.h include/cache.h \
+ include/filtercontainer.h include/remote_api.h include/fslock.h \
+ include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/formaction.h \
+ include/itemlist_formaction.h include/listformatter.h \
+ include/itemview_formaction.h include/help_formaction.h \
+ include/urlview_formaction.h include/select_formaction.h \
+ include/exceptions.h
+build-dbg/src/configcontainer.o: src/configcontainer.cpp config.h \
+ include/configcontainer.h include/configparser.h include/exceptions.h \
+ include/logger.h include/strprintf.h include/utils.h
+build-dbg/src/configparser.o: src/configparser.cpp include/configparser.h \
+ include/tagsouppullparser.h include/exceptions.h include/utils.h \
+ include/logger.h config.h include/strprintf.h include/configcontainer.h
+build-dbg/src/controller.o: src/controller.cpp config.h include/view.h \
+ include/controller.h include/urlreader.h include/configcontainer.h \
+ include/configparser.h include/rss.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h \
+ include/strprintf.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h include/keymap.h include/htmlrenderer.h \
+ include/textformatter.h include/stflpp.h \
+ include/filebrowser_formaction.h include/formaction.h include/history.h \
+ include/exceptions.h include/downloadthread.h include/exception.h \
+ include/formatstring.h include/rss_parser.h rss/rsspp.h \
+ include/oldreader_api.h include/feedhq_api.h include/ttrss_api.h \
+ include/json.hpp include/newsblur_api.h include/ocnews_api.h \
+ include/inoreader_api.h xlicense.h
+build-dbg/src/dialogs_formaction.o: src/dialogs_formaction.cpp config.h \
+ include/view.h include/controller.h include/urlreader.h \
+ include/configcontainer.h include/configparser.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ include/strprintf.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h include/keymap.h include/htmlrenderer.h \
+ include/textformatter.h include/stflpp.h \
+ include/filebrowser_formaction.h include/formaction.h include/history.h \
+ include/dialogs_formaction.h include/listformatter.h \
+ include/formatstring.h
+build-dbg/src/download.o: src/download.cpp include/download.h \
+ include/pb_controller.h include/configcontainer.h include/configparser.h \
+ include/queueloader.h include/fslock.h config.h
+build-dbg/src/downloadthread.o: src/downloadthread.cpp \
+ include/downloadthread.h include/controller.h include/urlreader.h \
+ include/configcontainer.h include/configparser.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h
+build-dbg/src/exception.o: src/exception.cpp include/exception.h \
+ include/exceptions.h include/configparser.h config.h include/utils.h \
+ include/logger.h include/strprintf.h include/configcontainer.h
+build-dbg/src/feedhq_api.o: src/feedhq_api.cpp include/feedhq_api.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ include/urlreader.h include/cache.h include/rss.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h
+build-dbg/src/feedhq_urlreader.o: src/feedhq_urlreader.cpp \
+ include/feedhq_api.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h include/urlreader.h include/cache.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h
+build-dbg/src/feedlist_formaction.o: src/feedlist_formaction.cpp \
+ include/feedlist_formaction.h include/list_formaction.h \
+ include/formaction.h include/stflpp.h include/keymap.h \
+ include/configparser.h include/rss.h include/configcontainer.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/history.h include/regexmanager.h \
+ include/view.h include/controller.h include/urlreader.h include/cache.h \
+ include/filtercontainer.h include/colormanager.h include/remote_api.h \
+ include/fslock.h include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/formaction.h \
+ include/reloadthread.h include/exceptions.h include/formatstring.h \
+ include/listformatter.h
+build-dbg/src/filebrowser_formaction.o: src/filebrowser_formaction.cpp \
+ include/filebrowser_formaction.h include/formaction.h include/stflpp.h \
+ include/keymap.h include/configparser.h include/rss.h \
+ include/configcontainer.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/history.h include/formatstring.h include/view.h \
+ include/controller.h include/urlreader.h include/cache.h \
+ include/filtercontainer.h include/colormanager.h include/regexmanager.h \
+ include/remote_api.h include/fslock.h include/htmlrenderer.h \
+ include/textformatter.h
+build-dbg/src/filtercontainer.o: src/filtercontainer.cpp \
+ include/filtercontainer.h include/configparser.h include/exceptions.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/configcontainer.h
+build-dbg/src/formaction.o: src/formaction.cpp include/formaction.h \
+ include/stflpp.h include/keymap.h include/configparser.h include/rss.h \
+ include/configcontainer.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/history.h include/view.h include/controller.h \
+ include/urlreader.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/exceptions.h
+build-dbg/src/formatstring.o: src/formatstring.cpp include/formatstring.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/configcontainer.h include/configparser.h
+build-dbg/src/fslock.o: src/fslock.cpp include/fslock.h include/logger.h \
+ config.h include/strprintf.h
+build-dbg/src/help_formaction.o: src/help_formaction.cpp config.h \
+ include/help_formaction.h include/formaction.h include/stflpp.h \
+ include/keymap.h include/configparser.h include/rss.h \
+ include/configcontainer.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h include/strprintf.h include/history.h \
+ include/formatstring.h include/view.h include/controller.h \
+ include/urlreader.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/listformatter.h
+build-dbg/src/history.o: src/history.cpp include/history.h
+build-dbg/src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
+ include/textformatter.h include/regexmanager.h include/configparser.h \
+ include/matcher.h filter/FilterParser.h include/tagsouppullparser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/configcontainer.h
+build-dbg/src/inoreader_api.o: src/inoreader_api.cpp \
+ include/inoreader_api.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h include/urlreader.h include/cache.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h
+build-dbg/src/inoreader_urlreader.o: src/inoreader_urlreader.cpp \
+ include/inoreader_api.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h include/urlreader.h include/cache.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h
+build-dbg/src/itemlist_formaction.o: src/itemlist_formaction.cpp \
+ include/controller.h include/urlreader.h include/configcontainer.h \
+ include/configparser.h include/rss.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h include/itemlist_formaction.h include/list_formaction.h \
+ include/formaction.h include/stflpp.h include/keymap.h include/history.h \
+ include/view.h include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/formaction.h \
+ include/listformatter.h include/exceptions.h include/formatstring.h
+build-dbg/src/itemview_formaction.o: src/itemview_formaction.cpp \
+ include/itemview_formaction.h include/formaction.h include/stflpp.h \
+ include/keymap.h include/configparser.h include/rss.h \
+ include/configcontainer.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/history.h include/htmlrenderer.h include/textformatter.h \
+ include/regexmanager.h include/view.h include/controller.h \
+ include/urlreader.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/remote_api.h include/fslock.h \
+ include/filebrowser_formaction.h include/exceptions.h \
+ include/formatstring.h
+build-dbg/src/keymap.o: src/keymap.cpp include/keymap.h \
+ include/configparser.h include/logger.h config.h include/strprintf.h \
+ include/exceptions.h include/utils.h include/configcontainer.h
+build-dbg/src/list_formaction.o: src/list_formaction.cpp \
+ include/list_formaction.h include/formaction.h include/stflpp.h \
+ include/keymap.h include/configparser.h include/rss.h \
+ include/configcontainer.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/history.h include/view.h include/controller.h \
+ include/urlreader.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/formaction.h
+build-dbg/src/listformatter.o: src/listformatter.cpp \
+ include/listformatter.h include/regexmanager.h include/configparser.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/configcontainer.h include/stflpp.h
+build-dbg/src/logger.o: src/logger.cpp include/logger.h config.h \
+ include/strprintf.h include/exception.h
+build-dbg/src/matcher.o: src/matcher.cpp include/matcher.h \
+ filter/FilterParser.h include/logger.h config.h include/strprintf.h \
+ include/utils.h include/configcontainer.h include/configparser.h \
+ include/exceptions.h
+build-dbg/src/newsblur_api.o: src/newsblur_api.cpp rss/rsspp.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/newsblur_api.h include/urlreader.h
+build-dbg/src/newsblur_urlreader.o: src/newsblur_urlreader.cpp \
+ include/newsblur_api.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h include/urlreader.h rss/rsspp.h include/logger.h \
+ config.h include/strprintf.h
+build-dbg/src/ocnews_api.o: src/ocnews_api.cpp include/ocnews_api.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ include/urlreader.h rss/rsspp.h include/utils.h include/logger.h \
+ config.h include/strprintf.h
+build-dbg/src/ocnews_urlreader.o: src/ocnews_urlreader.cpp \
+ include/ocnews_api.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h include/urlreader.h rss/rsspp.h include/logger.h \
+ config.h include/strprintf.h
+build-dbg/src/oldreader_api.o: src/oldreader_api.cpp \
+ include/oldreader_api.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h include/urlreader.h include/cache.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h
+build-dbg/src/oldreader_urlreader.o: src/oldreader_urlreader.cpp \
+ include/oldreader_api.h include/remote_api.h include/configcontainer.h \
+ include/configparser.h include/urlreader.h include/cache.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h
+build-dbg/src/pb_controller.o: src/pb_controller.cpp \
+ include/pb_controller.h include/configcontainer.h include/configparser.h \
+ include/download.h include/queueloader.h include/fslock.h \
+ include/pb_view.h include/keymap.h include/stflpp.h \
+ include/colormanager.h include/poddlthread.h config.h include/utils.h \
+ include/logger.h include/strprintf.h include/exceptions.h
+build-dbg/src/pb_view.o: src/pb_view.cpp include/pb_view.h \
+ include/keymap.h include/configparser.h include/stflpp.h \
+ include/colormanager.h include/pb_controller.h include/configcontainer.h \
+ include/download.h include/queueloader.h include/fslock.h \
+ include/poddlthread.h config.h include/logger.h include/strprintf.h \
+ stfl/dllist.h stfl/help.h include/utils.h
+build-dbg/src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
+ include/download.h include/configcontainer.h include/configparser.h \
+ include/logger.h config.h include/strprintf.h include/utils.h
+build-dbg/src/queueloader.o: src/queueloader.cpp include/stflpp.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/configcontainer.h include/configparser.h include/queueloader.h \
+ include/download.h include/pb_controller.h include/fslock.h
+build-dbg/src/regexmanager.o: src/regexmanager.cpp include/regexmanager.h \
+ include/configparser.h include/matcher.h filter/FilterParser.h \
+ include/logger.h config.h include/strprintf.h include/utils.h \
+ include/configcontainer.h include/exceptions.h
+build-dbg/src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
+ include/controller.h include/urlreader.h include/configcontainer.h \
+ include/configparser.h include/rss.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h include/cache.h include/filtercontainer.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h
+build-dbg/src/remote_api.o: src/remote_api.cpp include/remote_api.h \
+ include/configcontainer.h include/configparser.h include/utils.h \
+ include/logger.h config.h include/strprintf.h
+build-dbg/src/rss.o: src/rss.cpp include/rss.h include/configcontainer.h \
+ include/configparser.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/cache.h include/tagsouppullparser.h include/exceptions.h \
+ include/htmlrenderer.h include/textformatter.h include/regexmanager.h
+build-dbg/src/rss_parser.o: src/rss_parser.cpp rss/rsspp.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ rss/rsspp_internal.h include/rss_parser.h include/rss.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/cache.h include/htmlrenderer.h \
+ include/textformatter.h include/regexmanager.h include/ttrss_api.h \
+ include/urlreader.h include/json.hpp include/newsblur_api.h \
+ include/ocnews_api.h
+build-dbg/src/select_formaction.o: src/select_formaction.cpp \
+ include/select_formaction.h include/formaction.h include/stflpp.h \
+ include/keymap.h include/configparser.h include/rss.h \
+ include/configcontainer.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/history.h include/filtercontainer.h include/formatstring.h \
+ include/view.h include/controller.h include/urlreader.h include/cache.h \
+ include/colormanager.h include/regexmanager.h include/remote_api.h \
+ include/fslock.h include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/listformatter.h
+build-dbg/src/stflpp.o: src/stflpp.cpp include/stflpp.h include/logger.h \
+ config.h include/strprintf.h include/exception.h include/utils.h \
+ include/configcontainer.h include/configparser.h
+build-dbg/src/strprintf.o: src/strprintf.cpp include/strprintf.h
+build-dbg/src/tagsouppullparser.o: src/tagsouppullparser.cpp \
+ include/tagsouppullparser.h include/exceptions.h include/configparser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/configcontainer.h
+build-dbg/src/textformatter.o: src/textformatter.cpp \
+ include/textformatter.h include/regexmanager.h include/configparser.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/configcontainer.h \
+ include/htmlrenderer.h include/stflpp.h
+build-dbg/src/ttrss_api.o: src/ttrss_api.cpp include/json.hpp \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ include/ttrss_api.h rss/rsspp.h include/urlreader.h include/cache.h \
+ include/rss.h include/matcher.h filter/FilterParser.h include/utils.h \
+ include/logger.h config.h include/strprintf.h
+build-dbg/src/ttrss_urlreader.o: src/ttrss_urlreader.cpp \
+ include/ttrss_api.h rss/rsspp.h include/remote_api.h \
+ include/configcontainer.h include/configparser.h include/urlreader.h \
+ include/cache.h include/rss.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/json.hpp
+build-dbg/src/urlreader.o: src/urlreader.cpp include/urlreader.h \
+ include/configcontainer.h include/configparser.h include/utils.h \
+ include/logger.h config.h include/strprintf.h
+build-dbg/src/urlview_formaction.o: src/urlview_formaction.cpp \
+ include/urlview_formaction.h include/formaction.h include/stflpp.h \
+ include/keymap.h include/configparser.h include/rss.h \
+ include/configcontainer.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/history.h include/htmlrenderer.h include/textformatter.h \
+ include/regexmanager.h include/formatstring.h include/view.h \
+ include/controller.h include/urlreader.h include/cache.h \
+ include/filtercontainer.h include/colormanager.h include/remote_api.h \
+ include/fslock.h include/filebrowser_formaction.h \
+ include/listformatter.h
+build-dbg/src/utils.o: src/utils.cpp include/utils.h include/logger.h \
+ config.h include/strprintf.h include/configcontainer.h \
+ include/configparser.h
+build-dbg/src/view.o: src/view.cpp stfl/itemlist.h stfl/itemview.h \
+ stfl/help.h stfl/filebrowser.h stfl/urlview.h stfl/selecttag.h \
+ stfl/feedlist.h stfl/dialogs.h include/formatstring.h \
+ include/formaction.h include/stflpp.h include/keymap.h \
+ include/configparser.h include/rss.h include/configcontainer.h \
+ include/matcher.h filter/FilterParser.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/history.h \
+ include/feedlist_formaction.h include/list_formaction.h \
+ include/formaction.h include/regexmanager.h include/view.h \
+ include/controller.h include/urlreader.h include/cache.h \
+ include/filtercontainer.h include/colormanager.h include/remote_api.h \
+ include/fslock.h include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/itemlist_formaction.h \
+ include/listformatter.h include/itemview_formaction.h \
+ include/help_formaction.h include/urlview_formaction.h \
+ include/select_formaction.h include/dialogs_formaction.h \
+ include/reloadthread.h include/exception.h include/exceptions.h
+build-dbg/test/cache.o: test/cache.cpp test/catch.hpp test/test-helpers.h \
+ include/cache.h include/rss.h include/configcontainer.h \
+ include/configparser.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/rss_parser.h rss/rsspp.h include/remote_api.h
+build-dbg/test/configcontainer.o: test/configcontainer.cpp test/catch.hpp \
+ include/configcontainer.h include/configparser.h include/keymap.h \
+ include/exceptions.h
+build-dbg/test/configparser.o: test/configparser.cpp test/catch.hpp \
+ include/configparser.h
+build-dbg/test/filterparser.o: test/filterparser.cpp test/catch.hpp \
+ filter/FilterParser.h
+build-dbg/test/formatstring.o: test/formatstring.cpp test/catch.hpp \
+ include/formatstring.h
+build-dbg/test/history.o: test/history.cpp test/catch.hpp \
+ include/history.h
+build-dbg/test/htmlrenderer.o: test/htmlrenderer.cpp test/catch.hpp \
+ include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
+ include/configparser.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ include/configcontainer.h
+build-dbg/test/itemlist_formaction.o: test/itemlist_formaction.cpp \
+ test/catch.hpp test/test-helpers.h include/cache.h include/rss.h \
+ include/configcontainer.h include/configparser.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h include/itemlist_formaction.h \
+ include/list_formaction.h include/formaction.h include/stflpp.h \
+ include/keymap.h include/history.h include/regexmanager.h include/view.h \
+ include/controller.h include/urlreader.h include/filtercontainer.h \
+ include/colormanager.h include/remote_api.h include/fslock.h \
+ include/htmlrenderer.h include/textformatter.h \
+ include/filebrowser_formaction.h include/formaction.h \
+ include/listformatter.h include/feedlist_formaction.h stfl/itemlist.h \
+ stfl/feedlist.h
+build-dbg/test/keymap.o: test/keymap.cpp test/catch.hpp include/keymap.h \
+ include/configparser.h include/exceptions.h
+build-dbg/test/listformatter.o: test/listformatter.cpp test/catch.hpp \
+ include/listformatter.h include/regexmanager.h include/configparser.h \
+ include/matcher.h filter/FilterParser.h
+build-dbg/test/matcher.o: test/matcher.cpp test/catch.hpp \
+ include/matcher.h filter/FilterParser.h include/exceptions.h \
+ include/configparser.h
+build-dbg/test/regexmanager.o: test/regexmanager.cpp test/catch.hpp \
+ include/regexmanager.h include/configparser.h include/matcher.h \
+ filter/FilterParser.h include/exceptions.h
+build-dbg/test/remote_api.o: test/remote_api.cpp test/catch.hpp \
+ include/remote_api.h include/configcontainer.h include/configparser.h
+build-dbg/test/rss.o: test/rss.cpp test/catch.hpp rss/rsspp.h \
+ include/remote_api.h include/configcontainer.h include/configparser.h \
+ rss/rsspp_internal.h include/rss.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h include/rss_parser.h include/cache.h
+build-dbg/test/strprintf.o: test/strprintf.cpp test/catch.hpp \
+ include/strprintf.h
+build-dbg/test/tagsouppullparser.o: test/tagsouppullparser.cpp \
+ test/catch.hpp include/tagsouppullparser.h
+build-dbg/test/test.o: test/test.cpp test/catch.hpp include/logger.h \
+ config.h include/strprintf.h
+build-dbg/test/textformatter.o: test/textformatter.cpp test/catch.hpp \
+ include/textformatter.h include/regexmanager.h include/configparser.h \
+ include/matcher.h filter/FilterParser.h
+build-dbg/test/urlreader.o: test/urlreader.cpp test/catch.hpp \
+ include/urlreader.h include/configcontainer.h include/configparser.h
+build-dbg/test/utils.o: test/utils.cpp test/catch.hpp include/utils.h \
  include/logger.h config.h include/strprintf.h include/configcontainer.h \
  include/configparser.h


### PR DESCRIPTION
The Makefile now separates objects of regular and debug builds into the
two subfolders `./build` and `./build-debug` and links those two two
different binaries `./{pod,news}boat` and `./{pod,news}boat-dbg`.

Builds for the debug binaries can be invoked either by `make debug` or
by setting the `DEBUG=1` variable in any regular make invocation, e.g.
`make DEBUG=1 newsboat`.

What is currently missing is a good idea on how to handle the `clean` targets.
`make clean` works for the regular binaries/objects and a regular 
`make DEBUG=1 clean{,-.*}` works for the non debug variants, but that is
hardly a proper solution in my opinion.