### PR TITLE
Add format option for feed titles in query-feeds

### DIFF
--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -1022,6 +1022,7 @@ Examples:
 Identifier:Meaning
 [[download-filename-format-u]]<<download-filename-format-u,+u+>>:Filename part of the download URL. May be empty. May include https\://en.wikipedia.org/wiki/Query_string[a query string]
 [[download-filename-format-n]]<<download-filename-format-n,+n+>>:Name of the podcast feed
+[[download-filename-format-N]]<<download-filename-format-N,+N+>>:Name of the podcast feed. Contains the original feed's name, even when selected through a query feed
 [[download-filename-format-h]]<<download-filename-format-h,+h+>>:Name of the podcast feed's hostname
 [[download-filename-format-t]]<<download-filename-format-t,+t+>>:Title of the podcast
 [[download-filename-format-e]]<<download-filename-format-e,+e+>>:Extension of the podcast episode

--- a/include/controller.h
+++ b/include/controller.h
@@ -52,10 +52,7 @@ public:
 	{
 		return refresh_on_start;
 	}
-	void enqueue_url(const std::string& url,
-		const std::string& title,
-		const time_t pubDate,
-		std::shared_ptr<RssFeed> feed);
+	void enqueue_url(std::shared_ptr<RssItem> item, std::shared_ptr<RssFeed> feed);
 
 	void reload_urls_file();
 	void edit_urls_file();

