### PR TITLE
Add rust implementation of consolidate_whitespace

### DIFF
--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -10,6 +10,8 @@ char* rs_replace_all(
 		const char* from,
 		const char* to);
 
+char* rs_consolidate_whitespace( const char* str);
+
 void rs_cstring_free(char* str);
 
 class RustString {

--- a/include/utils.h
+++ b/include/utils.h
@@ -61,8 +61,7 @@ namespace utils {
 	std::vector<std::string> tokenize_quoted(const std::string& str,
 		std::string delimiters = " \r\n\t");
 
-	std::string consolidate_whitespace(const std::string& str,
-		std::string whitespace = " \r\n\t");
+	std::string consolidate_whitespace(const std::string& str);
 
 	std::vector<std::wstring> wtokenize(const std::wstring& str,
 		std::wstring delimiters = L" \r\n\t");

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -43,7 +43,7 @@ pub extern "C" fn rs_consolidate_whitespace( input: *const c_char) -> *mut c_cha
     let result = utils::consolidate_whitespace(rs_input);
     // Panic here can't happen because:
     // 1. panic can only happen if `result` contains null bytes;
-    // 2. `result` contains what `input` contained, and input is a 
+    // 2. `result` contains what `input` contained, and input is a
     // null-terminated string from C.
     let result = CString::new(result).unwrap();
     result.into_raw()

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -36,6 +36,17 @@ pub extern "C" fn rs_replace_all(
 }
 
 #[no_mangle]
+pub extern "C" fn rs_consolidate_whitespace( input: *const c_char) -> *mut c_char {
+    let rs_input = unsafe { CStr::from_ptr(input) };
+    let rs_input = rs_input.to_string_lossy().into_owned();
+
+    let result = utils::consolidate_whitespace(rs_input);
+
+    let result = CString::new(result).unwrap();
+    result.into_raw()
+}
+
+#[no_mangle]
 pub extern "C" fn rs_cstring_free(string: *mut c_char) {
     unsafe {
         if string.is_null() { return }

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -41,7 +41,10 @@ pub extern "C" fn rs_consolidate_whitespace( input: *const c_char) -> *mut c_cha
     let rs_input = rs_input.to_string_lossy().into_owned();
 
     let result = utils::consolidate_whitespace(rs_input);
-
+    // Panic here can't happen because:
+    // 1. panic can only happen if `result` contains null bytes;
+    // 2. `result` contains what `input` contained, and input is a 
+    // null-terminated string from C.
     let result = CString::new(result).unwrap();
     result.into_raw()
 }

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -6,8 +6,8 @@ pub fn consolidate_whitespace( input: String ) -> String {
     let found = input.find( |c: char| !c.is_whitespace() );
     let mut result = String::new();
 
-    if found.is_some() {
-        let (leading,rest) = input.split_at(found.unwrap());
+    if let Some(found) = found {
+        let (leading,rest) = input.split_at(found);
         let lastchar = input.chars().rev().next().unwrap();
 
         result.push_str(leading);

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -2,6 +2,30 @@ pub fn replace_all(input: String, from: &str, to: &str) -> String {
     input.replace(from, to)
 }
 
+pub fn consolidate_whitespace( input: String ) -> String {
+    let found = input.find( |c: char| !c.is_whitespace() );
+    let mut result = String::new();
+
+    if found.is_some() {
+        let (leading,rest) = input.split_at(found.unwrap());
+        let lastchar = input.chars().rev().next().unwrap();
+
+        result.push_str(leading);
+
+        let iter = rest.split_whitespace();
+        for elem in iter {
+            result.push_str(elem);
+            result.push(' ');
+        }
+        result.pop();
+        if lastchar.is_whitespace() {
+            result.push(' ');
+        }
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -32,4 +56,25 @@ mod tests {
             replace_all(String::from("o o o"), "o", "<o>"),
             String::from("<o> <o> <o>"));
     }
+
+    #[test]
+    fn t_consolidate_whitespace() {
+        assert_eq!(
+            consolidate_whitespace(String::from("LoremIpsum")),
+            String::from("LoremIpsum"));
+        assert_eq!(
+            consolidate_whitespace(String::from("Lorem Ipsum")),
+            String::from("Lorem Ipsum"));
+        assert_eq!(
+            consolidate_whitespace(String::from(" Lorem \t\tIpsum \t ")),
+            String::from(" Lorem Ipsum "));
+        assert_eq!(consolidate_whitespace(String::from(" Lorem \r\n\r\n\tIpsum")),
+            String::from(" Lorem Ipsum"));
+        assert_eq!(consolidate_whitespace(String::new()), String::new());
+        assert_eq!(consolidate_whitespace(String::from("    Lorem \t\tIpsum \t ")),
+            String::from("    Lorem Ipsum "));
+        assert_eq!(consolidate_whitespace(String::from("   Lorem \r\n\r\n\tIpsum")),
+            String::from("   Lorem Ipsum"));
+    }
 }
+

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -243,8 +243,7 @@ std::vector<std::string> utils::tokenize_spaced(const std::string& str,
 	return tokens;
 }
 
-std::string utils::consolidate_whitespace(const std::string& str,
-	__attribute__((unused))std::string whitespace) {
+std::string utils::consolidate_whitespace(const std::string& str) {
 
 	return RustString(rs_consolidate_whitespace(str.c_str()));
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -244,25 +244,9 @@ std::vector<std::string> utils::tokenize_spaced(const std::string& str,
 }
 
 std::string utils::consolidate_whitespace(const std::string& str,
-	std::string whitespace)
-{
-	std::string result;
-	std::string::size_type last_pos = str.find_first_not_of(whitespace);
-	std::string::size_type pos = str.find_first_of(whitespace, last_pos);
+	__attribute__((unused))std::string whitespace) {
 
-	if (last_pos != 0 && str != "") {
-		result.append(str.substr(0, last_pos));
-	}
-
-	while (std::string::npos != pos || std::string::npos != last_pos) {
-		result.append(str.substr(last_pos, pos - last_pos));
-		last_pos = str.find_first_not_of(whitespace, pos);
-		if (last_pos > pos)
-			result.append(" ");
-		pos = str.find_first_of(whitespace, last_pos);
-	}
-
-	return result;
+	return RustString(rs_consolidate_whitespace(str.c_str()));
 }
 
 std::vector<std::string> utils::tokenize_nl(const std::string& str,


### PR DESCRIPTION
You'll have to let me know if this is done the way we want.
I checked the current codebase and even though consolidate_whitespace has 2 arguments, one has a default arg which is never used. Because of this I just removed it from my implementation.