### PR TITLE
Fix 0..9 keys in article view

### DIFF
--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -32,14 +32,17 @@ namespace item_renderer {
 	/// `html-renderer` settings controls what tool is used to render HTML. \a
 	/// text_width dictates where text is wrapped. \a window_width dictates
 	/// where URLs are wrapped. \a rxman rules for \a location are used to
-	/// highlight the resulting text.
+	/// highlight the resulting text. \a links is filled with all the links
+	/// found in the article (which is useful for article view, which lets
+	/// users open the links by their number).
 	std::pair<std::string, size_t> to_stfl_list(
 			ConfigContainer& cfg,
 			std::shared_ptr<RssItem> item,
 			unsigned int text_width,
 			unsigned int window_width,
 			RegexManager* rxman,
-			const std::string& location);
+			const std::string& location,
+			std::vector<LinkPair>& links);
 
 	/// \brief Returns RssItem's text source as STFL list.
 	///

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -141,10 +141,10 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 		unsigned int text_width,
 		unsigned int window_width,
 		RegexManager* rxman,
-		const std::string& location)
+		const std::string& location,
+		std::vector<LinkPair>& links)
 {
 	std::vector<std::pair<LineType, std::string>> lines;
-	std::vector<LinkPair> links;
 
 	prepare_header(item, lines, links);
 	const std::string baseurl = get_item_base_link(item);

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -125,7 +125,8 @@ void ItemViewFormAction::prepare()
 					text_width,
 					window_width,
 					rxman,
-					"article");
+					"article",
+					links);
 		}
 
 		f->modify("article", "replace_inner", formatted_text);


### PR DESCRIPTION
In article view, numeric keys open a URL with a given number. I broke that behaviour in 485082f43f49f1c30974621107b1fa197618bf67 because I didn't fill articleview's `links` field, so the view thought that there are no links to open.

@j605, please confirm that this fixes the problem for you. Thanks for reporting it, too!