### PR TITLE
Add format strings for podboat

### DIFF
--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -989,11 +989,26 @@ Identifier:Meaning
 [[notify-format-D]]<<notify-format-D,+D+>>:Number of new unread feeds (i.e. that were added through the last reload)
 |======================================================================
 
+.Available Identifiers for podlist-format
+[frame="all", grid="all", format="dsv", options="header", cols="30,70"]
+|======================================================================
+Identifier:Meaning
+[[podlist-format-i]]<<podlist-format-i,+i+>>:Dowload index
+[[podlist-format-d]]<<podlist-format-d,+d+>>:Currently downloaded size in megabytes, displays one digit of precision
+[[podlist-format-t]]<<podlist-format-t,+t+>>:Total dowload size in megabytes, displays one digit of precision
+[[podlist-format-p]]<<podlist-format-p,+p+>>:Dowloaded precentage, displays one digit of precision
+[[podlist-format-k]]<<podlist-format-k,+k+>>:Dowload speed, displays two digit of precision
+[[podlist-format-S]]<<podlist-format-S,+S+>>:Status of download, displays one of the folowing; "queued", "downloading", "ready", "canceled", "deleted", "incomplete", "played", "finished" or "failed"
+[[podlist-format-u]]<<podlist-format-u,+u+>>:Url of the download
+[[podlist-format-F]]<<podlist-format-F,+F+>>:Filename of the download
+|======================================================================
+
 Examples:
 
 	feedlist-format     "%4i %n %11u %t"
 	articlelist-format  "%4i %f %D   %?T?|%-17T|  ?%t"
 	notify-format       "%d new articles (%n unread articles, %f unread feeds)"
+	podlist-format      "%4i [%-5p %%] %-12S %F"
 
 
 Dialog Titles

--- a/doc/podboat-cmds.dsv
+++ b/doc/podboat-cmds.dsv
@@ -1,3 +1,4 @@
 download-path||<path>||~/||Specifies the directory where podboat shall download the files to. Optionally, the placeholders "%n" (for the podcast feed's name) and "%h" (for the podcast feed's hostname) can be used to place downloads in a directory structure.||download-path "~/Downloads/%h/%n"
 max-downloads||<number>||1||Specifies the maximum number of parallel downloads when automatic download is enabled.||max-downloads 3
 player||<player command>||""||Specifies the player that shall be used for playback of downloaded files.||player "mp3blaster"
+podlist-format||<format>||"%4i [%dMB/%tMB] [%p %%] [%k kb/s] %S %u -> %F"||This variable defines the format of entries in podboat's download list. See the respective section in the documentation for more information on format strings.||podlist-format "%i %u %-20S %F"

--- a/doc/podboat-cmds.dsv
+++ b/doc/podboat-cmds.dsv
@@ -1,4 +1,4 @@
 download-path||<path>||~/||Specifies the directory where podboat shall download the files to. Optionally, the placeholders "%n" (for the podcast feed's name) and "%h" (for the podcast feed's hostname) can be used to place downloads in a directory structure.||download-path "~/Downloads/%h/%n"
 max-downloads||<number>||1||Specifies the maximum number of parallel downloads when automatic download is enabled.||max-downloads 3
 player||<player command>||""||Specifies the player that shall be used for playback of downloaded files.||player "mp3blaster"
-podlist-format||<format>||"%4i [%6.1dMB/%6.1tMB] [%5.1p %%] [%7.1k kb/s] %-20S %u -> %F"||This variable defines the format of entries in podboat's download list. See the respective section in the documentation for more information on format strings.||podlist-format "%i %u %-20S %F"
+podlist-format||<format>||"%4i [%6dMB/%6tMB] [%5p %%] [%7k kb/s] %-20S %u -> %F"||This variable defines the format of entries in podboat's download list. See the respective section in the documentation for more information on format strings.||podlist-format "%i %u %-20S %F"

--- a/doc/podboat-cmds.dsv
+++ b/doc/podboat-cmds.dsv
@@ -1,4 +1,4 @@
 download-path||<path>||~/||Specifies the directory where podboat shall download the files to. Optionally, the placeholders "%n" (for the podcast feed's name) and "%h" (for the podcast feed's hostname) can be used to place downloads in a directory structure.||download-path "~/Downloads/%h/%n"
 max-downloads||<number>||1||Specifies the maximum number of parallel downloads when automatic download is enabled.||max-downloads 3
 player||<player command>||""||Specifies the player that shall be used for playback of downloaded files.||player "mp3blaster"
