### PR TITLE
Deallocate regex_t if regex compilation failed

### DIFF
--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -141,6 +141,8 @@ bool Matcher::matchop_rxeq(expression* e, Matchable* item)
 		if ((err = regcomp(e->regex,
 			     e->literal.c_str(),
 			     REG_EXTENDED | REG_ICASE | REG_NOSUB)) != 0) {
+			delete e->regex;
+			e->regex = nullptr;
 			char buf[1024];
 			regerror(err, e->regex, buf, sizeof(buf));
 			throw MatcherException(


### PR DESCRIPTION
Here's how this bug came to be:
1. `FilterParser::parse_string` considers `title =~ "*A"` a valid filter expression, and returns `true` (success);
2. right after user entered their filter, `ItemListFormAction::prepare` is ran. It tries to compile the regex, fails, but never deallocates the `regex_t` instance;
3. subsequent calls to `prepare` use uninitialized `regex_t` instance, which leads to SIGSEGV.

Easily fixed by deallocating regex_t if regex failed to compile. I also audited the rest of `Matcher` for similar errors, but this was the only place that dynamically allocated resources.

Fixes #501 (@tsipinakis, can you double-check that?).