### PR TITLE
Do not create empty files if history is disabled

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -60,6 +60,9 @@ void history::load_from_file(const std::string& file)
 
 void history::save_to_file(const std::string& file, unsigned int limit)
 {
+	if (limit == 0)
+		return;
+
 	std::fstream f;
 	f.open(file.c_str(), std::fstream::out | std::fstream::trunc);
 	if (f.is_open()) {


### PR DESCRIPTION
Just a tiny nitpick that bothered me. If history is disabled there is no need to keep stub files around.