### PR TITLE
Initialize `cfg` member in UrlViewFormAction

### DIFF
--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -24,6 +24,7 @@ UrlViewFormAction::UrlViewFormAction(View* vv,
 	: FormAction(vv, formstr, cfg)
 	, quit(false)
 	, feed(feed)
+	, cfg(cfg)
 {
 }
 


### PR DESCRIPTION
#302 [added](https://github.com/newsboat/newsboat/commit/05fbbab67737a79a56258af314b3fd1ddad26695#diff-e1c0c863880bbe2b62e0b117e703ef56R37) `cfg` as a member of `UrlViewFormAction`, but [didn't initialize it](https://github.com/newsboat/newsboat/commit/05fbbab67737a79a56258af314b3fd1ddad26695#diff-7191f18e3136ed665a4130e20c029974R23) during construction. This caused segfauls (see #379).

I checked the rest of #302; all of the other `cfg` members are initialized properly.