### PR TITLE
Add Rust version of get_random_value function

### DIFF
--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -18,6 +18,8 @@ char* rs_trim(const char* str);
 
 char* rs_trim_end(const char* str);
 
+unsigned int rs_get_random_value(const unsigned int max);
+
 void rs_cstring_free(char* str);
 
 class RustString {

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -81,6 +81,11 @@ pub extern "C" fn rs_trim(input: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
+pub extern "C" fn rs_get_random_value(rs_max: u32 ) -> u32 {
+    utils::get_random_value(rs_max)
+}
+
+#[no_mangle]
 pub extern "C" fn rs_cstring_free(string: *mut c_char) {
     unsafe {
         if string.is_null() { return }

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Alexander Batischev <eual.jp@gmail.com>"]
 
 [dependencies]
 chrono = "0.4"
+rand = "0.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -45,6 +45,11 @@ pub fn trim_end(rs_str: String) -> String {
     rs_str.trim_right_matches(x).to_string()
 }
 
+extern crate rand;
+pub fn get_random_value(max: u32) -> u32 {
+   rand::random::<u32>() % max
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -1,3 +1,5 @@
+extern crate rand;
+
 pub fn replace_all(input: String, from: &str, to: &str) -> String {
     input.replace(from, to)
 }
@@ -45,7 +47,6 @@ pub fn trim_end(rs_str: String) -> String {
     rs_str.trim_right_matches(x).to_string()
 }
 
-extern crate rand;
 pub fn get_random_value(max: u32) -> u32 {
    rand::random::<u32>() % max
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1025,15 +1025,7 @@ std::string utils::quote(const std::string& str)
 
 unsigned int utils::get_random_value(unsigned int max)
 {
-	static bool initialized = false;
-	if (!initialized) {
-		initialized = true;
-		srand(~(time(nullptr) ^ getpid() ^ getppid()));
-	}
-	// OpenBSD will warn you that rand() can be deterministic. We don't
-	// care, because this function is only used for simple things like
-	// selecting a random unread item.
-	return static_cast<unsigned int>(rand() % max);
+	return rs_get_random_value(max);
 }
 
 std::string utils::quote_if_necessary(const std::string& str)


### PR DESCRIPTION
Rand crate requires rustc 1.22 or higher so that shouldn't be a problem.

I can see how the crate import might need to be moved. 