### PR TITLE
Implement strprintf::fmt as a Rust macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,9 @@ dependencies = [
 [[package]]
 name = "strprintf"
 version = "0.1.0"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "strprintf"
+version = "0.1.0"
+
+[[package]]
 name = "syn"
 version = "0.15.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 members = [
     "rust/libnewsboat",
     "rust/libnewsboat-ffi",
+    "rust/strprintf",
 ]

--- a/rust/strprintf/Cargo.toml
+++ b/rust/strprintf/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Alexander Batischev <eual.jp@gmail.com>"]
 
 [dependencies]
+libc = "0.2"

--- a/rust/strprintf/Cargo.toml
+++ b/rust/strprintf/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "strprintf"
+version = "0.1.0"
+authors = ["Alexander Batischev <eual.jp@gmail.com>"]
+
+[dependencies]

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -127,18 +127,22 @@ mod tests {
         assert_eq!(fmt!("%llu", std::u64::MAX), "18446744073709551615");
     }
 
-    /*
-    TEST_CASE("strprintf::fmt() formats void*", "[strprintf]")
-    {
-            const auto x = 42;
-            REQUIRE_FALSE(strprintf::fmt("%p", reinterpret_cast<const void*>(&x)).empty());
+    #[test]
+    fn formats_void_ptr() {
+        let x = 42i64;
+        let ptr = &x as *const i64;
+        assert_ne!(fmt!("%p", ptr as *const libc::c_void), "");
     }
 
-    TEST_CASE("strprintf::fmt() formats nullptr", "[strprintf]")
-    {
-            REQUIRE_FALSE(strprintf::fmt("%p", nullptr) == "(null)");
+    #[test]
+    fn formats_null_ptr() {
+        assert_eq!(fmt!("%p", std::ptr::null::<i32>()), "(nil)");
+        assert_eq!(fmt!("%p", std::ptr::null::<u32>()), "(nil)");
+        assert_eq!(fmt!("%p", std::ptr::null::<i64>()), "(nil)");
+        assert_eq!(fmt!("%p", std::ptr::null::<u64>()), "(nil)");
+        assert_eq!(fmt!("%p", std::ptr::null::<f32>()), "(nil)");
+        assert_eq!(fmt!("%p", std::ptr::null::<f64>()), "(nil)");
     }
-    */
 
     #[test]
     fn formats_float() {

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -1,3 +1,5 @@
+mod specifiers_iterator;
+
 macro_rules! fmt {
     ( $format:expr ) => {{
         let result: &str = $format;

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -37,10 +37,10 @@ where
     T: CReprHolder,
 {
     let mut buffer = Vec::<u8>::with_capacity(buf_size);
-    // Filling the vector with ones because CString::new() doesn't want any zeroes in there. The
-    // last byte is left unused, so that CString::new() can put a terminating zero byte there
-    // without triggering a re-allocation.
-    buffer.resize(buf_size - 1, 1);
+    // CString appends a null byte and calls Vec::into_byte_slice(). That conversion will shed all
+    // unused capacity. For this reason, we pre-fill the vector with dummy values, leaving one byte
+    // free, so CString's null byte doesn't trigger a re-allocation.
+    buffer.resize(buf_size - 1, 0);
     unsafe {
         // It's safe to use this function because we initialized the buffer and we know there are
         // no zeroes there

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -190,15 +190,19 @@ mod tests {
         assert_eq!(fmt!("%s", input), input);
     }
 
-    /*
-    // TODO: write the same test for str
-    // TODO: write the same test for String
-    TEST_CASE("strprintf::fmt() formats std::string", "[strprintf]")
-    {
-            const auto input = std::string("Hello, world!");
-            REQUIRE(strprintf::fmt("%s", input) == input);
+    #[test]
+    fn formats_borrowed_string() {
+        let input = String::from("Hello, world!");
+        assert_eq!(fmt!("%s", &input), input);
     }
 
+    #[test]
+    fn formats_moved_string() {
+        let input = String::from("Hello, world!");
+        assert_eq!(fmt!("%s", input.clone()), input);
+    }
+
+    /*
     TEST_CASE("strprintf::fmt() works fine with 1MB format string", "[strprintf]")
     {
             const auto format = std::string(1024 * 1024, ' ');

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -1,117 +1,13 @@
 extern crate libc;
 
 pub mod specifiers_iterator;
-
-// TODO: move traits into a separate mod, they occupy too much space here
-// TODO: write an internal module doc explaining the interplay between traits, fmt_arg, and fmt!
+pub mod traits;
 
 use std::ffi::CString;
 use std::vec::Vec;
+use traits::*;
 
-pub trait Printfable {
-    type Holder: CReprHolder;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder>;
-}
-
-impl Printfable for i32 {
-    type Holder = i32;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
-    }
-}
-
-impl Printfable for u32 {
-    type Holder = u32;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
-    }
-}
-
-impl Printfable for i64 {
-    type Holder = i64;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
-    }
-}
-
-impl Printfable for u64 {
-    type Holder = u64;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
-    }
-}
-
-/// `f32` can't be passed to variadic functions like `snprintf`, so it's converted into `f64`
-impl Printfable for f32 {
-    type Holder = f64;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self as f64)
-    }
-}
-
-impl Printfable for f64 {
-    type Holder = f64;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
-    }
-}
-
-impl<'a> Printfable for &'a str {
-    type Holder = CString;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        CString::new(*self).ok()
-    }
-}
-
-pub trait CReprHolder {
-    type Output;
-    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output;
-}
-
-impl CReprHolder for i32 {
-    type Output = i32;
-    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
-        *self
-    }
-}
-
-impl CReprHolder for u32 {
-    type Output = u32;
-    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
-        *self
-    }
-}
-
-impl CReprHolder for i64 {
-    type Output = i64;
-    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
-        *self
-    }
-}
-
-impl CReprHolder for u64 {
-    type Output = u64;
-    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
-        *self
-    }
-}
-
-// No need to implement CReprHolder for f32, as this trait is only invoked on results of
-// `Printfable::to_c_repr_holder`, and that converts f32 to f64
-
-impl CReprHolder for f64 {
-    type Output = f64;
-    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
-        *self
-    }
-}
-
-impl CReprHolder for CString {
-    type Output = *const libc::c_char;
-    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
-        self.as_ptr()
-    }
-}
+// TODO: write an internal module doc explaining the interplay between traits, fmt_arg, and fmt!
 
 /// Helper function for `fmt!`. Don't use directly.
 pub fn fmt_arg<T>(format: &str, arg: T) -> Option<String>

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -1,14 +1,15 @@
 macro_rules! fmt {
-    ( $format:expr ) => {
-        $format
-    };
+    ( $format:expr ) => {{
+        let result: &str = $format;
+        result
+    }};
 }
 
 #[cfg(test)]
 mod tests {
     #[test]
     fn returns_first_argument_if_it_is_the_only_one() {
-        let input = "Hello, world!";
-        assert_eq!(fmt!(input), input);
+        let input = String::from("Hello, world!");
+        assert_eq!(fmt!(&input), input);
     }
 }

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -67,83 +67,39 @@ mod tests {
     }
 
     #[test]
-    fn formats_int_x86_64() {
+    fn formats_i32() {
         assert_eq!(fmt!("%i", 42i32), "42");
-
-        let int_min = std::i32::MIN;
-        assert_eq!(int_min, -2147483648i32);
-        assert_eq!(fmt!("%i", int_min), "-2147483648");
-
-        let int_max = std::i32::MAX;
-        assert_eq!(int_max, 2147483647i32);
-        assert_eq!(fmt!("%i", int_max), "2147483647");
+        assert_eq!(fmt!("%i", std::i32::MIN), "-2147483648");
+        assert_eq!(fmt!("%i", std::i32::MAX), "2147483647");
     }
 
     #[test]
-    fn formats_unsigned_int_x86_64() {
+    fn formats_u32() {
         assert_eq!(fmt!("%u", 42u32), "42");
-
         assert_eq!(fmt!("%u", 0u32), "0");
-
-        let uint_max = std::u32::MAX;
-        assert_eq!(uint_max, 4294967295u32);
-        assert_eq!(fmt!("%u", uint_max), "4294967295");
+        assert_eq!(fmt!("%u", std::u32::MAX), "4294967295");
     }
 
     #[test]
-    fn formats_long_int_x86_64() {
+    fn formats_i64() {
         assert_eq!(fmt!("%li", 42i64), "42");
+        assert_eq!(fmt!("%li", std::i32::MIN as i64 - 1), "-2147483649");
+        assert_eq!(fmt!("%li", std::i32::MAX as i64 + 1), "2147483648");
 
-        let int_min = std::i32::MIN as i64;
-        let long_min = std::i64::MIN;
-        assert!(long_min < int_min);
-        assert_eq!(int_min, -2147483648);
-        assert_eq!(fmt!("%li", int_min - 1), "-2147483649");
-
-        let int_max = std::i32::MAX as i64;
-        let long_max = std::i64::MAX;
-        assert!(long_max > int_max);
-        assert_eq!(int_max, 2147483647);
-        assert_eq!(fmt!("%li", int_max + 1), "2147483648");
-    }
-
-    #[test]
-    fn formats_long_unsigned_int_x86_64() {
-        assert_eq!(fmt!("%lu", 42u64), "42");
-
-        assert_eq!(fmt!("%lu", 0u64), "0");
-
-        let ulong_max = std::u64::MAX;
-        assert_eq!(ulong_max, 18446744073709551615u64);
-        assert_eq!(fmt!("%lu", ulong_max), "18446744073709551615");
-    }
-
-    #[test]
-    fn formats_long_long_int_x86_64() {
         assert_eq!(fmt!("%lli", 42i64), "42");
-
-        // This is one bigger than actual std::numeric_limits<long long int>::min()
-        // on x86_64. The actual value can't be written in C++ as a literal because both GCC 8 and
-        // Clang complain about it being too small to be represented with long long int.
-        let input = -9223372036854775807i64;
-        let llong_min = std::i64::MIN;
-        assert!(llong_min <= input);
-        assert_eq!(fmt!("%lli", input), "-9223372036854775807");
-
-        let llong_max = std::i64::MAX;
-        assert_eq!(llong_max, 9223372036854775807i64);
-        assert_eq!(fmt!("%lli", llong_max), "9223372036854775807");
+        assert_eq!(fmt!("%lli", std::i64::MIN), "-9223372036854775808");
+        assert_eq!(fmt!("%lli", std::i64::MAX), "9223372036854775807");
     }
 
     #[test]
-    fn formats_unsigned_long_long_int_x86_64() {
+    fn formats_u64() {
+        assert_eq!(fmt!("%lu", 42u64), "42");
+        assert_eq!(fmt!("%lu", 0u64), "0");
+        assert_eq!(fmt!("%lu", std::u64::MAX), "18446744073709551615");
+
         assert_eq!(fmt!("%llu", 42u64), "42");
-
         assert_eq!(fmt!("%llu", 0u64), "0");
-
-        let ullong_max = std::u64::MAX;
-        assert_eq!(ullong_max, 18446744073709551615u64);
-        assert_eq!(fmt!("%llu", ullong_max), "18446744073709551615");
+        assert_eq!(fmt!("%llu", std::u64::MAX), "18446744073709551615");
     }
 
     /*

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -1,10 +1,53 @@
-mod specifiers_iterator;
+pub mod specifiers_iterator;
 
+/// A safe-ish wrapper around `libc::snprintf`.
+#[macro_export]
 macro_rules! fmt {
-    ( $format:expr ) => {{
-        let result: &str = $format;
-        result
-    }};
+    ( $format:expr ) => {
+        {
+            let format: &str = $format;
+            String::from(format)
+        }
+    };
+
+    ( $format:expr, $( $arg:expr ),+ ) => {
+        {
+            let format: &str = $format;
+
+            let mut result = String::new();
+
+            use $crate::specifiers_iterator::SpecifiersIterator;
+            let mut specifiers = SpecifiersIterator::from(format);
+
+            $(
+                let local_format = specifiers.next().unwrap_or("");
+                // Might fail if `local_format` contains a null byte. TODO decide if this is a good
+                // error-handling strategy, or we should report back to user, or panic, or what
+                if let Ok(local_format_cstring) = std::ffi::CString::new(local_format) {
+                    let buf_size = 1024usize;
+                    let buffer: std::vec::Vec<u8> = std::vec::Vec::with_capacity(buf_size);
+                    if let Ok(buffer) = std::ffi::CString::new(buffer) {
+                        unsafe {
+                            let buffer_ptr = buffer.into_raw();
+                            // TODO: check how many bytes were written
+                            let bytes_written = libc::snprintf(
+                                buffer_ptr,
+                                buf_size as libc::size_t,
+                                local_format_cstring.as_ptr() as *const libc::c_char,
+                                $arg);
+                            let buffer = std::ffi::CString::from_raw(buffer_ptr);
+                            let _bytes_written = bytes_written as usize;
+                            if let Ok(formatted) = buffer.into_string() {
+                                result.push_str(&formatted);
+                            }
+                        }
+                    }
+                }
+            )+
+
+            result
+        }
+    };
 }
 
 #[cfg(test)]
@@ -13,5 +56,13 @@ mod tests {
     fn returns_first_argument_if_it_is_the_only_one() {
         let input = String::from("Hello, world!");
         assert_eq!(fmt!(&input), input);
+    }
+
+    #[test]
+    fn replaces_printf_format_with_text_representation_of_an_argument() {
+        assert_eq!(fmt!("%i", 42), "42");
+        assert_eq!(fmt!("%i", -13), "-13");
+        assert_eq!(fmt!("%.3f", 3.1416), "3.142");
+        assert_eq!(fmt!("%i %i", 100500, -191), "100500 -191");
     }
 }

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -65,4 +65,138 @@ mod tests {
         assert_eq!(fmt!("%.3f", 3.1416), "3.142");
         assert_eq!(fmt!("%i %i", 100500, -191), "100500 -191");
     }
+
+    #[test]
+    fn formats_int_x86_64() {
+        assert_eq!(fmt!("%i", 42i32), "42");
+
+        let int_min = std::i32::MIN;
+        assert_eq!(int_min, -2147483648i32);
+        assert_eq!(fmt!("%i", int_min), "-2147483648");
+
+        let int_max = std::i32::MAX;
+        assert_eq!(int_max, 2147483647i32);
+        assert_eq!(fmt!("%i", int_max), "2147483647");
+    }
+
+    #[test]
+    fn formats_unsigned_int_x86_64() {
+        assert_eq!(fmt!("%u", 42u32), "42");
+
+        assert_eq!(fmt!("%u", 0u32), "0");
+
+        let uint_max = std::u32::MAX;
+        assert_eq!(uint_max, 4294967295u32);
+        assert_eq!(fmt!("%u", uint_max), "4294967295");
+    }
+
+    #[test]
+    fn formats_long_int_x86_64() {
+        assert_eq!(fmt!("%li", 42i64), "42");
+
+        let int_min = std::i32::MIN as i64;
+        let long_min = std::i64::MIN;
+        assert!(long_min < int_min);
+        assert_eq!(int_min, -2147483648);
+        assert_eq!(fmt!("%li", int_min - 1), "-2147483649");
+
+        let int_max = std::i32::MAX as i64;
+        let long_max = std::i64::MAX;
+        assert!(long_max > int_max);
+        assert_eq!(int_max, 2147483647);
+        assert_eq!(fmt!("%li", int_max + 1), "2147483648");
+    }
+
+    #[test]
+    fn formats_long_unsigned_int_x86_64() {
+        assert_eq!(fmt!("%lu", 42u64), "42");
+
+        assert_eq!(fmt!("%lu", 0u64), "0");
+
+        let ulong_max = std::u64::MAX;
+        assert_eq!(ulong_max, 18446744073709551615u64);
+        assert_eq!(fmt!("%lu", ulong_max), "18446744073709551615");
+    }
+
+    #[test]
+    fn formats_long_long_int_x86_64() {
+        assert_eq!(fmt!("%lli", 42i64), "42");
+
+        // This is one bigger than actual std::numeric_limits<long long int>::min()
+        // on x86_64. The actual value can't be written in C++ as a literal because both GCC 8 and
+        // Clang complain about it being too small to be represented with long long int.
+        let input = -9223372036854775807i64;
+        let llong_min = std::i64::MIN;
+        assert!(llong_min <= input);
+        assert_eq!(fmt!("%lli", input), "-9223372036854775807");
+
+        let llong_max = std::i64::MAX;
+        assert_eq!(llong_max, 9223372036854775807i64);
+        assert_eq!(fmt!("%lli", llong_max), "9223372036854775807");
+    }
+
+    #[test]
+    fn formats_unsigned_long_long_int_x86_64() {
+        assert_eq!(fmt!("%llu", 42u64), "42");
+
+        assert_eq!(fmt!("%llu", 0u64), "0");
+
+        let ullong_max = std::u64::MAX;
+        assert_eq!(ullong_max, 18446744073709551615u64);
+        assert_eq!(fmt!("%llu", ullong_max), "18446744073709551615");
+    }
+
+    /*
+    TEST_CASE("strprintf::fmt() formats void*", "[strprintf]")
+    {
+            const auto x = 42;
+            REQUIRE_FALSE(strprintf::fmt("%p", reinterpret_cast<const void*>(&x)).empty());
+    }
+
+    TEST_CASE("strprintf::fmt() formats nullptr", "[strprintf]")
+    {
+            REQUIRE_FALSE(strprintf::fmt("%p", nullptr) == "(null)");
+    }
+    */
+
+    #[test]
+    fn formats_double() {
+        let x = 42.0f64;
+        assert_eq!(fmt!("%f", x), "42.000000");
+        assert_eq!(fmt!("%.3f", x), "42.000");
+
+        let y = 42e138f64;
+        assert_eq!(fmt!("%e", y), "4.200000e+139");
+        assert_eq!(fmt!("%.3e", y), "4.200e+139");
+    }
+
+    /*
+    XXX: can't be easily ported since Rust doesn't let us pass f32 to a variadic function like
+    snprintf.
+    TEST_CASE("strprintf::fmt() formats float", "[strprintf]")
+    {
+            const auto x = 42.0f;
+            REQUIRE(strprintf::fmt("%f", x) == "42.000000");
+            REQUIRE(strprintf::fmt("%.3f", x) == "42.000");
+
+            const auto y = 42e3f;
+            REQUIRE(strprintf::fmt("%e", y) == "4.200000e+04");
+            REQUIRE(strprintf::fmt("%.3e", y) == "4.200e+04");
+    }
+
+    // TODO: write the same test for str
+    // TODO: write the same test for &str
+    // TODO: write the same test for String
+    TEST_CASE("strprintf::fmt() formats std::string", "[strprintf]")
+    {
+            const auto input = std::string("Hello, world!");
+            REQUIRE(strprintf::fmt("%s", input) == input);
+    }
+
+    TEST_CASE("strprintf::fmt() works fine with 1MB format string", "[strprintf]")
+    {
+            const auto format = std::string(1024 * 1024, ' ');
+            REQUIRE(strprintf::fmt(format) == format);
+    }
+    */
 }

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -178,20 +178,32 @@ mod tests {
     }
 
     #[test]
-    fn formats_void_ptr() {
+    fn formats_pointers() {
         let x = 42i64;
-        let ptr = &x as *const i64;
-        assert_ne!(fmt!("%p", ptr as *const libc::c_void), "");
+
+        let x_ptr = &x as *const i64;
+        let x_ptr_formatted = fmt!("%p", x_ptr);
+
+        let x_ptr_void = x_ptr as *const libc::c_void;
+        let x_ptr_void_formatted = fmt!("%p", x_ptr_void);
+        assert!(!x_ptr_formatted.is_empty());
+        assert_eq!(x_ptr_formatted, x_ptr_void_formatted);
     }
 
     #[test]
-    fn formats_null_ptr() {
-        assert_eq!(fmt!("%p", std::ptr::null::<i32>()), "(nil)");
-        assert_eq!(fmt!("%p", std::ptr::null::<u32>()), "(nil)");
-        assert_eq!(fmt!("%p", std::ptr::null::<i64>()), "(nil)");
-        assert_eq!(fmt!("%p", std::ptr::null::<u64>()), "(nil)");
-        assert_eq!(fmt!("%p", std::ptr::null::<f32>()), "(nil)");
-        assert_eq!(fmt!("%p", std::ptr::null::<f64>()), "(nil)");
+    fn formats_all_null_pointers_the_same() {
+        let i32_ptr_fmt = fmt!("%p", std::ptr::null::<i32>());
+        let u32_ptr_fmt = fmt!("%p", std::ptr::null::<u32>());
+        let i64_ptr_fmt = fmt!("%p", std::ptr::null::<i64>());
+        let u64_ptr_fmt = fmt!("%p", std::ptr::null::<u64>());
+        let f32_ptr_fmt = fmt!("%p", std::ptr::null::<f32>());
+        let f64_ptr_fmt = fmt!("%p", std::ptr::null::<f64>());
+        assert!(!i32_ptr_fmt.is_empty());
+        assert_eq!(i32_ptr_fmt, u32_ptr_fmt);
+        assert_eq!(u32_ptr_fmt, i64_ptr_fmt);
+        assert_eq!(i64_ptr_fmt, u64_ptr_fmt);
+        assert_eq!(u64_ptr_fmt, f32_ptr_fmt);
+        assert_eq!(f32_ptr_fmt, f64_ptr_fmt);
     }
 
     #[test]

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -1,3 +1,19 @@
+// Problem statement for `strprintf` crate: provide a way to interpolate printf-style format
+// strings using native Rust types. For example, it should be possible to format a string
+// "%i %.2f %x" using values 42u32, 3.1415f64, and 255u8, and get a `std::string::String` "42 3.14
+// ff".
+//
+// This is the same as strprintf module we already have in C++.
+//
+// The problem can be solved by wrapping `libc::snprintf`, which is what we do both here and in
+// C++. However, our experience with C++ showed that we should constrain what types can be
+// formatted. Otherwise, complex objects like `String` will be passed over FFI and lead to
+// unexpected results (e.g. garbage strings).
+//
+// To achieve that, we provide a `Printfable` trait that's implemented only for types that our
+// formatting macro accepts. Everything else will result in a compile-time error. See the docs in
+// `trait` module for more on that.
+
 extern crate libc;
 
 pub mod specifiers_iterator;
@@ -6,8 +22,6 @@ pub mod traits;
 use std::ffi::{CStr, CString};
 use std::vec::Vec;
 use traits::*;
-
-// TODO: write an internal module doc explaining the interplay between traits, fmt_arg, and fmt!
 
 /// Helper function to `fmt!`. **Use it only through that macro!**
 ///

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -1,7 +1,14 @@
+macro_rules! fmt {
+    ( $format:expr ) => {
+        $format
+    };
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+    fn returns_first_argument_if_it_is_the_only_one() {
+        let input = "Hello, world!";
+        assert_eq!(fmt!(input), input);
     }
 }

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -182,17 +182,6 @@ mod tests {
     */
 
     #[test]
-    fn formats_double() {
-        let x = 42.0f64;
-        assert_eq!(fmt!("%f", x), "42.000000");
-        assert_eq!(fmt!("%.3f", x), "42.000");
-
-        let y = 42e138f64;
-        assert_eq!(fmt!("%e", y), "4.200000e+139");
-        assert_eq!(fmt!("%.3e", y), "4.200e+139");
-    }
-
-    #[test]
     fn formats_float() {
         let x = 42.0f32;
         assert_eq!(fmt!("%f", x), "42.000000");
@@ -201,6 +190,35 @@ mod tests {
         let y = 42e3f32;
         assert_eq!(fmt!("%e", y), "4.200000e+04");
         assert_eq!(fmt!("%.3e", y), "4.200e+04");
+
+        assert_eq!(fmt!("%f", std::f32::INFINITY), "inf");
+        assert_eq!(fmt!("%F", std::f32::INFINITY), "INF");
+
+        assert_eq!(fmt!("%f", std::f32::NEG_INFINITY), "-inf");
+        assert_eq!(fmt!("%F", std::f32::NEG_INFINITY), "-INF");
+
+        assert_eq!(fmt!("%f", std::f32::NAN), "nan");
+        assert_eq!(fmt!("%F", std::f32::NAN), "NAN");
+    }
+
+    #[test]
+    fn formats_double() {
+        let x = 42.0f64;
+        assert_eq!(fmt!("%f", x), "42.000000");
+        assert_eq!(fmt!("%.3f", x), "42.000");
+
+        let y = 42e138f64;
+        assert_eq!(fmt!("%e", y), "4.200000e+139");
+        assert_eq!(fmt!("%.3e", y), "4.200e+139");
+
+        assert_eq!(fmt!("%f", std::f64::INFINITY), "inf");
+        assert_eq!(fmt!("%F", std::f64::INFINITY), "INF");
+
+        assert_eq!(fmt!("%f", std::f64::NEG_INFINITY), "-inf");
+        assert_eq!(fmt!("%F", std::f64::NEG_INFINITY), "-INF");
+
+        assert_eq!(fmt!("%f", std::f64::NAN), "nan");
+        assert_eq!(fmt!("%F", std::f64::NAN), "NAN");
     }
 
     /*

--- a/rust/strprintf/src/specifiers_iterator.rs
+++ b/rust/strprintf/src/specifiers_iterator.rs
@@ -117,4 +117,26 @@ mod tests {
         assert_eq!(iterator.next(), Some("%% of implementations conform"));
         assert_eq!(iterator.next(), None);
     }
+
+    #[test]
+    fn splits_2_megabyte_string() {
+        let spacer = String::from(" ").repeat(512);
+        let format = {
+            let mut result = spacer.clone();
+            result.push_str("%i");
+            result.push_str(&spacer);
+            result.push_str("%i");
+            result
+        };
+        let mut iterator = SpecifiersIterator::from(&format);
+        let expected = {
+            let mut result = spacer.clone();
+            result.push_str("%i");
+            result.push_str(&spacer);
+            result
+        };
+        assert_eq!(iterator.next(), Some(&*expected));
+        assert_eq!(iterator.next(), Some("%i"));
+        assert_eq!(iterator.next(), None);
+    }
 }

--- a/rust/strprintf/src/specifiers_iterator.rs
+++ b/rust/strprintf/src/specifiers_iterator.rs
@@ -1,12 +1,16 @@
-//! An iterator over `&str`, returning substrings that start with a printf-style format specifier
-//! (i.e. percent sign followed by some more symbols, like "%.4f hello").
+//! An iterator over `&str`, returning substrings that contain a single format specifier (i.e.
+//! percent sign followed by some more symbols, like "%.4f hello").
+//!
+//! **This module should only be used through `fmt!` macro.**
+#![doc(hidden)]
+
 pub struct SpecifiersIterator<'a> {
     /// The string this object iterates over.
     ///
-    /// Every time the iterator returns an item, that item is removed from the start of the string.
-    /// For example, as `SpecifiersIterator` iterates over a string "%i%o%u", the string will be
-    /// shortened first to "%o%u", then to "%u", and finally to "" (empty string), and all
-    /// subsequent calls to `next()` will return `None`.
+    /// Every time the iterator returns a substring, that substring is removed from the start of
+    /// the string. For example, as `SpecifiersIterator` iterates over a string "%i%o%u", the
+    /// string will be shortened first to "%o%u", then to "%u", and finally to "" (empty string).
+    /// After that, all subsequent calls to `next()` will return `None`.
     current_string: &'a str,
 }
 

--- a/rust/strprintf/src/specifiers_iterator.rs
+++ b/rust/strprintf/src/specifiers_iterator.rs
@@ -1,0 +1,120 @@
+//! An iterator over `&str`, returning substrings that start with a printf-style format specifier
+//! (i.e. percent sign followed by some more symbols, like "%.4f hello").
+pub struct SpecifiersIterator<'a> {
+    /// The string this object iterates over.
+    ///
+    /// Every time the iterator returns an item, that item is removed from the start of the string.
+    /// For example, as `SpecifiersIterator` iterates over a string "%i%o%u", the string will be
+    /// shortened first to "%o%u", then to "%u", and finally to "" (empty string), and all
+    /// subsequent calls to `next()` will return `None`.
+    current_string: &'a str,
+}
+
+impl<'a> SpecifiersIterator<'a> {
+    /// Create an iterator from a given string slice.
+    pub fn from(input: &'a str) -> SpecifiersIterator<'a> {
+        SpecifiersIterator {
+            current_string: input,
+        }
+    }
+}
+
+/// Returns positions of the first two percent signs in the string, or None if there are less than
+/// two percent signs.
+fn find_percent_signs(input: &str) -> Option<(usize, usize)> {
+    input.find('%').and_then(|first| {
+        input[first + 1..]
+            .find('%')
+            .and_then(|second| Some((first, first + 1 + second)))
+    })
+}
+
+impl<'a> Iterator for SpecifiersIterator<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut pair;
+        let mut current_offset = 0usize;
+        loop {
+            pair = find_percent_signs(&self.current_string[current_offset..]).and_then(
+                |(first, second)| Some((first + current_offset, second + current_offset)),
+            );
+            match pair {
+                Some((first, second)) if second - first == 1 => {
+                    // Found an escaped percent sign; continue the search after it
+                    current_offset = second + 1
+                }
+
+                Some(_) => {
+                    // Found a sequence of percent signs that is *not* an escaped percent sign
+                    break;
+                }
+
+                // Found no percent signs at all, no point in looping anymore
+                None => break,
+            }
+        }
+
+        match pair {
+            Some((_, second_percent_sign_pos)) => {
+                let (retval, new_string) = self.current_string.split_at(second_percent_sign_pos);
+                self.current_string = new_string;
+                Some(retval)
+            }
+
+            None if self.current_string.is_empty() => None,
+
+            None => {
+                let retval = self.current_string;
+                self.current_string = "";
+                Some(&retval)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_immediately_exhausted_if_given_and_empty_string() {
+        let mut iterator = SpecifiersIterator::from("");
+        assert_eq!(iterator.next(), None);
+    }
+
+    #[test]
+    fn returns_whole_original_string_if_there_are_no_specifiers() {
+        let input = "Hello, world! How are you today?";
+        let mut iterator = SpecifiersIterator::from(input);
+        assert_eq!(iterator.next(), Some(input));
+        assert_eq!(iterator.next(), None);
+    }
+
+    #[test]
+    fn returns_specifiers_one_by_one_until_exhausted() {
+        let input = "%i in decimal is the same as %o in octal or %x in hexadecimal";
+        let mut iterator = SpecifiersIterator::from(input);
+        assert_eq!(iterator.next(), Some("%i in decimal is the same as "));
+        assert_eq!(iterator.next(), Some("%o in octal or "));
+        assert_eq!(iterator.next(), Some("%x in hexadecimal"));
+        assert_eq!(iterator.next(), None);
+    }
+
+    #[test]
+    fn each_returned_string_contains_one_specifier() {
+        let input = "There were %i forks";
+        let mut iterator = SpecifiersIterator::from(input);
+        assert_eq!(iterator.next(), Some("There were %i forks"));
+        assert_eq!(iterator.next(), None);
+    }
+
+    #[test]
+    fn does_not_split_escaped_percent_sign() {
+        let input = "Only %.2f%% of implementations conform";
+        let mut iterator = SpecifiersIterator::from(input);
+        assert_eq!(iterator.next(), Some("Only %.2f"));
+        assert_eq!(iterator.next(), Some("%% of implementations conform"));
+        assert_eq!(iterator.next(), None);
+    }
+}

--- a/rust/strprintf/src/traits.rs
+++ b/rust/strprintf/src/traits.rs
@@ -1,0 +1,110 @@
+// TODO: write some docs for this
+
+extern crate libc;
+
+use std::ffi::CString;
+
+pub trait Printfable {
+    type Holder: CReprHolder;
+    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder>;
+}
+
+impl Printfable for i32 {
+    type Holder = i32;
+    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
+        Some(*self)
+    }
+}
+
+impl Printfable for u32 {
+    type Holder = u32;
+    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
+        Some(*self)
+    }
+}
+
+impl Printfable for i64 {
+    type Holder = i64;
+    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
+        Some(*self)
+    }
+}
+
+impl Printfable for u64 {
+    type Holder = u64;
+    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
+        Some(*self)
+    }
+}
+
+/// `f32` can't be passed to variadic functions like `snprintf`, so it's converted into `f64`
+impl Printfable for f32 {
+    type Holder = f64;
+    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
+        Some(*self as f64)
+    }
+}
+
+impl Printfable for f64 {
+    type Holder = f64;
+    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
+        Some(*self)
+    }
+}
+
+impl<'a> Printfable for &'a str {
+    type Holder = CString;
+    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
+        CString::new(*self).ok()
+    }
+}
+
+pub trait CReprHolder {
+    type Output;
+    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output;
+}
+
+impl CReprHolder for i32 {
+    type Output = i32;
+    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
+        *self
+    }
+}
+
+impl CReprHolder for u32 {
+    type Output = u32;
+    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
+        *self
+    }
+}
+
+impl CReprHolder for i64 {
+    type Output = i64;
+    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
+        *self
+    }
+}
+
+impl CReprHolder for u64 {
+    type Output = u64;
+    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
+        *self
+    }
+}
+
+// No need to implement CReprHolder for f32, as this trait is only invoked on results of
+// `Printfable::to_c_repr_holder`, and that converts f32 to f64
+
+impl CReprHolder for f64 {
+    type Output = f64;
+    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
+        *self
+    }
+}
+
+impl CReprHolder for CString {
+    type Output = *const libc::c_char;
+    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
+        self.as_ptr()
+    }
+}

--- a/rust/strprintf/src/traits.rs
+++ b/rust/strprintf/src/traits.rs
@@ -59,6 +59,13 @@ impl<'a> Printfable for &'a str {
     }
 }
 
+impl<T> Printfable for *const T {
+    type Holder = *const libc::c_void;
+    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
+        Some(*self as *const libc::c_void)
+    }
+}
+
 pub trait CReprHolder {
     type Output;
     fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output;
@@ -106,5 +113,12 @@ impl CReprHolder for CString {
     type Output = *const libc::c_char;
     fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
         self.as_ptr()
+    }
+}
+
+impl CReprHolder for *const libc::c_void {
+    type Output = *const libc::c_void;
+    fn to_c_repr(self: &Self) -> <Self as CReprHolder>::Output {
+        *self
     }
 }

--- a/rust/strprintf/src/traits.rs
+++ b/rust/strprintf/src/traits.rs
@@ -6,63 +6,77 @@ use std::ffi::CString;
 
 pub trait Printfable {
     type Holder: CReprHolder;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder>;
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder>;
 }
 
 impl Printfable for i32 {
     type Holder = i32;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        Some(self)
     }
 }
 
 impl Printfable for u32 {
     type Holder = u32;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        Some(self)
     }
 }
 
 impl Printfable for i64 {
     type Holder = i64;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        Some(self)
     }
 }
 
 impl Printfable for u64 {
     type Holder = u64;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        Some(self)
     }
 }
 
 /// `f32` can't be passed to variadic functions like `snprintf`, so it's converted into `f64`
 impl Printfable for f32 {
     type Holder = f64;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self as f64)
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        Some(self as f64)
     }
 }
 
 impl Printfable for f64 {
     type Holder = f64;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self)
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        Some(self)
     }
 }
 
 impl<'a> Printfable for &'a str {
     type Holder = CString;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        CString::new(*self).ok()
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        CString::new(self).ok()
+    }
+}
+
+impl<'a> Printfable for &'a String {
+    type Holder = CString;
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        CString::new(self.as_str()).ok()
+    }
+}
+
+impl Printfable for String {
+    type Holder = CString;
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        CString::new(self).ok()
     }
 }
 
 impl<T> Printfable for *const T {
     type Holder = *const libc::c_void;
-    fn to_c_repr_holder(self: &Self) -> Option<<Self as Printfable>::Holder> {
-        Some(*self as *const libc::c_void)
+    fn to_c_repr_holder(self: Self) -> Option<<Self as Printfable>::Holder> {
+        Some(self as *const libc::c_void)
     }
 }
 

--- a/test/strprintf.cpp
+++ b/test/strprintf.cpp
@@ -183,15 +183,40 @@ TEST_CASE("strprintf::fmt() formats unsigned long long int", "[strprintf]")
 	REQUIRE(strprintf::fmt("%llu", ullong_max) == "18446744073709551615");
 }
 
-TEST_CASE("strprintf::fmt() formats void*", "[strprintf]")
+TEST_CASE("strprintf::fmt() formats pointers", "[strprintf]")
 {
 	const auto x = 42;
-	REQUIRE_FALSE(strprintf::fmt("%p", reinterpret_cast<const void*>(&x)).empty());
+
+	const auto x_ptr = &x;
+	const auto x_ptr_formatted = strprintf::fmt("%p", x_ptr);
+
+	const auto x_ptr_void = reinterpret_cast<const void*>(x_ptr);
+	const auto x_ptr_void_formatted = strprintf::fmt("%p", x_ptr_void);
+
+	REQUIRE_FALSE(x_ptr_formatted.empty());
+	REQUIRE(x_ptr_formatted == x_ptr_void_formatted);
 }
 
-TEST_CASE("strprintf::fmt() formats nullptr", "[strprintf]")
+TEST_CASE("strprintf::fmt() formats null pointers the same", "[strprintf]")
 {
-	REQUIRE(strprintf::fmt("%p", nullptr) == "(nil)");
+	const auto int_ptr_fmt =
+		strprintf::fmt("%p", static_cast<const int*>(nullptr));
+	const auto uint_ptr_fmt =
+		strprintf::fmt("%p", static_cast<const unsigned int*>(nullptr));
+	const auto long_ptr_fmt =
+		strprintf::fmt("%p", static_cast<const long*>(nullptr));
+	const auto ulong_ptr_fmt =
+		strprintf::fmt("%p", static_cast<const unsigned long*>(nullptr));
+	const auto llong_ptr_fmt =
+		strprintf::fmt("%p", static_cast<const long long*>(nullptr));
+	const auto ullong_ptr_fmt =
+		strprintf::fmt("%p", static_cast<const unsigned long long*>(nullptr));
+	REQUIRE_FALSE(int_ptr_fmt.empty());
+	REQUIRE(int_ptr_fmt == uint_ptr_fmt);
+	REQUIRE(uint_ptr_fmt == long_ptr_fmt);
+	REQUIRE(long_ptr_fmt == ulong_ptr_fmt);
+	REQUIRE(ulong_ptr_fmt == llong_ptr_fmt);
+	REQUIRE(llong_ptr_fmt == ullong_ptr_fmt);
 }
 
 TEST_CASE("strprintf::fmt() formats double", "[strprintf]")

--- a/test/strprintf.cpp
+++ b/test/strprintf.cpp
@@ -191,7 +191,7 @@ TEST_CASE("strprintf::fmt() formats void*", "[strprintf]")
 
 TEST_CASE("strprintf::fmt() formats nullptr", "[strprintf]")
 {
-	REQUIRE_FALSE(strprintf::fmt("%p", nullptr) == "(null)");
+	REQUIRE(strprintf::fmt("%p", nullptr) == "(nil)");
 }
 
 TEST_CASE("strprintf::fmt() formats double", "[strprintf]")

--- a/test/strprintf.cpp
+++ b/test/strprintf.cpp
@@ -228,8 +228,10 @@ TEST_CASE("strprintf::fmt() formats std::string*", "[strprintf]")
 	REQUIRE(strprintf::fmt("%s", &input) == input);
 }
 
-TEST_CASE("strprintf::fmt() works fine with 1MB format string", "[strprintf]")
+TEST_CASE("strprintf::fmt() works fine with 2MB format string", "[strprintf]")
 {
-	const auto format = std::string(1024 * 1024, ' ');
-	REQUIRE(strprintf::fmt(format) == format);
+	const auto spacer = std::string(1024 * 1024, ' ');
+	const auto format = spacer + "%i" + spacer + "%i";
+	const auto expected = spacer + "42" + spacer + "100500";
+	REQUIRE(strprintf::fmt(format, 42, 100500) == expected);
 }


### PR DESCRIPTION
The title says most of it. Reviewers are advised to start by reading the large comment at the beginning of lib.rs, and looking through the docs in the other two modules. That'll give you the overview of goals and the design. I rewrote the history to make it appear like I came up with all the ideas first, and then just implemented them methodically.

Closes #447.