### PR TITLE
Fix name of "rev-sort" command in documentation

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -48,7 +48,7 @@ next-dialog||^V||Go to next dialog.
 prev-dialog||^G||Go to previous dialog.
 pipe-to|||||Pipe article to command.
 sort||g||Sort feeds/articles by interactively choosing the sort method.
-revsort||G||Sort feeds/articles by interactively choosing the sort method (reversed).
+rev-sort||G||Sort feeds/articles by interactively choosing the sort method (reversed).
 up||UP||Goes up one item in the list.
 down||DOWN||Goes down one item in the list.
 pageup||PPAGE||Goes up one page in the list.


### PR DESCRIPTION
In the documentation it said that the command is named `revsort`, but in the code it is `rev-sort`: https://github.com/newsboat/newsboat/blob/cfec81542fbeb5d0dc9af890fffef4931f82389c/src/keymap.cpp#L278-L280

This pull-request fixes the name in the documentation.

Alternatively you could also change the command to `revsort`, but this might break the config of multiple users.