### PR TITLE
Add external macro for log!

### DIFF
--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -1,4 +1,12 @@
 #[macro_use] extern crate once_cell;
 
-pub mod utils;
+
 pub mod logger;
+
+macro_rules! log {
+    ( $level:expr, $message:expr ) => {
+        logger::get_instance().log($level, $message);
+    }
+}
+
+pub mod utils;


### PR DESCRIPTION
This may not be the best way to solve this problem depending on overall structure of the port.

During #352 I found that the way the `log!` macro is written requires that the macro is being called from outside the crate (i.e. `log!` can be called from libnewsboat-ffi but not from within libnewsboat). 
This PR adds another version of the macro that will be crate private and allow the util functions to call `log!`.
Note: any other modules in libnewsboat that need `log!` will need
```rust
use logger::Level:
use logger;
```