-podlist-format||<format>||"%4i [%dMB/%tMB] [%p %%] [%k kb/s] %S %u -> %F"||This variable defines the format of entries in podboat's download list. See the respective section in the documentation for more information on format strings.||podlist-format "%i %u %-20S %F"
+podlist-format||<format>||"%4i [%6.1dMB/%6.1tMB] [%5.1p %%] [%7.1k kb/s] %-20S %u -> %F"||This variable defines the format of entries in podboat's download list. See the respective section in the documentation for more information on format strings.||podlist-format "%i %u %-20S %F"

--- a/include/pb_controller.h
+++ b/include/pb_controller.h
@@ -76,7 +76,6 @@ private:
 	std::string cache_file;
 	std::string searchfile;
 	std::string cmdlinefile;
-	std::string formatstr;
 
 	unsigned int max_dls;
 

--- a/include/pb_controller.h
+++ b/include/pb_controller.h
@@ -40,6 +40,7 @@ public:
 	}
 
 	std::string get_dlpath();
+	std::string get_formatstr();
 
 	unsigned int downloads_in_progress();
 	void reload_queue(bool remove_unplayed = false);
@@ -75,6 +76,7 @@ private:
 	std::string cache_file;
 	std::string searchfile;
 	std::string cmdlinefile;
+	std::string formatstr;
 
 	unsigned int max_dls;
 

--- a/include/pb_view.h
+++ b/include/pb_view.h
@@ -10,6 +10,7 @@ using namespace newsboat;
 namespace podboat {
 
 class pb_controller;
+class download;
 
 struct keymap_hint_entry;
 
@@ -38,6 +39,10 @@ private:
 	void set_bindings();
 
 	std::string prepare_keymaphint(keymap_hint_entry* hints);
+	std::string format_line(const std::string& podlist_format,
+			const download* dl,
+			unsigned int pos,
+			unsigned int width);
 	pb_controller* ctrl;
 	newsboat::stfl::form dllist_form;
 	newsboat::stfl::form help_form;

--- a/include/pb_view.h
+++ b/include/pb_view.h
@@ -40,7 +40,7 @@ private:
 
 	std::string prepare_keymaphint(keymap_hint_entry* hints);
 	std::string format_line(const std::string& podlist_format,
-			const download* dl,
+			const download& dl,
 			unsigned int pos,
 			unsigned int width);
 	pb_controller* ctrl;

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -136,7 +136,7 @@ configcontainer::configcontainer()
 		  {"podcast-auto-enqueue",
 			  configdata("no", configdata_t::BOOL)},
 		  {"podlist-format",
-			  configdata("%4i %n %11u %t", configdata_t::STR)},
+			  configdata( "%4i [%6.1dMB/%6.1tMB] [%5.1p %%] [%7.1k kb/s] %-20S %u -> %F", configdata_t::STR)},
 		  {"prepopulate-query-feeds",
 			  configdata("false", configdata_t::BOOL)},
 		  {"ssl-verifyhost", configdata("true", configdata_t::BOOL)},

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -135,6 +135,8 @@ configcontainer::configcontainer()
 		  {"player", configdata("", configdata_t::PATH)},
 		  {"podcast-auto-enqueue",
 			  configdata("no", configdata_t::BOOL)},
+		  {"podlist-format",
+			  configdata("%4i %n %11u %t", configdata_t::STR)},
 		  {"prepopulate-query-feeds",
 			  configdata("false", configdata_t::BOOL)},
 		  {"ssl-verifyhost", configdata("true", configdata_t::BOOL)},

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -136,7 +136,7 @@ configcontainer::configcontainer()
 		  {"podcast-auto-enqueue",
 			  configdata("no", configdata_t::BOOL)},
 		  {"podlist-format",
-			  configdata( "%4i [%6.1dMB/%6.1tMB] [%5.1p %%] [%7.1k kb/s] %-20S %u -> %F", configdata_t::STR)},
+			  configdata( "%4i [%6dMB/%6tMB] [%5p %%] [%7k kb/s] %-20S %u -> %F", configdata_t::STR)},
 		  {"prepopulate-query-feeds",
 			  configdata("false", configdata_t::BOOL)},
 		  {"ssl-verifyhost", configdata("true", configdata_t::BOOL)},

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -375,7 +375,7 @@ std::string pb_controller::get_dlpath()
 
 std::string pb_controller::get_formatstr()
 {
-  return cfg->get_configvalue("podlist-format");
+	return cfg->get_configvalue("podlist-format");
 }
 
 unsigned int pb_controller::downloads_in_progress()

