### PR TITLE
Makefile: add support for cross compiling via RUST_TARGET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,21 @@ RSSPPLIB_OUTPUT=librsspp.a
 
 CARGO_FLAGS+=--verbose
 ifeq ($(PROFILE),1)
+ifdef CARGO_BUILD_TARGET
+NEWSBOATLIB_OUTPUT=target/$(CARGO_BUILD_TARGET)/debug/libnewsboat.a
+LDFLAGS+=-L./target/$(CARGO_BUILD_TARGET)/debug
+else
 NEWSBOATLIB_OUTPUT=target/debug/libnewsboat.a
 LDFLAGS+=-L./target/debug
+endif
+else
+ifdef CARGO_BUILD_TARGET
+NEWSBOATLIB_OUTPUT=target/$(CARGO_BUILD_TARGET)/release/libnewsboat.a
+LDFLAGS+=-L./target/$(CARGO_BUILD_TARGET)/release
 else
 NEWSBOATLIB_OUTPUT=target/release/libnewsboat.a
-LDFLAGS+=-L.//target/release
+LDFLAGS+=-L./target/release
+endif
 CARGO_FLAGS+=--release
 endif
 LDFLAGS+=-lnewsboat -lpthread -ldl


### PR DESCRIPTION
RUST_TARGET can be set to compile against a specific target.

Void Linux uses it to cross-compile from x86_64 to arm and aarch64.

Problem is that cargo puts the produced objects in
./target/$RUST_TARGET/release instead of ./target/release and linking
will fail because -L./target/$RUST_TARGET/release needs to be passed.

in the meantime also remove extra slash from -L./target/release.

NOTE: The debug version wasn't tested, only the release.