### PR TITLE
Add a basename version of podboats filename display

### DIFF
--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -1000,7 +1000,7 @@ Identifier:Meaning
 [[podlist-format-k]]<<podlist-format-k,+k+>>:Dowload speed, displays two digit of precision
 [[podlist-format-S]]<<podlist-format-S,+S+>>:Status of download, displays one of the folowing; "queued", "downloading", "ready", "canceled", "deleted", "incomplete", "played", "finished" or "failed"
 [[podlist-format-u]]<<podlist-format-u,+u+>>:Url of the download
-[[podlist-format-F]]<<podlist-format-F,+F+>>:Filename of the download
+[[podlist-format-F]]<<podlist-format-F,+F+>>:Absolute filename of the download from the root directory (e.g. ~/downloads/podcast.mp3 -> /home/name/downloads/podcast.mp3)
 [[podlist-format-b]]<<podlist-format-b,+b+>>:Basename of the download (e.g. /home/name/downloads/podcast.mp3 -> podcast.mp3)
 |======================================================================
 

--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -1001,6 +1001,7 @@ Identifier:Meaning
 [[podlist-format-S]]<<podlist-format-S,+S+>>:Status of download, displays one of the folowing; "queued", "downloading", "ready", "canceled", "deleted", "incomplete", "played", "finished" or "failed"
 [[podlist-format-u]]<<podlist-format-u,+u+>>:Url of the download
 [[podlist-format-F]]<<podlist-format-F,+F+>>:Filename of the download
+[[podlist-format-b]]<<podlist-format-b,+b+>>:Basename of the download (e.g. /home/name/downloads/podcast.mp3 -> podcast.mp3)
 |======================================================================
 
 Examples:

--- a/include/download.h
+++ b/include/download.h
@@ -30,6 +30,7 @@ public:
 		return download_status;
 	}
 	const std::string filename() const;
+	const std::string basename() const;
 	const std::string url() const;
 	void set_filename(const std::string& str);
 	void set_url(const std::string& url);

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -29,6 +29,16 @@ const std::string Download::filename() const
 	return fn;
 }
 
+const std::string Download::basename() const
+{
+	std::string::size_type start = fn.rfind('/');
+
+	if (start != std::string::npos) {
+		return fn.substr(start+1);
+	}
+	return fn;
+}
+
 const std::string Download::url() const
 {
 	return url_;

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -367,6 +367,7 @@ std::string PbView::format_line(const std::string& podlist_format,
 	fmt.register_fmt('S', strprintf::fmt("%s", dl.status_text()));
 	fmt.register_fmt('u', strprintf::fmt("%s", dl.url()));
 	fmt.register_fmt('F', strprintf::fmt("%s", dl.filename()));
+	fmt.register_fmt('b', strprintf::fmt("%s", dl.basename()));
 
 	auto formattedLine = fmt.do_format(podlist_format, width);
 	return formattedLine;


### PR DESCRIPTION
I found that the `%F` specifier was still creating strings that were too long for my liking. 
This adds the `%b` specifier for basename of the path to the download.