### PR TITLE
Log caught json exceptions during retrieve_sid

### DIFF
--- a/src/ttrss_api.cpp
+++ b/src/ttrss_api.cpp
@@ -63,11 +63,15 @@ std::string ttrss_api::retrieve_sid() {
 	std::string sid;
 	try {
 		sid = content["session_id"];
-	} catch (json::exception& e) {}
+	} catch (json::exception& e) {
+		LOG(level::ERROR, "ttrss_api::retrieve_sid: %s", e.what());
+	}
 
 	try {
 		api_level = content["api_level"];
-	} catch (json::exception& e) {};
+	} catch (json::exception& e) {
+		LOG(level::ERROR, "ttrss_api::retrieve_sid: %s", e.what());
+	}
 
 	LOG(level::DEBUG, "ttrss_api::retrieve_sid: sid = '%s'", sid);
 


### PR DESCRIPTION
Hi,

I ran into a slight behavioural difference between newsbeuter and newsboat with my custom (TT-RSS style) server, which hit these exceptions (due to my server sending session_ids as a JSON integer).

I added the below whilst debugging this, and thought it might be useful as a permanent addition (since it only affects logging).

Thanks,
alown