### PR TITLE
add :q as in alternative command for quitting

### DIFF
--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -215,7 +215,7 @@ void formaction::handle_cmdline(const std::string& cmdline) {
 			} else {
 				v->show_error(_("usage: set <variable>[=<value>]"));
 			}
-		} else if (cmd == "quit") {
+		} else if (cmd == "q" || cmd == "quit") {
 			while (v->formaction_stack_size() > 0) {
 				v->pop_current_formaction();
 			}


### PR DESCRIPTION
Both vi and vim use :q to quit. There is a also variety of other tools that use
vi-like keybindings (and therefore use :q to quit), i.e.
 * cmus
 * tig