### PR TITLE
Use protected FormAction ConfigPointer in FormAction's children

### DIFF
--- a/include/dialogsformaction.h
+++ b/include/dialogsformaction.h
@@ -24,7 +24,6 @@ private:
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	bool update_list;
-	ConfigContainer* cfg;
 };
 
 } // namespace newsboat

--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -103,7 +103,6 @@ private:
 	unsigned int total_feeds;
 
 	FilterContainer* filters;
-	ConfigContainer* cfg;
 
 	std::string old_sort_order;
 };

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -49,7 +49,6 @@ private:
 	std::string dir;
 	std::string default_filename;
 
-	ConfigContainer* cfg;
 };
 
 } // namespace newsboat

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -98,6 +98,7 @@ protected:
 		bool markread);
 
 	View* v;
+	ConfigContainer* cfg;
 	std::shared_ptr<Stfl::Form> f;
 	bool do_redraw;
 
@@ -115,7 +116,6 @@ private:
 	std::vector<QnaPair> qna_prompts;
 	Operation finish_operation;
 	History* qna_history;
-	ConfigContainer* cfg;
 	std::shared_ptr<FormAction> parent_formaction;
 };
 

--- a/include/helpformaction.h
+++ b/include/helpformaction.h
@@ -30,7 +30,6 @@ private:
 	bool apply_search;
 	std::string searchphrase;
 	std::string context;
-	ConfigContainer* cfg;
 };
 
 } // namespace newsboat

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -158,7 +158,6 @@ private:
 	ListFormatter listfmt;
 	Cache* rsscache;
 	FilterContainer* filters;
-	ConfigContainer* cfg;
 };
 
 } // namespace newsboat

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -77,7 +77,6 @@ private:
 	std::shared_ptr<ItemListFormAction> itemlist;
 	bool in_search;
 	Cache* rsscache;
-	ConfigContainer* cfg;
 };
 
 } // namespace newsboat

--- a/include/listformaction.h
+++ b/include/listformaction.h
@@ -15,8 +15,6 @@ protected:
 		std::vector<std::string>* args = nullptr) override;
 	void open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
 		bool markread);
-
-	ConfigContainer* cfg;
 };
 
 } // namespace newsboat

--- a/include/selectformaction.h
+++ b/include/selectformaction.h
@@ -48,7 +48,6 @@ private:
 	std::string value;
 	std::vector<std::string> tags;
 	std::vector<FilterNameExprPair> filters;
-	ConfigContainer* cfg;
 };
 
 } // namespace newsboat

--- a/include/urlviewformaction.h
+++ b/include/urlviewformaction.h
@@ -34,7 +34,6 @@ private:
 	std::vector<LinkPair> links;
 	bool quit;
 	std::shared_ptr<RssFeed> feed;
-	ConfigContainer* cfg;
 };
 
 } // namespace newsboat

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -16,7 +16,6 @@ DialogsFormAction::DialogsFormAction(View* vv,
 	ConfigContainer* cfg)
 	: FormAction(vv, formstr, cfg)
 	, update_list(true)
-	, cfg(cfg)
 {
 }
 

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -40,7 +40,6 @@ FeedListFormAction::FeedListFormAction(View* vv,
 	, unread_feeds(0)
 	, total_feeds(0)
 	, filters(f)
-	, cfg(cfg)
 {
 	assert(true == m.parse(FILTER_UNREAD_FEEDS));
 	valid_cmds.push_back("tag");

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -27,7 +27,6 @@ FileBrowserFormAction::FileBrowserFormAction(View* vv,
 	ConfigContainer* cfg)
 	: FormAction(vv, formstr, cfg)
 	, quit(false)
-	, cfg(cfg)
 {
 	// In filebrowser, keyboard focus is at the input field, so user can't
 	// possibly use 'q' key to exit the dialog

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -16,11 +16,11 @@ History FormAction::cmdlinehistory;
 
 FormAction::FormAction(View* vv, std::string formstr, ConfigContainer* cfg)
 	: v(vv)
+	, cfg(cfg)
 	, f(new Stfl::Form(formstr))
 	, do_redraw(true)
 	, finish_operation(OP_NIL)
 	, qna_history(nullptr)
-	, cfg(cfg)
 {
 	if (v) {
 		if (cfg->get_configvalue_as_bool("show-keymap-hint") == false) {

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -19,7 +19,6 @@ HelpFormAction::HelpFormAction(View* vv,
 	: FormAction(vv, formstr, cfg)
 	, quit(false)
 	, apply_search(false)
-	, cfg(cfg)
 {
 }
 

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -38,7 +38,6 @@ ItemListFormAction::ItemListFormAction(View* vv,
 	, invalidation_mode(InvalidationMode::COMPLETE)
 	, rsscache(cc)
 	, filters(f)
-	, cfg(cfg)
 {
 	assert(true == m.parse(FILTER_UNREAD_ITEMS));
 }

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -29,7 +29,6 @@ ItemViewFormAction::ItemViewFormAction(View* vv,
 	, itemlist(il)
 	, in_search(false)
 	, rsscache(cc)
-	, cfg(cfg)
 {
 	valid_cmds.push_back("save");
 	std::sort(valid_cmds.begin(), valid_cmds.end());

--- a/src/listformaction.cpp
+++ b/src/listformaction.cpp
@@ -8,7 +8,6 @@ ListFormAction::ListFormAction(View* v,
 	std::string formstr,
 	ConfigContainer* cfg)
 	: FormAction(v, formstr, cfg)
-	, cfg(cfg)
 {
 }
 

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -25,7 +25,6 @@ SelectFormAction::SelectFormAction(View* vv,
 	: FormAction(vv, formstr, cfg)
 	, quit(false)
 	, type(SelectionType::TAG)
-	, cfg(cfg)
 {
 }
 

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -24,7 +24,6 @@ UrlViewFormAction::UrlViewFormAction(View* vv,
 	: FormAction(vv, formstr, cfg)
 	, quit(false)
 	, feed(feed)
-	, cfg(cfg)
 {
 }
 


### PR DESCRIPTION
Addresses #382 
I took a quick look through the rest of FormAction's children for redundant members. I did not see any.