### PR TITLE
Fix typo in json field name attachements to attachments

### DIFF
--- a/src/ttrss_api.cpp
+++ b/src/ttrss_api.cpp
@@ -360,8 +360,8 @@ rsspp::feed ttrss_api::fetch_feed(const std::string& id, CURL* cached_handle) {
 
 			if (!item_obj["attachments"].is_null())
 			{
-				if (item_obj["attachements"].size() >= 1) {
-					json a = item_obj["attachements"].front();
+				if (item_obj["attachments"].size() >= 1) {
+					json a = item_obj["attachments"].front();
 					if (!a["content_url"].is_null()) {
 						item.enclosure_url = a["content_url"];
 					}


### PR DESCRIPTION
In the ttrss api client was a typo for the attachments field name,
so the attachments wasn't gathered correctly.

Fixes #177