### PR TITLE
Nord colour scheme for newsboat.

### DIFF
--- a/contrib/colorschemes/nord
+++ b/contrib/colorschemes/nord
@@ -1,0 +1,21 @@
+# Newsboat colour scheme to work with the Nord palette
+# from Arctic Studios - https://github.com/arcticicestudio/nord
+# Tested with the iTerm2 Nord terminal colour scheme
+# https://github.com/arcticicestudio/nord-iterm2
+# though should work with any terminal using the palette
+
+color background          color236   default
+color listnormal          color248   default
+color listnormal_unread   color6     default
+color listfocus           color236   color12
+color listfocus_unread    color15    color12
+color info                color248   color236
+color article             color248   default
+
+# highlights
+highlight article "^(Feed|Link):.*$" color6 default bold
+highlight article "^(Title|Date|Author):.*$" color6 default bold
+highlight article "https?://[^ ]+" color10 default underline
+highlight article "\\[[0-9]+\\]" color10 default bold
+highlight article "\\[image\\ [0-9]+\\]" color10 default bold
+highlight feedlist "^─.*$" color6 color236 bold


### PR DESCRIPTION
A colour scheme for newsboat based on the Nord terminal palette.

Cool, blue, calm, and easy on the eyes.


 