### PR TITLE
Fix purge in query feeds

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -107,7 +107,13 @@ void ItemListFormAction::process_operation(Operation op,
 			for (const auto& pair : visible_items) {
 				pair.first->set_deleted(true);
 			}
-			rsscache->mark_feed_items_deleted(feed->rssurl());
+			if (feed->is_query_feed()) {
+				for (const auto& pair : visible_items) {
+					rsscache->mark_item_deleted(pair.first->guid(), true);
+				}
+			} else {
+				rsscache->mark_feed_items_deleted(feed->rssurl());
+			}
 			invalidate(InvalidationMode::COMPLETE);
 		}
 	} break;

--- a/src/rss.cpp
+++ b/src/rss.cpp
@@ -494,8 +494,7 @@ void RssFeed::update_items(std::vector<std::shared_ptr<RssFeed>> feeds)
 
 	LOG(Level::DEBUG, "RssFeed::update_items: query = `%s'", query);
 
-	struct timeval tv1, tv2, tvx;
-	gettimeofday(&tv1, nullptr);
+	ScopeMeasure sm("RssFeed::update_items");
 
 	Matcher m(query);
 
@@ -518,25 +517,11 @@ void RssFeed::update_items(std::vector<std::shared_ptr<RssFeed>> feeds)
 		}
 	}
 
-	gettimeofday(&tvx, nullptr);
+	sm.stopover("matching");
 
 	std::sort(items_.begin(), items_.end());
 
-	gettimeofday(&tv2, nullptr);
-	unsigned long diff =
-		(((tv2.tv_sec - tv1.tv_sec) * 1000000) + tv2.tv_usec) -
-		tv1.tv_usec;
-	unsigned long diffx =
-		(((tv2.tv_sec - tvx.tv_sec) * 1000000) + tv2.tv_usec) -
-		tvx.tv_usec;
-	LOG(Level::DEBUG,
-		"RssFeed::update_items matching took %lu.%06lu s",
-		diff / 1000000,
-		diff % 1000000);
-	LOG(Level::DEBUG,
-		"RssFeed::update_items sorting took %lu.%06lu s",
-		diffx / 1000000,
-		diffx % 1000000);
+	sm.stopover("sorting");
 }
 
 void RssFeed::set_rssurl(const std::string& u)

--- a/src/rss.cpp
+++ b/src/rss.cpp
@@ -504,11 +504,9 @@ void RssFeed::update_items(std::vector<std::shared_ptr<RssFeed>> feeds)
 	for (const auto& feed : feeds) {
 		if (!feed->is_query_feed()) { // don't fetch items from other query feeds!
 			for (const auto& item : feed->items()) {
-				if (m.matches(item.get())) {
+				if (!item->deleted() && m.matches(item.get())) {
 					LOG(Level::DEBUG,
-						"RssFeed::update_items: "
-						"Matcher "
-						"matches!");
+						"RssFeed::update_items: Matcher matches!");
 					item->set_feedptr(feed);
 					items_.push_back(item);
 					items_guid_map[item->guid()] = item;


### PR DESCRIPTION
This fixes #456, which turned out to be a two-fold problem:

1. deleting everything in a query feed didn't modify the database. Newsboat tried to delete all items with an "rssurl" of the current feed, but in query feeds, "rssurl" is a query; this didn't match any items, so none were deleted. Fixed by explicitly looping over all items and deleting them one by one.

2. when populating a query feed, Newsboat didn't check if the item is deleted. Fixed by adding such a check.

I also applied the boyscout rule and replaced a bit of home-grown benchmarking code with a `ScopeMeasure` from utils.

My excuse for not writing any tests is that we don't have tests for `FeedListFormAction` yet.

Reviews from anyone are welcome!