### PR TITLE
Fix for #290

### DIFF
--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -446,9 +446,9 @@ void PbController::play_file(const std::string& file)
 	if (player == "")
 		return;
 	cmdline.append(player);
-	cmdline.append(" '");
-	cmdline.append(utils::replace_all(file, "'", "%27"));
-	cmdline.append("'");
+	cmdline.append(" \"");
+	cmdline.append(utils::replace_all(file, "\"", "\\\""));
+	cmdline.append("\"");
 	Stfl::reset();
 	utils::run_interactively(cmdline, "PbController::play_file");
 }


### PR DESCRIPTION
The only time the queue file has any explicit changes of ' to %27 is if
an entry in the queue file doesn't have a set download path/filename to begin
with (calling QueueLoader::get_filename()). But it doesn't do the same to the
download-path if it's configured, so if you may end up with
"foo's/bar%27s.mp3" but it will try and play "foo%27s/bar%37s.mp3"

The only time this MIGHT make a difference is if the download path is
set to a remote address (http, ftp), but so far with what testing I
could do, this change hasn't affected playback of remote files.

The switch from wrapping the command string from ' to " is because the
shell expands \\' really weirdly, still counting it as a closing mark, so
you'll have to expand it 'foo'\\''s' for it to work properly.