--- a/include/queuemanager.h
+++ b/include/queuemanager.h
@@ -10,6 +10,7 @@ namespace newsboat {
 class ConfigContainer;
 class ConfigPaths;
 class RssFeed;
+class RssItem;
 
 class QueueManager {
 	ConfigContainer* cfg = nullptr;
@@ -18,17 +19,13 @@ class QueueManager {
 public:
 	QueueManager(ConfigContainer* cfg, ConfigPaths* paths);
 
-	void enqueue_url(const std::string& url,
-		const std::string& title,
-		const time_t pubDate,
+	void enqueue_url(std::shared_ptr<RssItem> item,
 		std::shared_ptr<RssFeed> feed);
 
 	void autoenqueue(std::shared_ptr<RssFeed> feed);
 
 private:
-	std::string generate_enqueue_filename(const std::string& url,
-		const std::string& title,
-		const time_t pubDate,
+	std::string generate_enqueue_filename(std::shared_ptr<RssItem> item,
 		std::shared_ptr<RssFeed> feed);
 };
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -659,12 +659,10 @@ std::vector<std::shared_ptr<RssItem>> Controller::search_for_items(
 	return items;
 }
 
-void Controller::enqueue_url(const std::string& url,
-	const std::string& title,
-	const time_t pubDate,
+void Controller::enqueue_url(std::shared_ptr<RssItem> item,
 	std::shared_ptr<RssFeed> feed)
 {
-	queueManager.enqueue_url(url, title, pubDate, feed);
+	queueManager.enqueue_url(item, feed);
 }
 
 void Controller::reload_urls_file()

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -952,17 +952,17 @@ std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 		gen_datestr(item.first->pubDate_timestamp(), datetime_format));
 	if (feed->rssurl() != item.first->feedurl() &&
 		item.first->get_feedptr() != nullptr) {
-		auto feedtitle = utils::replace_all(
-			item.first->get_feedptr()->title(), "<", "<>");
+		auto feedtitle = utils::quote_for_stfl(
+			item.first->get_feedptr()->title());
 		utils::remove_soft_hyphens(feedtitle);
 		fmt.register_fmt('T', feedtitle);
 	}
 
-	auto itemtitle = utils::replace_all(item.first->title(), "<", "<>");
+	auto itemtitle = utils::quote_for_stfl(item.first->title());
 	utils::remove_soft_hyphens(itemtitle);
 	fmt.register_fmt('t', itemtitle);
 
-	auto itemauthor = utils::replace_all(item.first->author(), "<", "<>");
+	auto itemauthor = utils::quote_for_stfl(item.first->author());
 	utils::remove_soft_hyphens(itemauthor);
 	fmt.register_fmt('a', itemauthor);
 

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -173,10 +173,7 @@ void ItemViewFormAction::process_operation(Operation op,
 	case OP_ENQUEUE: {
 		if (item->enclosure_url().length() > 0 &&
 			utils::is_http_url(item->enclosure_url())) {
-			v->get_ctrl()->enqueue_url(item->enclosure_url(),
-				item->title(),
-				item->pubDate_timestamp(),
-				feed);
+            v->get_ctrl()->enqueue_url(item, feed);
 			v->set_status(
 				strprintf::fmt(_("Added %s to download queue."),
 					item->enclosure_url()));

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -173,7 +173,7 @@ void ItemViewFormAction::process_operation(Operation op,
 	case OP_ENQUEUE: {
 		if (item->enclosure_url().length() > 0 &&
 			utils::is_http_url(item->enclosure_url())) {
-            v->get_ctrl()->enqueue_url(item, feed);
+			v->get_ctrl()->enqueue_url(item, feed);
 			v->set_status(
 				strprintf::fmt(_("Added %s to download queue."),
 					item->enclosure_url()));

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -108,12 +108,12 @@ std::string QueueManager::generate_enqueue_filename(std::shared_ptr<RssItem> ite
 
 	if (feed->rssurl() != item->feedurl() &&
 		item->get_feedptr() != nullptr) {
-		auto feedtitle = utils::replace_all(
-			item->get_feedptr()->title(), "<", "<>");
+		std::string feedtitle = utils::quote_for_stfl(
+			item->get_feedptr()->title());
 		utils::remove_soft_hyphens(feedtitle);
 		fmt.register_fmt('N', feedtitle);
 	} else {
-		fmt.register_fmt('N', title);
+		fmt.register_fmt('N', feed->title());
     }
 
 	const std::string dlpath = fmt.do_format(dlformat);

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -16,11 +16,10 @@ QueueManager::QueueManager(ConfigContainer* cfg_, ConfigPaths* paths_)
 	, paths(paths_)
 {}
 
-void QueueManager::enqueue_url(const std::string& url,
-	const std::string& title,
-	const time_t pubDate,
+void QueueManager::enqueue_url(std::shared_ptr<RssItem> item,
 	std::shared_ptr<RssFeed> feed)
 {
+	const std::string& url = item->enclosure_url();
 	bool url_found = false;
 	std::fstream f;
 	f.open(paths->queue_file(), std::fstream::in);
@@ -43,7 +42,7 @@ void QueueManager::enqueue_url(const std::string& url,
 		f.open(paths->queue_file(),
 			std::fstream::app | std::fstream::out);
 		const std::string filename =
-			generate_enqueue_filename(url, title, pubDate, feed);
+			generate_enqueue_filename(item, feed);
 		f << url << " " << Stfl::quote(filename) << std::endl;
 		f.close();
 	}
@@ -60,11 +59,13 @@ std::string get_hostname_from_url(const std::string& url)
 	return hostname;
 }
 
-std::string QueueManager::generate_enqueue_filename(const std::string& url,
-	const std::string& title,
-	const time_t pubDate,
-	std::shared_ptr<RssFeed> feed)
+std::string QueueManager::generate_enqueue_filename(std::shared_ptr<RssItem> item,
+		std::shared_ptr<RssFeed> feed)
 {
+	const std::string& url = item->enclosure_url();
+	const std::string& title = item->title();
+	const time_t pubDate = item->pubDate_timestamp();
+
 	std::string dlformat = cfg->get_configvalue("download-path");
 	if (dlformat[dlformat.length() - 1] != NEWSBEUTER_PATH_SEP[0]) {
 		dlformat.append(NEWSBEUTER_PATH_SEP);
@@ -105,6 +106,16 @@ std::string QueueManager::generate_enqueue_filename(const std::string& url,
 	fmt.register_fmt('t', title);
 	fmt.register_fmt('e', extension);
 
+	if (feed->rssurl() != item->feedurl() &&
+		item->get_feedptr() != nullptr) {
+		auto feedtitle = utils::replace_all(
+			item->get_feedptr()->title(), "<", "<>");
+		utils::remove_soft_hyphens(feedtitle);
+		fmt.register_fmt('N', feedtitle);
+	} else {
+		fmt.register_fmt('N', title);
+    }
+
 	const std::string dlpath = fmt.do_format(dlformat);
 	return dlpath;
 }
@@ -129,10 +140,7 @@ void QueueManager::autoenqueue(std::shared_ptr<RssFeed> feed)
 					"QueueManager::autoenqueue: enqueuing "
 					"`%s'",
 					item->enclosure_url());
-				enqueue_url(item->enclosure_url(),
-					item->title(),
-					item->pubDate_timestamp(),
-					feed);
+				enqueue_url(item, feed);
 				item->set_enqueued(true);
 			}
 		}


### PR DESCRIPTION
Introduces an '%N' formatting option to be used in the 'download-path'
and 'download-filename-format' format strings, which exposes the
items original feed-title, even if it is selected through a query-feed.

This allows users to group feeds under a query-feed in newsboat, while
maintaining seperate directories and naming-conventions in the filesystem.

If the item is not selected through a query feed, '%N' and '%n' behave
exactly the same.

Closes #428 

**Note to maintainers**:
This is my first feature to contribute. While the patch is functional, I expect
there to be some issues with regard to style and refactorings I made and
consider this to be WIP awaiting your feedback.
