### PR TITLE
Do not mention pre-commit hook in the contrib docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ Development
 -----------
 
 Decided to work on an issue, fix a bug or add a feature? Great! Be sure to
-check out [our style guide](doc/code-style.markdown) and install pre-commit
-hook.
+check out [our style guide](doc/code-style.markdown).
 
 You'll probably want to run the tests; here's how:
 

--- a/doc/code-style.markdown
+++ b/doc/code-style.markdown
@@ -8,14 +8,6 @@ Guidelines that could be easily automated, have been. Please install:
 - [EditorConfig plugin][editorconfig], so your editor can apply some of the
   formatting right as you type;
 - `clang-format` (part of `clang` package in most Linux distributions);
-- our pre-commit hook, which runs `clang-format` on each commit you make. Just
-  run:
-
-    ```shell
-    $ ln -s ../../git-hooks/pre-commit .git/hooks/pre-commit
-    ```
-
-    Note: `../..` is *not* a mistake.
 
 [editorconfig]: http://editorconfig.org/ "EditorConfig"
 

--- a/doc/code-style.markdown
+++ b/doc/code-style.markdown
@@ -7,7 +7,6 @@ a good argument for doing so.
 Guidelines that could be easily automated, have been. Please install:
 - [EditorConfig plugin][editorconfig], so your editor can apply some of the
   formatting right as you type;
-- `clang-format` (part of `clang` package in most Linux distributions);
 
 [editorconfig]: http://editorconfig.org/ "EditorConfig"
 


### PR DESCRIPTION
...as it is [disabled for now](https://github.com/newsboat/newsboat/issues/198#issuecomment-408687556) I think we should not mention it in the docs?

