### PR TITLE
Re-implement `Logger` in Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Alexander Batischev <eual.jp@gmail.com>"]
 
 [dependencies]
 libc = "0.2"
+chrono = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Alexander Batischev <eual.jp@gmail.com>"]
 [dependencies]
 libc = "0.2"
 
+[dev-dependencies]
+tempfile = "3"
+
 [lib]
 name = "newsboat"
 crate-type = ["staticlib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use libc::c_char;
 use std::ffi::{CStr, CString};
 
 pub mod utils;
+pub mod logger;
 
 #[no_mangle]
 pub extern "C" fn rs_replace_all(

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,3 +1,6 @@
+extern crate chrono;
+
+use self::chrono::offset::Local;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 
@@ -26,8 +29,10 @@ impl Logger {
 
     pub fn log(&mut self, message: &str) -> io::Result<()> {
         if let Some(ref mut logfile) = self.logfile {
-            logfile.write_all(message.as_bytes())?;
-            logfile.write_all("\n".as_bytes())?;
+            let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
+            let line = format!("[{}] {}\n", timestamp, message);
+
+            logfile.write_all(line.as_bytes())?;
         }
 
         Ok(())
@@ -41,6 +46,7 @@ mod tests {
     use super::*;
     
     use self::tempfile::TempDir;
+    use self::chrono::{TimeZone, Duration};
     use std::io::{self, BufReader, BufRead};
     use std::path;
 
@@ -79,9 +85,12 @@ mod tests {
             messages.push("Time to wrap up, see ya!");
             messages
         };
+
+        let start_time = Local::now();
         for msg in &messages {
             logger.log(msg)?;
         }
+        let finish_time = Local::now();
 
         // Dropping logger to force it to flush the log and close the file
         drop(logger);
@@ -90,7 +99,35 @@ mod tests {
         let reader = BufReader::new(file);
         for (line, expected) in reader.lines().zip(messages) {
             match line {
-                Ok(line) => assert_eq!(line, expected),
+                Ok(line) => {
+                    assert!(line.starts_with("["));
+
+                    let timestamp_end = line.find(']').expect("Failed to find the end of the timestamp");
+                    // "]" is an ASCII character, so it occupies one byte in UTF-8. As a result, we
+                    // can simply add one to get the next character's byte offset. And since the
+                    // next char should be a space, which is ASCII as well, we can just add 2.
+                    //
+                    // If timestamp is followed by something non-ASCII, indexing into &str will
+                    // panic and fail the test, which is good.
+                    assert_eq!(&line[timestamp_end+1..timestamp_end+2], " ");
+
+                    // Timestamp starts with "[", we skip it by starting at 1 rather than 0.
+                    let timestamp_str = &line[1..timestamp_end];
+                    let timestamp =
+                        Local::now()
+                        .timezone()
+                        .datetime_from_str(timestamp_str, "%Y-%m-%d %H:%M:%S")
+                        .expect("Failed to parse the timestamp from the log file");
+                    // `start_time` and `end_time` may have millisecond precision or better,
+                    // whereas `timestamp` is limited to seconds. Therefore, we account for
+                    // a situation where `start_time` is slightly bigger than `timestamp`.
+                    assert!(timestamp - start_time > Duration::seconds(-1));
+                    assert!(finish_time >= timestamp);
+
+                    // Message starts after "] " that follows the timestamp, hence +2.
+                    let message_str = &line[timestamp_end+2..];
+                    assert_eq!(message_str, expected);
+                }
                 Err(e) => return Err(e),
             }
         }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -47,7 +47,7 @@ pub enum Level {
 
     /// May be useful to programmers when debugging.
     ///
-    /// This level should be used for the most minutae details about program execution, like byte
+    /// This level should be used for the most minutiae details about program execution, like byte
     /// offsets, indices, sizes of internal data structures and so forth.
     Debug,
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -27,6 +27,7 @@ impl Logger {
     pub fn log(&mut self, message: &str) -> io::Result<()> {
         if let Some(ref mut logfile) = self.logfile {
             logfile.write_all(message.as_bytes())?;
+            logfile.write_all("\n".as_bytes())?;
         }
 
         Ok(())
@@ -81,7 +82,7 @@ mod tests {
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
 
-        assert_eq!(contents, message);
+        assert_eq!(contents, message.to_owned() + "\n");
 
         Ok(())
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,3 +1,5 @@
+//! Keeps a record of what the program did.
+
 extern crate chrono;
 
 use self::chrono::offset::Local;
@@ -6,13 +8,47 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// "Importance levels" for log messages.
+///
+/// Each message is assigned a level. set_loglevel instructs Logger to only store messages at and
+/// above a certain importance level, making the log file shorter and easier to understand.
 pub enum Level {
+    /// Not important at all, don't log.
+    ///
+    /// This level is purely for Logger's internal use, and shouldn't be passed to log(). That
+    /// isn't enforced in any way, though.
     None,
+
+    /// An error that can potentially be resolved by the user.
+    ///
+    /// This level should be used for configuration errors and the like.
     UserError,
+
+    /// An error that prevents program from working at all.
+    ///
+    /// E.g. failure to open a cache file is a critical error, because we can't do anything without
+    /// cache.
     Critical,
+
+    /// An error that prevents some function from working.
+    ///
+    /// E.g. failure to find an item in the cache prevents Newsboat from displaying it, but other
+    /// functions are still working, so overall it's not critical.
     Error,
+
+    /// Warning about a potential problem.
     Warn,
+
+    /// Useful information that can roughly explain what's going on.
+    ///
+    /// This level should be used with rought descriptions of stages that the program is going
+    /// through. Fine details (indices, array sizes etc.) should be logged at Level::Debug instead.
     Info,
+
+    /// May be useful to programmers when debugging.
+    ///
+    /// This level should be used for the most minutae details about program execution, like byte
+    /// offsets, indices, sizes of internal data structures and so forth.
     Debug,
 }
 
@@ -30,12 +66,39 @@ impl fmt::Display for Level {
     }
 }
 
+/// Keeps a record of what the program did.
+///
+/// Each message in the log is time-stamped, and marked with its importance level.
+///
+/// This is meant to be a long-lived, shared object that exists for the duration of the program.
+/// Users would call its `log` method to add messages to the log file, like this:
+///
+/// ```
+/// // Create and configure the logger
+/// let logger = Logger::new();
+/// logger.set_logfile("/path/to/my/log.txt");
+///
+/// // Only log critical and configuration errors
+/// logger.set_loglevel(Level::Critical);
+///
+/// // -- snip --
+///
+/// logger.log(Level::UserError, "Please specify a remote API to use");
+///
+/// // This one won't be logged because its importance level is too low
+/// logger.log(Level::Debug, format!("feeds.len() == {}", 42));
+/// ```
 pub struct Logger {
     logfile: Option<File>,
+
+    /// Maximum "importance level" of the messages that will be written to the log.
     loglevel: Level,
 }
 
 impl Logger {
+    /// Constructs an object that doesn't log anything.
+    ///
+    /// To make that Logger useful, you need to call set_logfile() and set_loglevel().
     pub fn new() -> Logger {
         Logger {
             logfile: None,
@@ -43,6 +106,15 @@ impl Logger {
         }
     }
 
+    /// Specifies the file to which the messages will be written.
+    ///
+    /// The file will be created if it doesn't exist yet. It will be opened in the append mode, so
+    /// its previous content will stay unchanged.
+    ///
+    /// # Errors
+    ///
+    /// This can't fail, but if the file couldn't be created or opened, an error message will be
+    /// printed to stderr.
     pub fn set_logfile(&mut self, filename: &str) {
         let file = OpenOptions::new()
             .create(true)
@@ -55,6 +127,15 @@ impl Logger {
         }
     }
 
+    /// Writes a message to a log.
+    ///
+    /// If `level` is lower than the logger's current level, the message won't be written. For
+    /// example, if Logger's level is set to Level::Critical, then Level::Error won't be written.
+    ///
+    /// # Errors
+    ///
+    /// If the message couldn't be written for whatever reason, this function ignores the failure.
+    /// Were you to check the return value of every log() call, you'd just stop writing logs.
     pub fn log(&mut self, level: Level, message: &str) {
         if level > self.loglevel {
             return;
@@ -69,6 +150,10 @@ impl Logger {
         }
     }
 
+    /// Sets maximum "importance level" of the messages that will be written to the log.
+    ///
+    /// For example, after the call to set_loglevel(Level::Error), only UserError, Critical, and
+    /// Error messages will be written.
     pub fn set_loglevel(&mut self, level: Level) {
         self.loglevel = level;
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -3,7 +3,7 @@ extern crate chrono;
 use self::chrono::offset::Local;
 use std::fmt;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Write};
+use std::io::Write;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Level {
@@ -55,19 +55,18 @@ impl Logger {
         }
     }
 
-    pub fn log(&mut self, level: Level, message: &str) -> io::Result<()> {
+    pub fn log(&mut self, level: Level, message: &str) {
         if level > self.loglevel {
-            return Ok(());
+            return;
         }
 
         if let Some(ref mut logfile) = self.logfile {
             let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S");
             let line = format!("[{}] {}: {}\n", timestamp, level, message);
 
-            logfile.write_all(line.as_bytes())?;
+            // Ignoring the error since checking every log() call will be too bothersome.
+            let _ = logfile.write_all(line.as_bytes());
         }
-
-        Ok(())
     }
 
     pub fn set_loglevel(&mut self, level: Level) {
@@ -160,7 +159,7 @@ mod tests {
 
         let start_time = Local::now();
         for msg in &messages {
-            logger.log(Level::Debug, msg)?;
+            logger.log(Level::Debug, msg);
         }
         let finish_time = Local::now();
 
@@ -212,7 +211,7 @@ mod tests {
         let msg = "Some test message";
 
         for (level, _level_str) in &levels {
-            logger.log(*level, msg)?;
+            logger.log(*level, msg);
         }
 
         // Dropping logger to force it to flush the log and close the file
@@ -254,7 +253,7 @@ mod tests {
         let msg = "Some test message";
 
         for (level, _level_str) in &levels {
-            logger.log(*level, msg)?;
+            logger.log(*level, msg);
         }
 
         // Dropping logger to force it to flush the log and close the file
@@ -271,7 +270,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(Level::None);
 
-            logger.log(Level::UserError, "hello")?;
+            logger.log(Level::UserError, "hello");
 
             drop(logger);
 
@@ -291,7 +290,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::UserError, "hello")?;
+            logger.log(Level::UserError, "hello");
 
             drop(logger);
 
@@ -312,7 +311,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Critical, "hello")?;
+            logger.log(Level::Critical, "hello");
 
             drop(logger);
 
@@ -331,7 +330,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Critical, "hello")?;
+            logger.log(Level::Critical, "hello");
 
             drop(logger);
 
@@ -353,7 +352,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Error, "hello")?;
+            logger.log(Level::Error, "hello");
 
             drop(logger);
 
@@ -371,7 +370,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Error, "hello")?;
+            logger.log(Level::Error, "hello");
 
             drop(logger);
 
@@ -394,7 +393,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Warn, "hello")?;
+            logger.log(Level::Warn, "hello");
 
             drop(logger);
 
@@ -411,7 +410,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Warn, "hello")?;
+            logger.log(Level::Warn, "hello");
 
             drop(logger);
 
@@ -435,7 +434,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Info, "hello")?;
+            logger.log(Level::Info, "hello");
 
             drop(logger);
 
@@ -451,7 +450,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Info, "hello")?;
+            logger.log(Level::Info, "hello");
 
             drop(logger);
 
@@ -476,7 +475,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Debug, "hello")?;
+            logger.log(Level::Debug, "hello");
 
             drop(logger);
 
@@ -491,7 +490,7 @@ mod tests {
             let (_tmp, logfile, mut logger) = setup_logger()?;
             logger.set_loglevel(level);
 
-            logger.log(Level::Debug, "hello")?;
+            logger.log(Level::Debug, "hello");
 
             drop(logger);
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,4 +1,5 @@
 use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
 
 pub struct Logger {
     logfile: Option<File>,
@@ -22,6 +23,14 @@ impl Logger {
             Err(error) => eprintln!("Couldn't open `{}' as a logfile: {}", filename, error),
         }
     }
+
+    pub fn log(&mut self, message: &str) -> io::Result<()> {
+        if let Some(ref mut logfile) = self.logfile {
+            logfile.write_all(message.as_bytes())?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -30,24 +39,49 @@ mod tests {
 
     use super::*;
     
-    use std::io;
     use self::tempfile::TempDir;
+    use std::io::{self, Read};
+    use std::path;
+
+    fn setup_logger() -> io::Result<(TempDir, path::PathBuf, Logger)> {
+        let tmp = TempDir::new()?;
+        let logfile = {
+            let mut logfile = tmp.path().to_owned();
+            logfile.push("example.log");
+            logfile
+        };
+        assert!(!logfile.exists());
+
+        let mut logger = Logger::new();
+        logger.set_logfile(logfile.to_str().unwrap());
+
+        Ok((tmp, logfile, logger))
+    }
 
     #[test]
     fn t_set_logfile() -> io::Result<()> {
-        let tmp = TempDir::new()?;
-        let filename = {
-            let mut filename = tmp.path().to_owned();
-            filename.push("example.log");
-            filename
-        };
+        let (_tmp, logfile, _logger) = setup_logger()?;
 
-        assert!(!filename.exists());
+        assert!(logfile.exists());
 
-        let mut logger = Logger::new();
-        logger.set_logfile(filename.to_str().unwrap());
+        Ok(())
+    }
 
-        assert!(filename.exists());
+    #[test]
+    fn t_log_writes_message_to_the_file() -> io::Result<()> {
+        let (_tmp, logfile, mut logger) = setup_logger()?;
+
+        let message = "Hello, world!";
+        logger.log(message)?;
+
+        // Dropping logger to force it to flush the log and close the file
+        drop(logger);
+
+        let mut file = File::open(logfile)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        assert_eq!(contents, message);
 
         Ok(())
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -41,7 +41,7 @@ pub enum Level {
 
     /// Useful information that can roughly explain what's going on.
     ///
-    /// This level should be used with rought descriptions of stages that the program is going
+    /// This level should be used with rough descriptions of stages that the program is going
     /// through. Fine details (indices, array sizes etc.) should be logged at Level::Debug instead.
     Info,
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 
+#[derive(Clone, Copy)]
 pub enum Level {
     None,
     UserError,
@@ -90,6 +91,37 @@ mod tests {
         Ok((tmp, logfile, logger))
     }
 
+    fn parse_log_line(line: &str) -> Option<(&str, &str, &str)> {
+        if !line.starts_with("[") {
+            return None;
+        }
+
+        let timestamp_end = line.find(']').expect("Failed to find the end of the timestamp");
+        // Timestamp starts with "[", we skip it by starting at 1 rather than 0.
+        let timestamp = &line[1..timestamp_end];
+
+        // "]" is an ASCII character, so it occupies one byte in UTF-8. As a result, we
+        // can simply add one to get the next character's byte offset. And since the
+        // next char should be a space, which is ASCII as well, we can just add 2.
+        //
+        // If timestamp is followed by something non-ASCII, indexing into &str will
+        // panic and fail the test, which is good.
+        if &line[timestamp_end+1..timestamp_end+2] != " " {
+            return None;
+        }
+
+        let level_end =
+            line[timestamp_end+2..]
+            .find(':')
+            .expect("Failed to find the end of the loglevel");
+        let level = &line[timestamp_end+2..timestamp_end+2+level_end];
+
+        // Message starts after ": " that follows the level, hence +2.
+        let message = &line[timestamp_end+2+level_end+2..];
+
+        Some((timestamp, level, message))
+    }
+
     #[test]
     fn t_set_logfile() -> io::Result<()> {
         let (_tmp, logfile, _logger) = setup_logger()?;
@@ -103,13 +135,11 @@ mod tests {
     fn t_log_writes_message_to_the_file() -> io::Result<()> {
         let (_tmp, logfile, mut logger) = setup_logger()?;
 
-        let messages = {
-            let mut messages = vec![];
-            messages.push("Hello, world!");
-            messages.push("I'm doing fine, how are you?");
-            messages.push("Time to wrap up, see ya!");
-            messages
-        };
+        let messages = vec![
+            "Hello, world!",
+            "I'm doing fine, how are you?",
+            "Time to wrap up, see ya!",
+        ];
 
         let start_time = Local::now();
         for msg in &messages {
@@ -125,19 +155,10 @@ mod tests {
         for (line, expected) in reader.lines().zip(messages) {
             match line {
                 Ok(line) => {
-                    assert!(line.starts_with("["));
+                    let (timestamp_str, _level, message) =
+                        parse_log_line(&line)
+                        .expect("Failed to split the log line into parts");
 
-                    let timestamp_end = line.find(']').expect("Failed to find the end of the timestamp");
-                    // "]" is an ASCII character, so it occupies one byte in UTF-8. As a result, we
-                    // can simply add one to get the next character's byte offset. And since the
-                    // next char should be a space, which is ASCII as well, we can just add 2.
-                    //
-                    // If timestamp is followed by something non-ASCII, indexing into &str will
-                    // panic and fail the test, which is good.
-                    assert_eq!(&line[timestamp_end+1..timestamp_end+2], " ");
-
-                    // Timestamp starts with "[", we skip it by starting at 1 rather than 0.
-                    let timestamp_str = &line[1..timestamp_end];
                     let timestamp =
                         Local::now()
                         .timezone()
@@ -149,10 +170,47 @@ mod tests {
                     assert!(timestamp - start_time > Duration::seconds(-1));
                     assert!(finish_time >= timestamp);
 
-                    // Message starts after "] " that follows the timestamp, hence +2.
-                    let message_str = &line[timestamp_end+2..];
-                    let level = String::from("DEBUG: ");
-                    assert_eq!(message_str, level + expected);
+                    assert_eq!(message, expected);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn t_different_loglevels_have_different_names() -> io::Result<()> {
+        let (_tmp, logfile, mut logger) = setup_logger()?;
+
+        let levels = vec![
+            (Level::UserError, "USERERROR"),
+            (Level::Critical, "CRITICAL"),
+            (Level::Error, "ERROR"),
+            (Level::Warn, "WARNING"),
+            (Level::Info, "INFO"),
+            (Level::Debug, "DEBUG"),
+        ];
+
+        let msg = "Some test message";
+
+        for (level, _level_str) in &levels {
+            logger.log(*level, msg)?;
+        }
+
+        // Dropping logger to force it to flush the log and close the file
+        drop(logger);
+
+        let file = File::open(logfile)?;
+        let reader = BufReader::new(file);
+        for (line, expected) in reader.lines().zip(levels.iter().map(|(_, l)| l)) {
+            match line {
+                Ok(line) => {
+                    let (_timestamp_str, level, _message) =
+                        parse_log_line(&line)
+                        .expect("Failed to split the log line into parts");
+
+                    assert_eq!(&level, expected);
                 }
                 Err(e) => return Err(e),
             }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,54 @@
+use std::fs::{File, OpenOptions};
+
+pub struct Logger {
+    logfile: Option<File>,
+}
+
+impl Logger {
+    pub fn new() -> Logger {
+        Logger {
+            logfile: None,
+        }
+    }
+
+    pub fn set_logfile(&mut self, filename: &str) {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(filename);
+
+        match file {
+            Ok(file) => self.logfile = Some(file),
+            Err(error) => eprintln!("Couldn't open `{}' as a logfile: {}", filename, error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate tempfile;
+
+    use super::*;
+    
+    use std::io;
+    use self::tempfile::TempDir;
+
+    #[test]
+    fn t_set_logfile() -> io::Result<()> {
+        let tmp = TempDir::new()?;
+        let filename = {
+            let mut filename = tmp.path().to_owned();
+            filename.push("example.log");
+            filename
+        };
+
+        assert!(!filename.exists());
+
+        let mut logger = Logger::new();
+        logger.set_logfile(filename.to_str().unwrap());
+
+        assert!(filename.exists());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This relates to #333.

I reimplemented everything but the singleton aspect of the existing logger, and thus didn't port the `LOG` macro. I already understand how these two things should be done, but it turns out I need to re-organize things first, otherwise I won't be able to test it. That's the topic for my next PR.

I decided to make this PR now because what I did here is complete, and can be reviewed. I better not hit you with gigantic PRs anymore :)

Everyone is welcome to review, especially so because I don't know whom to ask specifically. If there are Rust programmers reading this, please take a look!