### PR TITLE
Re-use ItemRenderer in ItemViewFormAction

### DIFF
--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -34,6 +34,21 @@ namespace item_renderer {
 		std::shared_ptr<RssItem> item,
 		std::vector<std::pair<LineType, std::string>>& lines,
 		std::vector<LinkPair>& /*links*/);
+
+	std::pair<std::string, size_t> to_stfl_list(
+			ConfigContainer& cfg,
+			std::shared_ptr<RssItem> item,
+			unsigned int text_width,
+			unsigned int window_width,
+			RegexManager* rxman,
+			const std::string& location);
+
+	std::pair<std::string, size_t> source_to_stfl_list(
+			std::shared_ptr<RssItem> item,
+			unsigned int text_width,
+			unsigned int window_width,
+			RegexManager* rxman,
+			const std::string& location);
 };
 
 } // namespace newsboat

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -29,6 +29,11 @@ namespace item_renderer {
 		std::vector<LinkPair>& thelinks,
 		const std::string& url,
 		bool raw);
+
+	void prepare_header(
+		std::shared_ptr<RssItem> item,
+		std::vector<std::pair<LineType, std::string>>& lines,
+		std::vector<LinkPair>& /*links*/);
 };
 
 } // namespace newsboat

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -3,6 +3,10 @@
 
 #include <memory>
 #include <string>
+#include <vector>
+
+#include "textformatter.h"
+#include "htmlrenderer.h"
 
 namespace newsboat {
 
@@ -17,6 +21,14 @@ namespace item_renderer {
 			std::shared_ptr<RssItem> item);
 
 	std::string get_item_base_link(const std::shared_ptr<RssItem>& item);
+
+	void render_html(
+		ConfigContainer& cfg,
+		const std::string& source,
+		std::vector<std::pair<LineType, std::string>>& lines,
+		std::vector<LinkPair>& thelinks,
+		const std::string& url,
+		bool raw);
 };
 
 } // namespace newsboat

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -20,21 +20,6 @@ namespace item_renderer {
 			ConfigContainer& cfg,
 			std::shared_ptr<RssItem> item);
 
