### PR TITLE
Whitelist strprintf input types

### DIFF
--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -63,7 +63,7 @@ namespace strprintf {
 
 	template<typename... Args>
 	std::string
-	fmt(const std::string& format, const nullptr_t argument, Args... args)
+	fmt(const std::string& format, const std::nullptr_t argument, Args... args)
 	{
 		return fmt_impl(format, argument, args...);
 	}

--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -8,39 +8,78 @@
 namespace newsboat {
 
 namespace strprintf {
+	namespace {
+		template<typename T, typename... Args>
+		std::string
+		fmt_impl(const std::string& format, const T& argument, Args... args);
+	}
+
 	std::pair<std::string, std::string> split_format(
 		const std::string& printf_format);
 
 	std::string fmt(const std::string& format);
 
-	template<typename T, typename... Args> std::string fmt(const std::string& format, const T& argument, Args... args);
-	template<typename... Args> std::string fmt(const std::string& format, const std::string& argument, Args... args);
-	template<typename... Args> std::string fmt(const std::string& format, const std::string* argument, Args... args);
-
-	template<typename T, typename... Args>
+	template<typename... Args>
 	std::string
-	fmt(const std::string& format, const T& argument, Args... args)
+	fmt(const std::string& format, const char* argument, Args... args)
 	{
-		std::string local_format, remaining_format;
-		std::tie(local_format, remaining_format) = split_format(format);
+		return fmt_impl(format, argument, args...);
+	}
 
-		char buffer[1024];
-		std::string result;
-		unsigned int len = 1 +
-			snprintf(buffer,
-				sizeof(buffer),
-				local_format.c_str(),
-				argument);
-		if (len <= sizeof(buffer)) {
-			result = buffer;
-		} else {
-			std::vector<char> buf(len);
-			snprintf(
-				buf.data(), len, local_format.c_str(), argument);
-			result = buf.data();
-		}
+	template<typename... Args>
+	std::string
+	fmt(const std::string& format, const int argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
+	}
 
-		return result + fmt(remaining_format, args...);
+	template<typename... Args>
+	std::string
+	fmt(const std::string& format, const unsigned int argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
+	}
+
+	template<typename... Args>
+	std::string
+	fmt(const std::string& format, const long int argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
+	}
+
+	template<typename... Args>
+	std::string
+	fmt(const std::string& format, const long unsigned int argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
+	}
+
+	template<typename... Args>
+	std::string
+	fmt(const std::string& format, const void* argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
+	}
+
+	template<typename... Args>
+	std::string
+	fmt(const std::string& format, const nullptr_t argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
+	}
+
+	template<typename... Args>
+	std::string
+	fmt(const std::string& format, const double argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
+	}
+
+	template<typename... Args>
+	std::string
+	fmt(const std::string& format, const float argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
 	}
 
 	template<typename... Args>
@@ -56,9 +95,36 @@ namespace strprintf {
 		const std::string* argument,
 		Args... args)
 	{
-		return fmt(format, *argument, args...);
+		return fmt(format, argument->c_str(), args...);
 	}
 
+	namespace {
+		template<typename T, typename... Args>
+		std::string
+		fmt_impl(const std::string& format, const T& argument, Args... args)
+		{
+			std::string local_format, remaining_format;
+			std::tie(local_format, remaining_format) = split_format(format);
+
+			char buffer[1024];
+			std::string result;
+			unsigned int len = 1 +
+				snprintf(buffer,
+					sizeof(buffer),
+					local_format.c_str(),
+					argument);
+			if (len <= sizeof(buffer)) {
+				result = buffer;
+			} else {
+				std::vector<char> buf(len);
+				snprintf(
+					buf.data(), len, local_format.c_str(), argument);
+				result = buf.data();
+			}
+
+			return result + fmt(remaining_format, args...);
+		}
+	}
 };
 
 } // namespace newsboat

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -144,7 +144,7 @@ CliArgsParser::CliArgsParser(int argc, char* argv[])
 					strprintf::fmt(_("%s: %d: invalid "
 							 "loglevel value"),
 						argv[0],
-						l);
+						static_cast<int>(l));
 
 				should_return = true;
 				return_code = EXIT_FAILURE;

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -282,7 +282,7 @@ void ConfigContainer::handle_action(const std::string& action,
 	LOG(Level::DEBUG,
 		"ConfigContainer::handle_action: action = %s, type = %u",
 		action,
-		cfgdata.type);
+		static_cast<unsigned int>(cfgdata.type));
 
 	if (params.size() < 1) {
 		throw ConfigHandlerException(

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -630,7 +630,7 @@ void KeyMap::handle_action(const std::string& action,
 					"KeyMap::handle_action: new operation "
 					"`%s' "
 					"(op = %u)",
-					it,
+					*it,
 					tmpcmd.op);
 				if (tmpcmd.op == OP_NIL)
 					throw ConfigHandlerException(
@@ -650,7 +650,8 @@ void KeyMap::handle_action(const std::string& action,
 					LOG(Level::DEBUG,
 						"KeyMap::handle_action: new "
 						"parameter `%s' (op = %u)",
-						it);
+						*it,
+						tmpcmd.op);
 					tmpcmd.args.push_back(*it);
 				}
 			}

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -231,7 +231,7 @@ int PbController::run(int argc, char* argv[])
 				std::cerr << strprintf::fmt(_("%s: %d: invalid "
 							      "loglevel value"),
 						     argv[0],
-						     l)
+						     static_cast<int>(l))
 					  << std::endl;
 				return EXIT_FAILURE;
 			}

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -18,9 +18,9 @@ TextFormatter::~TextFormatter() {}
 void TextFormatter::add_line(LineType type, std::string line)
 {
 	LOG(Level::DEBUG,
-		"TextFormatter::add_line: `%s' (line type %i)",
+		"TextFormatter::add_line: `%s' (line type %u)",
 		line,
-		type);
+		static_cast<unsigned int>(type));
 
 	auto clean_line = utils::wstr2str(
 		utils::clean_nonprintable_characters(utils::str2wstr(line)));
@@ -141,7 +141,7 @@ std::vector<std::string> format_text_plain_helper(
 			"TextFormatter::format_text_plain: got line `%s' type "
 			"%u",
 			text,
-			type);
+			static_cast<unsigned int>(type));
 
 		if (rxman && type != LineType::hr) {
 			rxman->quote_and_highlight(text, location);


### PR DESCRIPTION
Up until now, strprintf::fmt() gladly accepted anything that has been thrown at it: ints, strings, void pointers, std::vector iterators. It's the latter that cause problems: sprintf (used by fmt() internally) doesn't know how to format these complicated objects, and prints some garbage instead. C++ didn't notice, but as I work on the new Rust logger, I found that some log messages aren't valid UTF-8 because of this.

The only solution I could come up with is to whitelist the input types. strprintf::fmt() will fail the compilation with a long scary template error if you feed it something it doesn't expect. I don't know how to make the error any better, but hopefully it won't occur that often, and is simple enough to understand if you read it from the beginning.

Apart from the hideous error message, there is also an issue of repetitive code. I tried to avoid that with `enable_if` and `is_same`, but couldn't get it to work. I'd accept a PR fixing this if someone knows how!