### PR TITLE
Add EnvVar test helper

### DIFF
--- a/test/rss.cpp
+++ b/test/rss.cpp
@@ -224,29 +224,22 @@ TEST_CASE(
 	auto input = "2008-12-30T10:03:15-08:00";
 	auto expected = "Tue, 30 Dec 2008 18:03:15 +0000";
 
-	char* tz = getenv("TZ");
-	std::string tz_saved_value;
-	if (tz) {
-		// tz can be null, and buffer may be reused.  Save it if it
-		// exists.
-		tz_saved_value = tz;
-	}
+	TestHelpers::EnvVar tzEnv("TZ");
+	tzEnv.on_change([](){ ::tzset(); });
 
 	// US/Pacific and Australia/Sydney have pretty much opposite DST
 	// schedules, so for any given moment in time one of the following two
 	// sections will be observing DST while other won't
 	SECTION("Timezone Pacific")
 	{
-		setenv("TZ", "US/Pacific", 1);
-		tzset();
+		tzEnv.set("US/Pacific");
 		REQUIRE(rsspp::rss_parser::__w3cdtf_to_rfc822(input) ==
 			expected);
 	}
 
 	SECTION("Timezone Australia")
 	{
-		setenv("TZ", "Australia/Sydney", 1);
-		tzset();
+		tzEnv.set("Australia/Sydney");
 		REQUIRE(rsspp::rss_parser::__w3cdtf_to_rfc822(input) ==
 			expected);
 	}
@@ -256,27 +249,17 @@ TEST_CASE(
 	// tests will cover October
 	SECTION("Timezone Arizona")
 	{
-		setenv("TZ", "US/Arizona", 1);
-		tzset();
+		tzEnv.set("US/Arizona");
 		REQUIRE(rsspp::rss_parser::__w3cdtf_to_rfc822(input) ==
 			expected);
 	}
 
 	SECTION("Timezone UTC")
 	{
-		setenv("TZ", "UTC", 1);
-		tzset();
+		tzEnv.set("UTC");
 		REQUIRE(rsspp::rss_parser::__w3cdtf_to_rfc822(input) ==
 			expected);
 	}
-
-	// Reset back to original value
-	if (tz) {
-		setenv("TZ", tz_saved_value.c_str(), 1);
-	} else {
-		unsetenv("TZ");
-	}
-	tzset();
 }
 
 namespace newsboat {

--- a/test/test-helpers.cpp
+++ b/test/test-helpers.cpp
@@ -16,7 +16,7 @@ TEST_CASE("EnvVar object restores the environment variable to its original "
 
 	const auto overwrite = true;
 
-	::setenv(var, expected.c_str(), (int)overwrite);
+	::setenv(var, expected.c_str(), overwrite);
 	REQUIRE(expected == ::getenv(var));
 
 	{
@@ -24,7 +24,7 @@ TEST_CASE("EnvVar object restores the environment variable to its original "
 		REQUIRE(expected == ::getenv(var));
 
 		const auto newValue = std::string("totally new value");
-		::setenv(var, newValue.c_str(), (int)overwrite);
+		::setenv(var, newValue.c_str(), overwrite);
 
 		REQUIRE_FALSE(expected == ::getenv(var));
 	}
@@ -67,7 +67,7 @@ TEST_CASE("EnvVar::set() doesn't change the value to which the environment "
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), (int)overwrite);
+	::setenv(var, expected.c_str(), overwrite);
 	REQUIRE(expected == ::getenv(var));
 
 	{
@@ -93,7 +93,7 @@ TEST_CASE("EnvVar::set() runs a function (set by on_change()) after changing "
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), (int)overwrite);
+	::setenv(var, expected.c_str(), overwrite);
 
 	SECTION("The function is ran *after* the change") {
 		TestHelpers::EnvVar envVar(var);
@@ -141,7 +141,7 @@ TEST_CASE("EnvVar::unset() completely removes the variable from the environment"
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), (int)overwrite);
+	::setenv(var, expected.c_str(), overwrite);
 
 	char* value = ::getenv(var);
 	REQUIRE_FALSE(value == nullptr);
@@ -179,7 +179,7 @@ TEST_CASE("EnvVar::unset() doesn't change the value to which the environment "
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), (int)overwrite);
+	::setenv(var, expected.c_str(), overwrite);
 
 	char* value = ::getenv(var);
 	REQUIRE_FALSE(value == nullptr);
@@ -222,7 +222,7 @@ TEST_CASE("EnvVar::unset() runs a function (set by on_change()) after changing "
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), (int)overwrite);
+	::setenv(var, expected.c_str(), overwrite);
 
 	char* value = ::getenv(var);
 	REQUIRE_FALSE(value == nullptr);
@@ -266,11 +266,20 @@ TEST_CASE("EnvVar's destructor runs a function (set by on_change()) after "
 	const auto expected = std::string("let's try this out, shall we?");
 
 	SECTION("Variable wasn't even set") {
+		// Intentionally left empty.
+		//
+		// Catch framework runs each test case multiple times, each time
+		// entering some section it hasn't entered before. In our situation
+		// here, the test case will be ran twice: once with setenv() being
+		// called, and once without. As a result, EnvVar below will be created
+		// in two different situations: once when the environment variable is
+		// already present, and once when it's absent. The point of the test is
+		// that this wouldn't matter: EnvVar will behave the same regardless.
 	}
 
 	SECTION("Variable was set before EnvVar is created") {
 		const auto overwrite = true;
-		::setenv(var, expected.c_str(), (int)overwrite);
+		::setenv(var, expected.c_str(), overwrite);
 	}
 
 	auto counter = unsigned{};

--- a/test/test-helpers.cpp
+++ b/test/test-helpers.cpp
@@ -1,0 +1,289 @@
+#include "test-helpers.h"
+
+#include "3rd-party/catch.hpp"
+
+TEST_CASE("EnvVar object restores the environment variable to its original "
+		"state when the object is destroyed",
+		"[test-helpers]")
+{
+	const char var[] = "nEwSb0a7-tEsT-eNvIroNm3Nt-v4rIabLe";
+	{
+		INFO("Checking that noone else is using that environment variable");
+		REQUIRE(::getenv(var) == nullptr);
+	}
+
+	const auto expected = std::string("let's try this out, shall we?");
+
+	const auto overwrite = true;
+
+	::setenv(var, expected.c_str(), (int)overwrite);
+	REQUIRE(expected == ::getenv(var));
+
+	{
+		TestHelpers::EnvVar envVar(var);
+		REQUIRE(expected == ::getenv(var));
+
+		const auto newValue = std::string("totally new value");
+		::setenv(var, newValue.c_str(), (int)overwrite);
+
+		REQUIRE_FALSE(expected == ::getenv(var));
+	}
+
+	REQUIRE(expected == ::getenv(var));
+
+	::unsetenv(var);
+}
+
+TEST_CASE("EnvVar::set() changes the current state of the environment variable",
+		"[test-helpers]")
+{
+	const char var[] = "nEwSb0a7-tEsT-eNvIroNm3Nt-v4rIabLe";
+	{
+		INFO("Checking that noone else is using that environment variable");
+		REQUIRE(::getenv(var) == nullptr);
+	}
+
+	const auto expected = std::string("let's try this out, shall we?");
+
+	TestHelpers::EnvVar envVar(var);
+
+	envVar.set("absolutely new value");
+	REQUIRE_FALSE(expected == ::getenv(var));
+
+	envVar.set(expected);
+	REQUIRE(expected == ::getenv(var));
+}
+
+TEST_CASE("EnvVar::set() doesn't change the value to which the environment "
+		"variable is restored",
+		"[test-helpers]")
+{
+	const char var[] = "nEwSb0a7-tEsT-eNvIroNm3Nt-v4rIabLe";
+	{
+		INFO("Checking that noone else is using that environment variable");
+		REQUIRE(::getenv(var) == nullptr);
+	}
+
+	const auto expected = std::string("let's try this out, shall we?");
+
+	const auto overwrite = true;
+	::setenv(var, expected.c_str(), (int)overwrite);
+	REQUIRE(expected == ::getenv(var));
+
+	{
+		TestHelpers::EnvVar envVar(var);
+		envVar.set("some new value");
+	}
+
+	REQUIRE(expected == ::getenv(var));
+
+	::unsetenv(var);
+}
+
+TEST_CASE("EnvVar::set() runs a function (set by on_change()) after changing "
+		"the environment variable",
+		"[test-helpers]")
+{
+	const char var[] = "nEwSb0a7-tEsT-eNvIroNm3Nt-v4rIabLe";
+	{
+		INFO("Checking that noone else is using that environment variable");
+		REQUIRE(::getenv(var) == nullptr);
+	}
+
+	const auto expected = std::string("let's try this out, shall we?");
+
+	const auto overwrite = true;
+	::setenv(var, expected.c_str(), (int)overwrite);
+
+	SECTION("The function is ran *after* the change") {
+		TestHelpers::EnvVar envVar(var);
+
+		const auto newValue = std::string("totally new value here");
+		auto valueChanged = false;
+		envVar.on_change([&valueChanged, &newValue, &var](){
+			valueChanged = newValue == ::getenv(var);
+		});
+
+		envVar.set(newValue);
+
+		REQUIRE(valueChanged);
+	}
+
+	SECTION("The function is ran *once* per change") {
+		TestHelpers::EnvVar envVar(var);
+
+		auto counter = unsigned{};
+		envVar.on_change([&counter](){ counter++; });
+
+		REQUIRE(counter == 0);
+		envVar.set("new value");
+		REQUIRE(counter == 1);
+		envVar.set("some other value");
+		REQUIRE(counter == 2);
+
+		INFO("Same value as before, but function should still be called");
+		envVar.set("some other value");
+		REQUIRE(counter == 3);
+	}
+
+	::unsetenv(var);
+}
+
+TEST_CASE("EnvVar::unset() completely removes the variable from the environment",
+		"[test-helpers]")
+{
+	const char var[] = "nEwSb0a7-tEsT-eNvIroNm3Nt-v4rIabLe";
+	{
+		INFO("Checking that noone else is using that environment variable");
+		REQUIRE(::getenv(var) == nullptr);
+	}
+
+	const auto expected = std::string("let's try this out, shall we?");
+
+	const auto overwrite = true;
+	::setenv(var, expected.c_str(), (int)overwrite);
+
+	char* value = ::getenv(var);
+	REQUIRE_FALSE(value == nullptr);
+	REQUIRE(expected == value);
+	value = nullptr;
+
+	{
+		TestHelpers::EnvVar envVar(var);
+
+		value = ::getenv(var);
+		REQUIRE_FALSE(value == nullptr);
+		REQUIRE(expected == value);
+		value = nullptr;
+
+		envVar.unset();
+
+		value = ::getenv(var);
+		REQUIRE(value == nullptr);
+		value = nullptr;
+	}
+
+	::unsetenv(var);
+}
+
+TEST_CASE("EnvVar::unset() doesn't change the value to which the environment "
+		"variable is restored",
+		"[test-helpers]")
+{
+	const char var[] = "nEwSb0a7-tEsT-eNvIroNm3Nt-v4rIabLe";
+	{
+		INFO("Checking that noone else is using that environment variable");
+		REQUIRE(::getenv(var) == nullptr);
+	}
+
+	const auto expected = std::string("let's try this out, shall we?");
+
+	const auto overwrite = true;
+	::setenv(var, expected.c_str(), (int)overwrite);
+
+	char* value = ::getenv(var);
+	REQUIRE_FALSE(value == nullptr);
+	REQUIRE(expected == value);
+	value = nullptr;
+
+	{
+		TestHelpers::EnvVar envVar(var);
+
+		value = ::getenv(var);
+		REQUIRE_FALSE(value == nullptr);
+		REQUIRE(expected == value);
+		value = nullptr;
+
+		envVar.unset();
+
+		value = ::getenv(var);
+		REQUIRE(value == nullptr);
+		value = nullptr;
+	}
+
+	value = ::getenv(var);
+	REQUIRE_FALSE(value == nullptr);
+	REQUIRE(expected == value);
+	value = nullptr;
+
+	::unsetenv(var);
+}
+
+TEST_CASE("EnvVar::unset() runs a function (set by on_change()) after changing "
+		"the environment variable",
+		"[test-helpers]")
+{
+	const char var[] = "nEwSb0a7-tEsT-eNvIroNm3Nt-v4rIabLe";
+	{
+		INFO("Checking that noone else is using that environment variable");
+		REQUIRE(::getenv(var) == nullptr);
+	}
+
+	const auto expected = std::string("let's try this out, shall we?");
+
+	const auto overwrite = true;
+	::setenv(var, expected.c_str(), (int)overwrite);
+
+	char* value = ::getenv(var);
+	REQUIRE_FALSE(value == nullptr);
+	REQUIRE(expected == value);
+	value = nullptr;
+
+	{
+		TestHelpers::EnvVar envVar(var);
+
+		auto counter = unsigned{};
+		auto as_expected = false;
+		envVar.on_change([&counter, &as_expected, var]() {
+			as_expected = nullptr == ::getenv(var);
+			counter++;
+		});
+
+		value = ::getenv(var);
+		REQUIRE_FALSE(value == nullptr);
+		REQUIRE(expected == value);
+		value = nullptr;
+
+		envVar.unset();
+
+		REQUIRE(as_expected);
+		REQUIRE(counter == 1);
+	}
+
+	::unsetenv(var);
+}
+
+TEST_CASE("EnvVar's destructor runs a function (set by on_change()) after "
+		"restoring the varibale to its original state",
+		"[test-helpers]")
+{
+	const char var[] = "nEwSb0a7-tEsT-eNvIroNm3Nt-v4rIabLe";
+	{
+		INFO("Checking that noone else is using that environment variable");
+		REQUIRE(::getenv(var) == nullptr);
+	}
+
+	const auto expected = std::string("let's try this out, shall we?");
+
+	SECTION("Variable wasn't even set") {
+	}
+
+	SECTION("Variable was set before EnvVar is created") {
+		const auto overwrite = true;
+		::setenv(var, expected.c_str(), (int)overwrite);
+	}
+
+	auto counter = unsigned{};
+
+	{
+		TestHelpers::EnvVar envVar(var);
+		envVar.on_change([&counter](){ counter++; });
+	}
+
+	REQUIRE(counter == 1);
+
+	// It's a no-op if the variable is absent from the environment, so we don't
+	// need to put this inside a conditional to match SECTIONs above.
+	::unsetenv(var);
+}
+

--- a/test/test-helpers.h
+++ b/test/test-helpers.h
@@ -266,7 +266,7 @@ public:
 	void set(std::string new_value) const
 	{
 		const auto overwrite = true;
-		::setenv(name.c_str(), new_value.c_str(), (int)overwrite);
+		::setenv(name.c_str(), new_value.c_str(), overwrite);
 		if (on_change_fn) {
 			on_change_fn();
 		}

--- a/test/test-helpers.h
+++ b/test/test-helpers.h
@@ -207,6 +207,95 @@ public:
 	}
 };
 
+/* \brief Automatically restores environment variable to its original state
+ * when the test finishes running.
+ *
+ * When an EnvVar object is created, it remembers the state of the given
+ * environment variable. After that, the test can safely change the variable
+ * directly through setenv(3) and unsetenv(3), or via convenience methods set()
+ * and unset(). When the test finishes (with whatever result), the EnvVar
+ * restores the variable to its original state.
+ *
+ * If you need to run some code after the variable is changed (e.g. tzset(3)
+ * after a change to TZ), use `on_change()` method to specify a function that
+ * should be ran. Note that it will be executed only if the variable is changed
+ * through set() and unset() methods; EnvVar won't notice a change made using
+ * setenv(3), unsetenv(3), or a change made by someone else (e.g. different
+ * thread).
+ */
+class EnvVar {
+	std::function<void(void)> on_change_fn;
+	std::string name;
+	std::string value;
+	bool was_set = false;
+
+public:
+	/// \brief Safekeeps the value of environment variable \a name.
+	///
+	/// \note Accepts a string by value since you'll probably pass it
+	/// a temporary or a string literal anyway. Just do it, and use set() and
+	/// unset() methods, instead of keeping a local variable with a name in it
+	/// and calling setenv(3) and unsetenv(3).
+	EnvVar(std::string name_)
+		: name(std::move(name_))
+	{
+		const char* original = ::getenv(name.c_str());
+		was_set = original != nullptr;
+		if (was_set) {
+			value = std::string(original);
+		}
+	}
+
+	~EnvVar()
+	{
+		if (was_set) {
+			set(value);
+		} else {
+			unset();
+		}
+	}
+
+	/// \brief Changes the value of the environment variable.
+	///
+	/// \note This is equivalent to you calling setenv(3) yourself.
+	///
+	/// \note This does \emph{not} change the value to which EnvVar will
+	/// restore the variable when the test finished running. The variable is
+	/// always restored to the state it was in when EnvVar object was
+	/// constructed.
+	void set(std::string new_value) const
+	{
+		const auto overwrite = true;
+		::setenv(name.c_str(), new_value.c_str(), (int)overwrite);
+		if (on_change_fn) {
+			on_change_fn();
+		}
+	}
+
+	/// \brief Unsets the environment variable.
+	///
+	/// \note This does \emph{not} change the value to which EnvVar will
+	/// restore the variable when the test finished running. The variable is
+	/// always restored to the state it was in when EnvVar object was
+	void unset() const
+	{
+		::unsetenv(name.c_str());
+		if (on_change_fn) {
+			on_change_fn();
+		}
+	}
+
+	/// \brief Specifies a function that should be ran after each call to set()
+	/// or unset() methods, and also during object destruction.
+	///
+	/// In other words, the function will be ran after each change done via or
+	/// by this class.
+	void on_change(std::function<void(void)> fn)
+	{
+		on_change_fn = std::move(fn);
+	}
+};
+
 } // namespace TestHelpers
 
 #endif /* NEWSBOAT_TEST_HELPERS_H_ */

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -3,6 +3,7 @@
 #include <unistd.h> // chdir()
 
 #include "3rd-party/catch.hpp"
