### PR TITLE
Fix bind-key accepting invalid operations

### DIFF
--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -570,6 +570,13 @@ void keymap::handle_action(const std::string& action,
 			throw confighandlerexception(strprintf::fmt(
 				_("`%s' is not a valid context"), context));
 		operation op = get_opcode(params[1]);
+		if (op == OP_NIL) {
+			throw confighandlerexception(
+				strprintf::fmt(
+					_("'%s' is not a valid "
+					  "key command"),
+					params[1]));
+		}
 		if (op > OP_SK_MIN && op < OP_SK_MAX)
 			unset_key(getkey(op, context), context);
 		set_key(op, params[0], context);

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -117,4 +117,13 @@ TEST_CASE("handle_action()", "[keymap]")
 		REQUIRE_THROWS_AS(k.handle_action("an-invalid-action", params),
 			confighandlerexception);
 	}
+
+	SECTION("invalid-op throws exception")
+	{
+		params.push_back("I");
+		params.push_back("invalid-op");
+
+		REQUIRE_THROWS_AS(k.handle_action("bind-key", params), confighandlerexception);
+		REQUIRE_THROWS_AS(k.handle_action("macro", params), confighandlerexception);
+	}
 }


### PR DESCRIPTION
While binding a key using bind-key we didn't verify the return value of
get_opcode to make sure we're binding to a valid operation.

This makes newsboat throw an error when trying to bind to an invalid op
similarly to what happens when trying to use an invalid operation in a
macro.

---

I spent *way* too long trying to find out why `open-all-unread-in-browser-and-mark-read` wasn't working -- turns out I just spelt the operation wrong.