### PR TITLE
Add missing header and fix build on FreeBSD

### DIFF
--- a/include/queuemanager.h
+++ b/include/queuemanager.h
@@ -1,6 +1,7 @@
 #ifndef NEWSBOAT_QUEUEMANAGER_H_
 #define NEWSBOAT_QUEUEMANAGER_H_
 
+#include <ctime>
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
In file included from src/queuemanager.cpp:1:
include/queuemanager.h:22:9: error: unknown type name 'time_t'
                const time_t pubDate,
                      ^