### PR TITLE
Test and simplify utils::make_parents

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1010,24 +1010,19 @@ int utils::mkdir_parents(const std::string& p, mode_t mode)
 	int result = -1;
 
 	/* Have to copy the path because we're going to modify it */
-	const size_t length = p.length() + 1;
-	char* pathname = (char*)malloc(length);
-	if (pathname == nullptr) {
-		// errno is already set by malloc(), so simply return with an error
-		return -1;
-	}
-	strncpy(pathname, p.c_str(), length);
+	std::vector<char> pathname(p.cbegin(), p.cend());
+	pathname.push_back('\0');
 	/* This pointer will run through the whole string looking for '/'.
 	 * We move it by one if path starts with slash because if we don't, the
 	 * first call to access() will fail (because of empty path) */
-	char* curr = pathname + (*pathname == '/' ? 1 : 0);
+	char* curr = pathname.data() + (pathname[0] == '/' ? 1 : 0);
 
 	while (*curr) {
 		if (*curr == '/') {
 			*curr = '\0';
-			result = access(pathname, F_OK);
+			result = access(pathname.data(), F_OK);
 			if (result == -1) {
-				result = mkdir(pathname, mode);
+				result = mkdir(pathname.data(), mode);
 				if (result != 0 && errno != EEXIST)
 					break;
 			}
@@ -1047,7 +1042,6 @@ int utils::mkdir_parents(const std::string& p, mode_t mode)
 		}
 	}
 
