### PR TITLE
BUG: avoid null url in ocnews feed parser

### DIFF
--- a/src/ocnewsapi.cpp
+++ b/src/ocnewsapi.cpp
@@ -221,7 +221,9 @@ rsspp::Feed OcNewsApi::fetch_feed(const std::string& feed_id)
 		item.title = json_object_get_string(node);
 
 		json_object_object_get_ex(item_j, "url", &node);
-		item.link = json_object_get_string(node);
+		if (node) {
+			item.link = json_object_get_string(node);
+		}
 
 		json_object_object_get_ex(item_j, "author", &node);
 		item.author = json_object_get_string(node);


### PR DESCRIPTION
I had been getting a SEGFAULT with feeds such as `https://rss.art19.com/wolverine-the-long-night` which do not provide a `url` field, as they are purely podcasts (not saying I agree with the vendor here, but I'd rather not cause crashes).

The SEGFAULT only occurred when synced via nextcloud, not when using a `urls` file directly.
I did not try any of the other url sources, so this may need to be added there as well, I suppose.

I was able to narrow it down to the url field being `null`, and avoid the line of code which segfaults with an `if`

As a result, opening the item just opens the current working directory in the browser, rather than the feed, which is perhaps not desired behavior, but is consistent with behavior when the url is given directly in a `urls` file.