### PR TITLE
Fix spacer formatter in podlist-format

### DIFF
--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -79,7 +79,8 @@ void PbView::run(bool auto_download)
 			std::string code = "{list";
 			std::string formatstring = ctrl->get_formatstr();
 
-			unsigned int width = utils::to_u(dllist_form.get("feeds:w"));
+			dllist_form.run(-3); // compute all widget dimensions
+			unsigned int width = utils::to_u(dllist_form.get("dls:w"));
 
 			unsigned int i = 0;
 			for (const auto& dl : ctrl->downloads()) {


### PR DESCRIPTION
Fixes #434. The problem was two-fold:

1. a typo: the code was copy-pasted from FeedListFormaction, and
   "feeds:w" wasn't changed to "dls:s". I checked, and there are no
   other typos of this kind in this file;

2. the first time the loop is run, the widgets aren't painted yet, so
   they don't know their size. This can be rectified by force-repainting
   them, say, by downloading something. To fix the first run, I stuck
   a force-recalculation there. Shouldn't be a performance bottleneck
   since repaints don't happen often (every second during downloads, and
   as fast as user types commands).