### PR TITLE
Use https for theoldreader.com

### DIFF
--- a/src/oldreader_api.cpp
+++ b/src/oldreader_api.cpp
@@ -10,8 +10,8 @@
 #include "utils.h"
 
 #define OLDREADER_LOGIN "https://theoldreader.com/accounts/ClientLogin"
-#define OLDREADER_API_PREFIX "http://theoldreader.com/reader/api/0/"
-#define OLDREADER_FEED_PREFIX "http://theoldreader.com/reader/atom/"
+#define OLDREADER_API_PREFIX "https://theoldreader.com/reader/api/0/"
+#define OLDREADER_FEED_PREFIX "https://theoldreader.com/reader/atom/"
 
 #define OLDREADER_OUTPUT_SUFFIX "?output=json"
 

--- a/src/oldreader_urlreader.cpp
+++ b/src/oldreader_urlreader.cpp
@@ -21,15 +21,15 @@ void oldreader_urlreader::write_config()
 }
 
 #define BROADCAST_FRIENDS_URL                                          \
-	"http://theoldreader.com/reader/atom/user/-/state/com.google/" \
+	"https://theoldreader.com/reader/atom/user/-/state/com.google/" \
 	"broadcast-friends"
 #define STARRED_ITEMS_URL \
-	"http://theoldreader.com/reader/atom/user/-/state/com.google/starred"
+	"https://theoldreader.com/reader/atom/user/-/state/com.google/starred"
 #define SHARED_ITEMS_URL                                               \
-	"http://theoldreader.com/reader/atom/user/-/state/com.google/" \
+	"https://theoldreader.com/reader/atom/user/-/state/com.google/" \
 	"broadcast"
 #define POPULAR_ITEMS_URL                             \
-	"http://theoldreader.com/reader/public/atom/" \
+	"https://theoldreader.com/reader/public/atom/" \
 	"pop%2Ftopic%2Ftop%2Flanguage%2Fen"
 
 #define ADD_URL(url, caption)                 \


### PR DESCRIPTION
The online site theoldreader.com now supports https for all users. It was an paid extra in the past. Better to not send all your information in plain text, right? This simple change seems to work correctly.