### PR TITLE
Address @noctux' feedback on #343

### DIFF
--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -113,6 +113,13 @@ namespace strprintf {
 					sizeof(buffer),
 					local_format.c_str(),
 					argument);
+			// snprintf returns the length of the formatted string. If it's
+			// longer than the buffer size, we have to enlarge the buffer in
+			// order to get the whole result.
+			//
+			// `<=` is correct since we've added 1 to `len`, above. We have to
+			// do it because `buffer` has to fit not only the string but the
+			// terminating null byte as well.
 			if (len <= sizeof(buffer)) {
 				result = buffer;
 			} else {

--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -56,6 +56,20 @@ namespace strprintf {
 
 	template<typename... Args>
 	std::string
+	fmt(const std::string& format, const long long int argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
+	}
+
+	template<typename... Args>
+	std::string
+	fmt(const std::string& format, const long long unsigned int argument, Args... args)
+	{
+		return fmt_impl(format, argument, args...);
+	}
+
+	template<typename... Args>
+	std::string
 	fmt(const std::string& format, const void* argument, Args... args)
 	{
 		return fmt_impl(format, argument, args...);


### PR DESCRIPTION
> > Would it help if I added a comment saying "sprintf returns the length of the formatted string. If it's longer than the buffer size, we have to enlarge the buffer in order to get the whole result"?
>
> that comment would really be helpful.

Done.

> > However, you mentioning compile-time checking of format strings made me realise that the code doesn't check if the format string contains more formats than arguments passed to fmt—it only checks that there are enough formats to use all the arguments. So I'll be adding that additional check as well.

Turns out I was confused; the code doesn't check the format string at compile time. All it does is "unroll" a variadic call into a series of ordinary call, each specialized to its own type. The format-string-splitting happen at runtime.

> > I just fixed OS X builds, and it turns out that both GCC and Clang find that fmt is sometimes ambiguous.

That fix haven't landed in master yet, but I rebased it on top of this PR. Hopefully we'll see some green light [on Travis](https://travis-ci.org/newsboat/newsboat/builds/450446047) soon. I'm submitting the PR without the green light because:
1. the code can be reviewed as-is;
2. I won't be submitting that Travis fix as a PR (it's boring infrastructure stuff, I don't see how a review will help there), so it doesn't really matter for this PR.