### PR TITLE
Fix bug where feed items could be deleted during view

### DIFF
--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -69,6 +69,7 @@ private:
 
 	std::string guid;
 	std::shared_ptr<RssFeed> feed;
+	std::shared_ptr<RssItem> item;
 	bool show_source;
 	std::vector<LinkPair> links;
 	bool quit;

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -56,6 +56,7 @@ void ItemViewFormAction::init()
 		update_percent();
 	}
 	set_keymap_hints();
+	item = feed->get_item_by_guid(guid);
 }
 
 void ItemViewFormAction::update_head(const std::shared_ptr<RssItem>& item)
@@ -88,8 +89,6 @@ void ItemViewFormAction::prepare()
 			// XXX HACK: render once so that we get a proper widget width
 			f->run(-3);
 		}
-
-		std::shared_ptr<RssItem> item = feed->get_item_by_guid(guid);
 
 		update_head(item);
 
@@ -144,7 +143,6 @@ void ItemViewFormAction::process_operation(Operation op,
 	bool automatic,
 	std::vector<std::string>* args)
 {
-	std::shared_ptr<RssItem> item = feed->get_item_by_guid(guid);
 	bool hardquit = false;
 
 	/*
@@ -464,8 +462,6 @@ void ItemViewFormAction::handle_cmdline(const std::string& cmd)
 	if (!tokens.empty()) {
 		if (tokens[0] == "save" && tokens.size() >= 2) {
 			std::string filename = utils::resolve_tilde(tokens[1]);
-			std::shared_ptr<RssItem> item =
-				feed->get_item_by_guid(guid);
 
 			if (filename == "") {
 				v->show_error(_("Aborted saving."));
@@ -493,8 +489,6 @@ void ItemViewFormAction::handle_cmdline(const std::string& cmd)
 void ItemViewFormAction::finished_qna(Operation op)
 {
 	FormAction::finished_qna(op); // important!
-
-	std::shared_ptr<RssItem> item = feed->get_item_by_guid(guid);
 
 	switch (op) {
 	case OP_INT_EDITFLAGS_END:
@@ -586,7 +580,6 @@ void ItemViewFormAction::update_percent()
 
 std::string ItemViewFormAction::title()
 {
-	std::shared_ptr<RssItem> item = feed->get_item_by_guid(guid);
 	auto title = item->title();
 	utils::remove_soft_hyphens(title);
 	return strprintf::fmt(_("Article - %s"), title);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -741,9 +741,9 @@ bool View::get_random_unread(ItemListFormAction* itemlist,
 		itemlist->init();
 		if (itemlist->jump_to_random_unread_item()) {
 			if (itemview) {
-				itemview->init();
 				itemview->set_feed(itemlist->get_feed());
 				itemview->set_guid(itemlist->get_guid());
+				itemview->init();
 			}
 			return true;
 		}
@@ -766,9 +766,9 @@ bool View::get_previous_unread(ItemListFormAction* itemlist,
 			"same "
 			"feed");
 		if (itemview) {
-			itemview->init();
 			itemview->set_feed(itemlist->get_feed());
 			itemview->set_guid(itemlist->get_guid());
+			itemview->init();
 		}
 		return true;
 	} else if (cfg->get_configvalue_as_bool("goto-next-feed") == false) {
@@ -785,9 +785,9 @@ bool View::get_previous_unread(ItemListFormAction* itemlist,
 		itemlist->init();
 		if (itemlist->jump_to_previous_unread_item(true)) {
 			if (itemview) {
-				itemview->init();
 				itemview->set_feed(itemlist->get_feed());
 				itemview->set_guid(itemlist->get_guid());
+				itemview->init();
 			}
 			return true;
 		}
@@ -842,9 +842,9 @@ bool View::get_next_unread(ItemListFormAction* itemlist,
 			"View::get_next_unread: found unread article in same "
 			"feed");
 		if (itemview) {
-			itemview->init();
 			itemview->set_feed(itemlist->get_feed());
 			itemview->set_guid(itemlist->get_guid());
+			itemview->init();
 		}
 		return true;
 	} else if (cfg->get_configvalue_as_bool("goto-next-feed") == false) {
@@ -861,9 +861,9 @@ bool View::get_next_unread(ItemListFormAction* itemlist,
 		itemlist->init();
 		if (itemlist->jump_to_next_unread_item(true)) {
 			if (itemview) {
-				itemview->init();
 				itemview->set_feed(itemlist->get_feed());
 				itemview->set_guid(itemlist->get_guid());
+				itemview->init();
 			}
 			return true;
 		}
@@ -881,9 +881,9 @@ bool View::get_previous(ItemListFormAction* itemlist,
 	if (itemlist->jump_to_previous_item(false)) {
 		LOG(Level::DEBUG, "View::get_previous: article in same feed");
 		if (itemview) {
-			itemview->init();
 			itemview->set_feed(itemlist->get_feed());
 			itemview->set_guid(itemlist->get_guid());
+			itemview->init();
 		}
 		return true;
 	} else if (cfg->get_configvalue_as_bool("goto-next-feed") == false) {
@@ -897,9 +897,9 @@ bool View::get_previous(ItemListFormAction* itemlist,
 		itemlist->init();
 		if (itemlist->jump_to_previous_item(true)) {
 			if (itemview) {
-				itemview->init();
 				itemview->set_feed(itemlist->get_feed());
 				itemview->set_guid(itemlist->get_guid());
+				itemview->init();
 			}
 			return true;
 		}
@@ -916,9 +916,9 @@ bool View::get_next(ItemListFormAction* itemlist, ItemViewFormAction* itemview)
 	if (itemlist->jump_to_next_item(false)) {
 		LOG(Level::DEBUG, "View::get_next: article in same feed");
 		if (itemview) {
-			itemview->init();
 			itemview->set_feed(itemlist->get_feed());
 			itemview->set_guid(itemlist->get_guid());
+			itemview->init();
 		}
 		return true;
 	} else if (cfg->get_configvalue_as_bool("goto-next-feed") == false) {
@@ -932,9 +932,9 @@ bool View::get_next(ItemListFormAction* itemlist, ItemViewFormAction* itemview)
 		itemlist->init();
 		if (itemlist->jump_to_next_item(true)) {
 			if (itemview) {
-				itemview->init();
 				itemview->set_feed(itemlist->get_feed());
 				itemview->set_guid(itemlist->get_guid());
+				itemview->init();
 			}
 			return true;
 		}


### PR DESCRIPTION
Since we were getting the RssItem to display and operate on by guid, the guid became a pointer with extra steps negating the advantages of std::shared_ptr
Keeps a copy of RssItem* so if the original goes out of scope ours doesn't get deleted.