### PR TITLE
Let user interact with get_command_output()

### DIFF
--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -312,7 +312,13 @@ pub fn unescape_url(rs_str: String) -> Option<String> {
 /// Runs given command in a shell, and returns the output (from stdout; stderr is printed to the
 /// screen).
 pub fn get_command_output(cmd: &str) -> String {
-    let cmd = Command::new("sh").arg("-c").arg(cmd).output();
+    let cmd = Command::new("sh")
+        .arg("-c")
+        .arg(cmd)
+        // Inherit stdin so that the program can ask something of the user (see
+        // https://github.com/newsboat/newsboat/issues/455 for an example).
+        .stdin(Stdio::inherit())
+        .output();
     // from_utf8_lossy will convert any bad bytes to U+FFFD
     cmd.map(|cmd| String::from_utf8_lossy(&cmd.stdout).into_owned())
         .unwrap_or_else(|_| String::from(""))

--- a/src/remoteapi.cpp
+++ b/src/remoteapi.cpp
@@ -29,11 +29,14 @@ const std::string RemoteApi::read_password(const std::string& file)
 
 const std::string RemoteApi::eval_password(const std::string& cmd)
 {
+	LOG(Level::DEBUG, "RemoteApi::eval_password: running `%s`", cmd);
 	std::string pass = utils::get_command_output(cmd);
-	std::string::size_type pos = pass.find_first_of("\n\r");
+	LOG(Level::DEBUG, "RemoteApi::eval_password: command printed out `%s'", pass);
+	const auto pos = pass.find_first_of("\n\r");
 
 	if (pos != std::string::npos) {
 		pass.resize(pos);
+		LOG(Level::DEBUG, "RemoteApi::eval_password: ...clipping that to `%s'", pass);
 	}
 
 	return pass;


### PR DESCRIPTION
`get_command_output()` used to be implemented in terms of `popen()`, which connects *either* command's stdin or stdout to Newsboat. Our new implementation connected both, and thus broke commands that tried to ask the user something. This commit inherits stdin, mimicking the behaviour of `popen(command, 'r')`.

Fixes #455.