--- a/src/pb_controller.cpp
+++ b/src/pb_controller.cpp
@@ -373,6 +373,11 @@ std::string pb_controller::get_dlpath()
 	return cfg->get_configvalue("download-path");
 }
 
+std::string pb_controller::get_formatstr()
+{
+  return cfg->get_configvalue("podlist-format");
+}
+
 unsigned int pb_controller::downloads_in_progress()
 {
 	unsigned int count = 0;

--- a/src/pb_view.cpp
+++ b/src/pb_view.cpp
@@ -83,8 +83,7 @@ void pb_view::run(bool auto_download)
 
 			unsigned int i = 0;
 			for (const auto& dl : ctrl->downloads()) {
-				auto lbuf = strprintf::fmt(
-					format_line(formatstring, &dl, i, width));
+				auto lbuf = format_line(formatstring, dl, i, width);
 				code.append(
 					strprintf::fmt("{listitem[%u] text:%s}",
 						i,
@@ -352,7 +351,7 @@ void pb_view::set_dllist_keymap_hint()
 }
 
 std::string pb_view::format_line(const std::string& podlist_format,
-	const download* dl,
+	const download& dl,
 	unsigned int pos,
 	unsigned int width)
 {
@@ -360,14 +359,14 @@ std::string pb_view::format_line(const std::string& podlist_format,
 
 	fmt.register_fmt('i', strprintf::fmt("%u", pos + 1));
 	fmt.register_fmt('d',
-		strprintf::fmt("%.1f", dl->current_size() / (1024 * 1024)));
+		strprintf::fmt("%.1f", dl.current_size() / (1024 * 1024)));
 	fmt.register_fmt(
-		't', strprintf::fmt("%.1f", dl->total_size() / (1024 * 1024)));
-	fmt.register_fmt('p', strprintf::fmt("%.1f", dl->percents_finished()));
-	fmt.register_fmt('k', strprintf::fmt("%.1f", dl->kbps()));
-	fmt.register_fmt('S', strprintf::fmt("%s", dl->status_text()));
-	fmt.register_fmt('u', strprintf::fmt("%s", dl->url()));
-	fmt.register_fmt('F', strprintf::fmt("%s", dl->filename()));
+		't', strprintf::fmt("%.1f", dl.total_size() / (1024 * 1024)));
+	fmt.register_fmt('p', strprintf::fmt("%.1f", dl.percents_finished()));
+	fmt.register_fmt('k', strprintf::fmt("%.2f", dl.kbps()));
+	fmt.register_fmt('S', strprintf::fmt("%s", dl.status_text()));
+	fmt.register_fmt('u', strprintf::fmt("%s", dl.url()));
+	fmt.register_fmt('F', strprintf::fmt("%s", dl.filename()));
 
 	auto formattedLine = fmt.do_format(podlist_format, width);
 	return formattedLine;

--- a/src/pb_view.cpp
+++ b/src/pb_view.cpp
@@ -7,19 +7,18 @@
 #include <sstream>
 
 #include "config.h"
+#include "configcontainer.h"
 #include "dllist.h"
 #include "download.h"
+#include "formatstring.h"
 #include "help.h"
 #include "logger.h"
-#include "configcontainer.h"
 #include "pb_controller.h"
-#include "formatstring.h"
 #include "poddlthread.h"
 #include "strprintf.h"
 #include "utils.h"
 
 using namespace newsboat;
-
 
 namespace podboat {
 
@@ -82,21 +81,8 @@ void pb_view::run(bool auto_download)
 
 			unsigned int i = 0;
 			for (const auto& dl : ctrl->downloads()) {
-					 auto lbuf = strprintf::fmt( format_line( formatstring, &dl, i, 50) );
-				/*
-					 auto lbuf = strprintf::fmt(
-					" %4u [%6.1fMB/%6.1fMB] [%5.1f %%] "
-					"[%7.2f kb/s] %-20s %s -> %s",
-					i + 1,
-					dl.current_size() / (1024 * 1024),
-					dl.total_size() / (1024 * 1024),
-					dl.percents_finished(),
-					dl.kbps(),
-					dl.status_text(),
-					dl.url(),
-					dl.filename());
-          */
-
+				auto lbuf = strprintf::fmt(
+					format_line(formatstring, &dl, i, 50));
 				code.append(
 					strprintf::fmt("{listitem[%u] text:%s}",
 						i,
@@ -364,20 +350,22 @@ void pb_view::set_dllist_keymap_hint()
 }
 
 std::string pb_view::format_line(const std::string& podlist_format,
-  const download* dl,
+	const download* dl,
 	unsigned int pos,
 	unsigned int width)
 {
 	fmtstr_formatter fmt;
 
 	fmt.register_fmt('i', strprintf::fmt("%u", pos + 1));
-	fmt.register_fmt('d', strprintf::fmt("%6.1f", dl->current_size() / (1024 * 1024)));
-	fmt.register_fmt('t', strprintf::fmt("%6.1f", dl->total_size() / (1024 * 1024)));
-	fmt.register_fmt('p', strprintf::fmt("%5.1f", dl->percents_finished()));
-	fmt.register_fmt('k', strprintf::fmt("%7.1f", dl->kbps() ));
-	fmt.register_fmt('S', strprintf::fmt("%-20s", dl->status_text() ));
-	fmt.register_fmt('u', strprintf::fmt("%s", dl->url() ));
-	fmt.register_fmt('F', strprintf::fmt("%s", dl->filename() ));
+	fmt.register_fmt('d',
+		strprintf::fmt("%f", dl->current_size() / (1024 * 1024)));
+	fmt.register_fmt(
+		't', strprintf::fmt("%f", dl->total_size() / (1024 * 1024)));
+	fmt.register_fmt('p', strprintf::fmt("%f", dl->percents_finished()));
+	fmt.register_fmt('k', strprintf::fmt("%f", dl->kbps()));
+	fmt.register_fmt('S', strprintf::fmt("%s", dl->status_text()));
+	fmt.register_fmt('u', strprintf::fmt("%s", dl->url()));
+	fmt.register_fmt('F', strprintf::fmt("%s", dl->filename()));
 
 	auto formattedLine = fmt.do_format(podlist_format, width);
 	return formattedLine;

--- a/src/pb_view.cpp
+++ b/src/pb_view.cpp
@@ -360,11 +360,11 @@ std::string pb_view::format_line(const std::string& podlist_format,
 
 	fmt.register_fmt('i', strprintf::fmt("%u", pos + 1));
 	fmt.register_fmt('d',
-		strprintf::fmt("%f", dl->current_size() / (1024 * 1024)));
+		strprintf::fmt("%.1f", dl->current_size() / (1024 * 1024)));
 	fmt.register_fmt(
-		't', strprintf::fmt("%f", dl->total_size() / (1024 * 1024)));
-	fmt.register_fmt('p', strprintf::fmt("%f", dl->percents_finished()));
-	fmt.register_fmt('k', strprintf::fmt("%f", dl->kbps()));
+		't', strprintf::fmt("%.1f", dl->total_size() / (1024 * 1024)));
+	fmt.register_fmt('p', strprintf::fmt("%.1f", dl->percents_finished()));
+	fmt.register_fmt('k', strprintf::fmt("%.1f", dl->kbps()));
 	fmt.register_fmt('S', strprintf::fmt("%s", dl->status_text()));
 	fmt.register_fmt('u', strprintf::fmt("%s", dl->url()));
 	fmt.register_fmt('F', strprintf::fmt("%s", dl->filename()));

--- a/src/pb_view.cpp
+++ b/src/pb_view.cpp
@@ -79,10 +79,12 @@ void pb_view::run(bool auto_download)
 			std::string code = "{list";
 			std::string formatstring = ctrl->get_formatstr();
 
+			unsigned int width = utils::to_u(dllist_form.get("feeds:w"));
+
 			unsigned int i = 0;
 			for (const auto& dl : ctrl->downloads()) {
 				auto lbuf = strprintf::fmt(
-					format_line(formatstring, &dl, i, 50));
+					format_line(formatstring, &dl, i, width));
 				code.append(
 					strprintf::fmt("{listitem[%u] text:%s}",
 						i,


### PR DESCRIPTION
The default format for the display of podcast feeds on podboat extends well off the screen to the where only most of the url is visible.
This branch allows users to choose the format of this display in much the same way as newsboat.

Please consider accepting my pull request.