### PR TITLE
Do not rename feeds to the name of their hidden tag

### DIFF
--- a/include/urlreader.h
+++ b/include/urlreader.h
@@ -8,15 +8,37 @@
 
 namespace newsboat {
 
+/// \brief Base class for classes that supply Newsboat with feed URLs.
 class UrlReader {
 public:
 	UrlReader() = default;
 	virtual ~UrlReader() = default;
+
+	/// \brief Write URLs back to the input file.
+	///
+	/// This method is used after importing feeds from OPML.
 	virtual void write_config() = 0;
+
+	/// \brief Re-read the input file.
+	///
+	/// \note This overwrites the contents of `urls`, `tags`, and `alltags`, so
+	/// make sure to save your modifications with `write_config()`.
 	virtual void reload() = 0;
+
+	/// \brief User-visible description of where URLs come from.
+	///
+	/// This can be a path (e.g. ~/.newsboat/urls), a URL (e.g. the value of
+	/// `opml-url` setting), or a name of the remote API in use (e.g. "Tiny
+	/// Tiny RSS").
 	virtual std::string get_source() = 0;
+
+	/// \brief A list of feed URLs.
 	std::vector<std::string>& get_urls();
+
+	/// \brief Tags of feed that has url `url`.
 	std::vector<std::string>& get_tags(const std::string& url);
+
+	/// \brief List of all extant tags.
 	std::vector<std::string> get_alltags();
 
 protected:

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -28,10 +28,7 @@ void FileUrlReader::reload()
 		return;
 	}
 
-	std::string line;
-	while (!f.eof()) {
-		std::getline(f, line);
-
+	for (std::string line; std::getline(f, line); /* nothing */) {
 		// skip empty lines and comments
 		if (line.empty() || line[0] == '#') {
 			continue;

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -24,28 +24,35 @@ void FileUrlReader::reload()
 
 	std::fstream f;
 	f.open(filename.c_str(), std::fstream::in);
-	if (f.is_open()) {
-		std::string line;
-		while (!f.eof()) {
-			std::getline(f, line);
-			if (line.length() > 0 && line[0] != '#') {
-				std::vector<std::string> tokens =
-					utils::tokenize_quoted(line);
-				if (!tokens.empty()) {
-					std::string url = tokens[0];
-					urls.push_back(url);
-					tokens.erase(tokens.begin());
-					if (!tokens.empty()) {
-						tags[url] = tokens;
-						for (const auto& token :
-							tokens) {
-							alltags.insert(token);
-						}
-					}
-				}
-			}
-		};
+	if (!f.is_open()) {
+		return;
 	}
+
+	std::string line;
+	while (!f.eof()) {
+		std::getline(f, line);
+
+		// skip empty lines and comments
+		if (line.empty() || line[0] == '#') {
+			continue;
+		}
+
+		std::vector<std::string> tokens = utils::tokenize_quoted(line);
+		if (tokens.empty()) {
+			continue;
+		}
+
+		std::string url = tokens[0];
+		urls.push_back(url);
+
+		tokens.erase(tokens.begin());
+		if (!tokens.empty()) {
+			tags[url] = tokens;
+			for (const auto& token : tokens) {
+				alltags.insert(token);
+			}
+		}
+	};
 }
 
 void FileUrlReader::load_config(const std::string& file)

--- a/src/rss.cpp
+++ b/src/rss.cpp
@@ -228,7 +228,7 @@ std::string RssFeed::title() const
 	bool found_title = false;
 	std::string alt_title;
 	for (const auto& tag : tags_) {
-		if (tag.substr(0, 1) == "~" || tag.substr(0, 1) == "!") {
+		if (tag.substr(0, 1) == "~") {
 			found_title = true;
 			alt_title = tag.substr(1, tag.length() - 1);
 			break;


### PR DESCRIPTION
Fixes #498.

I also made a few small refactors along the way. They don't look controversial to me, so I pushed them along with the fix.

@j605, can you please check if this fixes the bug for you? A review will be appreciated as well :)