+#include "test-helpers.h"
 
 using namespace newsboat;
 
@@ -768,25 +769,17 @@ TEST_CASE(
 	"\"lynx\" if the variable is not set",
 	"[utils]")
 {
-	// Remember current BROWSER env variable
-	const char* original = getenv("BROWSER");
+	TestHelpers::EnvVar browserEnv("BROWSER");
 
 	// If BROWSER is not set, default browser is lynx(1)
-	unsetenv("BROWSER");
+	browserEnv.unset();
 	REQUIRE(utils::get_default_browser() == "lynx");
 
-	setenv("BROWSER", "firefox", 1);
+	browserEnv.set("firefox");
 	REQUIRE(utils::get_default_browser() == "firefox");
 
-	setenv("BROWSER", "opera", 1);
+	browserEnv.set("opera");
 	REQUIRE(utils::get_default_browser() == "opera");
-
-	// Restore BROWSER env variable
-	if (original) {
-		setenv("BROWSER", original, 1);
-	} else {
-		unsetenv("BROWSER");
-	}
 }
 
 TEST_CASE(


### PR DESCRIPTION
It provides a RAII-style way to ensure that the environment variables of the whole tests suite aren't affected by a single test failing.

Tried ["auto to stick" style](https://www.fluentcpp.com/2018/09/28/auto-stick-changing-style/), too. It's interesting, but I haven't found a way declare an `unsigned int` that way. I ended up writing `unsigned{}`, but what if I want an `unsigned long` or `unsigned short`?

Requesting a review from anyone who's interested :)