-	free(pathname);
 	return result;
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1020,11 +1020,13 @@ int utils::mkdir_parents(const std::string& p, mode_t mode)
 	while (*curr) {
 		if (*curr == '/') {
 			*curr = '\0';
-			result = access(pathname.data(), F_OK);
-			if (result == -1) {
-				result = mkdir(pathname.data(), mode);
-				if (result != 0 && errno != EEXIST)
+			result = mkdir(pathname.data(), mode);
+			if (result != 0) {
+				if (errno == EEXIST) {
+					result = 0;
+				} else {
 					break;
+				}
 			}
 			*curr = '/';
 		}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1038,6 +1038,13 @@ int utils::mkdir_parents(const std::string& p, mode_t mode)
 
 	if (result == 0) {
 		result = mkdir(p.c_str(), mode);
+
+		// It's not an error if the directory already exists. This happens when
+		// `p` ended with a slash, in which case the loop above creates all the
+		// path components.
+		if (result == -1 && errno == EEXIST) {
+			result = 0;
+		}
 	}
 
 	free(pathname);

--- a/test/test-helpers.h
+++ b/test/test-helpers.h
@@ -158,7 +158,7 @@ public:
 			// Catch doesn't let us run tests in multiple threads
 			// anyway.
 			std::string dirname = std::to_string(rand());
-			dirpath = tempdir.getPath() + dirname;
+			dirpath = tempdir.getPath() + dirname + "/";
 
 			int status = mkdir(dirpath.c_str(), S_IRWXU);
 			if (status == 0) {

--- a/test/test-helpers.h
+++ b/test/test-helpers.h
@@ -110,7 +110,7 @@ public:
 			// Catch doesn't let us run tests in multiple threads
 			// anyway.
 			std::string filename = std::to_string(rand());
-			filepath = tempdir.getPath() + "/" + filename;
+			filepath = tempdir.getPath() + filename;
 
 			struct stat buffer;
 			if (lstat(filepath.c_str(), &buffer) != 0) {
@@ -158,7 +158,7 @@ public:
 			// Catch doesn't let us run tests in multiple threads
 			// anyway.
 			std::string dirname = std::to_string(rand());
-			dirpath = tempdir.getPath() + "/" + dirname;
+			dirpath = tempdir.getPath() + dirname;
 
 			int status = mkdir(dirpath.c_str(), S_IRWXU);
 			if (status == 0) {

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1133,3 +1133,24 @@ TEST_CASE("mkdir_parents() creates all paths components and returns 0 if "
 		}
 	}
 }
+
+TEST_CASE("mkdir_parents() doesn't care if the path ends in a slash or not",
+		"[utils]")
+{
+	TestHelpers::TempDir tmp;
+
+	const auto path = tmp.getPath() + std::to_string(rand());
+
+	const auto check = [](const std::string& path) {
+		REQUIRE(utils::mkdir_parents(path, 0700) == 0);
+		REQUIRE(::access(path.c_str(), R_OK | X_OK) == 0);
+	};
+
+	SECTION("Path doesn't end in slash => directory created") {
+		check(path);
+	}
+
+	SECTION("Path ends in slash => directory created") {
+		check(path + "/");
+	}
+}

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1045,3 +1045,91 @@ TEST_CASE("unescape_url() takes a percent-encoded string and returns the string 
 	REQUIRE(utils::unescape_url("%00") == "");
 
 }
+
+TEST_CASE("mkdir_parents() creates all paths components and returns 0 if "
+		"the path now exists",
+		"[utils]")
+{
+	TestHelpers::TempDir tmp;
+
+	const auto require_return_zero = [](const std::string& path) {
+		REQUIRE(utils::mkdir_parents(path.c_str(), 0700) == 0);
+		REQUIRE(::access(path.c_str(), R_OK | X_OK) == 0);
+	};
+
+	SECTION("Simple test on temporary dir itself") {
+		const auto path = tmp.getPath();
+		INFO("Path is " << path);
+		require_return_zero(path);
+	}
+
+	SECTION("Zero intermediate directories") {
+		const auto path = tmp.getPath() + std::to_string(rand());
+		INFO("Path is " << path);
+
+		SECTION("Target doesn't yet exist") {
+			require_return_zero(path);
+		}
+
+		SECTION("Target already exists") {
+			REQUIRE(::mkdir(path.c_str(), 0700) == 0);
+			require_return_zero(path);
+		}
+	}
+
+	SECTION("One intermediate directory") {
+		const auto intermediate_path = tmp.getPath() + std::to_string(rand());
+		const auto path = intermediate_path + "/" + std::to_string(rand());
+		INFO("Path is " << path);
+
+		SECTION("Which doesn't exist") {
+			require_return_zero(path);
+		}
+
+		SECTION("Which exists") {
+			REQUIRE(::mkdir(intermediate_path.c_str(), 0700) == 0);
+
+			SECTION("Target doesn't exist") {
+				require_return_zero(path);
+			}
+
+			SECTION("Target exists") {
+				REQUIRE(::mkdir(path.c_str(), 0700) == 0);
+				require_return_zero(path);
+			}
+		}
+	}
+
+	SECTION("Two intermediate directories") {
+		const auto intermediate_path1 = tmp.getPath() + std::to_string(rand());
+		const auto intermediate_path2 =
+			intermediate_path1 + "/" + std::to_string(rand());
+		const auto path = intermediate_path2 + "/" + std::to_string(rand());
+		INFO("Path is " << path);
+
+		SECTION("Which don't exist") {
+			require_return_zero(path);
+		}
+
+		SECTION("First one exists") {
+			REQUIRE(::mkdir(intermediate_path1.c_str(), 0700) == 0);
+
+			SECTION("Second one exists") {
+				REQUIRE(::mkdir(intermediate_path2.c_str(), 0700) == 0);
+
+				SECTION("Target exists") {
+					REQUIRE(::mkdir(path.c_str(), 0700) == 0);
+					require_return_zero(path);
+				}
+
+				SECTION("Target doesn't exist") {
+					require_return_zero(path);
+				}
+			}
+
+			SECTION("Second one doesn't exist") {
+				require_return_zero(path);
+			}
+		}
+	}
+}


### PR DESCRIPTION
To test migrations in `ConfigPaths`, I needed a temporary directory that will remove itself at the end of the test. And I also stumbled upon a bug with `utils::make_parents` when the path ends with a slash.  Those changes formed a nice bundle, so I decided to submit them as a separate PR.

`TempDir` contains a questionable choice: I just `rm -rf` the temporary directory using `system()`, instead of writing my own recursive descent with `stat`. I admit this is laziness, but I don't think it matters much: the only way to inject something malicious into that `system()` call is to change the `TEMPDIR` environment variable. Surely the person running the tests won't try to pwn themselves?

Reviews from anyone are welcome!