### PR TITLE
Added config option to hide the title bar

### DIFF
--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -111,6 +111,7 @@ searchresult-title-format||<format>||"%N %V - Search result (%u unread, %t total
 selectfilter-title-format||<format>||"%N %V - Select Filter"||Format of the title in filter selection dialog. See "Format Strings" section of Newsboat manual for details on available formats.||selectfilter-title-format "Select Filter"
 selecttag-title-format||<format>||"%N %V - Select Tag"||Format of the title in tag selection dialog. See "Format Strings" section of Newsboat manual for details on available formats.||selecttag-title-format "Select Tag"
 show-keymap-hint||[yes/no]||yes||If set to `no`, then the keymap hints on the bottom of screen will not be displayed.||show-keymap-hint no
+show-title-bar||[yes/no]||yes||If set to `no`, then the title bar on the top of the screen will not be displayed.||show-title-bar no
 show-read-articles||[yes/no]||yes||If set to `yes`, then all articles of a feed are listed in the article list. If set to `no`, then only unread articles are listed.||show-read-articles no
 show-read-feeds||[yes/no]||yes||If set to `yes`, then all feeds, including those without unread articles, are listed. If set to `no`, then only feeds with one or more unread articles are list.||show-read-feeds no
 suppress-first-reload||[yes/no]||no||If set to `yes`, then the first automatic reload will be suppressed if `auto-reload` is set to `yes`.||suppress-first-reload yes

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -175,6 +175,7 @@ ConfigContainer::ConfigContainer()
 				  ConfigDataType::STR,
 				  true)},
 		  {"show-keymap-hint", ConfigData("yes", ConfigDataType::BOOL)},
+	          {"show-title-bar", ConfigData("yes", ConfigDataType::BOOL)},
 		  {"show-read-articles", ConfigData("yes", ConfigDataType::BOOL)},
 		  {"show-read-feeds", ConfigData("yes", ConfigDataType::BOOL)},
 		  {"suppress-first-reload",

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -26,6 +26,9 @@ FormAction::FormAction(View* vv, std::string formstr, ConfigContainer* cfg)
 		if (cfg->get_configvalue_as_bool("show-keymap-hint") == false) {
 			f->set("showhint", "0");
 		}
+		if (cfg->get_configvalue_as_bool("show-title-bar") == false) {
+			f->set("showtitle", "0");
+ 		}
 		if (cfg->get_configvalue_as_bool("swap-title-and-hints") ==
 			true) {
 			std::string hints = f->dump("hints", "", 0);

--- a/stfl/dialogs.stfl
+++ b/stfl/dialogs.stfl
@@ -8,6 +8,7 @@ vbox
   label#info[title]
     text[head]:"Dialogs"
     .expand:h
+    .display[showtitle]:1
   !list[dialogs]
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold

--- a/stfl/dllist.stfl
+++ b/stfl/dllist.stfl
@@ -10,6 +10,7 @@ vbox
   label#info[title]
     text[head]:"Queue"
     .expand:h
+    .display[showtitle]:1
   !list[dls]
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold

--- a/stfl/feedlist.stfl
+++ b/stfl/feedlist.stfl
@@ -12,6 +12,7 @@ vbox
   label#info[title]
     text[head]:"Your feeds"
     .expand:h
+    .display[showtitle]:1
   !list[feeds]
     .expand:vh
     richtext:1

--- a/stfl/filebrowser.stfl
+++ b/stfl/filebrowser.stfl
@@ -10,6 +10,7 @@ vbox
   label#info[title]
     text[head]:"File Browser"
     .expand:h
+    .display[showtitle]:1
   list[files]
     * this height is only a hack to expand the list correctly (bug?)
     .expand:vh .height:65535

--- a/stfl/help.stfl
+++ b/stfl/help.stfl
@@ -10,6 +10,7 @@ vbox
   label#info[title]
     text[head]:"Help"
     .expand:h
+    .display[showtitle]:1
   textview[helptext]
     richtext:1
     style_hl_normal[highlight]:

--- a/stfl/itemlist.stfl
+++ b/stfl/itemlist.stfl
@@ -12,6 +12,7 @@ vbox
   label#info[title]
     text[head]:"Articles for '#'"
     .expand:h
+    .display[showtitle]:1
   list[items]
     .expand:vh
     richtext:1

--- a/stfl/itemview.stfl
+++ b/stfl/itemview.stfl
@@ -10,6 +10,7 @@ vbox
   label#info[title]
     text[head]:"Article '#'"
     .expand:h
+    .display[showtitle]:1
   textview[article]
     style_normal[article]:
     style_end[styleend]:fg=blue,attr=bold

--- a/stfl/selecttag.stfl
+++ b/stfl/selecttag.stfl
@@ -10,6 +10,7 @@ vbox
   label#info[title]
     text[head]:"Select Tag"
     .expand:h
+    .display[showtitle]:1
   list[taglist]
     .expand:vh
     style_normal[listnormal]:

--- a/stfl/urlview.stfl
+++ b/stfl/urlview.stfl
@@ -10,6 +10,7 @@ vbox
   label#info[title]
     text[head]:"URLs"
     .expand:h
+    .display[showtitle]:1
   !list[urls]
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold


### PR DESCRIPTION
Implementation of Issue #375 (Disabling/hiding title bar)
The config option is show-title-bar and it behaves as expected when swap-title-and-hints is also active