### PR TITLE
Add Rust implementation of escape and unescape url

### DIFF
--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -34,8 +34,6 @@ char* rs_trim_end(const char* str);
 
 unsigned int rs_get_random_value(const unsigned int max);
 
-char* rs_escape_url(const char* str);
-
 char* rs_unescape_url(const char* str);
 
 void rs_cstring_free(char* str);

--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -34,6 +34,10 @@ char* rs_trim_end(const char* str);
 
 unsigned int rs_get_random_value(const unsigned int max);
 
+char* rs_escape_url(const char* str);
+
+char* rs_unescape_url(const char* str);
+
 void rs_cstring_free(char* str);
 
 char* rs_get_default_browser();

--- a/include/utils.h
+++ b/include/utils.h
@@ -151,7 +151,6 @@ namespace utils {
 	std::string get_content(xmlNode* node);
 	std::string get_basename(const std::string& url);
 
-	std::string escape_url(const std::string& url);
 	std::string unescape_url(const std::string& url);
 	void initialize_ssl_implementation(void);
 

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -139,20 +139,6 @@ pub extern "C" fn rs_get_random_value(rs_max: u32 ) -> u32 {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_escape_url(input: *const c_char) -> *mut c_char {
-    let rs_input = unsafe { CStr::from_ptr(input) };
-    let rs_input = rs_input.to_string_lossy().into_owned();
-
-    let result = utils::escape_url(rs_input);
-    // Panic here can't happen because:
-    // 1. panic can only happen if `result` contains null bytes;
-    // 2. `result` contains what `input` contained, and input is a
-    // null-terminated string from C.
-    let result = CString::new(result).unwrap();
-    result.into_raw()
-}
-
-#[no_mangle]
 pub extern "C" fn rs_unescape_url(input: *const c_char) -> *mut c_char {
     let rs_input = unsafe { CStr::from_ptr(input) };
     let rs_input = rs_input.to_string_lossy().into_owned();

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -139,6 +139,36 @@ pub extern "C" fn rs_get_random_value(rs_max: u32 ) -> u32 {
 }
 
 #[no_mangle]
+pub extern "C" fn rs_escape_url(input: *const c_char) -> *mut c_char {
+    let rs_input = unsafe { CStr::from_ptr(input) };
+    let rs_input = rs_input.to_string_lossy().into_owned();
+
+    let result = utils::escape_url(rs_input);
+    // Panic here can't happen because:
+    // 1. panic can only happen if `result` contains null bytes;
+    // 2. `result` contains what `input` contained, and input is a
+    // null-terminated string from C.
+    let result = CString::new(result).unwrap();
+    result.into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn rs_unescape_url(input: *const c_char) -> *mut c_char {
+    let rs_input = unsafe { CStr::from_ptr(input) };
+    let rs_input = rs_input.to_string_lossy().into_owned();
+
+    let result = utils::unescape_url(rs_input);
+    // Panic here can't happen because:
+    // 1. It would have already occured within unescape_url
+    // 2. panic can only happen if `result` contains null bytes;
+    // 3. `result` contains what `input` contained, and input is a
+    // null-terminated string from C.
+    let result = CString::new(result).unwrap();
+    result.into_raw()
+}
+
+
+#[no_mangle]
 pub extern "C" fn rs_cstring_free(string: *mut c_char) {
     unsafe {
         if string.is_null() { return }

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -3,6 +3,7 @@ extern crate libnewsboat;
 
 use libc::c_char;
 use std::ffi::{CStr, CString};
+use std::ptr;
 
 use libnewsboat::{utils, logger};
 
@@ -149,8 +150,11 @@ pub extern "C" fn rs_unescape_url(input: *const c_char) -> *mut c_char {
     // 2. panic can only happen if `result` contains null bytes;
     // 3. `result` contains what `input` contained, and input is a
     // null-terminated string from C.
-    let result = CString::new(result).unwrap();
-    result.into_raw()
+    if result.is_some(){
+            let result = CString::new(result.unwrap()).unwrap();
+            return result.into_raw()
+    }
+    return ptr::null_mut()
 }
 
 

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -7,6 +7,8 @@ use self::regex::Regex;
 use self::url::{Url};
 use self::url::percent_encoding::*;
 
+use logger::{Level, self};
+
 pub fn replace_all(input: String, from: &str, to: &str) -> String {
     input.replace(from, to)
 }
@@ -452,7 +454,9 @@ mod tests {
         for attr in &valid {
             assert!(is_valid_attribute(attr));
         }
+    }
 
+    #[test]
     fn t_escape_url() {
         assert!(escape_url(String::from("foo bar")) ==
                 String::from("foo%20bar"));

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -7,8 +7,6 @@ use self::regex::Regex;
 use self::url::{Url};
 use self::url::percent_encoding::*;
 
-use logger::{Level, self};
-
 pub fn replace_all(input: String, from: &str, to: &str) -> String {
     input.replace(from, to)
 }
@@ -231,16 +229,14 @@ pub fn is_valid_podcast_type(mimetype: &str) -> bool {
     matches || found
 }
 
-pub fn unescape_url(rs_str: String) -> String {
+pub fn unescape_url(rs_str: String) -> Option<String> {
     let result = percent_decode(rs_str.as_bytes());
     let result = result.decode_utf8();
     if result.is_err() {
-        log!(Level::Error,
-                    &format!("percent_decode failed to escape url {}", rs_str));
-        panic!("Escaping url Failed");
+            return None
     }
 
-    result.unwrap().replace("\0","")
+    Some(result.unwrap().replace("\0",""))
 }
 
 #[cfg(test)]
@@ -451,10 +447,10 @@ mod tests {
 
     #[test]
     fn t_unescape_url() {
-        assert!(unescape_url(String::from("foo%20bar")) ==
+        assert!(unescape_url(String::from("foo%20bar")).unwrap() ==
                              String::from("foo bar"));
         assert!(unescape_url(
-                String::from("%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D")) ==
+                String::from("%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D")).unwrap() ==
             String::from("!#$&'()*+,/:;=?@[]"));
     }
 }

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -231,13 +231,6 @@ pub fn is_valid_podcast_type(mimetype: &str) -> bool {
     matches || found
 }
 
-pub fn escape_url(rs_str: String) -> String {
-    define_encode_set! {
-        pub URL_ENCODE_SET = [SIMPLE_ENCODE_SET] | {' ','!','#','$','&','\'','(',')','*','+',',','/',':',';','=','?','@','[',']'}
-    }
-    percent_encode(rs_str.as_bytes(),URL_ENCODE_SET).to_string()
-}
-
 pub fn unescape_url(rs_str: String) -> String {
     let result = percent_decode(rs_str.as_bytes());
     let result = result.decode_utf8();
@@ -454,14 +447,6 @@ mod tests {
         for attr in &valid {
             assert!(is_valid_attribute(attr));
         }
-    }
-
-    #[test]
-    fn t_escape_url() {
-        assert!(escape_url(String::from("foo bar")) ==
-                String::from("foo%20bar"));
-        assert!(escape_url(String::from("!#$&'()*+,/:;=?@[]")) ==
-                String::from("%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"));
     }
 
     #[test]

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1118,11 +1118,6 @@ curl_proxytype utils::get_proxy_type(const std::string& type)
 	return CURLPROXY_HTTP;
 }
 
-std::string utils::escape_url(const std::string& url)
-{
-	return RustString(rs_escape_url(url.c_str()));
-}
-
 std::string utils::unescape_url(const std::string& url)
 {
 	return RustString(rs_unescape_url(url.c_str()));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1122,8 +1122,8 @@ std::string utils::unescape_url(const std::string& url)
 {
 	char* ptr = rs_unescape_url(url.c_str());
 	if (ptr == nullptr) {
-		LOG(Level::DEBUG, "Rust failed to escape url: %s", url );
-		throw std::runtime_error("escaping url failed");
+		LOG(Level::DEBUG, "Rust failed to unescape url: %s", url );
+		throw std::runtime_error("unescaping url failed");
 	} else {
 		return RustString(ptr);
 	}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1120,30 +1120,12 @@ curl_proxytype utils::get_proxy_type(const std::string& type)
 
 std::string utils::escape_url(const std::string& url)
 {
-	CURL* easyhandle = curl_easy_init();
-	char* output = curl_easy_escape(easyhandle, url.c_str(), 0);
-	if (!output) {
-		LOG(Level::DEBUG, "Libcurl failed to escape url: %s", url);
-		throw std::runtime_error("escaping url failed");
-	}
-	std::string s = output;
-	curl_free(output);
-	curl_easy_cleanup(easyhandle);
-	return s;
+	return RustString(rs_escape_url(url.c_str()));
 }
 
 std::string utils::unescape_url(const std::string& url)
 {
-	CURL* easyhandle = curl_easy_init();
-	char* output = curl_easy_unescape(easyhandle, url.c_str(), 0, NULL);
-	if (!output) {
-		LOG(Level::DEBUG, "Libcurl failed to escape url: %s", url);
-		throw std::runtime_error("escaping url failed");
-	}
-	std::string s = output;
-	curl_free(output);
-	curl_easy_cleanup(easyhandle);
-	return s;
+	return RustString(rs_unescape_url(url.c_str()));
 }
 
 std::wstring utils::clean_nonprintable_characters(std::wstring text)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1120,7 +1120,13 @@ curl_proxytype utils::get_proxy_type(const std::string& type)
 
 std::string utils::unescape_url(const std::string& url)
 {
-	return RustString(rs_unescape_url(url.c_str()));
+	char* ptr = rs_unescape_url(url.c_str());
+	if (ptr == nullptr) {
+		LOG(Level::DEBUG, "Rust failed to escape url: %s", url );
+		throw std::runtime_error("escaping url failed");
+	} else {
+		return RustString(ptr);
+	}
 }
 
 std::wstring utils::clean_nonprintable_characters(std::wstring text)

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -949,15 +949,6 @@ TEST_CASE("is_valid_attribute returns true if given string is an STFL attribute"
 	}
 }
 
-TEST_CASE("escape_url() takes a string and returns the string in "
-		"percent-encoding format",
-		"[utils]")
-{
-	REQUIRE(utils::escape_url("foo bar") == "foo%20bar");
-	REQUIRE(utils::escape_url("!#$&'()*+,/:;=?@[]") ==
-			"%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D");
-}
-
 TEST_CASE("unescape_url() takes a percent-encoded string and returns the string "
 		"with a precent escaped string",
 		"[utils]")

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -947,4 +947,24 @@ TEST_CASE("is_valid_attribute returns true if given string is an STFL attribute"
 	for (const auto& attr : valid) {
 		REQUIRE(utils::is_valid_attribute(attr));
 	}
+
+TEST_CASE("escape_url() takes a string and returns the string in "
+		"percent-encoding format",
+		"[utils]")
+{
+	REQUIRE(utils::escape_url("foo bar") == "foo%20bar");
+	REQUIRE(utils::escape_url("!#$&'()*+,/:;=?@[]") ==
+			"%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D");
+}
+
+TEST_CASE("unescape_url() takes a percent-encoded string and returns the string "
+		"with a precent escaped string",
+		"[utils]")
+{
+	REQUIRE(utils::unescape_url("foo%20bar") == "foo bar");
+	REQUIRE(utils::unescape_url(
+			"%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D") ==
+			"!#$&'()*+,/:;=?@[]");
+	REQUIRE(utils::unescape_url("%00") == "");
+
 }

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -947,6 +947,7 @@ TEST_CASE("is_valid_attribute returns true if given string is an STFL attribute"
 	for (const auto& attr : valid) {
 		REQUIRE(utils::is_valid_attribute(attr));
 	}
+}
 
 TEST_CASE("escape_url() takes a string and returns the string in "
 		"percent-encoding format",


### PR DESCRIPTION
Did these together because they were related. Addresses 2/40ths of #334 
I found a crate `urlencoding` which does exactly what we need since the old implementation uses a curllib call which we no longer have access to in Rust.
 
I can see an argument against this inclusion being the leftpad incident. Since `urlencoding` is licenced under MIT, I could just borrow their code for our purposes.