### PR TITLE
Add "open-in-browser" action to urlview_formaction

### DIFF
--- a/src/urlview_formaction.cpp
+++ b/src/urlview_formaction.cpp
@@ -25,6 +25,7 @@ urlview_formaction::~urlview_formaction() {
 void urlview_formaction::process_operation(operation op, bool /* automatic */, std::vector<std::string> * /* args */) {
 	bool hardquit = false;
 	switch (op) {
+	case OP_OPENINBROWSER:
 	case OP_OPEN: {
 		std::string posstr = f->get("feedpos");
 		if (posstr.length() > 0) {


### PR DESCRIPTION
Fixes issue #23

The urlview window now behaves as expected when recieving
OP_OPENINBROWSER allowing common user-defined macros to work
in this view.