### PR TITLE
Upgrade for-range loops

### DIFF
--- a/include/download.h
+++ b/include/download.h
@@ -23,20 +23,20 @@ class download {
 public:
 	explicit download(pb_controller* c = 0);
 	~download();
-	double percents_finished();
-	const std::string status_text();
+	double percents_finished() const;
+	const std::string status_text() const;
 	dlstatus status() const
 	{
 		return download_status;
 	}
-	const std::string filename();
-	const std::string url();
+	const std::string filename() const;
+	const std::string url() const;
 	void set_filename(const std::string& str);
 	void set_url(const std::string& url);
 	void set_progress(double downloaded, double total);
 	void set_status(dlstatus dls);
 	void set_kbps(double kbps);
-	double kbps();
+	double kbps() const;
 	void set_offset(unsigned long offset);
 
 	double current_size() const

--- a/include/rss_parser.h
+++ b/include/rss_parser.h
@@ -47,19 +47,22 @@ private:
 
 	void set_item_title(std::shared_ptr<rss_feed> feed,
 		std::shared_ptr<rss_item> x,
-		rsspp::item& item);
-	void set_item_author(std::shared_ptr<rss_item> x, rsspp::item& item);
-	void set_item_content(std::shared_ptr<rss_item> x, rsspp::item& item);
-	void set_item_enclosure(std::shared_ptr<rss_item> x, rsspp::item& item);
-	std::string get_guid(rsspp::item& item);
+		const rsspp::item& item);
+	void set_item_author(std::shared_ptr<rss_item> x,
+		const rsspp::item& item);
+	void set_item_content(std::shared_ptr<rss_item> x,
+		const rsspp::item& item);
+	void set_item_enclosure(std::shared_ptr<rss_item> x,
+		const rsspp::item& item);
+	std::string get_guid(const rsspp::item& item) const;
 
 	void add_item_to_feed(std::shared_ptr<rss_feed> feed,
 		std::shared_ptr<rss_item> item);
 
 	void handle_content_encoded(std::shared_ptr<rss_item> x,
-		rsspp::item& item);
+		const rsspp::item& item) const;
 	void handle_itunes_summary(std::shared_ptr<rss_item> x,
-		rsspp::item& item);
+		const rsspp::item& item);
 	bool is_html_type(const std::string& type);
 	void fetch_ttrss(const std::string& feed_id);
 	void fetch_newsblur(const std::string& feed_id);

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -577,7 +577,7 @@ std::shared_ptr<rss_feed> cache::internalize_rssfeed(std::string rssurl,
 	run_sql(query, rssitem_callback, &feed);
 
 	std::vector<std::shared_ptr<rss_item>> filtered_items;
-	for (auto item : feed->items()) {
+	for (const auto& item : feed->items()) {
 		try {
 			if (!ign || !ign->matches(item.get())) {
 				item->set_cache(this);
@@ -654,7 +654,7 @@ cache::search_for_items(const std::string& querystr, const std::string& feedurl)
 	}
 
 	run_sql(query, search_item_callback, &items);
-	for (auto item : items) {
+	for (const auto& item : items) {
 		item->set_cache(this);
 	}
 
@@ -721,7 +721,7 @@ void cache::cleanup_cache(std::vector<std::shared_ptr<rss_feed>>& feeds)
 		LOG(level::DEBUG, "cache::cleanup_cache: cleaning up cache...");
 		std::string list = "(";
 
-		for (auto feed : feeds) {
+		for (const auto& feed : feeds) {
 			std::string name =
 				prepare_query("'%q'", feed->rssurl());
 			list.append(name);
@@ -862,7 +862,7 @@ void cache::mark_all_read(std::shared_ptr<rss_feed> feed)
 		"UPDATE rss_item SET unread = '0' WHERE unread != '0' AND guid "
 		"IN (";
 
-	for (auto item : feed->items()) {
+	for (const auto& item : feed->items()) {
 		query.append(prepare_query("'%q',", item->guid()));
 	}
 	query.append("'');");
@@ -972,7 +972,7 @@ void cache::remove_old_deleted_items(const std::string& rssurl,
 		return;
 	}
 	std::string guidset = "(";
-	for (auto guid : guids) {
+	for (const auto& guid : guids) {
 		guidset.append(prepare_query("'%q', ", guid));
 	}
 	guidset.append("'')");
@@ -1004,7 +1004,7 @@ void cache::mark_items_read_by_guid(const std::vector<std::string>& guids)
 {
 	scope_measure m1("cache::mark_items_read_by_guid");
 	std::string guidset("(");
-	for (auto guid : guids) {
+	for (const auto& guid : guids) {
 		guidset.append(prepare_query("'%q', ", guid));
 	}
 	guidset.append("'')");
@@ -1054,7 +1054,7 @@ void cache::clean_old_articles()
 void cache::fetch_descriptions(rss_feed* feed)
 {
 	std::vector<std::string> guids;
-	for (auto item : feed->items()) {
+	for (const auto& item : feed->items()) {
 		guids.push_back(prepare_query("'%q'", item->guid()));
 	}
 	std::string in_clause = utils::join(guids, ", ");

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -88,12 +88,12 @@ void colormanager::handle_action(const std::string& action,
 
 void colormanager::dump_config(std::vector<std::string>& config_output)
 {
-	for (auto color : fg_colors) {
+	for (const auto& color : fg_colors) {
 		std::string configline = strprintf::fmt("color %s %s %s",
 			color.first,
 			color.second,
 			bg_colors[color.first]);
-		for (auto attrib : attributes[color.first]) {
+		for (const auto& attrib : attributes[color.first]) {
 			configline.append(" ");
 			configline.append(attrib);
 		}
@@ -123,7 +123,7 @@ void colormanager::set_pb_colors(podboat::pb_view* v)
 			colorattr.append("bg=");
 			colorattr.append(bgcit->second);
 		}
-		for (auto attr : attit->second) {
+		for (const auto& attr : attit->second) {
 			if (colorattr.length() > 0)
 				colorattr.append(",");
 			colorattr.append("attr=");

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -252,7 +252,7 @@ void configcontainer::register_commands(configparser& cfgparser)
 	// parser
 	// -> if the resp. config option is encountered, it is passed to the
 	// configcontainer
-	for (auto cfg : config_data) {
+	for (const auto& cfg : config_data) {
 		cfgparser.register_handler(cfg.first, this);
 	}
 }
@@ -392,7 +392,7 @@ void configcontainer::toggle(const std::string& key)
 
 void configcontainer::dump_config(std::vector<std::string>& config_output)
 {
-	for (auto cfg : config_data) {
+	for (const auto& cfg : config_data) {
 		std::string configline = cfg.first + " ";
 		assert(cfg.second.type != configdata_t::INVALID);
 		switch (cfg.second.type) {
@@ -410,7 +410,7 @@ void configcontainer::dump_config(std::vector<std::string>& config_output)
 			if (cfg.second.multi_option) {
 				std::vector<std::string> tokens =
 					utils::tokenize(cfg.second.value, " ");
-				for (auto token : tokens) {
+				for (const auto& token : tokens) {
 					configline.append(
 						utils::quote(token) + " ");
 				}
@@ -438,7 +438,7 @@ std::vector<std::string> configcontainer::get_suggestions(
 	const std::string& fragment)
 {
 	std::vector<std::string> result;
-	for (auto cfg : config_data) {
+	for (const auto& cfg : config_data) {
 		if (cfg.first.substr(0, fragment.length()) == fragment)
 			result.push_back(cfg.first);
 	}

--- a/src/dialogs_formaction.cpp
+++ b/src/dialogs_formaction.cpp
@@ -38,7 +38,7 @@ void dialogs_formaction::prepare()
 		listformatter listfmt;
 
 		unsigned int i = 1;
-		for (auto fa : v->get_formaction_names()) {
+		for (const auto& fa : v->get_formaction_names()) {
 			LOG(level::DEBUG,
 				"dialogs_formaction::prepare: p1 = %p p2 = %p",
 				v->get_formaction(fa.first).get(),

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -24,12 +24,12 @@ download::download(pb_controller* c)
 
 download::~download() {}
 
-const std::string download::filename()
+const std::string download::filename() const
 {
 	return fn;
 }
 
-const std::string download::url()
+const std::string download::url() const
 {
 	return url_;
 }
@@ -39,7 +39,7 @@ void download::set_filename(const std::string& str)
 	fn = str;
 }
 
-double download::percents_finished()
+double download::percents_finished() const
 {
 	if (totalsize < 1) {
 		return 0.0;
@@ -48,7 +48,7 @@ double download::percents_finished()
 	}
 }
 
-const std::string download::status_text()
+const std::string download::status_text() const
 {
 	switch (download_status) {
 	case dlstatus::QUEUED:
@@ -100,7 +100,7 @@ void download::set_kbps(double k)
 	curkbps = k;
 }
 
-double download::kbps()
+double download::kbps() const
 {
 	return curkbps;
 }

--- a/src/feedlist_formaction.cpp
+++ b/src/feedlist_formaction.cpp
@@ -267,7 +267,7 @@ REDO:
 				v->get_cfg()->get_configvalue_as_bool(
 					"reload-only-visible-feeds");
 			std::vector<int> idxs;
-			for (auto feed : visible_feeds) {
+			for (const auto& feed : visible_feeds) {
 				idxs.push_back(feed.second);
 			}
 			v->get_ctrl()->start_reload_all_thread(
@@ -499,7 +499,7 @@ void feedlist_formaction::update_visible_feeds(
 
 	unsigned int i = 0;
 
-	for (auto feed : feeds) {
+	for (const auto& feed : feeds) {
 		feed->set_index(i + 1);
 		if ((tag == "" || feed->matches_tag(tag)) &&
 			(!apply_filter || m.matches(feed.get())) &&
@@ -529,7 +529,7 @@ void feedlist_formaction::set_feedlist(
 
 	update_visible_feeds(feeds);
 
-	for (auto feed : visible_feeds) {
+	for (const auto& feed : visible_feeds) {
 		if (feed.first->unread_item_count() > 0)
 			++unread_feeds;
 
@@ -816,7 +816,7 @@ void feedlist_formaction::mark_pos_if_visible(unsigned int pos)
 	scope_measure m1("feedlist_formaction::mark_pos_if_visible");
 	unsigned int vpos = 0;
 	v->get_ctrl()->update_visible_feeds();
-	for (auto feed : visible_feeds) {
+	for (const auto& feed : visible_feeds) {
 		if (feed.second == pos) {
 			LOG(level::DEBUG,
 				"feedlist_formaction::mark_pos_if_visible: "
@@ -830,7 +830,7 @@ void feedlist_formaction::mark_pos_if_visible(unsigned int pos)
 	}
 	vpos = 0;
 	pos = v->get_ctrl()->get_pos_of_next_unread(pos);
-	for (auto feed : visible_feeds) {
+	for (const auto& feed : visible_feeds) {
 		if (feed.second == pos) {
 			LOG(level::DEBUG,
 				"feedlist_formaction::mark_pos_if_visible: "
@@ -859,7 +859,7 @@ void feedlist_formaction::set_regexmanager(regexmanager* r)
 	std::vector<std::string>& attrs = r->get_attrs("feedlist");
 	unsigned int i = 0;
 	std::string attrstr;
-	for (auto attribute : attrs) {
+	for (const auto& attribute : attrs) {
 		attrstr.append(
 			strprintf::fmt("@style_%u_normal:%s ", i, attribute));
 		attrstr.append(
@@ -946,7 +946,7 @@ void feedlist_formaction::set_pos()
 	if (set_filterpos) {
 		set_filterpos = false;
 		unsigned int i = 0;
-		for (auto feed : visible_feeds) {
+		for (const auto& feed : visible_feeds) {
 			if (feed.second == filterpos) {
 				f->set("feedpos", std::to_string(i));
 				return;

--- a/src/filtercontainer.cpp
+++ b/src/filtercontainer.cpp
@@ -37,7 +37,7 @@ void filtercontainer::handle_action(const std::string& action,
 
 void filtercontainer::dump_config(std::vector<std::string>& config_output)
 {
-	for (auto filter : filters) {
+	for (const auto& filter : filters) {
 		config_output.push_back(strprintf::fmt("define-filter %s %s",
 			utils::quote(filter.first),
 			utils::quote(filter.second)));

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -108,7 +108,7 @@ void formaction::process_op(operation op,
 		if (automatic) {
 			std::string cmdline = "set ";
 			if (args) {
-				for (auto arg : *args) {
+				for (const auto& arg : *args) {
 					cmdline.append(strprintf::fmt(
 						"%s ", stfl::quote(arg)));
 				}
@@ -177,7 +177,7 @@ std::vector<std::string> formaction::get_suggestions(
 		fragment);
 	std::vector<std::string> result;
 	// first check all formaction command suggestions
-	for (auto cmd : valid_cmds) {
+	for (const auto& cmd : valid_cmds) {
 		LOG(level::DEBUG,
 			"formaction::get_suggestions: extracted part: %s",
 			cmd.substr(0, fragment.length()));
@@ -200,7 +200,7 @@ std::vector<std::string> formaction::get_suggestions(
 					variable_suggestions =
 						v->get_cfg()->get_suggestions(
 							variable_fragment);
-					for (auto suggestion :
+					for (const auto& suggestion :
 						variable_suggestions) {
 						std::string line = fragment +
 							suggestion.substr(
@@ -288,7 +288,7 @@ void formaction::handle_cmdline(const std::string& cmdline)
 			if (tokens.empty()) {
 				v->show_error(_("usage: source <file> [...]"));
 			} else {
-				for (auto token : tokens) {
+				for (const auto& token : tokens) {
 					try {
 						v->get_ctrl()->load_configfile(
 							utils::resolve_tilde(

--- a/src/help_formaction.cpp
+++ b/src/help_formaction.cpp
@@ -86,7 +86,7 @@ void help_formaction::prepare()
 		unsigned int syskey_count = 0;
 
 		for (unsigned int i = 0; i < 3; i++) {
-			for (auto desc : descs) {
+			for (const auto& desc : descs) {
 				bool condition;
 				switch (i) {
 				case 0:

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -70,7 +70,7 @@ unsigned int htmlrenderer::add_link(std::vector<linkpair>& links,
 {
 	bool found = false;
 	unsigned int i = 1;
-	for (auto l : links) {
+	for (const auto& l : links) {
 		if (l.first == link) {
 			found = true;
 			break;
@@ -710,7 +710,7 @@ void htmlrenderer::render(std::istream& input,
 			if (itunes_hack) {
 				std::vector<std::string> paragraphs =
 					utils::tokenize_nl(text);
-				for (auto paragraph : paragraphs) {
+				for (const auto& paragraph : paragraphs) {
 					if (paragraph != "\n") {
 						add_nonempty_line(
 							curline, tables, lines);
@@ -724,7 +724,7 @@ void htmlrenderer::render(std::istream& input,
 			} else if (inside_pre) {
 				std::vector<std::string> paragraphs =
 					utils::tokenize_nl(text);
-				for (auto paragraph : paragraphs) {
+				for (const auto& paragraph : paragraphs) {
 					if (paragraph == "\n") {
 						add_line_softwrappable(
 							curline, lines);

--- a/src/inoreader_urlreader.cpp
+++ b/src/inoreader_urlreader.cpp
@@ -59,23 +59,23 @@ void inoreader_urlreader::reload()
 	ur.reload();
 
 	std::vector<std::string>& file_urls(ur.get_urls());
-	for (auto url : file_urls) {
+	for (const auto& url : file_urls) {
 		if (url.substr(0, 6) == "query:") {
 			urls.push_back(url);
 			std::vector<std::string>& file_tags(ur.get_tags(url));
 			tags[url] = ur.get_tags(url);
-			for (auto tag : file_tags) {
+			for (const auto& tag : file_tags) {
 				alltags.insert(tag);
 			}
 		}
 	}
 
 	std::vector<tagged_feedurl> feedurls = api->get_subscribed_urls();
-	for (auto url : feedurls) {
+	for (const auto& url : feedurls) {
 		LOG(level::DEBUG, "added %s to URL list", url.first);
 		urls.push_back(url.first);
 		tags[url.first] = url.second;
-		for (auto tag : url.second) {
+		for (const auto& tag : url.second) {
 			LOG(level::DEBUG, "%s: added tag %s", url.first, tag);
 			alltags.insert(tag);
 		}

--- a/src/itemlist_formaction.cpp
+++ b/src/itemlist_formaction.cpp
@@ -455,7 +455,7 @@ void itemlist_formaction::process_operation(operation op,
 						"like I'm in a pseudo-feed "
 						"(search "
 						"result, query feed)");
-					for (auto item : feed->items()) {
+					for (const auto& item : feed->items()) {
 						item->set_unread_nowrite_notify(
 							false,
 							true); // TODO: do we
@@ -833,7 +833,7 @@ void itemlist_formaction::do_update_visible_items()
 	 */
 
 	unsigned int i = 0;
-	for (auto item : items) {
+	for (const auto& item : items) {
 		item->set_index(i + 1);
 		if (!apply_filter || m.matches(item.get())) {
 			new_visible_items.push_back(itemptr_pos_pair(item, i));
@@ -901,7 +901,7 @@ void itemlist_formaction::prepare()
 		if (invalidation_mode == InvalidationMode::COMPLETE) {
 			listfmt.clear();
 
-			for (auto item : visible_items) {
+			for (const auto& item : visible_items) {
 				auto line = item2formatted_line(item,
 					width,
 					itemlist_format,
@@ -909,7 +909,7 @@ void itemlist_formaction::prepare()
 				listfmt.add_line(line, item.second);
 			}
 		} else if (invalidation_mode == InvalidationMode::PARTIAL) {
-			for (auto itempos : invalidated_itempos) {
+			for (const auto& itempos : invalidated_itempos) {
 				auto item = visible_items[itempos];
 				auto line = item2formatted_line(item,
 					width,
@@ -1277,7 +1277,7 @@ void itemlist_formaction::set_regexmanager(regexmanager* r)
 	std::vector<std::string>& attrs = r->get_attrs("articlelist");
 	unsigned int i = 0;
 	std::string attrstr;
-	for (auto attribute : attrs) {
+	for (const auto& attribute : attrs) {
 		attrstr.append(
 			strprintf::fmt("@style_%u_normal:%s ", i, attribute));
 		attrstr.append(
@@ -1324,7 +1324,7 @@ void itemlist_formaction::prepare_set_filterpos()
 	if (set_filterpos) {
 		set_filterpos = false;
 		unsigned int i = 0;
-		for (auto item : visible_items) {
+		for (const auto& item : visible_items) {
 			if (item.second == filterpos) {
 				f->set("itempos", std::to_string(i));
 				return;

--- a/src/itemview_formaction.cpp
+++ b/src/itemview_formaction.cpp
@@ -641,7 +641,7 @@ void itemview_formaction::set_regexmanager(regexmanager* r)
 	std::vector<std::string>& attrs = r->get_attrs("article");
 	unsigned int i = 0;
 	std::string attrstr;
-	for (auto attribute : attrs) {
+	for (const auto& attribute : attrs) {
 		attrstr.append(
 			strprintf::fmt("@style_%u_normal:%s ", i, attribute));
 		i++;

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -391,7 +391,7 @@ void keymap::get_keymap_descriptions(std::vector<keymap_desc>& descs,
 
 		for (unsigned int j = 0; opdescs[j].op != OP_NIL; ++j) {
 			bool already_added = false;
-			for (auto keymap : keymap_[ctx]) {
+			for (const auto& keymap : keymap_[ctx]) {
 				operation op = keymap.second;
 				if (op != OP_NIL) {
 					if (opdescs[j].op == op &&
@@ -512,7 +512,7 @@ void keymap::dump_config(std::vector<std::string>& config_output)
 	for (unsigned int i = 1; contexts[i] != nullptr;
 		i++) { // TODO: optimize
 		std::map<std::string, operation>& x = keymap_[contexts[i]];
-		for (auto keymap : x) {
+		for (const auto& keymap : x) {
 			if (keymap.second < OP_INT_MIN) {
 				std::string configline = "bind-key ";
 				configline.append(utils::quote(keymap.first));
@@ -524,14 +524,14 @@ void keymap::dump_config(std::vector<std::string>& config_output)
 			}
 		}
 	}
-	for (auto macro : macros_) {
+	for (const auto& macro : macros_) {
 		std::string configline = "macro ";
 		configline.append(macro.first);
 		configline.append(" ");
 		unsigned int i = 0;
-		for (auto cmd : macro.second) {
+		for (const auto& cmd : macro.second) {
 			configline.append(getopname(cmd.op));
-			for (auto arg : cmd.args) {
+			for (const auto& arg : cmd.args) {
 				configline.append(" ");
 				configline.append(utils::quote(arg));
 			}
@@ -646,13 +646,13 @@ std::string keymap::getkey(operation op, const std::string& context)
 	if (context == "all") {
 		for (unsigned int i = 0; contexts[i] != nullptr; i++) {
 			std::string ctx(contexts[i]);
-			for (auto keymap : keymap_[ctx]) {
+			for (const auto& keymap : keymap_[ctx]) {
 				if (keymap.second == op)
 					return keymap.first;
 			}
 		}
 	} else {
-		for (auto keymap : keymap_[context]) {
+		for (const auto& keymap : keymap_[context]) {
 			if (keymap.second == op)
 				return keymap.first;
 		}
@@ -662,7 +662,7 @@ std::string keymap::getkey(operation op, const std::string& context)
 
 std::vector<macrocmd> keymap::get_macro(const std::string& key)
 {
-	for (auto macro : macros_) {
+	for (const auto& macro : macros_) {
 		if (macro.first == key) {
 			return macro.second;
 		}

--- a/src/list_formaction.cpp
+++ b/src/list_formaction.cpp
@@ -51,7 +51,7 @@ void list_formaction::open_unread_items_in_browser(
 	bool markread)
 {
 	int tabcount = 0;
-	for (auto item : feed->items()) {
+	for (const auto& item : feed->items()) {
 		if (tabcount < v->get_cfg()->get_configvalue_as_int(
 				       "max-browser-tabs")) {
 			if (item->unread()) {

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -65,7 +65,7 @@ void listformatter::set_line(const unsigned int itempos,
 void listformatter::add_lines(const std::vector<std::string>& thelines,
 	unsigned int width)
 {
-	for (auto line : thelines) {
+	for (const auto& line : thelines) {
 		add_line(utils::replace_all(line, "\t", "        "),
 			UINT_MAX,
 			width);
@@ -76,7 +76,7 @@ std::string listformatter::format_list(regexmanager* rxman,
 	const std::string& location)
 {
 	format_cache = "{list";
-	for (auto line : lines) {
+	for (const auto& line : lines) {
 		std::string str = line.first;
 		if (rxman)
 			rxman->quote_and_highlight(str, location);

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -166,7 +166,7 @@ bool matcher::matchop_cont(expression* e, matchable* item)
 	std::vector<std::string> elements =
 		utils::tokenize(item->get_attribute(e->name), " ");
 	std::string literal = e->literal;
-	for (auto elem : elements) {
+	for (const auto& elem : elements) {
 		if (literal == elem) {
 			return true;
 		}

--- a/src/newsblur_urlreader.cpp
+++ b/src/newsblur_urlreader.cpp
@@ -28,7 +28,7 @@ void newsblur_urlreader::reload()
 	ur.reload();
 
 	std::vector<std::string>& file_urls(ur.get_urls());
-	for (auto url : file_urls) {
+	for (const auto& url : file_urls) {
 		if (url.substr(0, 6) == "query:") {
 			urls.push_back(url);
 		}
@@ -36,11 +36,11 @@ void newsblur_urlreader::reload()
 
 	std::vector<tagged_feedurl> feedurls = api->get_subscribed_urls();
 
-	for (auto url : feedurls) {
+	for (const auto& url : feedurls) {
 		LOG(level::INFO, "added %s to URL list", url.first);
 		urls.push_back(url.first);
 		tags[url.first] = url.second;
-		for (auto tag : url.second) {
+		for (const auto& tag : url.second) {
 			LOG(level::DEBUG, "%s: added tag %s", url.first, tag);
 			alltags.insert(tag);
 		}

--- a/src/ocnews_urlreader.cpp
+++ b/src/ocnews_urlreader.cpp
@@ -27,7 +27,7 @@ void ocnews_urlreader::reload()
 	ur.reload();
 
 	std::vector<std::string>& file_urls(ur.get_urls());
-	for (auto url : file_urls) {
+	for (const auto& url : file_urls) {
 		if (url.substr(0, 6) == "query:") {
 			urls.push_back(url);
 		}
@@ -35,11 +35,11 @@ void ocnews_urlreader::reload()
 
 	std::vector<tagged_feedurl> feedurls = api->get_subscribed_urls();
 
-	for (auto url : feedurls) {
+	for (const auto& url : feedurls) {
 		LOG(level::INFO, "added %s to URL list", url.first);
 		urls.push_back(url.first);
 		tags[url.first] = url.second;
-		for (auto tag : url.second) {
+		for (const auto& tag : url.second) {
 			LOG(level::DEBUG, "%s: added tag %s", url.first, tag);
 			alltags.insert(tag);
 		}

--- a/src/oldreader_api.cpp
+++ b/src/oldreader_api.cpp
@@ -84,7 +84,7 @@ std::string oldreader_api::retrieve_auth()
 	curl_easy_cleanup(handle);
 
 	std::vector<std::string> lines = utils::tokenize(result);
-	for (auto line : lines) {
+	for (const auto& line : lines) {
 		LOG(level::DEBUG,
 			"oldreader_api::retrieve_auth: line = %s",
 			line);

--- a/src/oldreader_urlreader.cpp
+++ b/src/oldreader_urlreader.cpp
@@ -59,23 +59,23 @@ void oldreader_urlreader::reload()
 	ur.reload();
 
 	std::vector<std::string>& file_urls(ur.get_urls());
-	for (auto url : file_urls) {
+	for (const auto& url : file_urls) {
 		if (url.substr(0, 6) == "query:") {
 			urls.push_back(url);
 			std::vector<std::string>& file_tags(ur.get_tags(url));
 			tags[url] = ur.get_tags(url);
-			for (auto tag : file_tags) {
+			for (const auto& tag : file_tags) {
 				alltags.insert(tag);
 			}
 		}
 	}
 
 	std::vector<tagged_feedurl> feedurls = api->get_subscribed_urls();
-	for (auto url : feedurls) {
+	for (const auto& url : feedurls) {
 		LOG(level::DEBUG, "added %s to URL list", url.first);
 		urls.push_back(url.first);
 		tags[url.first] = url.second;
-		for (auto tag : url.second) {
+		for (const auto& tag : url.second) {
 			LOG(level::DEBUG, "%s: added tag %s", url.first, tag);
 			alltags.insert(tag);
 		}

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -397,7 +397,7 @@ void pb_controller::reload_queue(bool remove_unplayed)
 double pb_controller::get_total_kbps()
 {
 	double result = 0.0;
-	for (auto& dl : downloads_) {
+	for (const auto& dl : downloads_) {
 		if (dl.status() == dlstatus::DOWNLOADING) {
 			result += dl.kbps();
 		}

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -375,7 +375,7 @@ std::string pb_controller::get_dlpath()
 unsigned int pb_controller::downloads_in_progress()
 {
 	unsigned int count = 0;
-	for (auto dl : downloads_) {
+	for (const auto& dl : downloads_) {
 		if (dl.status() == dlstatus::DOWNLOADING)
 			++count;
 	}
@@ -397,7 +397,7 @@ void pb_controller::reload_queue(bool remove_unplayed)
 double pb_controller::get_total_kbps()
 {
 	double result = 0.0;
-	for (auto dl : downloads_) {
+	for (auto& dl : downloads_) {
 		if (dl.status() == dlstatus::DOWNLOADING) {
 			result += dl.kbps();
 		}

--- a/src/pb_view.cpp
+++ b/src/pb_view.cpp
@@ -77,7 +77,7 @@ void pb_view::run(bool auto_download)
 			std::string code = "{list";
 
 			unsigned int i = 0;
-			for (auto& dl : ctrl->downloads()) {
+			for (const auto& dl : ctrl->downloads()) {
 				auto lbuf = strprintf::fmt(
 					" %4u [%6.1fMB/%6.1fMB] [%5.1f %%] "
 					"[%7.2f kb/s] %-20s %s -> %s",

--- a/src/pb_view.cpp
+++ b/src/pb_view.cpp
@@ -77,7 +77,7 @@ void pb_view::run(bool auto_download)
 			std::string code = "{list";
 
 			unsigned int i = 0;
-			for (auto dl : ctrl->downloads()) {
+			for (auto& dl : ctrl->downloads()) {
 				auto lbuf = strprintf::fmt(
 					" %4u [%6.1fMB/%6.1fMB] [%5.1f %%] "
 					"[%7.2f kb/s] %-20s %s -> %s",
@@ -279,7 +279,7 @@ void pb_view::run_help()
 
 	std::string code = "{list";
 
-	for (auto desc : descs) {
+	for (const auto& desc : descs) {
 		std::string line = "{listitem text:";
 
 		std::string descline;

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -27,7 +27,7 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 	std::vector<download> dltemp;
 	std::fstream f;
 
-	for (auto dl : downloads) {
+	for (auto& dl : downloads) {
 		if (dl.status() == dlstatus::DOWNLOADING) { // we are not
 							    // allowed to reload
 							    // if a download is
@@ -78,7 +78,7 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 					utils::tokenize_quoted(line);
 				bool url_found = false;
 
-				for (auto dl : dltemp) {
+				for (auto& dl : dltemp) {
 					if (fields[0] == dl.url()) {
 						LOG(level::INFO,
 							"queueloader::reload: "
@@ -90,7 +90,7 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 					}
 				}
 
-				for (auto dl : downloads) {
+				for (auto& dl : downloads) {
 					if (fields[0] == dl.url()) {
 						LOG(level::INFO,
 							"queueloader::reload: "
@@ -167,7 +167,7 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 
 	f.open(queuefile.c_str(), std::fstream::out);
 	if (f.is_open()) {
-		for (auto dl : dltemp) {
+		for (auto& dl : dltemp) {
 			f << dl.url() << " " << stfl::quote(dl.filename());
 			if (dl.status() == dlstatus::READY)
 				f << " downloaded";

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -27,7 +27,7 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 	std::vector<download> dltemp;
 	std::fstream f;
 
-	for (auto& dl : downloads) {
+	for (const auto& dl : downloads) {
 		if (dl.status() == dlstatus::DOWNLOADING) { // we are not
 							    // allowed to reload
 							    // if a download is
@@ -78,7 +78,7 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 					utils::tokenize_quoted(line);
 				bool url_found = false;
 
-				for (auto& dl : dltemp) {
+				for (const auto& dl : dltemp) {
 					if (fields[0] == dl.url()) {
 						LOG(level::INFO,
 							"queueloader::reload: "
@@ -90,7 +90,7 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 					}
 				}
 
-				for (auto& dl : downloads) {
+				for (const auto& dl : downloads) {
 					if (fields[0] == dl.url()) {
 						LOG(level::INFO,
 							"queueloader::reload: "
@@ -167,7 +167,7 @@ void queueloader::reload(std::vector<download>& downloads, bool remove_unplayed)
 
 	f.open(queuefile.c_str(), std::fstream::out);
 	if (f.is_open()) {
-		for (auto& dl : dltemp) {
+		for (const auto& dl : dltemp) {
 			f << dl.url() << " " << stfl::quote(dl.filename());
 			if (dl.status() == dlstatus::READY)
 				f << " downloaded";

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -21,9 +21,9 @@ regexmanager::regexmanager()
 
 regexmanager::~regexmanager()
 {
-	for (auto location : locations) {
+	for (const auto& location : locations) {
 		if (location.second.first.size() > 0) {
-			for (auto regex : location.second.first) {
+			for (const auto& regex : location.second.first) {
 				delete regex;
 			}
 		}
@@ -32,7 +32,7 @@ regexmanager::~regexmanager()
 
 void regexmanager::dump_config(std::vector<std::string>& config_output)
 {
-	for (auto foo : cheat_store_for_dump_config) {
+	for (const auto& foo : cheat_store_for_dump_config) {
 		config_output.push_back(foo);
 	}
 }
@@ -205,7 +205,7 @@ void regexmanager::handle_action(const std::string& action,
 
 int regexmanager::article_matches(matchable* item)
 {
-	for (auto matcher : matchers) {
+	for (const auto& matcher : matchers) {
 		if (matcher.first->matches(item)) {
 			return matcher.second;
 		}
@@ -242,7 +242,7 @@ void regexmanager::quote_and_highlight(std::string& str,
 	std::vector<regex_t*>& regexes = locations[location].first;
 
 	unsigned int i = 0;
-	for (auto regex : regexes) {
+	for (const auto& regex : regexes) {
 		if (!regex)
 			continue;
 		std::string initial_marker = extract_initial_marker(str);

--- a/src/rss.cpp
+++ b/src/rss.cpp
@@ -157,7 +157,7 @@ unsigned int rss_feed::unread_item_count()
 {
 	std::lock_guard<std::mutex> lock(item_mutex);
 	unsigned int count = 0;
-	for (auto item : items_) {
+	for (const auto& item : items_) {
 		if (item->unread())
 			++count;
 	}
@@ -166,7 +166,7 @@ unsigned int rss_feed::unread_item_count()
 
 bool rss_feed::matches_tag(const std::string& tag)
 {
-	for (auto t : tags_) {
+	for (const auto& t : tags_) {
 		if (tag == t)
 			return true;
 	}
@@ -183,7 +183,7 @@ std::string rss_feed::get_firsttag()
 std::string rss_feed::get_tags()
 {
 	std::string tags;
-	for (auto t : tags_) {
+	for (const auto& t : tags_) {
 		if (t.substr(0, 1) != "~" && t.substr(0, 1) != "!") {
 			tags.append(t);
 			tags.append(" ");
@@ -195,7 +195,7 @@ std::string rss_feed::get_tags()
 void rss_feed::set_tags(const std::vector<std::string>& tags)
 {
 	tags_.clear();
-	for (auto tag : tags) {
+	for (const auto& tag : tags) {
 		tags_.push_back(tag);
 	}
 }
@@ -233,7 +233,7 @@ std::string rss_feed::title() const
 {
 	bool found_title = false;
 	std::string alt_title;
-	for (auto tag : tags_) {
+	for (const auto& tag : tags_) {
 		if (tag.substr(0, 1) == "~" || tag.substr(0, 1) == "!") {
 			found_title = true;
 			alt_title = tag.substr(1, tag.length() - 1);
@@ -252,7 +252,7 @@ std::string rss_feed::description() const
 
 bool rss_feed::hidden() const
 {
-	for (auto tag : tags_) {
+	for (const auto& tag : tags_) {
 		if (tag.substr(0, 1) == "!") {
 			return true;
 		}
@@ -427,11 +427,11 @@ void rss_ignores::handle_action(const std::string& action,
 		ignores.push_back(feedurl_expr_pair(
 			ignore_rssurl, new matcher(ignore_expr)));
 	} else if (action == "always-download") {
-		for (auto param : params) {
+		for (const auto& param : params) {
 			ignores_lastmodified.push_back(param);
 		}
 	} else if (action == "reset-unread-on-update") {
-		for (auto param : params) {
+		for (const auto& param : params) {
 			resetflag.push_back(param);
 		}
 	} else
@@ -441,7 +441,7 @@ void rss_ignores::handle_action(const std::string& action,
 
 void rss_ignores::dump_config(std::vector<std::string>& config_output)
 {
-	for (auto ign : ignores) {
+	for (const auto& ign : ignores) {
 		std::string configline = "ignore-article ";
 		if (ign.first == "*")
 			configline.append("*");
@@ -451,11 +451,11 @@ void rss_ignores::dump_config(std::vector<std::string>& config_output)
 		configline.append(utils::quote(ign.second->get_expression()));
 		config_output.push_back(configline);
 	}
-	for (auto ign_lm : ignores_lastmodified) {
+	for (const auto& ign_lm : ignores_lastmodified) {
 		config_output.push_back(strprintf::fmt(
 			"always-download %s", utils::quote(ign_lm)));
 	}
-	for (auto rf : resetflag) {
+	for (const auto& rf : resetflag) {
 		config_output.push_back(strprintf::fmt(
 			"reset-unread-on-update %s", utils::quote(rf)));
 	}
@@ -463,14 +463,14 @@ void rss_ignores::dump_config(std::vector<std::string>& config_output)
 
 rss_ignores::~rss_ignores()
 {
-	for (auto ign : ignores) {
+	for (const auto& ign : ignores) {
 		delete ign.second;
 	}
 }
 
 bool rss_ignores::matches(rss_item* item)
 {
-	for (auto ign : ignores) {
+	for (const auto& ign : ignores) {
 		LOG(level::DEBUG,
 			"rss_ignores::matches: ign.first = `%s' item->feedurl "
 			"= "
@@ -490,7 +490,7 @@ bool rss_ignores::matches(rss_item* item)
 
 bool rss_ignores::matches_lastmodified(const std::string& url)
 {
-	for (auto ignore_url : ignores_lastmodified) {
+	for (const auto& ignore_url : ignores_lastmodified) {
 		if (url == ignore_url)
 			return true;
 	}
@@ -499,7 +499,7 @@ bool rss_ignores::matches_lastmodified(const std::string& url)
 
 bool rss_ignores::matches_resetunread(const std::string& url)
 {
-	for (auto rf : resetflag) {
+	for (const auto& rf : resetflag) {
 		if (url == rf)
 			return true;
 	}
@@ -522,10 +522,10 @@ void rss_feed::update_items(std::vector<std::shared_ptr<rss_feed>> feeds)
 	items_.clear();
 	items_guid_map.clear();
 
-	for (auto feed : feeds) {
+	for (const auto& feed : feeds) {
 		if (feed->rssurl().substr(0, 6) !=
 			"query:") { // don't fetch items from other query feeds!
-			for (auto item : feed->items()) {
+			for (const auto& item : feed->items()) {
 				if (m.matches(item.get())) {
 					LOG(level::DEBUG,
 						"rss_feed::update_items: "
@@ -713,7 +713,7 @@ void rss_feed::remove_old_deleted_items()
 {
 	std::lock_guard<std::mutex> lock(item_mutex);
 	std::vector<std::string> guids;
-	for (auto item : items_) {
+	for (const auto& item : items_) {
 		guids.push_back(item->guid());
 	}
 	ch->remove_old_deleted_items(rssurl_, guids);
@@ -743,7 +743,7 @@ void rss_feed::purge_deleted_items()
 void rss_feed::set_feedptrs(std::shared_ptr<rss_feed> self)
 {
 	std::lock_guard<std::mutex> lock(item_mutex);
-	for (auto item : items_) {
+	for (const auto& item : items_) {
 		item->set_feedptr(self);
 	}
 }
@@ -771,7 +771,7 @@ std::string rss_feed::get_status()
 void rss_feed::unload()
 {
 	std::lock_guard<std::mutex> lock(item_mutex);
-	for (auto item : items_) {
+	for (const auto& item : items_) {
 		item->unload();
 	}
 }

--- a/src/rss_parser.cpp
+++ b/src/rss_parser.cpp
@@ -352,7 +352,7 @@ void rss_parser::fill_feed_items(std::shared_ptr<rss_feed> feed)
 	 * each item, and fill it with the appropriate values from the data
 	 * structure.
 	 */
-	for (auto item : f.items) {
+	for (auto& item : f.items) {
 		std::shared_ptr<rss_item> x(new rss_item(ch));
 
 		set_item_title(feed, x, item);

--- a/src/rss_parser.cpp
+++ b/src/rss_parser.cpp
@@ -352,7 +352,7 @@ void rss_parser::fill_feed_items(std::shared_ptr<rss_feed> feed)
 	 * each item, and fill it with the appropriate values from the data
 	 * structure.
 	 */
-	for (auto& item : f.items) {
+	for (const auto& item : f.items) {
 		std::shared_ptr<rss_item> x(new rss_item(ch));
 
 		set_item_title(feed, x, item);

--- a/src/rss_parser.cpp
+++ b/src/rss_parser.cpp
@@ -450,7 +450,7 @@ void rss_parser::fill_feed_items(std::shared_ptr<rss_feed> feed)
 
 void rss_parser::set_item_title(std::shared_ptr<rss_feed> feed,
 	std::shared_ptr<rss_item> x,
-	rsspp::item& item)
+	const rsspp::item& item)
 {
 	std::string title = item.title;
 
@@ -466,7 +466,8 @@ void rss_parser::set_item_title(std::shared_ptr<rss_feed> feed,
 	}
 }
 
-void rss_parser::set_item_author(std::shared_ptr<rss_item> x, rsspp::item& item)
+void rss_parser::set_item_author(std::shared_ptr<rss_item> x,
+	const rsspp::item& item)
 {
 	/*
 	 * some feeds only have a feed-wide managingEditor, which we use as an
@@ -484,7 +485,7 @@ void rss_parser::set_item_author(std::shared_ptr<rss_item> x, rsspp::item& item)
 }
 
 void rss_parser::set_item_content(std::shared_ptr<rss_item> x,
-	rsspp::item& item)
+	const rsspp::item& item)
 {
 	handle_content_encoded(x, item);
 
@@ -513,7 +514,7 @@ void rss_parser::set_item_content(std::shared_ptr<rss_item> x,
 		x->description());
 }
 
-std::string rss_parser::get_guid(rsspp::item& item)
+std::string rss_parser::get_guid(const rsspp::item& item) const
 {
 	/*
 	 * We try to find a GUID (some unique identifier) for an item. If the
@@ -535,7 +536,7 @@ std::string rss_parser::get_guid(rsspp::item& item)
 }
 
 void rss_parser::set_item_enclosure(std::shared_ptr<rss_item> x,
-	rsspp::item& item)
+	const rsspp::item& item)
 {
 	x->set_enclosure_url(item.enclosure_url);
 	x->set_enclosure_type(item.enclosure_type);
@@ -572,7 +573,7 @@ void rss_parser::add_item_to_feed(std::shared_ptr<rss_feed> feed,
 }
 
 void rss_parser::handle_content_encoded(std::shared_ptr<rss_item> x,
-	rsspp::item& item)
+	const rsspp::item& item) const
 {
 	if (x->description() != "")
 		return;
@@ -588,7 +589,7 @@ void rss_parser::handle_content_encoded(std::shared_ptr<rss_item> x,
 }
 
 void rss_parser::handle_itunes_summary(std::shared_ptr<rss_item> x,
-	rsspp::item& item)
+	const rsspp::item& item)
 {
 	if (x->description() != "")
 		return;

--- a/src/select_formaction.cpp
+++ b/src/select_formaction.cpp
@@ -99,7 +99,7 @@ void select_formaction::prepare()
 		unsigned int i = 0;
 		switch (type) {
 		case selection_type::TAG:
-			for (auto tag : tags) {
+			for (const auto& tag : tags) {
 				std::string tagstr = strprintf::fmt(
 					"%4u  %s (%u)",
 					i + 1,
@@ -111,7 +111,7 @@ void select_formaction::prepare()
 			}
 			break;
 		case selection_type::FILTER:
-			for (auto filter : filters) {
+			for (const auto& filter : filters) {
 				std::string tagstr = strprintf::fmt(
 					"%4u  %s", i + 1, filter.first);
 				listfmt.add_line(tagstr, i);

--- a/src/tagsouppullparser.cpp
+++ b/src/tagsouppullparser.cpp
@@ -38,7 +38,7 @@ void tagsouppullparser::set_input(std::istream& is)
 std::string tagsouppullparser::get_attribute_value(
 	const std::string& name) const
 {
-	for (auto attr : attributes) {
+	for (const auto& attr : attributes) {
 		if (attr.first == name) {
 			return attr.second;
 		}

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -30,7 +30,7 @@ void textformatter::add_line(LineType type, std::string line)
 void textformatter::add_lines(
 	const std::vector<std::pair<LineType, std::string>>& lines)
 {
-	for (auto line : lines) {
+	for (const auto& line : lines) {
 		add_line(line.first,
 			utils::replace_all(line.second, "\t", "        "));
 	}
@@ -62,7 +62,7 @@ std::vector<std::string> wrap_line(const std::string& line, const size_t width)
 
 	std::string curline = prefix;
 
-	for (auto word : words) {
+	for (auto& word : words) {
 		size_t word_width = utils::strwidth_stfl(word);
 		size_t curline_width = utils::strwidth_stfl(curline);
 
@@ -133,7 +133,7 @@ std::vector<std::string> format_text_plain_helper(
 			line);
 	};
 
-	for (auto line : lines) {
+	for (const auto& line : lines) {
 		auto type = line.first;
 		auto text = line.second;
 
@@ -154,7 +154,7 @@ std::vector<std::string> format_text_plain_helper(
 				continue;
 			}
 			text = utils::consolidate_whitespace(text);
-			for (auto line : wrap_line(text, wrap_width)) {
+			for (const auto& line : wrap_line(text, wrap_width)) {
 				store_line(line);
 			}
 			break;
@@ -167,7 +167,7 @@ std::vector<std::string> format_text_plain_helper(
 			if (total_width == 0) {
 				store_line(text);
 			} else {
-				for (auto line : wrap_line(text, total_width)) {
+				for (const auto& line : wrap_line(text, total_width)) {
 					store_line(line);
 				}
 			}
@@ -196,7 +196,7 @@ std::pair<std::string, std::size_t> textformatter::format_text_to_list(
 		lines, rxman, location, wrap_width, total_width);
 
 	auto format_cache = std::string("{list");
-	for (auto line : formatted) {
+	for (auto& line : formatted) {
 		if (line != "") {
 			utils::trim_end(line);
 			format_cache.append(strprintf::fmt(

--- a/src/ttrss_api.cpp
+++ b/src/ttrss_api.cpp
@@ -139,7 +139,7 @@ json ttrss_api::run_op(const std::string& op,
 		// packing all information
 		//       into strings. If things start to break, this would be a
 		//       good place to start.
-		for (auto arg : args) {
+		for (const auto& arg : args) {
 			requestparam[arg.first] = arg.second;
 		}
 
@@ -247,7 +247,7 @@ std::vector<tagged_feedurl> ttrss_api::get_subscribed_urls()
 		// getFeeds with cat_id -3 since 1.5.0, so at least since
 		// api-level 2
 		std::map<int, std::string> category_names;
-		for (auto& cat : categories) {
+		for (const auto& cat : categories) {
 			std::string cat_name = cat["title"];
 			int cat_id = parse_category_id(cat["id"]);
 			category_names[cat_id] = cat_name;
@@ -280,7 +280,7 @@ std::vector<tagged_feedurl> ttrss_api::get_subscribed_urls()
 			fetch_feeds_per_category(json(nullptr), feeds);
 
 			// then fetch the feeds of all categories
-			for (auto& i : categories) {
+			for (const auto& i : categories) {
 				fetch_feeds_per_category(i, feeds);
 			}
 		} catch (json::exception& e) {
@@ -384,7 +384,7 @@ rsspp::feed ttrss_api::fetch_feed(const std::string& id, CURL* cached_handle)
 	LOG(level::DEBUG, "ttrss_api::fetch_feed: %d items", content.size());
 
 	try {
-		for (auto& item_obj : content) {
+		for (const auto& item_obj : content) {
 			rsspp::item item;
 
 			if (!item_obj["title"].is_null()) {

--- a/src/ttrss_urlreader.cpp
+++ b/src/ttrss_urlreader.cpp
@@ -28,12 +28,12 @@ void ttrss_urlreader::reload()
 
 	// std::vector<std::string>& file_urls(ur.get_urls());
 	auto& file_urls(ur.get_urls());
-	for (auto url : file_urls) {
+	for (const auto& url : file_urls) {
 		if (url.substr(0, 6) == "query:") {
 			urls.push_back(url);
 			std::vector<std::string>& file_tags(ur.get_tags(url));
 			tags[url] = ur.get_tags(url);
-			for (auto tag : file_tags) {
+			for (const auto& tag : file_tags) {
 				alltags.insert(tag);
 			}
 		}
@@ -41,11 +41,11 @@ void ttrss_urlreader::reload()
 
 	auto feedurls = api->get_subscribed_urls();
 
-	for (auto url : feedurls) {
+	for (const auto& url : feedurls) {
 		LOG(level::DEBUG, "added %s to URL list", url.first);
 		urls.push_back(url.first);
 		tags[url.first] = url.second;
-		for (auto tag : url.second) {
+		for (const auto& tag : url.second) {
 			LOG(level::DEBUG, "%s: added tag %s", url.first, tag);
 			alltags.insert(tag);
 		}

--- a/src/urlreader.cpp
+++ b/src/urlreader.cpp
@@ -26,7 +26,7 @@ std::vector<std::string>& urlreader::get_tags(const std::string& url)
 std::vector<std::string> urlreader::get_alltags()
 {
 	std::vector<std::string> tmptags;
-	for (auto t : alltags) {
+	for (const auto& t : alltags) {
 		if (t.substr(0, 1) != "~")
 			tmptags.push_back(t);
 	}
@@ -65,7 +65,7 @@ void file_urlreader::reload()
 					tokens.erase(tokens.begin());
 					if (!tokens.empty()) {
 						tags[url] = tokens;
-						for (auto token : tokens) {
+						for (const auto& token : tokens) {
 							alltags.insert(token);
 						}
 					}
@@ -86,10 +86,10 @@ void file_urlreader::write_config()
 	std::fstream f;
 	f.open(filename.c_str(), std::fstream::out);
 	if (f.is_open()) {
-		for (auto url : urls) {
+		for (const auto& url : urls) {
 			f << url;
 			if (tags[url].size() > 0) {
-				for (auto tag : tags[url]) {
+				for (const auto& tag : tags[url]) {
 					f << " \"" << tag << "\"";
 				}
 			}
@@ -118,7 +118,7 @@ void opml_urlreader::reload()
 	std::vector<std::string> urls =
 		utils::tokenize_quoted(this->get_source(), " ");
 
-	for (auto url : urls) {
+	for (const auto& url : urls) {
 		LOG(level::DEBUG,
 			"opml_urlreader::reload: downloading `%s'",
 			url);

--- a/src/urlview_formaction.cpp
+++ b/src/urlview_formaction.cpp
@@ -99,7 +99,7 @@ void urlview_formaction::prepare()
 	if (do_redraw) {
 		listformatter listfmt;
 		unsigned int i = 0;
-		for (auto link : links) {
+		for (const auto& link : links) {
 			listfmt.add_line(
 				strprintf::fmt("%2u  %s", i + 1, link.first),
 				i);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -915,7 +915,7 @@ std::string utils::substr_with_width(const std::string& str,
 	std::wstring result;
 	std::wstring tagbuf;
 
-	for (auto wc : wstr) {
+	for (const auto& wc : wstr) {
 		if (in_bracket) {
 			tagbuf += wc;
 			if (wc == L'>') { // tagbuf is escaped less-than or tag
@@ -957,7 +957,7 @@ std::string utils::join(const std::vector<std::string>& strings,
 {
 	std::string result;
 
-	for (auto str : strings) {
+	for (const auto& str : strings) {
 		result.append(str);
 		result.append(separator);
 	}

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -86,7 +86,7 @@ void view::set_keymap(keymap* k)
 
 void view::update_bindings()
 {
-	for (auto& form : formaction_stack) {
+	for (const auto& form : formaction_stack) {
 		if (form) {
 			set_bindings(form);
 		}
@@ -436,7 +436,7 @@ void view::set_feedlist(std::vector<std::shared_ptr<rss_feed>> feeds)
 	try {
 		std::lock_guard<std::mutex> lock(mtx);
 
-		for (auto feed : feeds) {
+		for (const auto& feed : feeds) {
 			if (feed->rssurl().substr(0, 6) != "query:") {
 				feed->set_feedptrs(feed);
 			}
@@ -694,7 +694,7 @@ char view::confirm(const std::string& prompt, const std::string& charset)
 
 void view::notify_itemlist_change(std::shared_ptr<rss_feed> feed)
 {
-	for (auto& form : formaction_stack) {
+	for (const auto& form : formaction_stack) {
 		if (form != nullptr && form->id() == "articlelist") {
 			std::shared_ptr<itemlist_formaction> itemlist =
 				std::dynamic_pointer_cast<itemlist_formaction,
@@ -1009,7 +1009,7 @@ void view::pop_current_formaction()
 	} else if (formaction_stack.size() > 0) {
 		// first, we set back the parent formactions of those who
 		// reference the formaction we just removed
-		for (auto& form : formaction_stack) {
+		for (const auto& form : formaction_stack) {
 			if (form->get_parent_formaction() == f) {
 				form->set_parent_formaction(
 					formaction_stack[0]);
@@ -1018,7 +1018,7 @@ void view::pop_current_formaction()
 		// we set the new formaction based on the removed formaction's
 		// parent.
 		unsigned int i = 0;
-		for (auto& form : formaction_stack) {
+		for (const auto& form : formaction_stack) {
 			if (form == f->get_parent_formaction()) {
 				current_formaction = i;
 				break;
@@ -1051,7 +1051,7 @@ void view::remove_formaction(unsigned int pos)
 	if (f != nullptr && formaction_stack.size() > 0) {
 		// we set back the parent formactions of those who reference the
 		// formaction we just removed
-		for (auto& form : formaction_stack) {
+		for (const auto& form : formaction_stack) {
 			if (form->get_parent_formaction() == f) {
 				form->set_parent_formaction(
 					formaction_stack[0]);
@@ -1071,7 +1071,7 @@ void view::set_colors(std::map<std::string, std::string>& fgc,
 
 void view::apply_colors_to_all_formactions()
 {
-	for (auto& form : formaction_stack) {
+	for (const auto& form : formaction_stack) {
 		apply_colors(form);
 	}
 	if (formaction_stack.size() > 0 &&
@@ -1102,7 +1102,7 @@ void view::apply_colors(std::shared_ptr<formaction> fa)
 			colorattr.append("bg=");
 			colorattr.append(bgcit->second);
 		}
-		for (auto attr : attit->second) {
+		for (const auto& attr : attit->second) {
 			if (colorattr.length() > 0)
 				colorattr.append(",");
 			colorattr.append("attr=");
@@ -1170,7 +1170,7 @@ std::vector<std::pair<unsigned int, std::string>> view::get_formaction_names()
 {
 	std::vector<std::pair<unsigned int, std::string>> formaction_names;
 	unsigned int i = 0;
-	for (auto& form : formaction_stack) {
+	for (const auto& form : formaction_stack) {
 		if (form && form->id() != "dialogs") {
 			formaction_names.push_back(
 				std::pair<unsigned int, std::string>(


### PR DESCRIPTION
Hi,

Most of the C++11 for-range loops seem to be doing a copy of object that is currently used. I've made it so it uses a reference and added a const where applicable.

Compiling & tests report no errors.