-	std::string get_item_base_link(const std::shared_ptr<RssItem>& item);
-
-	void render_html(
-		ConfigContainer& cfg,
-		const std::string& source,
-		std::vector<std::pair<LineType, std::string>>& lines,
-		std::vector<LinkPair>& thelinks,
-		const std::string& url,
-		bool raw);
-
-	void prepare_header(
-		std::shared_ptr<RssItem> item,
-		std::vector<std::pair<LineType, std::string>>& lines,
-		std::vector<LinkPair>& /*links*/);
-
 	std::pair<std::string, size_t> to_stfl_list(
 			ConfigContainer& cfg,
 			std::shared_ptr<RssItem> item,

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -5,8 +5,8 @@
 #include <string>
 #include <vector>
 
-#include "textformatter.h"
 #include "htmlrenderer.h"
+#include "textformatter.h"
 
 namespace newsboat {
 
@@ -29,7 +29,7 @@ namespace item_renderer {
 
 	/// \brief Returns RssItem as STFL list.
 	///
-	/// `html-renderer` settings controlls what tool is used to render HTML. \a
+	/// `html-renderer` settings controls what tool is used to render HTML. \a
 	/// text_width dictates where text is wrapped. \a window_width dictates
 	/// where URLs are wrapped. \a rxman rules for \a location are used to
 	/// highlight the resulting text.

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -9,10 +9,7 @@ namespace newsboat {
 class ConfigContainer;
 class RssItem;
 
-class ItemRenderer {
-public:
-	ItemRenderer() = default;
-
+namespace item_renderer {
 	std::string to_plain_text(
 			ConfigContainer& cfg,
 			std::shared_ptr<RssItem> item);

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -10,12 +10,12 @@ class ConfigContainer;
 class RssItem;
 
 class ItemRenderer {
-	ConfigContainer* cfg;
-
 public:
-	ItemRenderer(ConfigContainer* cfg);
+	ItemRenderer() = default;
 
-	std::string to_plain_text(std::shared_ptr<RssItem> item);
+	std::string to_plain_text(
+			ConfigContainer& cfg,
+			std::shared_ptr<RssItem> item);
 };
 
 } // namespace newsboat

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -13,13 +13,26 @@ namespace newsboat {
 class ConfigContainer;
 class RssItem;
 
+/// \brief Creates different textual representations of an RssItem.
 namespace item_renderer {
+	/// \brief Returns feed's title of the item, or some replacement value if
+	/// the title isn't available.
 	std::string get_feedtitle(std::shared_ptr<RssItem> item);
 
+	/// \brief Returns plain-text representation of the RssItem.
+	///
+	/// Markup is mostly stripped. Links are numbered and tagged. The text is
+	/// wrapped at the width specified by the `text-width` setting.
 	std::string to_plain_text(
 			ConfigContainer& cfg,
 			std::shared_ptr<RssItem> item);
 
+	/// \brief Returns RssItem as STFL list.
+	///
+	/// `html-renderer` settings controlls what tool is used to render HTML. \a
+	/// text_width dictates where text is wrapped. \a window_width dictates
+	/// where URLs are wrapped. \a rxman rules for \a location are used to
+	/// highlight the resulting text.
 	std::pair<std::string, size_t> to_stfl_list(
 			ConfigContainer& cfg,
 			std::shared_ptr<RssItem> item,
@@ -28,6 +41,11 @@ namespace item_renderer {
 			RegexManager* rxman,
 			const std::string& location);
 
+	/// \brief Returns RssItem's text source as STFL list.
+	///
+	/// \a text_width dictates where text is wrapped. \a window_width dictates
+	/// where URLs are wrapped. \a rxman rules for \a location are used to
+	/// highlight the resulting text.
 	std::pair<std::string, size_t> source_to_stfl_list(
 			std::shared_ptr<RssItem> item,
 			unsigned int text_width,

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -15,6 +15,8 @@ namespace item_renderer {
 	std::string to_plain_text(
 			ConfigContainer& cfg,
 			std::shared_ptr<RssItem> item);
+
+	std::string get_item_base_link(const std::shared_ptr<RssItem>& item);
 };
 
 } // namespace newsboat

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -10,6 +10,8 @@ class ConfigContainer;
 class RssItem;
 
 namespace item_renderer {
+	std::string get_feedtitle(std::shared_ptr<RssItem> item);
+
 	std::string to_plain_text(
 			ConfigContainer& cfg,
 			std::shared_ptr<RssItem> item);

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -41,8 +41,9 @@ public:
 
 	void finished_qna(Operation op) override;
 
-	std::vector<std::pair<LineType, std::string>> render_html(
+	void render_html(
 		const std::string& source,
+		std::vector<std::pair<LineType, std::string>>& lines,
 		std::vector<LinkPair>& thelinks,
 		const std::string& url);
 

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -54,6 +54,7 @@ private:
 	void process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
+	void update_head(const std::shared_ptr<RssItem>& item);
 	void set_head(const std::string& s,
 		const std::string& feedtitle,
 		unsigned int unread,

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -829,8 +829,7 @@ void Controller::write_item(std::shared_ptr<RssItem> item,
 
 void Controller::write_item(std::shared_ptr<RssItem> item, std::ostream& ostr)
 {
-	ItemRenderer renderer;
-	ostr << renderer.to_plain_text(cfg, item) << std::endl;
+	ostr << item_renderer::to_plain_text(cfg, item) << std::endl;
 }
 
 void Controller::enqueue_items(std::shared_ptr<RssFeed> feed)

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -829,8 +829,8 @@ void Controller::write_item(std::shared_ptr<RssItem> item,
 
 void Controller::write_item(std::shared_ptr<RssItem> item, std::ostream& ostr)
 {
-	ItemRenderer renderer(&cfg);
-	ostr << renderer.to_plain_text(item) << std::endl;
+	ItemRenderer renderer;
+	ostr << renderer.to_plain_text(cfg, item) << std::endl;
 }
 
 void Controller::enqueue_items(std::shared_ptr<RssFeed> feed)

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -62,6 +62,11 @@ std::string ItemRenderer::to_plain_text(std::shared_ptr<RssItem> item) {
 		lines.push_back(std::make_pair(LineType::softwrappable, link));
 	}
 
+	if (!item->flags().empty()) {
+		const auto flags = StrPrintf::fmt("%s%s", _("Flags: "), item->flags());
+		lines.push_back(std::make_pair(LineType::wrappable, flags));
+	}
+
 	if (!item->enclosure_url().empty()) {
 		std::string dlurl(_("Podcast Download URL: "));
 		dlurl.append(item->enclosure_url());

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -7,10 +7,6 @@
 
 namespace newsboat {
 
-ItemRenderer::ItemRenderer(ConfigContainer* cfg_)
-	: cfg(cfg_)
-{}
-
 std::string get_feedtitle(std::shared_ptr<RssItem> item) {
 	std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
 
@@ -29,8 +25,10 @@ std::string get_feedtitle(std::shared_ptr<RssItem> item) {
 	return feedtitle;
 }
 
-std::string ItemRenderer::to_plain_text(std::shared_ptr<RssItem> item) {
-
+std::string ItemRenderer::to_plain_text(
+		ConfigContainer& cfg,
+		std::shared_ptr<RssItem> item)
+{
 	std::vector<std::pair<LineType, std::string>> lines;
 
 	const auto feedtitle = get_feedtitle(item);
@@ -78,10 +76,11 @@ std::string ItemRenderer::to_plain_text(std::shared_ptr<RssItem> item) {
 	HtmlRenderer rnd(true);
 	std::vector<LinkPair> links; // not used
 	rnd.render(item->description(), lines, links, item->feedurl());
+
 	TextFormatter txtfmt;
 	txtfmt.add_lines(lines);
 
-	unsigned int width = cfg->get_configvalue_as_int("text-width");
+	unsigned int width = cfg.get_configvalue_as_int("text-width");
 	if (width == 0) {
 		width = 80;
 	}

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -25,12 +25,11 @@ std::string get_feedtitle(std::shared_ptr<RssItem> item) {
 	return feedtitle;
 }
 
-std::string ItemRenderer::to_plain_text(
-		ConfigContainer& cfg,
-		std::shared_ptr<RssItem> item)
+void prepare_header(
+	std::shared_ptr<RssItem> item,
+	std::vector<std::pair<LineType, std::string>>& lines,
+	std::vector<LinkPair>& /*links*/)
 {
-	std::vector<std::pair<LineType, std::string>> lines;
-
 	const auto feedtitle = get_feedtitle(item);
 	if (!feedtitle.empty()) {
 		std::string title(_("Feed: "));
@@ -72,9 +71,18 @@ std::string ItemRenderer::to_plain_text(
 	}
 
 	lines.push_back(std::make_pair(LineType::wrappable, std::string("")));
+}
+
+std::string ItemRenderer::to_plain_text(
+		ConfigContainer& cfg,
+		std::shared_ptr<RssItem> item)
+{
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	prepare_header(item, lines, links);
 
 	HtmlRenderer rnd(true);
-	std::vector<LinkPair> links; // not used
 	rnd.render(item->description(), lines, links, item->feedurl());
 
 	TextFormatter txtfmt;

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -10,7 +10,7 @@
 namespace newsboat {
 
 std::string item_renderer::get_feedtitle(std::shared_ptr<RssItem> item) {
-	std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
+	const std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
 
 	std::string feedtitle;
 	if (feedptr) {
@@ -44,7 +44,7 @@ void prepare_header(
 			}
 		};
 
-	const auto feedtitle = item_renderer::get_feedtitle(item);
+	const std::string feedtitle = item_renderer::get_feedtitle(item);
 	add_line(feedtitle, _("Feed: "));
 	add_line(item->title(), _("Title: "));
 	add_line(item->author(), _("Author: "));
@@ -68,14 +68,11 @@ void prepare_header(
 
 std::string get_item_base_link(const std::shared_ptr<RssItem>& item)
 {
-	std::string baseurl;
 	if (!item->get_base().empty()) {
-		baseurl = item->get_base();
+		return item->get_base();
 	} else {
-		baseurl = item->feedurl();
+		return item->feedurl();
 	}
-
-	return baseurl;
 }
 
 void render_html(

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -27,7 +27,7 @@ std::string item_renderer::get_feedtitle(std::shared_ptr<RssItem> item) {
 	return feedtitle;
 }
 
-void prepare_header(
+void item_renderer::prepare_header(
 	std::shared_ptr<RssItem> item,
 	std::vector<std::pair<LineType, std::string>>& lines,
 	std::vector<LinkPair>& /*links*/)

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -27,7 +27,7 @@ std::string item_renderer::get_feedtitle(std::shared_ptr<RssItem> item) {
 	return feedtitle;
 }
 
-void item_renderer::prepare_header(
+void prepare_header(
 	std::shared_ptr<RssItem> item,
 	std::vector<std::pair<LineType, std::string>>& lines,
 	std::vector<LinkPair>& /*links*/)
@@ -75,7 +75,7 @@ void item_renderer::prepare_header(
 	lines.push_back(std::make_pair(LineType::wrappable, std::string("")));
 }
 
-std::string item_renderer::get_item_base_link(const std::shared_ptr<RssItem>& item)
+std::string get_item_base_link(const std::shared_ptr<RssItem>& item)
 {
 	std::string baseurl;
 	if (!item->get_base().empty()) {
@@ -87,7 +87,7 @@ std::string item_renderer::get_item_base_link(const std::shared_ptr<RssItem>& it
 	return baseurl;
 }
 
-void item_renderer::render_html(
+void render_html(
 	ConfigContainer& cfg,
 	const std::string& source,
 	std::vector<std::pair<LineType, std::string>>& lines,
@@ -159,7 +159,7 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 	std::vector<LinkPair> links;
 
 	prepare_header(item, lines, links);
-	const std::string baseurl = item_renderer::get_item_base_link(item);
+	const std::string baseurl = get_item_base_link(item);
 	const auto body = item->description();
 	render_html(cfg, body, lines, links, baseurl, false);
 

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -7,7 +7,7 @@
 
 namespace newsboat {
 
-std::string get_feedtitle(std::shared_ptr<RssItem> item) {
+std::string item_renderer::get_feedtitle(std::shared_ptr<RssItem> item) {
 	std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
 
 	std::string feedtitle;
@@ -30,7 +30,7 @@ void prepare_header(
 	std::vector<std::pair<LineType, std::string>>& lines,
 	std::vector<LinkPair>& /*links*/)
 {
-	const auto feedtitle = get_feedtitle(item);
+	const auto feedtitle = item_renderer::get_feedtitle(item);
 	if (!feedtitle.empty()) {
 		const auto title = StrPrintf::fmt("%s%s", _("Feed: "), feedtitle);
 		lines.push_back(std::make_pair(LineType::wrappable, title));

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -32,30 +32,25 @@ void prepare_header(
 {
 	const auto feedtitle = get_feedtitle(item);
 	if (!feedtitle.empty()) {
-		std::string title(_("Feed: "));
-		title.append(feedtitle);
+		const auto title = StrPrintf::fmt("%s%s", _("Feed: "), feedtitle);
 		lines.push_back(std::make_pair(LineType::wrappable, title));
 	}
 
 	if (!item->title().empty()) {
-		std::string title(_("Title: "));
-		title.append(item->title());
+		const auto title = StrPrintf::fmt("%s%s", _("Title: "), item->title());
 		lines.push_back(std::make_pair(LineType::wrappable, title));
 	}
 
 	if (!item->author().empty()) {
-		std::string author(_("Author: "));
-		author.append(item->author());
+		const auto author = StrPrintf::fmt("%s%s", _("Author: "), item->author());
 		lines.push_back(std::make_pair(LineType::wrappable, author));
 	}
 
-	std::string date(_("Date: "));
-	date.append(item->pubDate());
+	const auto date = StrPrintf::fmt("%s%s", _("Date: "), item->pubDate());
 	lines.push_back(std::make_pair(LineType::wrappable, date));
 
 	if (!item->link().empty()) {
-		std::string link(_("Link: "));
-		link.append(item->link());
+		const auto link = StrPrintf::fmt("%s%s", _("Link: "), item->link());
 		lines.push_back(std::make_pair(LineType::softwrappable, link));
 	}
 
@@ -65,8 +60,7 @@ void prepare_header(
 	}
 
 	if (!item->enclosure_url().empty()) {
-		std::string dlurl(_("Podcast Download URL: "));
-		dlurl.append(item->enclosure_url());
+		const auto dlurl = StrPrintf::fmt("%s%s", _("Podcast Download URL: "), item->enclosure_url());
 		lines.push_back(std::make_pair(LineType::softwrappable, dlurl));
 	}
 

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -60,7 +60,13 @@ void prepare_header(
 	}
 
 	if (!item->enclosure_url().empty()) {
-		const auto dlurl = StrPrintf::fmt("%s%s", _("Podcast Download URL: "), item->enclosure_url());
+		auto dlurl = StrPrintf::fmt(
+			"%s%s",
+			_("Podcast Download URL: "),
+			Utils::censor_url(item->enclosure_url()));
+		if (!item->enclosure_type().empty()) {
+			dlurl.append(StrPrintf::fmt("%s%s", _("type: "), item->enclosure_type()));
+		}
 		lines.push_back(std::make_pair(LineType::softwrappable, dlurl));
 	}
 

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -15,23 +15,29 @@ std::string ItemRenderer::to_plain_text(std::shared_ptr<RssItem> item) {
 
 	std::vector<std::pair<LineType, std::string>> lines;
 
-	std::string title(_("Title: "));
-	title.append(item->title());
-	lines.push_back(std::make_pair(LineType::wrappable, title));
+	if (!item->title().empty()) {
+		std::string title(_("Title: "));
+		title.append(item->title());
+		lines.push_back(std::make_pair(LineType::wrappable, title));
+	}
 
-	std::string author(_("Author: "));
-	author.append(item->author());
-	lines.push_back(std::make_pair(LineType::wrappable, author));
+	if (!item->author().empty()) {
+		std::string author(_("Author: "));
+		author.append(item->author());
+		lines.push_back(std::make_pair(LineType::wrappable, author));
+	}
 
 	std::string date(_("Date: "));
 	date.append(item->pubDate());
 	lines.push_back(std::make_pair(LineType::wrappable, date));
 
-	std::string link(_("Link: "));
-	link.append(item->link());
-	lines.push_back(std::make_pair(LineType::softwrappable, link));
+	if (!item->link().empty()) {
+		std::string link(_("Link: "));
+		link.append(item->link());
+		lines.push_back(std::make_pair(LineType::softwrappable, link));
+	}
 
-	if (item->enclosure_url() != "") {
+	if (!item->enclosure_url().empty()) {
 		std::string dlurl(_("Podcast Download URL: "));
 		dlurl.append(item->enclosure_url());
 		lines.push_back(std::make_pair(LineType::softwrappable, dlurl));

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -32,34 +32,25 @@ void prepare_header(
 	std::vector<std::pair<LineType, std::string>>& lines,
 	std::vector<LinkPair>& /*links*/)
 {
+	const auto add_line =
+		[&lines]
+		(const std::string& value,
+		 const std::string& name,
+		 LineType lineType = LineType::wrappable)
+		{
+			if (!value.empty()) {
+				const auto line = StrPrintf::fmt("%s%s", name, value);
+				lines.push_back(std::make_pair(lineType, line));
+			}
+		};
+
 	const auto feedtitle = item_renderer::get_feedtitle(item);
-	if (!feedtitle.empty()) {
-		const auto title = StrPrintf::fmt("%s%s", _("Feed: "), feedtitle);
-		lines.push_back(std::make_pair(LineType::wrappable, title));
-	}
-
-	if (!item->title().empty()) {
-		const auto title = StrPrintf::fmt("%s%s", _("Title: "), item->title());
-		lines.push_back(std::make_pair(LineType::wrappable, title));
-	}
-
-	if (!item->author().empty()) {
-		const auto author = StrPrintf::fmt("%s%s", _("Author: "), item->author());
-		lines.push_back(std::make_pair(LineType::wrappable, author));
-	}
-
-	const auto date = StrPrintf::fmt("%s%s", _("Date: "), item->pubDate());
-	lines.push_back(std::make_pair(LineType::wrappable, date));
-
-	if (!item->link().empty()) {
-		const auto link = StrPrintf::fmt("%s%s", _("Link: "), item->link());
-		lines.push_back(std::make_pair(LineType::softwrappable, link));
-	}
-
-	if (!item->flags().empty()) {
-		const auto flags = StrPrintf::fmt("%s%s", _("Flags: "), item->flags());
-		lines.push_back(std::make_pair(LineType::wrappable, flags));
-	}
+	add_line(feedtitle, _("Feed: "));
+	add_line(item->title(), _("Title: "));
+	add_line(item->author(), _("Author: "));
+	add_line(item->pubDate(), _("Date: "));
+	add_line(item->link(), _("Link: "), LineType::softwrappable);
+	add_line(item->flags(), _("Flags: "));
 
 	if (!item->enclosure_url().empty()) {
 		auto dlurl = StrPrintf::fmt(

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -11,9 +11,34 @@ ItemRenderer::ItemRenderer(ConfigContainer* cfg_)
 	: cfg(cfg_)
 {}
 
+std::string get_feedtitle(std::shared_ptr<RssItem> item) {
+	std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
+
+	std::string feedtitle;
+	if (feedptr) {
+		if (!feedptr->title().empty()) {
+			feedtitle = feedptr->title();
+			Utils::remove_soft_hyphens(feedtitle);
+		} else if (!feedptr->link().empty()) {
+			feedtitle = feedptr->link();
+		} else if (!feedptr->rssurl().empty()) {
+			feedtitle = feedptr->rssurl();
+		}
+	}
+
+	return feedtitle;
+}
+
 std::string ItemRenderer::to_plain_text(std::shared_ptr<RssItem> item) {
 
 	std::vector<std::pair<LineType, std::string>> lines;
+
+	const auto feedtitle = get_feedtitle(item);
+	if (!feedtitle.empty()) {
+		std::string title(_("Feed: "));
+		title.append(feedtitle);
+		lines.push_back(std::make_pair(LineType::wrappable, title));
+	}
 
 	if (!item->title().empty()) {
 		std::string title(_("Title: "));

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -73,6 +73,18 @@ void prepare_header(
 	lines.push_back(std::make_pair(LineType::wrappable, std::string("")));
 }
 
+std::string item_renderer::get_item_base_link(const std::shared_ptr<RssItem>& item)
+{
+	std::string baseurl;
+	if (!item->get_base().empty()) {
+		baseurl = item->get_base();
+	} else {
+		baseurl = item->feedurl();
+	}
+
+	return baseurl;
+}
+
 std::string item_renderer::to_plain_text(
 		ConfigContainer& cfg,
 		std::shared_ptr<RssItem> item)
@@ -83,7 +95,8 @@ std::string item_renderer::to_plain_text(
 	prepare_header(item, lines, links);
 
 	HtmlRenderer rnd(true);
-	rnd.render(item->description(), lines, links, item->feedurl());
+	const auto item_base = get_item_base_link(item);
+	rnd.render(item->description(), lines, links, item_base);
 
 	TextFormatter txtfmt;
 	txtfmt.add_lines(lines);
@@ -95,5 +108,6 @@ std::string item_renderer::to_plain_text(
 
 	return txtfmt.format_text_plain(width);
 }
+
 
 }

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -73,7 +73,7 @@ void prepare_header(
 	lines.push_back(std::make_pair(LineType::wrappable, std::string("")));
 }
 
-std::string ItemRenderer::to_plain_text(
+std::string item_renderer::to_plain_text(
 		ConfigContainer& cfg,
 		std::shared_ptr<RssItem> item)
 {

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -7,6 +7,7 @@
 #include "config.h"
 #include "exceptions.h"
 #include "formatstring.h"
+#include "itemrenderer.h"
 #include "logger.h"
 #include "strprintf.h"
 #include "textformatter.h"
@@ -57,19 +58,7 @@ void ItemViewFormAction::init()
 
 void ItemViewFormAction::update_head(const std::shared_ptr<RssItem>& item)
 {
-	std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
-
-	std::string feedtitle;
-	if (feedptr) {
-		if (!feedptr->title().empty()) {
-			feedtitle = feedptr->title();
-			Utils::remove_soft_hyphens(feedtitle);
-		} else if (!feedptr->link().empty()) {
-			feedtitle = feedptr->link();
-		} else if (!feedptr->rssurl().empty()) {
-			feedtitle = feedptr->rssurl();
-		}
-	}
+	const auto feedtitle = item_renderer::get_feedtitle(item);
 
 	unsigned int unread_item_count = feed->unread_item_count();
 	// we need to subtract because the current item isn't yet marked

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -58,7 +58,7 @@ void ItemViewFormAction::init()
 
 void ItemViewFormAction::update_head(const std::shared_ptr<RssItem>& item)
 {
-	const auto feedtitle = item_renderer::get_feedtitle(item);
+	const std::string feedtitle = item_renderer::get_feedtitle(item);
 
 	unsigned int unread_item_count = feed->unread_item_count();
 	// we need to subtract because the current item isn't yet marked
@@ -91,7 +91,7 @@ void ItemViewFormAction::prepare()
 
 		update_head(item);
 
-		std::string widthstr = f->get("article:w");
+		const std::string widthstr = f->get("article:w");
 		const unsigned int window_width = Utils::to_u(widthstr, 0);
 
 		unsigned int text_width =

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -75,59 +75,59 @@ void ItemViewFormAction::prepare()
 
 		std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
 
-		std::string feedtitle, feedheader;
-		if (feedptr.get() != nullptr) {
-			if (feedptr->title().length() > 0) {
+		std::string feedtitle;
+		if (feedptr) {
+			if (!feedptr->title().empty()) {
 				feedtitle = feedptr->title();
 				Utils::remove_soft_hyphens(feedtitle);
-			} else if (feedptr->link().length() > 0) {
+			} else if (!feedptr->link().empty()) {
 				feedtitle = feedptr->link();
-			} else if (feedptr->rssurl().length() > 0) {
+			} else if (!feedptr->rssurl().empty()) {
 				feedtitle = feedptr->rssurl();
 			}
 		}
-		if (feedtitle.length() > 0) {
-			feedheader =
+		if (!feedtitle.empty()) {
+			const auto feedheader =
 				StrPrintf::fmt("%s%s", _("Feed: "), feedtitle);
 			textfmt.add_line(LineType::wrappable, feedheader);
 		}
 
-		if (item->title().length() > 0) {
-			std::string title = StrPrintf::fmt(
+		if (!item->title().empty()) {
+			auto title = StrPrintf::fmt(
 				"%s%s", _("Title: "), item->title());
 			Utils::remove_soft_hyphens(title);
 			textfmt.add_line(LineType::wrappable, title);
 		}
 
-		if (item->author().length() > 0) {
-			std::string author = StrPrintf::fmt(
+		if (!item->author().empty()) {
+			auto author = StrPrintf::fmt(
 				"%s%s", _("Author: "), item->author());
 			Utils::remove_soft_hyphens(author);
 			textfmt.add_line(LineType::wrappable, author);
 		}
 
-		if (item->link().length() > 0) {
-			std::string link = StrPrintf::fmt("%s%s",
+		if (!item->link().empty()) {
+			const auto link = StrPrintf::fmt("%s%s",
 				_("Link: "),
 				Utils::censor_url(item->link()));
 			textfmt.add_line(LineType::softwrappable, link);
 		}
 
-		std::string date =
+		const auto date =
 			StrPrintf::fmt("%s%s", _("Date: "), item->pubDate());
 		textfmt.add_line(LineType::wrappable, date);
 
-		if (item->flags().length() > 0) {
-			std::string flags = StrPrintf::fmt(
+		if (!item->flags().empty()) {
+			const auto flags = StrPrintf::fmt(
 				"%s%s", _("Flags: "), item->flags());
 			textfmt.add_line(LineType::wrappable, flags);
 		}
 
-		if (item->enclosure_url().length() > 0) {
+		if (!item->enclosure_url().empty()) {
 			std::string enc_url = StrPrintf::fmt("%s%s",
 				_("Podcast Download URL: "),
 				Utils::censor_url(item->enclosure_url()));
-			if (item->enclosure_type() != "") {
+			if (!item->enclosure_type().empty()) {
 				enc_url.append(StrPrintf::fmt(" (%s%s)",
 					_("type: "),
 					item->enclosure_type()));
@@ -140,8 +140,9 @@ void ItemViewFormAction::prepare()
 		unsigned int unread_item_count = feed->unread_item_count();
 		// we need to subtract because the current item isn't yet marked
 		// as read
-		if (item->unread())
+		if (item->unread()) {
 			unread_item_count--;
+		}
 		set_head(item->title(),
 			feedtitle,
 			unread_item_count,
@@ -152,17 +153,20 @@ void ItemViewFormAction::prepare()
 			render_source(lines,
 				Utils::quote_for_stfl(item->description()));
 		} else {
-			std::string baseurl = item->get_base() != ""
-				? item->get_base()
-				: item->feedurl();
-			lines = render_html(
-				item->description(), links, baseurl);
+			std::string baseurl;
+			if (!item->get_base().empty()) {
+				baseurl = item->get_base();
+			} else {
+				baseurl = item->feedurl();
+			}
+
+			lines = render_html(item->description(), links, baseurl);
 		}
 
 		textfmt.add_lines(lines);
 
 		std::string widthstr = f->get("article:w");
-		unsigned int window_width = Utils::to_u(widthstr, 0);
+		const unsigned int window_width = Utils::to_u(widthstr, 0);
 
 		unsigned int textwidth =
 			cfg->get_configvalue_as_int("text-width");

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -90,73 +90,11 @@ void ItemViewFormAction::prepare()
 		std::shared_ptr<RssItem> item = feed->get_item_by_guid(guid);
 		TextFormatter textfmt;
 
-		std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
-
-		std::string feedtitle;
-		if (feedptr) {
-			if (!feedptr->title().empty()) {
-				feedtitle = feedptr->title();
-				Utils::remove_soft_hyphens(feedtitle);
-			} else if (!feedptr->link().empty()) {
-				feedtitle = feedptr->link();
-			} else if (!feedptr->rssurl().empty()) {
-				feedtitle = feedptr->rssurl();
-			}
-		}
-		if (!feedtitle.empty()) {
-			const auto feedheader =
-				StrPrintf::fmt("%s%s", _("Feed: "), feedtitle);
-			textfmt.add_line(LineType::wrappable, feedheader);
-		}
-
-		if (!item->title().empty()) {
-			auto title = StrPrintf::fmt(
-				"%s%s", _("Title: "), item->title());
-			Utils::remove_soft_hyphens(title);
-			textfmt.add_line(LineType::wrappable, title);
-		}
-
-		if (!item->author().empty()) {
-			auto author = StrPrintf::fmt(
-				"%s%s", _("Author: "), item->author());
-			Utils::remove_soft_hyphens(author);
-			textfmt.add_line(LineType::wrappable, author);
-		}
-
-		if (!item->link().empty()) {
-			const auto link = StrPrintf::fmt("%s%s",
-				_("Link: "),
-				Utils::censor_url(item->link()));
-			textfmt.add_line(LineType::softwrappable, link);
-		}
-
-		const auto date =
-			StrPrintf::fmt("%s%s", _("Date: "), item->pubDate());
-		textfmt.add_line(LineType::wrappable, date);
-
-		if (!item->flags().empty()) {
-			const auto flags = StrPrintf::fmt(
-				"%s%s", _("Flags: "), item->flags());
-			textfmt.add_line(LineType::wrappable, flags);
-		}
-
-		if (!item->enclosure_url().empty()) {
-			std::string enc_url = StrPrintf::fmt("%s%s",
-				_("Podcast Download URL: "),
-				Utils::censor_url(item->enclosure_url()));
-			if (!item->enclosure_type().empty()) {
-				enc_url.append(StrPrintf::fmt(" (%s%s)",
-					_("type: "),
-					item->enclosure_type()));
-			}
-			textfmt.add_line(LineType::softwrappable, enc_url);
-		}
-
-		textfmt.add_line(LineType::wrappable, std::string());
+		std::vector<std::pair<LineType, std::string>> lines;
+		item_renderer::prepare_header(item, lines, links);
 
 		update_head(item);
 
-		std::vector<std::pair<LineType, std::string>> lines;
 		if (show_source) {
 			render_source(lines, Utils::quote_for_stfl(item->description()));
 		} else {

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -88,12 +88,11 @@ void ItemViewFormAction::prepare()
 		}
 
 		std::shared_ptr<RssItem> item = feed->get_item_by_guid(guid);
-		TextFormatter textfmt;
+
+		update_head(item);
 
 		std::vector<std::pair<LineType, std::string>> lines;
 		item_renderer::prepare_header(item, lines, links);
-
-		update_head(item);
 
 		if (show_source) {
 			render_source(lines, Utils::quote_for_stfl(item->description()));
@@ -102,8 +101,6 @@ void ItemViewFormAction::prepare()
 			const auto body = item->description();
 			item_renderer::render_html(*cfg, body, lines, links, baseurl, false);
 		}
-
-		textfmt.add_lines(lines);
 
 		std::string widthstr = f->get("article:w");
 		const unsigned int window_width = Utils::to_u(widthstr, 0);
@@ -116,6 +113,9 @@ void ItemViewFormAction::prepare()
 				textwidth -= 5;
 			}
 		}
+
+		TextFormatter textfmt;
+		textfmt.add_lines(lines);
 
 		std::string formatted_text;
 		std::tie(formatted_text, num_lines) =

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -161,13 +161,7 @@ void ItemViewFormAction::prepare()
 			render_source(lines,
 				Utils::quote_for_stfl(item->description()));
 		} else {
-			std::string baseurl;
-			if (!item->get_base().empty()) {
-				baseurl = item->get_base();
-			} else {
-				baseurl = item->feedurl();
-			}
-
+			const std::string baseurl = item_renderer::get_item_base_link(item);
 			lines = render_html(item->description(), links, baseurl);
 		}
 

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -55,6 +55,34 @@ void ItemViewFormAction::init()
 	set_keymap_hints();
 }
 
+void ItemViewFormAction::update_head(const std::shared_ptr<RssItem>& item)
+{
+	std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
+
+	std::string feedtitle;
+	if (feedptr) {
+		if (!feedptr->title().empty()) {
+			feedtitle = feedptr->title();
+			Utils::remove_soft_hyphens(feedtitle);
+		} else if (!feedptr->link().empty()) {
+			feedtitle = feedptr->link();
+		} else if (!feedptr->rssurl().empty()) {
+			feedtitle = feedptr->rssurl();
+		}
+	}
+
+	unsigned int unread_item_count = feed->unread_item_count();
+	// we need to subtract because the current item isn't yet marked
+	// as read
+	if (item->unread()) {
+		unread_item_count--;
+	}
+	set_head(item->title(),
+		feedtitle,
+		unread_item_count,
+		feed->total_item_count());
+};
+
 void ItemViewFormAction::prepare()
 {
 	/*
@@ -137,16 +165,7 @@ void ItemViewFormAction::prepare()
 
 		textfmt.add_line(LineType::wrappable, std::string());
 
-		unsigned int unread_item_count = feed->unread_item_count();
-		// we need to subtract because the current item isn't yet marked
-		// as read
-		if (item->unread()) {
-			unread_item_count--;
-		}
-		set_head(item->title(),
-			feedtitle,
-			unread_item_count,
-			feed->total_item_count());
+		update_head(item);
 
 		std::vector<std::pair<LineType, std::string>> lines;
 		if (show_source) {

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -66,8 +66,8 @@ void ItemViewFormAction::prepare()
 	if (do_redraw) {
 		{
 			ScopeMeasure("itemview::prepare: rendering");
-			f->run(-3); // XXX HACK: render once so that we get a
-				    // proper widget width
+			// XXX HACK: render once so that we get a proper widget width
+			f->run(-3);
 		}
 
 		std::shared_ptr<RssItem> item = feed->get_item_by_guid(guid);

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -161,7 +161,8 @@ void ItemViewFormAction::prepare()
 			render_source(lines, Utils::quote_for_stfl(item->description()));
 		} else {
 			const std::string baseurl = item_renderer::get_item_base_link(item);
-			render_html(item->description(), lines, links, baseurl);
+			const auto body = item->description();
+			item_renderer::render_html(*cfg, body, lines, links, baseurl, false);
 		}
 
 		textfmt.add_lines(lines);
@@ -606,41 +607,6 @@ void ItemViewFormAction::finished_qna(Operation op)
 	} break;
 	default:
 		break;
-	}
-}
-
-void ItemViewFormAction::render_html(
-	const std::string& source,
-	std::vector<std::pair<LineType, std::string>>& lines,
-	std::vector<LinkPair>& thelinks,
-	const std::string& url)
-{
-	std::string renderer = cfg->get_configvalue("html-renderer");
-	if (renderer == "internal") {
-		HtmlRenderer rnd;
-		rnd.render(source, lines, thelinks, url);
-	} else {
-		char* argv[4];
-		argv[0] = const_cast<char*>("/bin/sh");
-		argv[1] = const_cast<char*>("-c");
-		argv[2] = const_cast<char*>(renderer.c_str());
-		argv[3] = nullptr;
-		LOG(Level::DEBUG,
-			"ItemViewFormAction::render_html: source = %s",
-			source);
-		LOG(Level::DEBUG,
-			"ItemViewFormAction::render_html: html-renderer = %s",
-			argv[2]);
-
-		std::string output = Utils::run_program(argv, source);
-		std::istringstream is(output);
-		std::string line;
-		getline(is, line);
-		while (!is.eof()) {
-			lines.push_back(std::make_pair(LineType::softwrappable,
-				Utils::quote_for_stfl(line)));
-			getline(is, line);
-		}
 	}
 }
 

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -158,11 +158,10 @@ void ItemViewFormAction::prepare()
 
 		std::vector<std::pair<LineType, std::string>> lines;
 		if (show_source) {
-			render_source(lines,
-				Utils::quote_for_stfl(item->description()));
+			render_source(lines, Utils::quote_for_stfl(item->description()));
 		} else {
 			const std::string baseurl = item_renderer::get_item_base_link(item);
-			lines = render_html(item->description(), links, baseurl);
+			render_html(item->description(), lines, links, baseurl);
 		}
 
 		textfmt.add_lines(lines);
@@ -610,16 +609,16 @@ void ItemViewFormAction::finished_qna(Operation op)
 	}
 }
 
-std::vector<std::pair<LineType, std::string>> ItemViewFormAction::render_html(
+void ItemViewFormAction::render_html(
 	const std::string& source,
+	std::vector<std::pair<LineType, std::string>>& lines,
 	std::vector<LinkPair>& thelinks,
 	const std::string& url)
 {
-	std::vector<std::pair<LineType, std::string>> result;
 	std::string renderer = cfg->get_configvalue("html-renderer");
 	if (renderer == "internal") {
 		HtmlRenderer rnd;
-		rnd.render(source, result, thelinks, url);
+		rnd.render(source, lines, thelinks, url);
 	} else {
 		char* argv[4];
 		argv[0] = const_cast<char*>("/bin/sh");
@@ -638,12 +637,11 @@ std::vector<std::pair<LineType, std::string>> ItemViewFormAction::render_html(
 		std::string line;
 		getline(is, line);
 		while (!is.eof()) {
-			result.push_back(std::make_pair(LineType::softwrappable,
+			lines.push_back(std::make_pair(LineType::softwrappable,
 				Utils::quote_for_stfl(line)));
 			getline(is, line);
 		}
 	}
-	return result;
 }
 
 void ItemViewFormAction::set_regexmanager(RegexManager* r)

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -26,6 +26,9 @@ static const auto ITEM_DESCRIPTON = std::string("<p>Hello, world!</p>");
 static const auto ITEM_DESCRIPTON_RENDERED = std::string("Hello, world!");
 static const auto ITEM_ENCLOSURE_URL =
 	std::string("https://example.com/see-more.mp3");
+static const auto ITEM_FLAGS = std::string("wasdhjkl");
+// Flags are sorted for rendering.
+static const auto ITEM_FLAGS_RENDERED = std::string("adhjklsw");
 std::pair<std::shared_ptr<RssItem>, std::shared_ptr<RssFeed>> test_item(Cache* c)
 {
 	auto feed = test_feed(c);
@@ -37,6 +40,7 @@ std::pair<std::shared_ptr<RssItem>, std::shared_ptr<RssFeed>> test_item(Cache* c
 	item->set_author(ITEM_AUTHOR);
 	item->set_pubDate(ITEM_PUBDATE);
 	item->set_link(ITEM_LINK);
+	item->set_flags(ITEM_FLAGS);
 
 	return {item, feed};
 }
@@ -71,6 +75,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 			"Author: " + ITEM_AUTHOR + '\n' +
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 			"Link: " + ITEM_LINK + '\n' +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
 			" \n" +
 			ITEM_DESCRIPTON_RENDERED + '\n';
 
@@ -89,6 +94,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 			"Author: " + ITEM_AUTHOR + '\n' +
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 			"Link: " + ITEM_LINK + '\n' +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
 			"Podcast Download URL: " + ITEM_ENCLOSURE_URL + '\n' +
 			" \n" +
 			ITEM_DESCRIPTON_RENDERED + '\n';
@@ -109,6 +115,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 			"Author: " + ITEM_AUTHOR + '\n' +
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 			"Link: " + ITEM_LINK + '\n' +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
 			" \n" +
 			ITEM_DESCRIPTON_RENDERED + '\n' +
 			" \n" +
@@ -149,6 +156,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 		"Author: " + ITEM_AUTHOR + '\n' +
 		"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 		"Link: " + ITEM_LINK + '\n' +
+		"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
 		" \n";
 
 	SECTION("If `text-width` is not set, text is rendered in 80 columns") {
@@ -235,6 +243,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 			"Author: " + ITEM_AUTHOR + '\n' +
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 			"Link: " + ITEM_LINK + '\n' +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
 			" \n";
 
 		REQUIRE(result == expected);
@@ -250,6 +259,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 			"Author: " + ITEM_AUTHOR + '\n' +
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 			"Link: " + ITEM_LINK + '\n' +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
 			" \n";
 
 		REQUIRE(result == expected);
@@ -265,6 +275,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 			"Title: " + ITEM_TITLE + '\n' +
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 			"Link: " + ITEM_LINK + '\n' +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
 			" \n";
 
 		REQUIRE(result == expected);
@@ -280,6 +291,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 			"Title: " + ITEM_TITLE + '\n' +
 			"Author: " + ITEM_AUTHOR + '\n' +
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
 			" \n";
 
 		REQUIRE(result == expected);
@@ -296,8 +308,25 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 			"Author: " + ITEM_AUTHOR + '\n' +
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 			"Link: " + ITEM_LINK + '\n' +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
 			" \n" +
 			ITEM_DESCRIPTON_RENDERED + '\n';
+
+		REQUIRE(result == expected);
+	}
+
+	SECTION("Item without flags") {
+		item->set_flags("");
+
+		const auto result = renderer.to_plain_text(item);
+
+		const auto expected = std::string() +
+			"Feed: " + FEED_TITLE + '\n' +
+			"Title: " + ITEM_TITLE + '\n' +
+			"Author: " + ITEM_AUTHOR + '\n' +
+			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
+			"Link: " + ITEM_LINK + '\n' +
+			" \n";
 
 		REQUIRE(result == expected);
 	}

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -58,7 +58,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 	cfg.set_configvalue("text-width", "80");
 
 	Cache rsscache(":memory:", &cfg);
-	ItemRenderer renderer(&cfg);
+	ItemRenderer renderer;
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
@@ -67,7 +67,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 	SECTION("Item without an enclosure") {
 		item->set_description(ITEM_DESCRIPTON);
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -86,7 +86,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 		item->set_description(ITEM_DESCRIPTON);
 		item->set_enclosure_url(ITEM_ENCLOSURE_URL);
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -107,7 +107,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 				ITEM_DESCRIPTON +
 				"<p>See also <a href='https://example.com'>this site</a>.</p>");
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -138,7 +138,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 	ConfigContainer cfg;
 
 	Cache rsscache(":memory:", &cfg);
-	ItemRenderer renderer(&cfg);
+	ItemRenderer renderer;
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
@@ -160,7 +160,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 		" \n";
 
 	SECTION("If `text-width` is not set, text is rendered in 80 columns") {
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nisl \n" +
@@ -173,7 +173,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 	SECTION("If `text-width` is set to zero, text is rendered in 80 columns") {
 		cfg.set_configvalue("text-width", "0");
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nisl \n" +
@@ -186,7 +186,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 	SECTION("Text is rendered in 37 columns") {
 		cfg.set_configvalue("text-width", "37");
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, \n"
@@ -203,7 +203,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 	SECTION("Text is rendered in 120 columns") {
 		cfg.set_configvalue("text-width", "120");
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
@@ -227,7 +227,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	cfg.set_configvalue("text-width", "80");
 
 	Cache rsscache(":memory:", &cfg);
-	ItemRenderer renderer(&cfg);
+	ItemRenderer renderer;
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
@@ -236,7 +236,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without a feed title") {
 		item->get_feedptr()->set_title("");
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Title: " + ITEM_TITLE + '\n' +
@@ -252,7 +252,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without a title") {
 		item->set_title("");
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -268,7 +268,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without an author") {
 		item->set_author("");
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -284,7 +284,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without a link") {
 		item->set_link("");
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -300,7 +300,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without an enclosure") {
 		item->set_description(ITEM_DESCRIPTON);
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -318,7 +318,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without flags") {
 		item->set_flags("");
 
-		const auto result = renderer.to_plain_text(item);
+		const auto result = renderer.to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -8,7 +8,7 @@
 using namespace newsboat;
 
 static const auto FEED_TITLE = std::string("Funniest jokes ever");
-std::shared_ptr<RssFeed> test_feed(Cache* c)
+std::shared_ptr<RssFeed> create_test_feed(Cache* c)
 {
 	auto feed = std::make_shared<RssFeed>(c);
 
@@ -29,9 +29,9 @@ static const auto ITEM_ENCLOSURE_URL =
 static const auto ITEM_FLAGS = std::string("wasdhjkl");
 // Flags are sorted for rendering.
 static const auto ITEM_FLAGS_RENDERED = std::string("adhjklsw");
-std::pair<std::shared_ptr<RssItem>, std::shared_ptr<RssFeed>> test_item(Cache* c)
+std::pair<std::shared_ptr<RssItem>, std::shared_ptr<RssFeed>> create_test_item(Cache* c)
 {
-	auto feed = test_feed(c);
+	const auto feed = create_test_feed(c);
 
 	auto item = std::make_shared<RssItem>(c);
 
@@ -61,7 +61,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
-	std::tie(item, feed) = test_item(&rsscache);
+	std::tie(item, feed) = create_test_item(&rsscache);
 
 	SECTION("Item without an enclosure") {
 		item->set_description(ITEM_DESCRIPTON);
@@ -140,7 +140,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
-	std::tie(item, feed) = test_item(&rsscache);
+	std::tie(item, feed) = create_test_item(&rsscache);
 
 	item->set_description(
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
@@ -228,7 +228,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
-	std::tie(item, feed) = test_item(&rsscache);
+	std::tie(item, feed) = create_test_item(&rsscache);
 
 	SECTION("Item without a feed title") {
 		item->get_feedptr()->set_title("");
@@ -342,7 +342,7 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
-	std::tie(item, feed) = test_item(&rsscache);
+	std::tie(item, feed) = create_test_item(&rsscache);
 
 	SECTION("Single-paragraph description") {
 		const auto description = std::string() +
@@ -371,7 +371,7 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 			REQUIRE(result == expected);
 		}
 
-		// cat is pretty much guaranteed ot be present in any Unix-like
+		// cat is pretty much guaranteed to be present in any Unix-like
 		// environment, so let's use that instead of the less common w3m.
 		SECTION("/bin/cat as a renderer") {
 			cfg.set_configvalue("html-renderer", "/bin/cat");
@@ -422,7 +422,7 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 			REQUIRE(result == expected);
 		}
 
-		// cat is pretty much guaranteed ot be present in any Unix-like
+		// cat is pretty much guaranteed to be present in any Unix-like
 		// environment, so let's use that instead of the less common w3m.
 		SECTION("/bin/cat as a renderer") {
 			cfg.set_configvalue("html-renderer", "/bin/cat");
@@ -455,7 +455,7 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed title without "
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
-	std::tie(item, feed) = test_item(&rsscache);
+	std::tie(item, feed) = create_test_item(&rsscache);
 
 	SECTION("Title without soft hyphens") {
 		feed->set_title("Welcome, lovely strangers!");
@@ -478,7 +478,7 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed self-link "
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
-	std::tie(item, feed) = test_item(&rsscache);
+	std::tie(item, feed) = create_test_item(&rsscache);
 
 	const auto feedlink = std::string("https://rss.example.com/~joe/");
 
@@ -498,7 +498,7 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed URL "
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
-	std::tie(item, feed) = test_item(&rsscache);
+	std::tie(item, feed) = create_test_item(&rsscache);
 
 	const auto feedurl = std::string("https://example.com/~joe/entries.rss");
 

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -186,3 +186,76 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 		REQUIRE(result == expected);
 	}
 }
+
+TEST_CASE("Empty fields are not rendered", "[ItemRenderer]") {
+	TestHelpers::EnvVar tzEnv("TZ");
+	tzEnv.set("UTC");
+
+	ConfigContainer cfg;
+	// ItemRenderer uses that setting, so let's fix its value to make the test
+	// reproducible
+	cfg.set_configvalue("text-width", "80");
+
+	Cache rsscache(":memory:", &cfg);
+	ItemRenderer renderer(&cfg);
+
+	auto item = test_item(&rsscache);
+
+	SECTION("Item without a title") {
+		item->set_title("");
+
+		const auto result = renderer.to_plain_text(item);
+
+		const auto expected = std::string() +
+			"Author: " + ITEM_AUTHOR + '\n' +
+			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
+			"Link: " + ITEM_LINK + '\n' +
+			" \n";
+
+		REQUIRE(result == expected);
+	}
+
+	SECTION("Item without an author") {
+		item->set_author("");
+
+		const auto result = renderer.to_plain_text(item);
+
+		const auto expected = std::string() +
+			"Title: " + ITEM_TITLE + '\n' +
+			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
+			"Link: " + ITEM_LINK + '\n' +
+			" \n";
+
+		REQUIRE(result == expected);
+	}
+
+	SECTION("Item without a link") {
+		item->set_link("");
+
+		const auto result = renderer.to_plain_text(item);
+
+		const auto expected = std::string() +
+			"Title: " + ITEM_TITLE + '\n' +
+			"Author: " + ITEM_AUTHOR + '\n' +
+			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
+			" \n";
+
+		REQUIRE(result == expected);
+	}
+
+	SECTION("Item without an enclosure") {
+		item->set_description(ITEM_DESCRIPTON);
+
+		const auto result = renderer.to_plain_text(item);
+
+		const auto expected = std::string() +
+			"Title: " + ITEM_TITLE + '\n' +
+			"Author: " + ITEM_AUTHOR + '\n' +
+			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
+			"Link: " + ITEM_LINK + '\n' +
+			" \n" +
+			ITEM_DESCRIPTON_RENDERED + '\n';
+
+		REQUIRE(result == expected);
+	}
+}

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -45,20 +45,19 @@ std::pair<std::shared_ptr<RssItem>, std::shared_ptr<RssFeed>> test_item(Cache* c
 	return {item, feed};
 }
 
-TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
+TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 		"of an RSS item, ready to be displayed to the user",
-		"[ItemRenderer]")
+		"[item_renderer]")
 {
 	TestHelpers::EnvVar tzEnv("TZ");
 	tzEnv.set("UTC");
 
 	ConfigContainer cfg;
-	// ItemRenderer uses that setting, so let's fix its value to make the test
+	// item_renderer uses that setting, so let's fix its value to make the test
 	// reproducible
 	cfg.set_configvalue("text-width", "80");
 
 	Cache rsscache(":memory:", &cfg);
-	ItemRenderer renderer;
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
@@ -67,7 +66,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 	SECTION("Item without an enclosure") {
 		item->set_description(ITEM_DESCRIPTON);
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -86,7 +85,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 		item->set_description(ITEM_DESCRIPTON);
 		item->set_enclosure_url(ITEM_ENCLOSURE_URL);
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -107,7 +106,7 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 				ITEM_DESCRIPTON +
 				"<p>See also <a href='https://example.com'>this site</a>.</p>");
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -128,9 +127,9 @@ TEST_CASE("ItemRenderer::to_plain_text() produces a rendered representation "
 	}
 }
 
-TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
+TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 		"in `text-width` setting",
-		"[ItemRenderer]")
+		"[item_renderer]")
 {
 	TestHelpers::EnvVar tzEnv("TZ");
 	tzEnv.set("UTC");
@@ -138,7 +137,6 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 	ConfigContainer cfg;
 
 	Cache rsscache(":memory:", &cfg);
-	ItemRenderer renderer;
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
@@ -160,7 +158,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 		" \n";
 
 	SECTION("If `text-width` is not set, text is rendered in 80 columns") {
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nisl \n" +
@@ -173,7 +171,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 	SECTION("If `text-width` is set to zero, text is rendered in 80 columns") {
 		cfg.set_configvalue("text-width", "0");
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nisl \n" +
@@ -186,7 +184,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 	SECTION("Text is rendered in 37 columns") {
 		cfg.set_configvalue("text-width", "37");
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, \n"
@@ -203,7 +201,7 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 	SECTION("Text is rendered in 120 columns") {
 		cfg.set_configvalue("text-width", "120");
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
@@ -216,18 +214,17 @@ TEST_CASE("ItemRenderer::to_plain_text() renders text to the width specified "
 	}
 }
 
-TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
+TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 {
 	TestHelpers::EnvVar tzEnv("TZ");
 	tzEnv.set("UTC");
 
 	ConfigContainer cfg;
-	// ItemRenderer uses that setting, so let's fix its value to make the test
+	// item_renderer uses that setting, so let's fix its value to make the test
 	// reproducible
 	cfg.set_configvalue("text-width", "80");
 
 	Cache rsscache(":memory:", &cfg);
-	ItemRenderer renderer;
 
 	std::shared_ptr<RssItem> item;
 	std::shared_ptr<RssFeed> feed;
@@ -236,7 +233,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without a feed title") {
 		item->get_feedptr()->set_title("");
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Title: " + ITEM_TITLE + '\n' +
@@ -252,7 +249,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without a title") {
 		item->set_title("");
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -268,7 +265,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without an author") {
 		item->set_author("");
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -284,7 +281,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without a link") {
 		item->set_link("");
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -300,7 +297,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without an enclosure") {
 		item->set_description(ITEM_DESCRIPTON);
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -318,7 +315,7 @@ TEST_CASE("Empty fields are not rendered", "[ItemRenderer]")
 	SECTION("Item without flags") {
 		item->set_flags("");
 
-		const auto result = renderer.to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -509,29 +509,3 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed URL "
 	const auto result = item_renderer::get_feedtitle(item);
 	REQUIRE(result == feedurl);
 }
-
-TEST_CASE("item_renderer::get_item_base_link() returns item's xml:base "
-		"if that's defined, and item's feed URL otherwise",
-		"[item_renderer]")
-{
-	ConfigContainer cfg;
-	Cache rsscache(":memory:", &cfg);
-
-	std::shared_ptr<RssItem> item;
-	std::shared_ptr<RssFeed> feed;
-	std::tie(item, feed) = test_item(&rsscache);
-
-	const auto feedurl = std::string("https://rss.example.com/something");
-	item->set_feedurl(feedurl);
-
-	SECTION("xml:base is not empty") {
-		const auto baseurl = std::string("https://example.com/else");
-		item->set_base(baseurl);
-
-		REQUIRE(item_renderer::get_item_base_link(item) == baseurl);
-	}
-
-	SECTION("xml:base is empty") {
-		REQUIRE(item_renderer::get_item_base_link(item) == feedurl);
-	}
-}

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -392,3 +392,29 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed URL "
 	const auto result = item_renderer::get_feedtitle(item);
 	REQUIRE(result == feedurl);
 }
+
+TEST_CASE("item_renderer::get_item_base_link() returns item's xml:base "
+		"if that's defined, and item's feed URL otherwise",
+		"[item_renderer]")
+{
+	ConfigContainer cfg;
+	Cache rsscache(":memory:", &cfg);
+
+	std::shared_ptr<RssItem> item;
+	std::shared_ptr<RssFeed> feed;
+	std::tie(item, feed) = test_item(&rsscache);
+
+	const auto feedurl = std::string("https://rss.example.com/something");
+	item->set_feedurl(feedurl);
+
+	SECTION("xml:base is not empty") {
+		const auto baseurl = std::string("https://example.com/else");
+		item->set_base(baseurl);
+
+		REQUIRE(item_renderer::get_item_base_link(item) == baseurl);
+	}
+
+	SECTION("xml:base is empty") {
+		REQUIRE(item_renderer::get_item_base_link(item) == feedurl);
+	}
+}


### PR DESCRIPTION
This PR wraps the work started in #311, fixing a number of bugs in the process:

1. item headers were looking differently in internal and external pagers. Now they're the same;
2. `html-renderer` setting was ignored if external pager was in use. Now users can pair any renderer with any pager;
3. `ItemViewFormAction` wasn't displaying the last line of the text rendered by an external renderer.

This refactoring also enabled me to test some of the code, which is nice.

Sorry it's a lot of changes, but I didn't see a clear way to refactor any quicker. The commits are small, though, so should be manageable if reviewed commit-by-commit.

@der-lyse, this is the PR [you were looking forward to](https://github.com/newsboat/newsboat/pull/311#discussion_r224562615); here you go ;)