### PR TITLE
Port CliArgsParser to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,8 +202,10 @@ version = "2.15.0"
 dependencies = [
  "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -636,6 +648,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +788,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71c63a540a9ee4e15e56c3ed9b11a2f121239b9f6d7b7fe30f616e048148df9a"
@@ -827,6 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "37daa55a7240c4931c84559f03b3cad7d19535840d1c4a0cc4e9b2fb0dcf70ff"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "proptest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strprintf 0.1.0",
  "tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,23 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "gettext-rs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gettext-sys 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "locale_config 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gettext-sys"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +202,20 @@ dependencies = [
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -205,6 +236,8 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl-sys 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gettext-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gettext-sys 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -236,6 +269,17 @@ dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "locale_config"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -521,6 +565,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -535,6 +591,14 @@ dependencies = [
 name = "regex-syntax"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -758,12 +822,22 @@ dependencies = [
 
 [[package]]
 name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -798,10 +872,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum gettext-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b2502071e088651bd5fec87a896be2a5b908e817070d350a534a305abc9c6048"
+"checksum gettext-sys 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)" = "62c644c0b8b73706fb8c7420533fd30abf6f41c2703994bc6f0826fceb7fb3d6"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum libz-sys 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "44ebbc760fd2d2f4d93de09a0e13d97e057612052e871da9985cedcb451e6bd5"
+"checksum locale_config 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "14fbee0e39bc2dd6a2427c4fdea66e9826cc1fd09b0a0b7550359f5f6efe1dab"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
@@ -834,8 +913,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26"
+"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
+"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
@@ -865,6 +946,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wait-timeout 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b9f3bf741a801531993db6478b95682117471f76916f5e690dd8d45395b09349"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/config.sh
+++ b/config.sh
@@ -111,6 +111,9 @@ if [ `uname -s` = "Darwin" ]; then
     # rand crate needs Security framework, and rustc doesn't (can't) link it
     # into libnewsboat.a
     echo 'LDFLAGS+=-framework Security' >> config.mk
+    # gettext-sys crate needs CoreFoundation framework, and rustc doesn't
+    # (can't) link it into libnewsboat.a
+    echo 'LDFLAGS+=-framework CoreFoundation' >> config.mk
 elif [ `uname -s` != "OpenBSD" ]; then
 	check_pkg "ncursesw" || \
 	check_custom "ncursesw5" "ncursesw5-config" || \

--- a/include/cliargsparser.h
+++ b/include/cliargsparser.h
@@ -22,11 +22,15 @@ public:
 
 	std::string importfile() const;
 
+	/// If `do_read_import()` is `true`, Newsboat should import read articles
+	/// info from  `readinfo_import_file()`.
 	bool do_read_import() const;
+	std::string readinfo_import_file() const;
 
+	/// If `do_read_export()` is `true`, Newsboat should export read articles
+	/// info to `readinfo_export_file()`.
 	bool do_read_export() const;
-
-	std::string readinfofile() const;
+	std::string readinfo_export_file() const;
 
 	std::string program_name() const;
 

--- a/include/cliargsparser.h
+++ b/include/cliargsparser.h
@@ -8,86 +8,163 @@
 
 namespace newsboat {
 class CliArgsParser {
-public:
-	CliArgsParser(int argc, char* argv[]);
-
-	bool do_import = false;
-	bool do_export = false;
-	bool do_vacuum = false;
-	std::string importfile;
-	bool do_read_import = false;
-	bool do_read_export = false;
-	std::string program_name;
-	std::string readinfofile;
-	unsigned int show_version = 0;
-	bool silent = false;
-	bool using_nonstandard_configs = false;
+	bool m_do_import = false;
+	bool m_do_export = false;
+	bool m_do_vacuum = false;
+	std::string m_importfile;
+	bool m_do_read_import = false;
+	bool m_do_read_export = false;
+	std::string m_program_name;
+	std::string m_readinfofile;
+	unsigned int m_show_version = 0;
+	bool m_silent = false;
+	bool m_using_nonstandard_configs = false;
 
 	/// If `should_return` is `true`, the creator of `CliArgsParser` object
 	/// should call `exit(return_code)`.
 	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool should_return = false;
-	int return_code = 0;
+	bool m_should_return = false;
+	int m_return_code = 0;
 
 	/// If `display_msg` is not empty, the creator of `CliArgsParser` should
 	/// print its contents to stderr.
 	///
 	/// \note The contents of this string should be checked before
 	/// processing `should_return`.
-	std::string display_msg;
+	std::string m_display_msg;
 
 	/// If `should_print_usage` is `true`, the creator of `CliArgsParser`
 	/// object should print usage information.
 	///
 	/// \note This field should be checked before processing
 	/// `should_return`.
-	bool should_print_usage = false;
+	bool m_should_print_usage = false;
 
-	bool refresh_on_start = false;
+	bool m_refresh_on_start = false;
 
 	/// The value of `url_file` should only be used if `set_url_file` is
 	/// `true`.
 	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool set_url_file = false;
-	std::string url_file;
+	bool m_set_url_file = false;
+	std::string m_url_file;
 
 	/// The value of `lock_file` should only be used if `set_lock_file` is
 	/// `true`.
 	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool set_lock_file = false;
-	std::string lock_file;
+	bool m_set_lock_file = false;
+	std::string m_lock_file;
 
 	/// The value of `cache_file` should only be used if `set_cache_file` is
 	/// `true`.
 	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool set_cache_file = false;
-	std::string cache_file;
+	bool m_set_cache_file = false;
+	std::string m_cache_file;
 
 	/// The value of `config_file` should only be used if `set_config_file`
 	/// is `true`.
 	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool set_config_file = false;
-	std::string config_file;
+	bool m_set_config_file = false;
+	std::string m_config_file;
 
 	/// If 'execute_cmds' is true, the 'CliArgsParser' object holds commands
 	/// that should be executed in cmds_to_execute vector.
 	///
 	/// \note The parser does not check if the passed commands are valid.
 	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool execute_cmds = false;
-	std::vector<std::string> cmds_to_execute;
+	bool m_execute_cmds = false;
+	std::vector<std::string> m_cmds_to_execute;
 
 	/// The value of `log_file` should only be used if `set_log_file` is
 	/// `true`.
 	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool set_log_file = false;
-	std::string log_file;
+	bool m_set_log_file = false;
+	std::string m_log_file;
 
 	/// The value of `log_level` should only be used if `set_log_level` is
 	/// `true`.
 	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool set_log_level = false;
-	Level log_level = Level::NONE;
+	bool m_set_log_level = false;
+	Level m_log_level = Level::NONE;
+
+public:
+	CliArgsParser(int argc, char* argv[]);
+
+	bool do_import() const;
+
+	bool do_export() const;
+
+	bool do_vacuum() const;
+
+	std::string importfile() const;
+
+	bool do_read_import() const;
+
+	bool do_read_export() const;
+
+	std::string readinfofile() const;
+
+	std::string program_name() const;
+
+	unsigned int show_version() const;
+
+	bool silent() const;
+
+	bool using_nonstandard_configs() const;
+
+	/// If `should_return()` is `true`, the creator of `CliArgsParser` object
+	/// should call `exit(return_code())`.
+	bool should_return() const;
+	int return_code() const;
+
+	/// If `display_msg()` is not empty, the creator of `CliArgsParser` should
+	/// print its contents to stderr.
+	///
+	/// \note The contents of this string should be checked before processing
+	/// `should_return`.
+	std::string display_msg() const;
+
+	/// If `should_print_usage()` is `true`, the creator of `CliArgsParser`
+	/// object should print usage information.
+	///
+	/// \note This field should be checked before processing
+	/// `should_return`.
+	bool should_print_usage() const;
+
+	bool refresh_on_start() const;
+
+	/// `url_file()` should only be called if `set_url_file()` returned `true`.
+	bool set_url_file() const;
+	std::string url_file() const;
+
+	/// `lock_file()` should only be called if `set_lock_file()` returned
+	/// `true`.
+	bool set_lock_file() const;
+	std::string lock_file() const;
+
+	/// `cache_file()` should only be called if `set_cache_file()` returned
+	/// `true`.
+	bool set_cache_file() const;
+	std::string cache_file() const;
+
+	/// `config_file()` should only be called if `set_config_file` returned
+	/// `true`.
+	bool set_config_file() const;
+	std::string config_file() const;
+
+	/// If 'execute_cmds()' is true, Newsboat should execute commands from
+	/// `cmds_to_execute()`.
+	///
+	/// \note The parser does not check if the passed commands are valid.
+	bool execute_cmds() const;
+	std::vector<std::string> cmds_to_execute() const;
+
+	/// `log_file()` should only be called if `set_log_file()` returned `true`.
+	bool set_log_file() const;
+	std::string log_file() const;
+
+	/// `log_level()` should only be called if `set_log_level` returned `true`.
+	bool set_log_level() const;
+	Level log_level() const;
 };
 } // namespace newsboat
 

--- a/include/cliargsparser.h
+++ b/include/cliargsparser.h
@@ -8,86 +8,11 @@
 
 namespace newsboat {
 class CliArgsParser {
-	bool m_do_import = false;
-	bool m_do_export = false;
-	bool m_do_vacuum = false;
-	std::string m_importfile;
-	bool m_do_read_import = false;
-	bool m_do_read_export = false;
-	std::string m_program_name;
-	std::string m_readinfofile;
-	unsigned int m_show_version = 0;
-	bool m_silent = false;
-	bool m_using_nonstandard_configs = false;
-
-	/// If `should_return` is `true`, the creator of `CliArgsParser` object
-	/// should call `exit(return_code)`.
-	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool m_should_return = false;
-	int m_return_code = 0;
-
-	/// If `display_msg` is not empty, the creator of `CliArgsParser` should
-	/// print its contents to stderr.
-	///
-	/// \note The contents of this string should be checked before
-	/// processing `should_return`.
-	std::string m_display_msg;
-
-	/// If `should_print_usage` is `true`, the creator of `CliArgsParser`
-	/// object should print usage information.
-	///
-	/// \note This field should be checked before processing
-	/// `should_return`.
-	bool m_should_print_usage = false;
-
-	bool m_refresh_on_start = false;
-
-	/// The value of `url_file` should only be used if `set_url_file` is
-	/// `true`.
-	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool m_set_url_file = false;
-	std::string m_url_file;
-
-	/// The value of `lock_file` should only be used if `set_lock_file` is
-	/// `true`.
-	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool m_set_lock_file = false;
-	std::string m_lock_file;
-
-	/// The value of `cache_file` should only be used if `set_cache_file` is
-	/// `true`.
-	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool m_set_cache_file = false;
-	std::string m_cache_file;
-
-	/// The value of `config_file` should only be used if `set_config_file`
-	/// is `true`.
-	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool m_set_config_file = false;
-	std::string m_config_file;
-
-	/// If 'execute_cmds' is true, the 'CliArgsParser' object holds commands
-	/// that should be executed in cmds_to_execute vector.
-	///
-	/// \note The parser does not check if the passed commands are valid.
-	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool m_execute_cmds = false;
-	std::vector<std::string> m_cmds_to_execute;
-
-	/// The value of `log_file` should only be used if `set_log_file` is
-	/// `true`.
-	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool m_set_log_file = false;
-	std::string m_log_file;
-
-	/// The value of `log_level` should only be used if `set_log_level` is
-	/// `true`.
-	// TODO: replace this with std::optional once we upgraded to C++17.
-	bool m_set_log_level = false;
-	Level m_log_level = Level::NONE;
+	void* rs_cliargsparser = nullptr;
 
 public:
 	CliArgsParser(int argc, char* argv[]);
+	~CliArgsParser();
 
 	bool do_import() const;
 

--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -174,13 +174,13 @@ int main(int argc, char* argv[])
 	c.set_view(&v);
 	CliArgsParser args(argc, argv);
 
-	if (args.should_print_usage) {
-		print_usage(args.program_name);
-		if (args.should_return) {
-			return args.return_code;
+	if (args.should_print_usage()) {
+		print_usage(args.program_name());
+		if (args.should_return()) {
+			return args.return_code();
 		}
-	} else if (args.show_version) {
-		print_version(args.program_name, args.show_version);
+	} else if (args.show_version()) {
+		print_version(args.program_name(), args.show_version());
 		return EXIT_SUCCESS;
 	}
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2017-07-19 20:19+0300\n"
 "Last-Translator: Alejandro Gallo <aamsgallo@gmail.com>\n"
 "Language-Team: Alejandro Gallo <aamsgallo@gmail.com>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -26,95 +26,95 @@ msgstr ""
 "Ús: %s [-i <arxiu>|-e] [-u <arxiu url>] [-c <arxiu caché>] [-x "
 "<comando> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "exportar la font OPML a la sortida estàndard"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "actualizar les fonts al inicio"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<arxiu>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "importar arxiu OPML"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<arxiu url>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "llegir fonts URLs de fonts RSS desde <arxiu url>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<arxiu caché>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "utilitzar <arxiu caché> com arxiu de caché"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<arxiu config>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "llegir configuració desde <arxiu config>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<comando>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "executar llista de comandos"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "inicio silencioso"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "mostrar informació de la versió"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<nivell log>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "escriure un registre amb un determinat nivell (valors vàlids: 1 a 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<arxiu log>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "utilitzar <arxiu log> com arxiu de salida per el registre"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "exportar llista d'articles llegits a <arxiu>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "importar llista d'articles llegits desde <arxiu>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "esta ajuda"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, fuzzy, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -122,50 +122,50 @@ msgid ""
 msgstr ""
 "newsboat és software lliure, y llicenciat sota la MIT/X Consortium License."
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: valor de loglevel invàlid"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' no és un color vàlid"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' no és un atribut vàlid"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' no és un element de configuració vàlid"
@@ -177,73 +177,95 @@ msgstr ""
 "newsboat: recàrrega finalitzada, %f fonts no llegides (%n total d'articles "
 "no llegits)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Articles a la font «%T» (%u no llegits, %t en total) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Diàlegs"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Les teves fonts (%u no llegides, %t en total)%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Obrir Fitxter&Guardar Fitxer? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Ajuda"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Articles a la font «%T» (%u no llegits, %t en total) - %U"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Resultat de la búsqueda (%u no llegits, %t en total)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Seleccionar filtre"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Seleccionar etiqueta"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "s'esperava un valor lògic, s'ha trobat `%s' en el seu lloc"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "s'esperava un valor enter, s'ha trobat `%s' en el seu lloc"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "valor de configuració invàlid `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+#, fuzzy
+msgid "invalid parameters."
+msgstr "paràmetres invàlids."
+
+#: src/confighandlerexception.cpp:18
+#, fuzzy
+msgid "too few parameters."
+msgstr "insuficients paràmetres."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "comando desconegut (error de software)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "no es va poder obrir l'arxiu."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "error desconegut (error de software)."
+
+#: src/configparser.cpp:105
 #, fuzzy, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Error al processar el comando `%s' (%s línea %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "comando invàlid `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -252,51 +274,51 @@ msgstr ""
 "Per favor defineix la variable d'entorn HOME, o afegeix un usuari vàlid per "
 "la UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Iniciant %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Error: una instància de %s ja s'està executant (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Carregant configuració..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "fet."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Obrint caché..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Error: l'apertura de l'arxiu de caché `%s' va fallar: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Carregant URLs desde %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -305,7 +327,7 @@ msgstr ""
 "Error: no hi ha URLs configurades. Per favor omple l'arxiu %s amb URLs de "
 "fonts RSS, o importa un arxiu OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -313,7 +335,7 @@ msgstr ""
 "Sembla que la font OPML a la cual et vas subscriure no conté fonts. Por "
 "favor llénala amb fonts, e intenta-ho de nou."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -322,7 +344,7 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de The Old Reader. Si "
 "us plau fes-ho i intenta-ho de nou."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -331,7 +353,7 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de Tiny Tiny RSS. Si "
 "us plau fes-ho e intenta-ho de nou."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -340,7 +362,7 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de NewsBlur Reader. "
 "Si us plau fes-ho e intenta-ho de nou."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -349,228 +371,175 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de The Old Reader. Si "
 "us plau fes-ho i intenta-ho de nou."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Carregant articles des del caché..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Netejant el caché totalment..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Error al carregar les fonts desde la base de dades: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Error al carregar la font «%s»: %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Omplint les fonts de consulta..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Important la llista d'articles llegits..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Exportant la llista d'articles llegits..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Netejant el caché..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "va fallar: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Error: no es van poder marcar com llegides totes les fonts: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, fuzzy, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ocurrió un error al processar %s."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importació de %s finalitzada."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u articles no llegits"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "comando invàlid `%s'"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Título: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Autor: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Fecha: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Enllaç: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "URL de descàrrega del podcast: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: no es va poder obrir l'arxiu de configuració `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Tancar"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Anar a diàleg"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Tancar diàleg"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Cap element seleccionat!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Error: no es pot eliminar la llista de fonts!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Posició invàlida!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "en cua"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "descàrregant"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "cancelado"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "eliminado"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "acabat"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "fallido"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "incomplet"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "llest"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "reproduït"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "desconegut (error de software)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "l'atribut `%s' no està disponible."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "l'expressió regular «%s» és invàlida: %s"
-
-#: src/exception.cpp:52
-#, fuzzy
-msgid "invalid parameters."
-msgstr "paràmetres invàlids."
-
-#: src/exception.cpp:54
-#, fuzzy
-msgid "too few parameters."
-msgstr "insuficients paràmetres."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "comando desconegut (error de software)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "no es va poder obrir l'arxiu."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "error desconegut (error de software)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "índex de fonts invàlid (error de software)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Gent a la que segueixes"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Elements destacats"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Elements compartits"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Ninguna font seleccionada!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "ptaln"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -579,7 +548,7 @@ msgstr ""
 "¿Ordenar per (p)rimera etiqueta/(t)ítulo/número de (a)rtículos/número de "
 "articles no (l)eídos/(n)ada?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -588,226 +557,230 @@ msgstr ""
 "¿Ordenar inversament per (p)rimera etiqueta/(t)ítulo/número de (a)rtículos/"
 "número d'articles no (l)eídos/(n)ada?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Marcant font com llegida..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Error: no es va poder marcar la font com llegida: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "No hi ha fonts amb elements no llegits."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Ja estàs en la última font."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Ja estàs en la primera font."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Marcant totes les fonts com llegides..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Error: no es va poder processar el comando de filtre `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "No hi ha filtres definits."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Buscar: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "¿Realment desitjes sortir (s:Sí n:No)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "sn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "s"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Sortir"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Obrir"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Següent no llegit"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Actualitzar"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Actualitzar tot"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Marcar com llegit"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Marcar tot com llegit"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Buscar"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Ajuda"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Error: no es va poder processar el comando de filtre!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Buscant..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Error al buscar `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "No hi ha resultats."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "La posició no és visible!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Llista de fonts - %u no llegides, %u en total"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "¿Realment desitjes sobrescriure `%s' (s:Sí n:No)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Arxiu: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Guardar arxiu - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Guardar"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Guardar arxiu - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "no es va poder processar l'expressió de filtre `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "uso: definir <variable>[=<valor>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "ús: font <arxiu> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "ús: dumpconfig <arxiu>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuració guardada com %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "No és un comando: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Guardant marcadors..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Marcador guardat."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Error al guardar el marcador: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Título: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Descripció: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 #, fuzzy
 msgid "Feed title: "
 msgstr "Arxiu: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "Guardant marcats..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -815,15 +788,15 @@ msgstr ""
 "el soporte per marcadors no està configurat. Si us plau define la variable "
 "de configuració `bookmark-cmd' adecuadament."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Atajos de teclado genéricos:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Funcions no definides:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Borrar"
 
@@ -851,202 +824,221 @@ msgstr "flash incrustrat"
 msgid "unknown (bug)"
 msgstr "desconegut (error de software)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 #, fuzzy
 msgid "Broadcast items"
 msgstr "Ja estàs en el último element."
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 #, fuzzy
 msgid "Liked items"
 msgstr "Elements compartits"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Cambiant l'estat de lectura per l'article..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Error al cambiar l'estat de lectura: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "llista de URLs vacía."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Indicadors: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Error: cap element seleccionat!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Error: no es pot recarregar resultats de búsqueda."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "No hi ha elements no llegits."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Ja estàs en el último element."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Ja estàs en el primer element."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "No hi ha fonts no llegides."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Marcant totes les fonts com llegides..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Encadenar article al comando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "ftmaeg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "¿Ordenar per (f)echa/(t)ítulo/(i)ndicadors/(a)utor/(e)nlace/(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "¿Ordenar inversament per (f)echa/(t)ítulo/(i)ndicadors/(a)utor/(e)nlace/"
 "(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Indicadors actualizats."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: va fallar aplicar el filtre: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Guardat abortat."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Guardar article com %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: no es va poder guardar l'article com %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado de la búsqueda - «%s»"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Consultar font - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Llista d'articles - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Adalt"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Desota"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Font: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Autor: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Fecha: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Enllaç: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "URL de descàrrega del podcast: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "tipus: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Adalt"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Desota"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar l'article com llegit: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Se añadió %s a la cua de descàrregues."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "URL invàlida: «%s»"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Article guardat com %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no es va poder escriure l'article en l'arxiu %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Iniciant el navegador..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar l'article com no llegit: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Anar a URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Obrir en el navegador"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Agregar a la cua"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Article - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Error: expressió regular invàlida!"
 
@@ -1358,26 +1350,36 @@ msgstr "Anar al començament de la pàgina/llista"
 msgid "Move to the end of page/list"
 msgstr "Anar al final de la pàgina/llista"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' no és un context vàlid"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' no és un comando de tecla vàlid"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "l'atribut `%s' no està disponible."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "l'expressió regular «%s» és invàlida: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Error fatal: no es va poder determinar el directori d'inici!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1385,16 +1387,16 @@ msgstr ""
 "Per favor defineix la variable d'entorn HOME, o afegeix un usuari vàlid per "
 "la UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Error: no es va poder obrir l'arxiu de configuració `%s'!"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Netejant cua..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1404,115 +1406,123 @@ msgstr ""
 "uso: %s [-i <arxiu>|-e] [-u <arxiu url>] [-c <arxiu caché>] [-x "
 "<comando> ...] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<arxiu caché>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "utilitzar <arxiu caché> com arxiu de caché"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "començar descàrrega en començar el programa"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u descàrregues paral.leles"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Cua (%u descàrregues en procés, %u en total) - %.2f kb/s total%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Error: no es pot sortir: descàrrega en progrés."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Error: la descàrrega deu finalizar abans de que es pugui reproduir l'arxiu."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Error: no es pot executar l'operació: descàrrega(s) en progrés."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Descarregar"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Purga finalitzades"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Cambiar a descàrrega automàtica"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Reproduir"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "Marcar com finalitzat"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' és un tipus de diàleg invàlid"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' no és una expressió regular vàlida: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sCarregant %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Error al obtenir %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Error: font invàlida!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "insuficients arguments"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' no és una expressió regular vàlida: %s"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Error: URL no soportada: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Seleccionar etiqueta"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Seleccionar filtre"
 
@@ -1524,70 +1534,70 @@ msgstr "atribut no trobat"
 msgid "EOF found while reading XML tag"
 msgstr "EOF trobat al llegir l'etiqueta XML"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Cap enllaç seleccionat!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Guardar marcador"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Error: la font no conté elements!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "No hi ha etiquetes definides."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Actualitzant consulta de font..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "el node arrel de XML és nul"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "no es va poder iniciar libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "no es va poder processar el búfer"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "no es va poder processar l'arxiu"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "sense versió de RSS"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "versió de RSS invàlida"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "versió d'Atom invàlida"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "sense versió d'Atom"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "format de font no suportat"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "no es va trobar cap canal RSS"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "format de font no suportat"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/ca.po
+++ b/po/ca.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2017-07-19 20:19+0300\n"
 "Last-Translator: Alejandro Gallo <aamsgallo@gmail.com>\n"
 "Language-Team: Alejandro Gallo <aamsgallo@gmail.com>\n"
@@ -149,9 +149,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: valor de loglevel invàlid"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1391,6 +1391,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Error: no es va poder obrir l'arxiu de configuració `%s'!"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: valor de loglevel invàlid"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/de.po
+++ b/po/de.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2018-12-22 15:47+0100\n"
 "Last-Translator: Lysander Trischler <github@lyse.isobeef.org>\n"
 "Language-Team: Andreas Krennmair <ak@newsbeuter.org>, Simon Nagl "
@@ -156,9 +156,9 @@ msgstr "newsboat::matcherexception gefangen mit Nachricht: %s"
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "newsboat::exception gefangen mit Nachricht: %s"
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: ungültiger Loglevel-Wert"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1385,6 +1385,11 @@ msgstr ""
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Fataler Fehler: Konnte Konfigurationsverzeichnis „%s“ nicht anlegen: (%i) %s"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: ungültiger Loglevel-Wert"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/de.po
+++ b/po/de.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2018-12-22 15:47+0100\n"
 "Last-Translator: Lysander Trischler <github@lyse.isobeef.org>\n"
 "Language-Team: Andreas Krennmair <ak@newsbeuter.org>, Simon Nagl "
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -26,97 +26,97 @@ msgstr ""
 "Verwendung: %s [-i <datei>|-e] [-u <urldatei>] [-c <cachedatei>] [-x "
 "<befehl> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "OPML-Feed auf die Standardausgabe exportieren"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "Feeds beim Start neu laden"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<datei>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "OPML-Datei importieren"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<urldatei>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "RSS-Feed-URLs aus <urldatei> lesen"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<cachedatei>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "<cachedatei> als Zwischenspeicherdatei verwenden"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<configdatei>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "Konfiguration aus <configdatei> lesen"
 
 # Es wird ein SQLite-VACUUM-Befehl ausgeführt.
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "Zwischenspeicherdatei kompaktifizieren"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<befehl>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "Liste von Befehlen ausführen"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "ruhiger Start"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "Versionsinformation anzeigen"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<loglevel>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 "Logdatei mit einem bestimmten Loglevel (gültige Werte: 1 bis 6) schreiben"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<logdatei>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "Logs nach <logdatei> schreiben"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "Liste von gelesenen Artikeln nach <datei> exportieren"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "Liste von gelesenen Artikeln aus <datei> importieren"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "diese Hilfe anzeigen"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -125,7 +125,7 @@ msgstr ""
 "newsboat ist Freie Software und steht unter der MIT-Lizenz. („%s -vv“ zeigt "
 "den vollständigen Lizenztext an.) "
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
@@ -133,7 +133,7 @@ msgstr ""
 "Es wird die unter der MIT-Lizenz stehende Bibliothek JSON für Modernes C++ "
 "verwendet: https://github.com/nlohmann/json"
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
@@ -141,38 +141,38 @@ msgstr ""
 "Die eingesetzte Implementierung des alphanumerischen Sortieralgorithmuses "
 "steht unter der MIT-Lizenz: http://www.davekoelle.com/alphanum.html"
 
-#: newsboat.cpp:186
-#, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+#: newsboat.cpp:192
+#, fuzzy, c-format
+msgid "Caught newsboat::DbException with message: %s"
 msgstr "newsboat::dbexception gefangen mit Nachricht: %s"
 
-#: newsboat.cpp:193
-#, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+#: newsboat.cpp:199
+#, fuzzy, c-format
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "newsboat::matcherexception gefangen mit Nachricht: %s"
 
-#: newsboat.cpp:199 podboat.cpp:32
-#, c-format
-msgid "Caught newsboat::exception with message: %s"
+#: newsboat.cpp:205 podboat.cpp:37
+#, fuzzy, c-format
+msgid "Caught newsboat::Exception with message: %s"
 msgstr "newsboat::exception gefangen mit Nachricht: %s"
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: ungültiger Loglevel-Wert"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' ist keine gültige Farbe"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' ist kein gültiges Attribut"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' ist kein gültiges Konfigurationselement"
@@ -184,72 +184,92 @@ msgstr ""
 "newsboat: Neuladen beendet, %f ungelesene Feeds (%n ungelesene Artikel "
 "insgesamt)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Artikel im Feed '%T' (%u ungelesen, %t gesamt) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialoge"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Ihre Feeds (%u ungelesen, %t gesamt)%?T? - Tag `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Datei öffnen&Datei speichern? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Hilfe"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artikel '%T' (%u ungelesen, %t gesamt)"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Suchergebnisse (%u ungelesen, %t gesamt)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Filter auswählen"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Tag auswählen"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "erwartete Wahrheitswert, fand stattdessen `%s'"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "erwartete Ganzzahl, fand stattdessen `%s'"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "ungültiger Konfigurationswert `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "Ungültige Parameter."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "Zu wenige Parameter."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "Unbekannter Befehl (Bug)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "Datei konnte nicht geöffnet werden."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "Unbekannter Fehler (Bug)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Fehler beim Verarbeiten von Befehl `%s' (%s Zeile %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "unbekannter Befehl `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -259,52 +279,52 @@ msgstr ""
 "Bitte setzen Sie die Umgebungsvariable HOME oder fügen Sie einen gültigen "
 "Benutzer für UID %u hinzu!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Starte %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Fehler: Eine Instanz von %s läuft bereits (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Lade Konfiguration..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "Fertig."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Öffne Zwischenspeicher..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Fehler: Das Öffnen der Zwischenspeicherdatei `%s' schlug fehl: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 "Fehler: Sie müssen „cookie-cache“ setzen, um NewsBlur verwenden zu können.\n"
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "Die Datei %s kann weder gelesen noch erstellt werden\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Lade URLs von %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -313,7 +333,7 @@ msgstr ""
 "Fehler: keine URLs konfiguriert. Bitte füllen Sie die Datei %s mit RSS-Feed-"
 "URLs oder importieren Sie eine OPML-Datei."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -321,7 +341,7 @@ msgstr ""
 "Es sieht so aus als würde die konfigurierte OPML-Datei keine Feeds "
 "enthalten. Bitte füllen Sie diese mit Feeds, und probieren Sie es erneut."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -329,7 +349,7 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem The-Old-Reader-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -337,7 +357,7 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem Tiny-Tiny-RSS-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -345,7 +365,7 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem NewsBlur-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -353,225 +373,174 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem Inoreader-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Lade Artikel aus dem Zwischenspeicher..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Bereinige Zwischenspeicher gründlich..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Fehler beim Laden der Feeds aus der Datenbank: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Fehler beim Laden von Feed `%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Query-Feed vorbefüllen..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importiere Liste von gelesenen Artikeln..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Exportierte Liste von gelesenen Artikeln..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Bereinige Zwischenspeicher..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "Fehlgeschlagen: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Fehler: Konnte nicht alle Feeds als gelesen markieren: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ein Fehler ist beim Parsen von %s aufgetreten."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Import von %s fertig."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u ungelesene Artikel"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: unbekannter Befehl"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Titel: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Autor: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Datum: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Link: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Podcast-Download-URL: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fehler: Konnte Konfigurationsdatei `%s' nicht öffnen!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Schließen"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "gehe zu Dialog"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Dialog schließen"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Kein Element ausgewählt!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Fehler: Sie können die Feedliste nicht entfernen!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Ungültige Position!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "in Warteschlange"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "wird herunterladen"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "abgebrochen"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "gelöscht"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "fertig"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "fehlgeschlagen"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "unvollständig"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "bereit"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "abgespielt"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "Unbekannt (Bug)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "Attribut `%s' ist nicht verfügbar."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "Regulärer Ausdruck '%s' ist ungültig: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "Ungültige Parameter."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "Zu wenige Parameter."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "Unbekannter Befehl (Bug)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "Datei konnte nicht geöffnet werden."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "Unbekannter Fehler (Bug)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "ungültiger Feed-Index (Bug)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Personen, deren regelmäßiger Leser Sie sind"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "markierte Artikel"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "empfohlene Artikel"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Kein Feed ausgewählt!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr "etauzn"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -579,7 +548,7 @@ msgstr ""
 "Sortieren nach (e)rstemtag/(t)itel/(a)rtikelzahl/(u)ngeleseneartikel/"
 "(z)uletztaktualisiert/(n)ichts?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -587,224 +556,228 @@ msgstr ""
 "Umgekehrt sortieren nach (e)rstemtag/(t)itel/(a)rtikelzahl/"
 "(u)ngeleseneartikel/(z)uletztaktualisiert/(n)ichts?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr "Query-Feeds können nicht im Browser geöffnet werden!"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Markiere Feed als gelesen..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Fehler: Konnte Feed nicht als gelesen markieren: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Keine Feeds mit ungelesenen Artikeln."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Bereits beim letzten Feed."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Bereits beim ersten Feed."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Markiere alle Feeds als gelesen..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Fehler: Konnte Filterkommando `%s' nicht parsen: %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Keine Filter definiert."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Suche nach: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Wollen Sie wirklich beenden (j:Ja n:Nein)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "jn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "j"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Beenden"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "nächster Ungelesener"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "neu laden"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "alle neu laden"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "gelesen markieren"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "alle gelesen markieren"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Suchen"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Hilfe"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Fehler: Konnte Filterkommando nicht parsen!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Suche..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Fehler beim Suchen nach `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Keine Ergebnisse."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Position nicht sichtbar!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Feedliste - %u ungelesen, %u gesamt"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Wollen Sie wirklich `%s' überschreiben (y:Ja n:Nein)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Datei: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Datei speichern - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Speichern"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Datei speichern - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "Fehler: Konnte Filterkommando `%s' nicht parsen: %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "Verwendung: set <variable>[=<wert>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "Verwendung: source <datei> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "Verwendung: dumpconfig <datei> [...]"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Konfiguration nach %s gespeichert"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Kein Befehl: `%s'"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Speichere Lesezeichen..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Lesezeichen gespeichert."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Fehler beim Speichern des Lesezeichens: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Titel: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Beschreibung: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Feed-Titel: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Speichere Lesezeichen im Autopilot-Modus..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -812,15 +785,15 @@ msgstr ""
 "Die Lesezeichen-Unterstützung ist nicht konfiguriert. Bitte setzen Sie die "
 "Konfigurationsvariable `bookmark-cmd' entsprechend."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Allgemeine Tastenbelegungen:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Unbelegte Funktionen:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Löschen"
 
@@ -848,198 +821,217 @@ msgstr "eingebettetes Flash"
 msgid "unknown (bug)"
 msgstr "unbekannt (Bug)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "geteilte Artikel"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "für gut befundene Artikel"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "gespeicherte Webseiten"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Schalte Gelesen-Flag für Artikel um..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Fehler beim Umschalten des Gelesen-Flags: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "URL-Liste leer."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Flags: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Fehler: Keinen Artikel ausgewählt!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Fehler: Sie können Suchergebnisse nicht neu laden."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Keine ungelesenen Artikel."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Bereits beim letzten Artikel."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Bereits beim ersten Artikel."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Keine ungelesenen Feeds."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 msgid "Marking all above as read..."
 msgstr "Markiere alle obenstehenden Artikel als gelesen..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Artikel zu Befehl umleiten: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfalg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Sortieren nach (d)atum/(t)itel/(f)lags/(a)utor/(l)ink/(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Umgekehrt sortieren nach (d)atum/(t)itel/(f)lags/(a)utor/(l)ink/(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Flags aktualisiert."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Fehler: Anwenden des Filters fehlgeschlagen: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Speichern abgebrochen."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artikel nach %s gespeichert"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fehler: Konnte Artikel nicht nach %s speichern"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Suchergebnis - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Query-Feed - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikelliste - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Anfang"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Ende"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Feed: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Autor: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Datum: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Link: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Podcast-Download-URL: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "Typ: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Anfang"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Ende"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fehler beim Markieren des Artikels als gelesen: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s zur Download-Warteschlange hinzugefügt."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Ungültige URL: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Artikel nach %s gespeichert."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Fehler: Konnte Artikel nicht nach %s speichern"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Starte Browser..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Fehler beim Markieren des Artikels als ungelesen: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Gehe zu URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "im Browser öffnen"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "in Warteschlange"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Fehler: Ungültiger regulärer Ausdruck!"
 
@@ -1349,28 +1341,38 @@ msgstr "zum Anfang der Seite/Liste gehen"
 msgid "Move to the end of page/list"
 msgstr "zum Ende der Seite/Liste gehen"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' ist kein gültiger Kontext"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' ist kein gültiges Tastenkommando"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "Attribut `%s' ist nicht verfügbar."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "Regulärer Ausdruck '%s' ist ungültig: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: Konfigurationsverzeichnis '%s' nicht zugänglich, benutze stattdessen "
 "'%s'."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Schwerer Fehler: Konnte das Home-Verzeichnis nicht feststellen!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1378,17 +1380,17 @@ msgstr ""
 "Bitte setzen Sie die Umgebungsvariable HOME oder fügen Sie einen gültigen "
 "Benutzer für UID %u hinzu!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Fataler Fehler: Konnte Konfigurationsverzeichnis „%s“ nicht anlegen: (%i) %s"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Bereinige Warteschlange..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1397,114 +1399,122 @@ msgstr ""
 "%s %s\n"
 "Verwendung: %s [-C <configdatei>] [-q <warteschlangendatei>] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<warteschlangendatei>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "<warteschlangendatei> als Warteschlangendatei verwenden"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "beim Programmstart automatisch herunterladen"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u parallele Downloads"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr ""
 "Warteschlange (%u Download im Gange, %u insgesamt) - %.2f kb/s insgesamt%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Fehler: Kann nicht beenden: Download(s) im Gange."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Fehler: Download muss abgeschlossen sein bevor die Datei abgespielt werden "
 "kann."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Fehler: Kann Vorgang nicht durchführen: Download(s) im Gange."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Herunterladen"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Löschen"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "fertige aufräumen"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "automatisches Herunterladen umschalten"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Abspielen"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "als fertig markieren"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' ist ein ungültiger Dialogtyp"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' is kein gültiger regulärer Ausdruck: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sLade %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Fehler beim Abholen von %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Fehler: Ungültiger Feed!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a, %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "zu wenige Parameter"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' ist kein gültiger Filterausdruck"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a, %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Fehler: Nicht unterstützte URL: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Tag auswählen"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Filter auswählen"
 
@@ -1516,70 +1526,70 @@ msgstr "Attribut nicht gefunden"
 msgid "EOF found while reading XML tag"
 msgstr "Ende der Datei gefunden beim Lesen eines XML-Tags"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Kein Link ausgewählt!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Lesezeichen speichern"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Fehler: Feed enthält keine Elemente!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Keine Tags definiert."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Aktualisiere Query-Feed..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "XML-Rootknoten ist NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "konnte libcurl nicht initialisieren"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "konnte Puffer nicht parsen"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "konnte Datei nicht parsen"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "keine RSS-Version"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "ungültige RSS-Version"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "ungültige Atom-Version"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "keine Atom-Version"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "nicht unterstütztes Feed-Format"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "kein RSS-Channel gefunden"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "nicht unterstütztes Feed-Format"
 
 #~ msgid "'%s' is not a valid key command"
 #~ msgstr "`%s' ist kein gültiges Tastenkommando"

--- a/po/es.po
+++ b/po/es.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2013-02-08 06:24-0500\n"
 "Last-Translator: OmeGa <omega@mailoo.org>\n"
 "Language-Team: OmeGa omega@mailoo.org\n"
@@ -149,10 +149,10 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
-msgstr ""
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
+msgstr "`%s' es un tipo de diálogo inválido"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
 #: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
@@ -1388,6 +1388,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Error: ¡no se pudo abrir el archivo de configuración `%s'!"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr ""
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/es.po
+++ b/po/es.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2013-02-08 06:24-0500\n"
 "Last-Translator: OmeGa <omega@mailoo.org>\n"
 "Language-Team: OmeGa omega@mailoo.org\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -26,95 +26,95 @@ msgstr ""
 "uso: %s [-i <archivo>|-e] [-u <archivo url>] [-c <archivo caché>] [-x "
 "<comando> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "exportar la fuente OPML a salida estándar"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "actualizar las fuentes al inicio"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<archivo>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "importar archivo OPML"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<archivo url>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "leer fuentes URLs de fuentes RSS desde <archivo url>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<archivo caché>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "utilizar <archivo caché> como archivo de caché"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<archivo config>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "leer configuración desde <archivo config>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<comando>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "ejecutar lista de comandos"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "inicio silencioso"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "mostrar información de la versión"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<nivel log>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "escribir un registro con un determinado nivel (valores válidos: 1 a 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<archivo log>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "utilizar <archivo log> como archivo de salida para el registro"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "exportar lista de artículos leídos a <archivo>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "importar lista de artículos leídos desde <archivo>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "esta ayuda"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, fuzzy, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -122,50 +122,50 @@ msgid ""
 msgstr ""
 "newsboat es software libre, y licenciado bajo la MIT/X Consortium License."
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' no es un color válido"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' no es un atributo válido"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' no es un elemento de configuración válido"
@@ -177,73 +177,93 @@ msgstr ""
 "newsboat: recarga finalizada, %f fuentes no leídas (%n total de artículos no "
 "leídos)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Artículos en la fuente «%T» (%u no leídos, %t en total) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Diálogos"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Tus fuentes (%u no leídas, %t en total)%?T? - etiqueta `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Abrir archivo&Guardar archivo? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Ayuda"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artículos en la fuente «%T» (%u no leídos, %t en total) - %U"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Resultado de la búsqueda (%u no leídos, %t en total)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Seleccionar filtro"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Seleccionar etiqueta"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "se esperaba un valor lógico, se encontró `%s' en su lugar"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "se esperaba un valor entero, se encontró `%s' en su lugar"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "valor de configuración inválido `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "parámetros inválidos."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "insuficientes parámetros."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "comando desconocido (error de software)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "no se pudo abrir el archivo."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "error desconocido (error de software)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Error al procesar el comando `%s' (%s línea %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "comando inválido `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -252,51 +272,51 @@ msgstr ""
 "¡Por favor define la variable de entorno HOME, o añade un usuario válido "
 "para UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Iniciando %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Error: una instancia de %s ya se está ejecutando (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Cargando configuración..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "hecho."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Abriendo caché..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Error: la apertura del archivo de caché `%s' falló: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Cargando URLs desde %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -305,7 +325,7 @@ msgstr ""
 "Error: no hay URLs configuradas. Por favor llena el archivo %s con URLs de "
 "fuentes RSS, o importa un archivo OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -313,7 +333,7 @@ msgstr ""
 "Parece que la fuente OPML a la cual te suscribiste no contiene fuentes. Por "
 "favor llénala con fuentes, e inténtalo de nuevo."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -322,7 +342,7 @@ msgstr ""
 "Parece que no has configurado ninguna fuente en tu cuenta de The Old Reader. "
 "Por favor hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -331,7 +351,7 @@ msgstr ""
 "Parece que no has configurado ninguna fuente en tu cuenta de Tiny Tiny RSS. "
 "Por favor hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -340,7 +360,7 @@ msgstr ""
 "Parece que no has configurado ninguna fuente en tu cuenta de NewsBlur. Por "
 "favor hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -349,226 +369,175 @@ msgstr ""
 "Parece que no has configurado ninguna fuente en tu cuenta de The Old Reader. "
 "Por favor hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Cargando artículos desde caché..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Limpiando el caché totalmente..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Error al cargar las fuentes desde la base de datos: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Error al cargar la fuente «%s»: %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Rellenando las fuentes de consulta..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importando la lista de artículos leídos..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Exportando la lista de artículos leídos..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Limpiando el caché..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "falló: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Error: no se pudieron marcar como leídas todas las fuentes: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ocurrió un error al procesar %s."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importación de %s finalizada."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u artículos no leídos"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "comando inválido `%s'"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Título: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Autor: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Fecha: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Enlace: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "URL de descarga del podcast: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: ¡no se pudo abrir el archivo de configuración `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Ir a diálogo"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Cerrar diálogo"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "¡Ningún elemento seleccionado!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Error: ¡no puedes eliminar la lista de fuentes!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "¡Posición inválida!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "en cola"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "descargando"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "cancelado"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "eliminado"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "terminado"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "fallido"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "incompleto"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr ""
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "reproducido"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "desconocido (error de software)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "el atributo `%s' no está disponible."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "la expresión regular «%s» es inválida: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "parámetros inválidos."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "insuficientes parámetros."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "comando desconocido (error de software)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "no se pudo abrir el archivo."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "error desconocido (error de software)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "índice de fuentes inválido (error de software)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Gente a la que sigues"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Elementos destacados"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Elementos compartidos"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "¡Ninguna fuente seleccionada!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "ptaln"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -577,7 +546,7 @@ msgstr ""
 "¿Ordenar por (p)rimera etiqueta/(t)ítulo/número de (a)rtículos/número de "
 "artículos no (l)eídos/(n)ada?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -586,226 +555,230 @@ msgstr ""
 "¿Ordenar inversamente por (p)rimera etiqueta/(t)ítulo/número de (a)rtículos/"
 "número de artículos no (l)eídos/(n)ada?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Marcando fuente como leída..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Error: no se pudo marcar la fuente como leída: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "No hay fuentes con elementos no leídos."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Ya estás en la última fuente."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Ya estás en la primera fuente."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Marcando todas las fuentes como leídas..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Error: no se pudo procesar el comando de filtro `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "No hay filtros definidos."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Buscar: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "¿Realmente deseas salir (s:Sí n:No)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "sn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "s"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Salir"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Abrir"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Siguiente no leído"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Actualizar"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Actualizar todo"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Marcar como leído"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Marcar todo como leído"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Buscar"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Ayuda"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Error: ¡no se pudo procesar el comando de filtro!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Buscando..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Error al buscar `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "No hay resultados."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "¡La posición no es visible!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista de fuentes - %u no leídas, %u en total"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "¿Realmente deseas sobrescribir `%s' (s:Sí n:No)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Archivo: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Guardar archivo - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Guardar"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Guardar archivo - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "no se pudo procesar la expresión de filtro `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "uso: definir <variable>[=<valor>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "uso: fuente <archivo> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "uso: dumpconfig <archivo>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuración guardada como %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "No es un comando: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Guardando marcados..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Marcador guardado."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Error al guardar el marcados: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Título: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Descripción: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 #, fuzzy
 msgid "Feed title: "
 msgstr "Archivo: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "Guardando marcados..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -813,15 +786,15 @@ msgstr ""
 "el soporte para marcadores no está configurado. Por favor define la variable "
 "de configuración `bookmark-cmd' adecuadamente."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Atajos de teclado genéricos:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Funciones no definidas:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Borrar"
 
@@ -849,202 +822,221 @@ msgstr "flash incrustado"
 msgid "unknown (bug)"
 msgstr "desconocido (error de software)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 #, fuzzy
 msgid "Broadcast items"
 msgstr "Ya estás en el último elemento."
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 #, fuzzy
 msgid "Liked items"
 msgstr "Elementos compartidos"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Cambiando el estado de lectura para el artículo..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Error al cambiar el estado de lectura: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "lista de URLs vacía."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Indicadores: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Error: ¡ningún elemento seleccionado!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Error: no puedes recargar resultados de búsqueda."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "No hay elementos no leídos."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Ya estás en el último elemento."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Ya estás en el primer elemento."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "No hay fuentes no leídas."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Marcando todas las fuentes como leídas..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Encadenar artículo al comando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "ftmaeg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "¿Ordenar por (f)echa/(t)ítulo/(i)ndicadores/(a)utor/(e)nlace/(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "¿Ordenar inversamente por (f)echa/(t)ítulo/(i)ndicadores/(a)utor/(e)nlace/"
 "(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Indicadores actualizados."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: falló aplicar el filtro: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Guardado abortado."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Guardar artículo como %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: no se pudo guardar el artículo como %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado de la búsqueda - «%s»"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Consultar fuente - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista de artículos - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Arriba"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Abajo"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Fuente: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Autor: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Fecha: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Enlace: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "URL de descarga del podcast: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Arriba"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Abajo"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar el artículo como leído: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Se añadió %s a la cola de descargas."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "URL inválida: «%s»"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Artículo guardado como %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no se pudo escribir el artículo en el archivo %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Iniciando el navegador..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar el artículo como no leído: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Ir a URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Abrir en el navegador"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Agregar a la cola"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Artículo - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Error: ¡expresión regular inválida!"
 
@@ -1355,26 +1347,36 @@ msgstr "Ir al comienzo de la página/lista"
 msgid "Move to the end of page/list"
 msgstr "Ir al final de la página/lista"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' no es un contexto válido"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' no es un comando de tecla válido"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "el atributo `%s' no está disponible."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "la expresión regular «%s» es inválida: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Error fatal: ¡no se pudo determinar el directorio de inicio!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1382,16 +1384,16 @@ msgstr ""
 "¡Por favor define la variable de entorno HOME, o añade un usuario válido "
 "para UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Error: ¡no se pudo abrir el archivo de configuración `%s'!"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Limpiando cola..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1401,116 +1403,124 @@ msgstr ""
 "uso: %s [-i <archivo>|-e] [-u <archivo url>] [-c <archivo caché>] [-x "
 "<comando> ...] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<archivo>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "utilizar <archivo caché> como archivo de caché"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr ""
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u descargas paralelas"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Cola (%u descargas en proceso, %u en total) - %.2f kb/s total%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Error: no se puede salir: descarga(s) en progreso."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Error: la descarga debe finalizar antes de que se pueda reproducir el "
 "archivo."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Erros: no se puede ejecutar la operación: descarga(s) en progreso."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Descargar"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Purgar finalizadas"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Cambiar a descarga automática"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Reproducir"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "Purgar finalizadas"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' es un tipo de diálogo inválido"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' no es una expresión regular válida: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sCargando %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Error al obtener %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Error: ¡fuente inválida!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "insuficientes argumentos"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' no es una expresión regular válida: %s"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Error: URL no soportada: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Seleccionar etiqueta"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Seleccionar filtro"
 
@@ -1522,70 +1532,70 @@ msgstr "atributo no encontrado"
 msgid "EOF found while reading XML tag"
 msgstr "EOF encontrado al leer la etiqueta XML"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "¡Ningún enlace seleccionado!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Guardar marcador"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Error: ¡la fuente no contiene elementos!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "No hay etiquetas definidas."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Actualizando consulta de fuente..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "el nodo raíz de XML es nulo"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "no se pudo iniciar libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "no se pudo procesar el búfer"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "no se pudo procesar el archivo"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "sin versión de RSS"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "versión de RSS inválida"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "versión de Atom inválida"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "sin versión de Atom"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "formato de fuente no soportado"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "no se encontró ningún canal RSS"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "formato de fuente no soportado"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2017-12-10 18:12+0100\n"
 "Last-Translator: José Manuel García-Patos <josemanuel@gesaku.es>\n"
 "Language-Team:  <>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -25,145 +25,145 @@ msgstr ""
 "uso: %s [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x <command> ...] [-"
 "h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "exportar feed OPML a stdout"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "actualizar feeds al iniciar"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<file>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "importar archivo OPML"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<urlfile>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "leer URLs de feeds RSS desde <urlfile>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<cachefile>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "usar <cachefile> como archivo de caché"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<configfile>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "leer configuracion desde <configfile>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "compactar la caché"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<command>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "ejecutar lista de comandos"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "no mostrar mensajes al inicio"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "leer informacion de la version"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<loglevel>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "nivel de detalle para el archivo de log (valores válidos: 1 a 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<logfile>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "usar <logfile> como archivo de log"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "exportar lista de artículos leídos a <archivo>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "importar lista de artículos leídos desde <archivo>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "esta ayuda"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, fuzzy, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
 "see the full text.)"
 msgstr "newsboat es software libre bajo licencia MIT"
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: Nivel de log inválido"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' no es un color válido"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' no es un atributo válido."
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' no es un elemento de configuración válido"
@@ -175,72 +175,92 @@ msgstr ""
 "newsboat: recarga finalizada, %f feeds no leídos (%n total de artículos no "
 "leídos)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Artículos en el feed '%T' (%u no leídos, %t total) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Diálogos"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Tus feeds (%u no leídos, %t total)%?T? - etiqueta `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Abrir arcivo&Salvar archivo? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Ayuda"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - '%T' (%u no leídos, %t total)"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Resultado de la búsqueda (%u unread, %t total)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Seleccionar filtro"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Seleccionar etiqueta"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URL"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "se esperaba un valor lógico, se ha encontrado `%s' en su lugar"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "se esperaba un valor entero, se encontró `%s' en su lugar"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "Valor de configuración `%s' inválido"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "parametros inválidos."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "no suficientes parámetros."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "comando desconocido (bug)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "no se pudo abrir el archivo."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "error desconocido (bug)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Error ejecutando el comando `%s' (%s linea %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "comando desconocido `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -249,51 +269,51 @@ msgstr ""
 "Por favor declara la variable de entorno HOME o añade un usuario válido para "
 "UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Iniciando %s %s... "
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Error: una instancia de %s esta ejecutandose (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Cargando la configuración... "
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "hecho."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Abriendo caché... "
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Error: abriendo el archivo de caché `%s' fallo: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s es inaccesible y no se puede crear\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Cargando URL desde %s... "
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -302,7 +322,7 @@ msgstr ""
 "Error: no hay URL configuradas. Por favor inserta RSS en el fichero %s o "
 "importa un fichero OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -310,7 +330,7 @@ msgstr ""
 "Parece que el feed OPML al que te has subscrito no contiene feeds. Por "
 "favor, rellénalo con feeds e inténtalo de nuevo."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -318,7 +338,7 @@ msgstr ""
 "Parece que no has configurado ningun feed en tu cuenta de The Old Reader. "
 "Por favor, hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -326,7 +346,7 @@ msgstr ""
 "Parece que no has configurado ningun feed en tu cuenta de Tiny Tiny RSS. Por "
 "favor, hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -334,7 +354,7 @@ msgstr ""
 "Parece que no has configurado ningun feed en tu cuenta de NewsBlur. Por "
 "favor, hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -342,226 +362,175 @@ msgstr ""
 "Parece que no has configurado ningun feed en tu cuenta de Inoreader. Por "
 "favor, hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Cargando artículos desde la caché... "
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Limpiando minuciosamente la caché... "
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Error al cargar los feeds desde la base de datos: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Error cargando feed '%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Preparando consulta de feeds... "
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importando lista de artículos leídos... "
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Exportando lista de artículos leídos... "
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Limpiando la caché... "
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "fallo: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Error: no se ha podido marcar todos los feeds como leídos: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Se produjo un error analizando %s."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importacion de %s finalizada."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u artículos no leídos"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: comando desconocido"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Título: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Autor: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Fecha: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Enlace: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "URL de descarga de podcast: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: ¡no se pudo abrir el archivo de configuración `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Ir a Diálogo"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Cerrar Diálogo"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "¡Ningún objeto seleccionado!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Error: ¡no puedes eliminar la lista de feeds!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "¡Posicion inválida!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "encolado"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "descargando"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "cancelado"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "borrado"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "finalizado"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "fallido"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "incompleto"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "listo"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "ejecutado"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "desconocido (bug)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "El atributo `%s' no está disponible."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "la expresión regular '%s' no es válida: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "parametros inválidos."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "no suficientes parámetros."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "comando desconocido (bug)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "no se pudo abrir el archivo."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "error desconocido (bug)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "Indice de feeds inválido (fallo)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Personas a las que sigues"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Elementos destacados"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Elementos compartidos"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "¡No hay feeds seleccionados!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "ftaun"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -570,7 +539,7 @@ msgstr ""
 "¿Ordenar por primera etiqueta (f)/(t)ítulo/número de (a)rtíclulos/número de "
 "artíc(u)los no leídos/(n)ada?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -579,224 +548,228 @@ msgstr ""
 "¿Orden inverso por primera etiqueta (f)/(t)ítulo/número de (a)rtíclulos/"
 "n(u)mero de artículos no leídos/(n)ada?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr "¡No puedo abrir los feeds en el navegador!"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Marcando feed como leido..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Error: no se pudo marcar el feed como leido: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "No hay feeds con elementos no leídos"
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Ya estás en el último feed."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Ya estás en el primer feed."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Marcando todos los feeds como leídos... "
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Error: no he podido entender el comando de filtrado `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "No hay filtros definidos."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Buscar: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "¿Realmente quieres salir (y:Si n:No)?"
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Salir"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Abrir"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Siguiente no leido"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Recargar"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Recargar todos"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Marcar como leido"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Marcar todo como leido"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Buscar"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Ayuda"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Error: ¡no he podido entender el comando de filtrado!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Buscando... "
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Error buscando `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Sin resultados."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "¡Posición no visible!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista de Feeds - %u no leídos, %u total"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "¿Realmente quieres sobreescribir `%s' (y:Si n:No)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Archivo: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Guardar Archivo - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Guardar"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Salvar Archivo - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "No se pudo analizar el comando de filtrado `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "Uso: set <variable>[=<valor>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "uso: fuente <archivo> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "uso: dumpconfig <archivo>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuracion guardada en %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "No es un comando: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Guardando marcador..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Marcador guardado."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Error guardando marcador: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Título: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Descripción: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Título del feed: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Guardando marcador automáticamente... "
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -804,15 +777,15 @@ msgstr ""
 "El soporte para marcadores no está connfigurado. Por favor configure la "
 "variable `bookmark-cmd'."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Atajos de teclado genéricos:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Funciones sin atajo de teclado:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Limpiar"
 
@@ -840,199 +813,218 @@ msgstr "flash incrustado"
 msgid "unknown (bug)"
 msgstr "desconodico (bug)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "Elementos compartidos"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "Elementos favoritos"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "Páginas web guardadas"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Cambiando marca de lectura para el artículo..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Error cambiando la marca de lectura: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "Lista de URL vacia."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Marcas: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Error: ¡ningun objeto seleccionado!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Error: no puedes recargar los resultados de la busqueda."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Ningun elemento por leer."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Ya estás en el último elemento"
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Ya estás en el primer elemento."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Ningún feed por leer."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Marcando todos los feeds como leídos... "
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Conectar artículo a comando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfalg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "¿Ordenar por fecha (d)/(t)ítulo/marcas (f)/(a)utor/en(l)ace/(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "¿Orden inverso por fecha (d)/(t)ítulo/marcas (f)/(a)utor/en(l)ace/(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Marcas actualizadas."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: Fallo al aplicar el filtro: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Guardado abortado."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artículo guardado como %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: No se pudo guardar el artículo como %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado de la búsqueda - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Consultar Feed - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista de artículos - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Arriba"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Abajo"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Feed: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Autor: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Fecha: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Enlace: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "URL de descarga de podcast: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Arriba"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Abajo"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar artículo como leido: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Añadido %s a la cola de descarga."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "URL inválida: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Artículo guardado como %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no se pudo escribir el artículo en el fichero %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Iniciando navegador..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar artículo como no leido: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Ir a URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Abrir en navegador"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Encolado"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Artículo - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Error: ¡expresión regular inválida!"
 
@@ -1344,28 +1336,38 @@ msgstr "Ir al principio de la página/lista"
 msgid "Move to the end of page/list"
 msgstr "Ir al final de la página/lista"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' no es un contexto válido"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' no es un atajo de teclado válido"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "El atributo `%s' no está disponible."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "la expresión regular '%s' no es válida: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: el directorio de configuración '%s' no es accesible. Usaremos '%s' en "
 "su lugar."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Error fatal: no se pudo encontrar el directorio home!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1373,16 +1375,16 @@ msgstr ""
 "Por favor declara la variable de entorno HOME o añade un usuario válido para "
 "UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Error: ¡no se pudo abrir el archivo de configuración `%s'!"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Limpiando la cola..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1391,111 +1393,119 @@ msgstr ""
 "%s %s\n"
 "uso: %s [-C <file>] [-q <file>] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<queuefile>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "usar <queuefile> como archivo de cola"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "iniciar descarga al inicio"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u descargas paralelas"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Cola (%u descargas en proceso, %u total) - %.2f kb/s total%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Error: no se puede salir: descarga(s) en proceso"
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Error: la descarga ha de acabar antes de poder reproducir el archivo."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Error: imposible ejecutar operación: descarga(s) en proceso."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Descarga"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Borrar"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Limpiar finalizadas"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Activar/Desactivar Descarga Automatica"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Ejecutar"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "Marcar como finalizada/s"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' no es un tipo de diálogo válido"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' no es una expresión regular válida: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sCargando %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Error al descargar %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Error: ¡feed inválido!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a, %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "no bastantes parámetros."
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' no es una expresión válida en un filtro"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a, %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Error: URL no soportada: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Selecciona Etiqueta"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Selecciona Filtro"
 
@@ -1507,70 +1517,70 @@ msgstr "atributo no encontrado"
 msgid "EOF found while reading XML tag"
 msgstr "Fin De Fichero (EOF) encontrado leyendo etiqueta XML"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "¡Ningún enlace seleccionado!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Guardar Marcador"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URL"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Error: ¡el feed no contiene elementos!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "No hay etiquetas definidas."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Actualizando consulta de feed..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "nodo raíz XML es NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "no se pudo inicializar libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "no se pudo leer el búfer"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "no se pudo leer el archivo"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "sin versión RSS"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "versión RSS inválida"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "versión Atom inválida"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "sin versión Atom"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "formato de feed no soportado"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "ningún canal RSS encontrado"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "formato de feed no soportado"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2017-12-10 18:12+0100\n"
 "Last-Translator: José Manuel García-Patos <josemanuel@gesaku.es>\n"
 "Language-Team:  <>\n"
@@ -147,9 +147,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: Nivel de log inválido"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1379,6 +1379,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Error: ¡no se pudo abrir el archivo de configuración `%s'!"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: Nivel de log inválido"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2017-07-11 10:22+0200\n"
 "Last-Translator: rugie <fliehen@posteo.net>\n"
 "Language-Team: Nicolas Martyanoff <khaelin@gmail.com>\n"
@@ -155,9 +155,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s : %d : la valeur du degré de verbosité du journal est incorrecte"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1388,6 +1388,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Erreur : échec de l'ouverture du fichier de configuration `%s' !"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s : %d : la valeur du degré de verbosité du journal est incorrecte"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2017-07-11 10:22+0200\n"
 "Last-Translator: rugie <fliehen@posteo.net>\n"
 "Language-Team: Nicolas Martyanoff <khaelin@gmail.com>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -27,97 +27,97 @@ msgstr ""
 "utilisation : %s [-i <fichier>|-e] [-u <fichier_url>] [-c <fichier_cache>] [-"
 "x <commande> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "exporter le fil au format OPML vers la sortie stdout"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "rafraîchir les fils au démarrage"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<fichier>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "importer un fichier OPML"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<fichier_url>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "lire les liens des fils RSS depuis le fichier <fichier_url>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<fichier_cache>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "utiliser <fichier_cache> comme fichier de cache"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<fichier_configuration>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "lire la configuration depuis <fichier_configuration>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "compresse le cache"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<commande>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "exécuter une liste de commandes"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "démarrage silencieux (sans sortie d'affichage)"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "obtenir des informations sur la version"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<verbosité_journal>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 "écrire un fichier de journal, à un certain degré de verbosité (valeurs "
 "acceptées : de 1 à 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<fichier_journal>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "utiliser <fichier_journal> pour écrire le journal"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "exporter la liste des articles lus vers <fichier>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "importer une liste d'articles lus depuis <fichier>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "ce texte d'aide"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -126,7 +126,7 @@ msgstr ""
 "newsboat est un logiciel libre, publié sous la licence MIT/X Consortium. "
 "(Tapez `%s -vv' pour voir le reste du texte.)"
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
@@ -134,44 +134,44 @@ msgstr ""
 "Il contient la bibliothèque JSON for Modern C++, publiée sous la licence MIT/"
 "X Consortiumhttps://github.com/nlohmann/json"
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s : %d : la valeur du degré de verbosité du journal est incorrecte"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' n'est pas une valeur de couleur valide"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "'%s' n'est pas un attribut valide"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' n'est pas un élément de configuration valide"
@@ -182,72 +182,92 @@ msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr ""
 "newsboat : rechargement terminé, %f fils à lire (%n articles à lire au total)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Articles dans le fil '%T' (%u à lire, %t au total) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Vues"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Vos fils (%u à lire, %t au total)%?T? - étiquette `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Ouvrir un fichier&Enregistrer le fichier? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Aide"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Article '%T' (%u à lire, %t au total) - %U"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Résultat de la recherche (%u à lire, %t au total)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Choisir un filtre"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Choisir une étiquette"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - Liens"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "une valeur booléenne fût anticipée, et non `%s'"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "un nombre entier fût anticipé, et non `%s'"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "valeur de configuration incorrecte : `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "paramètres invalides."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "paramètres insuffisants."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "commande inconnue (bug)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "le fichier n'a pu être ouvert."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "erreur inconnue (bug)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Erreur lors du traitement de la commande `%s' (%s ligne %u) : %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "commande inconnue `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -256,51 +276,51 @@ msgstr ""
 "Veuillez définir la variable d'environnement HOME ou ajouter un utilisateur "
 "valide pour l'UID %u !"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Démarrage de %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Erreur : %s est déjà en cours d'exécution (PID : %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Chargement de la configuration..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "fait."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Ouverture du cache..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Erreur : l'ouverture du fichier de cache `%s' a échoué : %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s est inaccessible et ne peut être créé\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Chargement des liens depuis %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -309,7 +329,7 @@ msgstr ""
 "Erreur : aucun lien renseigné. Veuillez remplir le fichier %s avec des liens "
 "de fils RSS ou importer un fichier OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -317,7 +337,7 @@ msgstr ""
 "Il semble que le fichier OPML que vous avez ajouté ne contient aucun fil. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -325,7 +345,7 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte The Old Reader. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -333,7 +353,7 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte Tiny Tiny RSS. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -341,7 +361,7 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte NewsBlur. Ajoutez-"
 "en puis réessayez."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -349,226 +369,175 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte Inoreader. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Chargement des articles depuis le cache..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Nettoyage en profondeur du cache..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Erreur lors du chargement des fils depuis la base de données : "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Erreur lors du chargement du fil '%s' : %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Pré-remplissage des fils de requête ..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importation de la liste d'articles lus..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Exportation de la liste d'articles lus..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Nettoyage du cache..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "échoué : "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Erreur : Tous les fils n'ont pu être marqués comme lus : %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Une erreur est survenue lors de l'analyse de %s."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importation de %s terminée."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u articles à lire"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s : %s : commande inconnue"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Titre : "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Auteur : "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Date : "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Lien : "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Lien de téléchargement du podcast : "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Erreur : échec de l'ouverture du fichier de configuration `%s' !"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Fermer"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Passer à la vue"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Fermer la vue"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Aucun élément sélectionné !"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Erreur : la liste de fils ne peut être supprimée !"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Position invalide !"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "en attente"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "téléchargement"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "annulé"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "supprimé"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "terminé"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "erreur"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "incomplet"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "prêt"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "lu"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "inconnu (bug)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "l'attribut '%s' n'est pas disponible."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "l'expression régulière '%s' est invalide : %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "paramètres invalides."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "paramètres insuffisants."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "commande inconnue (bug)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "le fichier n'a pu être ouvert."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "erreur inconnue (bug)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "Index de fil invalide (bug)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Personnes que vous suivez"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Éléments favoris"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Éléments partagés"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Aucun fil sélectionné !"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "ptnia"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -577,7 +546,7 @@ msgstr ""
 "Trier par (p)remière étiquette/(t)itre/(n)ombre d'articles/nombre d'articles "
 "à l(i)re/(a)ucun ?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -586,225 +555,229 @@ msgstr ""
 "Trier en sens inverse par (p)remier tag/(t)itre/(n)nombre d'articles/nombre "
 "d'articles à l(i)re/(a)ucun ?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 "Les fils de requête ne sont pas faits pour être ouverts dans un navigateur !"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Fil marqué comme étant lu..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Erreur : Le fil n'a pu être marqué comme étant lu : %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Aucun fil ne possède des éléments à lire"
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Vous êtes déjà au dernier fil."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Vous êtes déjà au premier fil."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Tous les fils sont marqués comme lus..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Erreur : échec lors de l'analyse de l'expression de filtrage `%s' : %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Aucun filtre défini."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Rechercher : "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filtre : "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Souhaitez-vous réellement quitter (o : Oui n : Non) ? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "on"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "o"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Quitter"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Ouvrir"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Suivant"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Recharger"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Tout recharger"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Marquer comme lu"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Tout marquer comme lu"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Rechercher"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Aide"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Erreur : l'analyse de l'expression de filtrage a échoué !"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Recherche en cours..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Erreur lors de la recherche de '%s' : %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Aucun résultat."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Position non visible !"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Liste de fils - %u à lire, %u au total"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Souhaitez-vous réellement écraser `%s' (y : Oui n : No)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Fichier : "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Enregistrer le fichier - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Enregistrer"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Enregistrer le fichier - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "échec de l'analyse de l'expression de filtrage `%s' : %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "utilisation : set <variable>[=<valeur>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "utilisation : source <fichier> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "utilisation : dumpconfig <fichier>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuration enregistrée dans %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "commande inconnue : %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Enregistrement du signet..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Signet enregistré."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Erreur lors de l'enregistrement du signet : "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "Lien : "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Titre : "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Description : "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Titre : "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Enregistrement du signet automatiquement..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -812,15 +785,15 @@ msgstr ""
 "Le support des signets n'est pas configuré. Veuillez modifier la variable de "
 "configuration 'bookmark-cmd' puis réessayer."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Raccourcis habituels :"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Fonctions non attribuées :"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Effacer"
 
@@ -848,199 +821,218 @@ msgstr "flash embarqué"
 msgid "unknown (bug)"
 msgstr "inconnu (bug)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "Éléments partagés"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "Éléments favoris"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "Pages web sauvegardées"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Basculement de l'état de lecture de l'article..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Erreur lors du basculement de l'état de lecture : %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "L'article ne contient aucun lien."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Signaux : "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Erreur : aucun élément sélectionné !"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Erreur : les résultats de recherche ne peuvent être rechargés."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Aucun élément à lire."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Déjà au dernier élément."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Déjà au premier élément."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Aucun fil ne contient d'éléments à lire."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Tous les fils sont marqués comme lus..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Passer l'article à la commande : "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtxalg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Trier par (d)ate/(t)itre/signau(x)/(a)uteur/(l)ien/(g)uid ?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Trier en sens inverse par (d)ate/(t)itre/signau(x)/(a)uteur/(l)ien/(g)uid ?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Signaux actualisés."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Erreur : l'application du filtre a échoué : %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Enregistrement annulé."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Article enregistré dans %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Erreur : l'article n'a pu être enregistré dans %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Résultats de la recherche - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Fil de requête - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Articles - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Début"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Fin"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Fil : "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Auteur : "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Date : "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Lien : "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Lien de téléchargement du podcast : "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "type : "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Début"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Fin"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Erreur lors du passage de l'article à l'état lu : %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Ajout de %s à la file d'attente."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Lien invalide : '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Article enregistré dans %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Erreur : échec lors de l'enregistrement vers %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Lancement du navigateur..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Erreur en marquant l'article comme lu : %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Aller à l'addresse #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Ouvrir dans le navigateur"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Ajouter à la file d'attente"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Article - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Erreur : expression régulière incorrecte !"
 
@@ -1352,29 +1344,39 @@ msgstr "Aller au début de la page/liste"
 msgid "Move to the end of page/list"
 msgstr "Aller à la fin de la page/liste"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' n'est pas un contexte valide"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' n'est pas un raccourci correct"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "l'attribut '%s' n'est pas disponible."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "l'expression régulière '%s' est invalide : %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG : le répertoire de configuration '%s' n'est pas accessible, '%s' sera "
 "utilisé."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr ""
 "Erreur fatale : l'emplacement du répertoire personnel n'a pu être déterminé !"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1382,16 +1384,16 @@ msgstr ""
 "Veuillez définir la variable d'environnement HOME ou ajouter un utilisateur "
 "valide pour l'UID %u !"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Erreur : échec de l'ouverture du fichier de configuration `%s' !"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Nettoyage de la file d'attente..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1401,114 +1403,122 @@ msgstr ""
 "utilisation : %s [-i <fichier>|-e] [-u <fichier_url>] [-c <fichier_cache>] [-"
 "x <commande> ...] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<fichier_liste>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "utiliser le fichier <fichier_liste> comme file d'attente"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "commencer le téléchargement au démarrage"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u téléchargements en parallèle"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr ""
 "File d'attente (%u téléchargements en cours, %u au total) - %.2f kb/s au "
 "total%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Erreur : impossible de quitter : téléchargement en cours"
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Erreur : le téléchargement doit se terminer avant de pouvoir lire le fichier."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Erreur : impossible d'effectuer l'opération : téléchargement en cours."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Télécharger"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Supprimer"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Nettoyer"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Téléchargement automatique"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Lire"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "Marquer comme terminé"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' n'est pas un type de vue valide"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' n'est pas une expression régulière correcte : %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sChargement de %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Erreur lors de la récupération de %s : %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Erreur : fil invalide !"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "paramètres insuffisants"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' n'est pas une expression de filtrage correcte"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Erreur : le format du lien n'est pas pris en charge : %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Choisir une étiquette"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Choisir un filtre"
 
@@ -1520,70 +1530,70 @@ msgstr "attribut non trouvé"
 msgid "EOF found while reading XML tag"
 msgstr "EOF rencontré durant la lecture d'une balise XML"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Aucun lien sélectionné !"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Créer un signet"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "Liens"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Erreur : le fil est vide !"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Aucune étiquette définie."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Mise à jour du fil de requête..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "Le nœud racine XML est NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "l'initialisation de libcurl a échoué"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "l'analyse du contenu a échoué"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "l'analyse du fichier a échoué"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "pas de version RSS"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "version RSS incorrecte"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "version Atom incorrecte"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "pas de version Atom"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "le format du fil n'est pas supporté"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "Aucun canal RSS trouvé"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "le format du fil n'est pas supporté"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2008-01-28 10:00+0100\n"
 "Last-Translator: Zsolt Udvari <udvzsolt@gmail.com>\n"
 "Language-Team: \n"
@@ -13,7 +13,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -24,95 +24,95 @@ msgstr ""
 "használat: %s [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x "
 "<command> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "OPML exportálása az stdout-ra"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "források frissítése induláskor"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<file>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "OPML fájl importálása"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<urlfile>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "RSS források URL-jeinek olvasása <urlfile>-ból"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<cachefile>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "<cachefile> használata cache fájlként"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<configfile>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "beállítások olvasása <configfile>-ból"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<command>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "parancsok listájának futtatása"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr ""
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "verzió információ"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<loglevel>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "log írása az adott szinten (érvényes értékek: 1-től 6-ig)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<logfile>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "<logfile> használata naplófájlként"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "olvasott cikkek listájának exportálása <file>-ba"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "olvasott cikkek listájának importálása <file>-ból"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "ez a súgó"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, fuzzy, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -120,50 +120,50 @@ msgid ""
 msgstr ""
 "newsboat egy ingyenes szoftver és MIT/X Consortium License-szel rendelkezik."
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' nem érvényes szín"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' nem érvényes attríbútum"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' nem érvényes konfigurációs elem"
@@ -174,73 +174,93 @@ msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr ""
 "newsboat: újratöltés befejezve, %f olvasatlan üzenet (%n olvasatlan összesen)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Cikkek '%T'-ben (%u olvasatlan, %t összesen) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialógusok"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Hírek (%u olvasatlan, %t összesen)%?T? - cimke `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?File megnyitása&Menti a fájlt? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Súgó"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Cikkek '%T'-ben (%u olvasatlan, %t összesen) - %U"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Keresési eredmény (%u olvasatlan, %t összesen)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Szűrő kiválasztása"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Cimke kiválasztása"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URL"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "logikai értéket várok, viszont `%s'-t találtam"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "egész értéket várok, viszont `%s'-t találtam"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "érvénytelen konfigurációs érték: `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "érvénytelen paraméter."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "túl kevés paraméter."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "ismeretlen parancs (bug)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "a file-t nem tudtam megnyitni."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "ismeretlen hiba (bug)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Hiba a `%s' (%s line %u) parancs végrehajtása közben: %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "ismeretlen parancs: `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -249,51 +269,51 @@ msgstr ""
 "Kérlek, állítsd be a HOME változót vagy adj valódi felhasználót a(z) %u UID-"
 "hoz!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "%s %s indítása..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Hiba: egy példány már fut %s-ből (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Konfiguráció betöltése..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "kész."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Cache megnyitása..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Hiba `%s' cache-file megnyitása közben: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "URL-ek betöltése %s-ből..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -302,7 +322,7 @@ msgstr ""
 "Hiba: nincs URL beállítva. Kérlek töltsd fel a(z) %s file-t RSS URL-ekkel "
 "vagy importálj egy OPML file-ból."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -310,7 +330,7 @@ msgstr ""
 "Úgy tűnik, az OPML, amit betöltöttél, nem tartalmaz hírforrásokat. Töltsd "
 "fel forrásokkal és próbáld újra!"
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -319,7 +339,7 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -328,7 +348,7 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -337,7 +357,7 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -346,226 +366,175 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Cikkek töltése a cache-bõl..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "A cache teljes ürítése..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Nem sikerült betölteni a forrásokat az adatbázisból: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Hiba a `%s' forrás betöltése közben: %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "A lekérdezési mezők kezdeti feltöltése..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Olvasott cikkek listájának importálása..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Olvasott cikkek listájának exportálása..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "A cache takarítása..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "nem sikerült: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Hiba: nem tudtam olvasottnak megjelölni: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Egy hiba lépett fel, miközben %s-t elemeztem."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s importálása befejeződött."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u olvasatlan hír"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "ismeretlen parancs: `%s'"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Cím: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Szerzõ: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Dátum: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Link: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Podcast letöltés URL: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Hiba: nem tudtam megnyitni a(z) `%s' konfigurációs fájlt!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Bezár"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Goto Dialógus"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Bezár Dialógus"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Nincs elem kijelölve!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Hiba: nem törölheted a cikk listát!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Érvénytelen pozíció!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "listába"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "letöltés"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "megszakítva"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "törölve"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "befejezve"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "hibás"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "befejezetlen"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr ""
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "lejátszott"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "ismeretlen (bug)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "%s argumentum nem elérhető."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "'%s' reguláris kifejezés érvénytelen: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "érvénytelen paraméter."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "túl kevés paraméter."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "ismeretlen parancs (bug)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "a file-t nem tudtam megnyitni."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "ismeretlen hiba (bug)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "érvénytelen hírforrás index (bug)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Akik téged követnek"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Csillagozott elemek"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Megosztott elemek"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Nincs forrás kijelölve"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "ecson"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -574,7 +543,7 @@ msgstr ""
 "Rendezés (e)lső cimke/(c)ím/cikk(s)zám/(o)olvasatlan források száma/semmi "
 "szeri(n)t?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -583,226 +552,230 @@ msgstr ""
 "Visszafele rendezés (e)lső cimke/(c)ím/cikk(s)zám/(o)olvasatlan források "
 "száma/semmi szeri(n)t?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Forrás olvasottá tétele..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Hiba: nem tudtam olvasottnak megjelölni: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Nincs forrás olvasatlan elemekkel."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Az összes forrás olvasottként jelölése..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Hiba: nem tudtam feldolgozni a filter parancsot: `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Nincs szűrő (filter) definiálva."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Keresés: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Biztos kilépsz (i:Igen n:Nem)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "in"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "i"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Kilép"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Megnyit"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Köv. olvasatlan"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Újratölt"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Mind újratölt"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Olvasottnak megjelöl"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Mindet olvasottnak"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Keres"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Súgó"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Hiba: nem tudtam feldolgozni a filter parancsot!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Keresés..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Hiba `%s' keresése közben: %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Nincs találat."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "A pozíció nem látható!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Forrás lista - %u olvasatlan, %u összesen"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Biztos felülírod `%s'-t (y:Yes n:No)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "File: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - File mentése - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Mentés"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "File mentése - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "nem tudtam feldolgozni a filter parancsot `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "használat: set <változó>[=<érték>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "használat: source <file> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "használat: dumpconfig <file>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Konfiguráció elmentve %s-be"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Nem parancs: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Könyvjelző mentése..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Könyvjelző elmentve."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Hiba a könyvjelző mentése közben: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Cím: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Leírás: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 #, fuzzy
 msgid "Feed title: "
 msgstr "File: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "Könyvjelző mentése..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -810,15 +783,15 @@ msgstr ""
 "könyvjelző lehetőség nem konfigurált. Kérlek állítsd be a `bookmark-cmd' "
 "változót megfelelően."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Általános kötések:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Kötetlen funkciók:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Vissza"
 
@@ -846,200 +819,219 @@ msgstr "beágyazott flash"
 msgid "unknown (bug)"
 msgstr "ismeretlen (bug)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 #, fuzzy
 msgid "Liked items"
 msgstr "Megosztott elemek"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Az olvasott jelző ki/beállítása a cikkre..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Hiba az olvasott jelző állítása közben: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "URL lista üres."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Jelzõk: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Hiba: nincs elem kijelölve!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Hiba: nem töltheted újra a keresési eredményt."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Nincs olvasatlan elem."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Nincs olvasatlan forrás."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Az összes forrás olvasottként jelölése..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "A cikk pipe-olása a parancsnak: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dcjslg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Rendezés (d)átum/(c)ím/(j)elzők/(s)zerző/(l)ink/(g)uid alapján?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Fordított rendezés (d)átum/(c)ím/(j)elzők/(s)zerző/(l)ink/(g)uid alapján?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Jelzők frissítve."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Hiba: szűrő alkalmazása nem sikerült: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Mentés megszakítva."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Cikk mentése %s-be"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Hiba: nem tudtam a cikket %s fájlba menteni"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Keresés eredménye . '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Lekérdezési lista - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Cikk lista - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Fent"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Lent"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Forrás: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Szerzõ: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Dátum: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Link: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Podcast letöltés URL: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "típus: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Fent"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Lent"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Hiba a cikk olvasottá tétele közben: %s "
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s hozzáadása a letöltési listához."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Érvénytelen URL: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Cikk mentve %s-be."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Hiba: nem tudtam a cikket a(z) %s file-ba menteni"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Böngésző indítása..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Hiba a cikk olvasatlanná tétele közben: %s "
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Ugrás: URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Megnyitás böngészőben"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Lista"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Cikk %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Hiba: érvénytelen reguláris kifejezés!"
 
@@ -1355,26 +1347,36 @@ msgstr "Mozgatás az oldal/lista elejére"
 msgid "Move to the end of page/list"
 msgstr "Mozgatás az oldal/lista végére"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' nem valódi környezet"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' nem érvényes billentyűparancs"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "%s argumentum nem elérhető."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "'%s' reguláris kifejezés érvénytelen: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Végzetes hiba: nem tudtam meghatározni a home-könyvtárat!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1382,16 +1384,16 @@ msgstr ""
 "Kérlek, állítsd be a HOME változót vagy adj valódi felhasználót a(z) %u UID-"
 "hoz!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Hiba: nem tudtam megnyitni a(z) `%s' konfigurációs fájlt!"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Lista törlése..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1401,114 +1403,122 @@ msgstr ""
 "használat: %s [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x "
 "<command> ...] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<file>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "<cachefile> használata cache fájlként"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr ""
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u párhuzamos letöltés"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Lista (%u letöltés folyamatban, %u összesen) - %.2f kb/s összesen%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Hiba: nem léphetsz ki: letöltés(ek) folyamatban."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Hiba: a letöltésnek be kell fejeződnie, mielőtt lejátszhatnád."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Hiba: nem hajthatom végre: letöltés(ek) folyamatban."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Letöltés"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Törlés"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Takarítás befejezve"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Automatikus letöltés"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Lejátszás"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "Takarítás befejezve"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' érvénytelen dialógus típus"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' nem valódi reguláris kifejezés: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sTöltés %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Hiba letöltés közben: %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Hiba: érvénytelen hírforrás!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "túl kevés paraméter"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' nem valódi reguláris kifejezés: %s"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Hiba: nem támogatott URL: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Cimke kijelölése"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Szűrő kijelölése"
 
@@ -1520,70 +1530,70 @@ msgstr "argumentumot nem találom"
 msgid "EOF found while reading XML tag"
 msgstr "EOF-t találtam XML cimke olvasása közben"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Nincs link kijelölve!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Könyvjelző mentése"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URL-ek: "
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Hiba: a forrás nem tartalmaz elemeket!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Nincs cimke definiálva."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Források lekérdezése..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "XML gyökér bejegyzés NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "nem tudtam inicializálni a libcurl-t"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "nem tudtam a buffer-t elemezni"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "nem tudtam feldolgozni a file-t"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "nincs RSS verzió"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "érvénytelen RSS verzió"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "érvénytelen Atom verzió"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "nincs Atom verzió"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "nem támogatott forrás formátum"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "nem találtam RSS csatornát"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "nem támogatott forrás formátum"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2008-01-28 10:00+0100\n"
 "Last-Translator: Zsolt Udvari <udvzsolt@gmail.com>\n"
 "Language-Team: \n"
@@ -147,10 +147,10 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
-msgstr ""
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
+msgstr "`%s' érvénytelen dialógus típus"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
 #: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
@@ -1388,6 +1388,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Hiba: nem tudtam megnyitni a(z) `%s' konfigurációs fájlt!"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr ""
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/it.po
+++ b/po/it.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2018-06-11 14:47+0200\n"
 "Last-Translator: Francesco Ariis <fa-ml@ariis.it>\n"
 "Language-Team: Claudio M. Alessi <somppy@gmail.com>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "X-Poedit-Language: Italian\n"
 "X-Poedit-Country: ITALY\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -26,95 +26,95 @@ msgstr ""
 "uso: %s [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x <comando> ...] [-"
 "h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "esporta il feed OPML sullo stdout"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "ricarica i feed all'avvio"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<file>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "importa file OPML"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<urlfile>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "leggi gli URL dei feed RSS da <urlfile>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<cachefile>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "usa <cachefile> come file cache"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<configfile>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "leggi la configurazione da <configfile>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "compatta la cache"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<comando>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "esegui un elenco di comandi"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "avvio silenzioso"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "ottieni informazioni sulla versione"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<loglevel>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "scrivi un log con un certo loglevel (valori validi: da 1 a 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<logfile>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "usa <logfile> come log file di output"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "esporta lista articoli letti su <file>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "importa lista articoli letti da <file>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "questo aiuto"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -123,7 +123,7 @@ msgstr ""
 "Newsboat è software libero sotto Licenza MIT. (Premi `%s -vv' per leggere il "
 "testo integrale.)"
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
@@ -131,44 +131,44 @@ msgstr ""
 "Include la libreria JSON for Modern C++, sotto licenza MIT: https://github."
 "com/nlohmann/json"
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
-#, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+#: newsboat.cpp:192
+#, fuzzy, c-format
+msgid "Caught newsboat::DbException with message: %s"
 msgstr "Ricevuto newsboat::dbexception con messaggio: %s"
 
-#: newsboat.cpp:193
-#, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+#: newsboat.cpp:199
+#, fuzzy, c-format
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Ricevuto newsboat::matcherexception con messaggio: %s"
 
-#: newsboat.cpp:199 podboat.cpp:32
-#, c-format
-msgid "Caught newsboat::exception with message: %s"
+#: newsboat.cpp:205 podboat.cpp:37
+#, fuzzy, c-format
+msgid "Caught newsboat::Exception with message: %s"
 msgstr "Ricevuto newsboat::exception con messaggio: %s"
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: livello loglevel non valido"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' non è un colore valido"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' non è un attributo valido"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' non è un elemento di configurazione valido"
@@ -180,72 +180,92 @@ msgstr ""
 "newsboat: caricamento terminato, %f feed non letti (%n totale articoli non "
 "letti)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Articoli nel feed '%T' (%u non letti, %t totali) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Schermate"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - I tuoi feed (%u non letti, %t totali)%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Apri File&Salva File? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Aiuto"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Articolo '%T' (%u non letti, %t in totale) - %U"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Risultati della ricerca (%u non letti, %t totali) "
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Seleziona Filtro"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Seleziona Tag"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URL"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "atteso valore booleano, trovato `%s' invece"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "atteso valore intero, trovato `%s' invece"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "Valore di configurazione non valido %s"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "parametri non validi."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "parametri insufficienti."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "comando sconosciuto (bug)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "Il file non può essere aperto."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "errore sconosciuto (bug)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Errore elaborando il comando `%s' (%s linea %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "comando sconosciuto `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -255,51 +275,51 @@ msgstr ""
 "Per favore, imposta la variabile d'ambiente HOME o aggiungi un utente valido "
 "per l'UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Sto avviando %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Errore: un'istanza di %s è già in esecuzione (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Sto caricando la configurazione..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "fatto."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Sto aprendo la cache..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Errore: apertura del file cache `%s' fallita: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s è inaccessibile e non può essere creato\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Sto caricando gli URL da %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -308,7 +328,7 @@ msgstr ""
 "Errore: nessun URL configurato. Per favore, inserisci i feed RSS nel file %s "
 "o importa un file OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -316,7 +336,7 @@ msgstr ""
 "Sembra che il feed OPML di cui hai chiesto la sottoscrizione non contenga "
 "feed. Per favore, inserisci i feed e riprova."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -324,7 +344,7 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account The Old "
 "Reader. Per favore, fallo e riprova."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -332,7 +352,7 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account Tiny Tiny "
 "RSS. Per favore, fallo e riprova."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -340,7 +360,7 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account NewsBlur. Per "
 "favore, fallo e riprova."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -348,225 +368,174 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account Inoreader. "
 "Per favore, fallo e riprova."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Sto caricando gli articoli dalla cache..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Sto pulendo accuratamente la cache..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Errore durante il caricamento dei feed dal database: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Errore durante il caricamento del feed `%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Sto precompilando l'interrogazione dei feed..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Sto importando la lista degli articoli letti..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Sto esportando la lista degli articoli letti..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Sto pulendo la cache..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "fallito: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Errore: impossibile contrassegnare tutti i feed letti: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Si è verificato un errore analizzando %s."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importazione di %s finita."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u articoli non letti"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: comando sconosciuto"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Titolo: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Autore: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Data: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Collegamento: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "URL scaricamento podcast: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Errore: impossibile aprire il file di configurazione `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Chiudi"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Vai alla schermata"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Chiudi schermata"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Nessuna voce selezionata!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Errore: non puoi rimuovere la lista dei feed!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Posizione non valida!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "in coda"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "sto scaricando"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "cancellato"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "eliminato"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "finito"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "fallito"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "incompleto"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "pronto"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "iniziato"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "sconosciuto (bug)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "l'attributo `%s' non è disponibile."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "l'espressione regolare `%s' non è valida: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "parametri non validi."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "parametri insufficienti."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "comando sconosciuto (bug)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "Il file non può essere aperto."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "errore sconosciuto (bug)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "indice del feed non valido (bug)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Persone che segui"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Item selezionati"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Item condivisi"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Nessun feed selezionato!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr "ptuman"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -574,7 +543,7 @@ msgstr ""
 "Ordina per (p)rimotag/(t)itolo/n(u)meroarticolo/nu(m)eroarticolononletto/"
 "ultimo(a)ggiornamento/(n)iente?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -582,224 +551,228 @@ msgstr ""
 "Ordina al contrario per (p)rimotag/(t)itolo/n(u)meroarticolo/"
 "nu(m)eroarticolononletto/ultimo(a)ggiornamento/(n)iente?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr "Non posso aprire i query feed nel browser!"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Sto contrassegnando il feed come letto..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Errore: impossibile contrassegnare il feed come letto: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Nessun feed con voci non lette."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Già all'ultimo feed."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Già al primo feed."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Sto segnando tutti i feed come letti..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Errore: impossibile analizzare il comando di filtro `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Nessun filtro definito."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Ricerca: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Vuoi veramente uscire (s:Si n:No)?"
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "sn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "s"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Esci"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Apri"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Prossimo non letto"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Ricarica"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Ricarica tutti"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Segna come letto"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Marca tutti come letti"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Cerca"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Aiuto"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Errore: impossibile analizzare il comando di filtro!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Sto cercando..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Errore durante la ricerca di `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Nessun risultato."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Posizione non visibile!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista feed - %u non letti, %u totali"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Vuoi veramente sovrascrivere `%s' (s:Si n:No)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "File: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Salva File - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Cancella"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Salva"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Salva File - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "impossibile analizzare l'espressione di filtro `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "uso: set <variabile>[=<valore>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "uso: source <file> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "uso: dumpconfig <file>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configurazione salvata su %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Non è un comando: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Sto salvando il segnalibro..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Segnalibro salvato."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Errore durante il salvataggio del segnalibro: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Titolo: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Descrizione: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Titolo del feed: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Sto salvando il segnalibro su autopilot..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -807,15 +780,15 @@ msgstr ""
 "funzionalità per i segnalibri non configurata. Per favore, imposta "
 "appropriatamente la variabile di configurazione `bookmark-cmd'."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Associazioni di tasti generiche:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Funzioni non associate:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Pulisci"
 
@@ -843,199 +816,218 @@ msgstr "flash integrato"
 msgid "unknown (bug)"
 msgstr "sconosciuto (bug)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "Voci trasmesse"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "Elementi preferiti"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "Pagine web salvate"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Cambiando la flag \"letto\" per l'articolo..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Errore cambiando la flag \"letto\": %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "Lista URL vuota."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Flag: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Errore: nessuna voce selezionata!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Errore: non puoi ricaricare i risultati della ricerca."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Nessuna voce non letta."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Già all'ultimo elemento."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Già al primo elemento."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Nessun feed non letto."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 msgid "Marking all above as read..."
 msgstr "Contrassegno i feed al di sopra come letti..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Metti in pipe l'articolo col comando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfacg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Ordina per (d)ata/(t)itolo/(f)lag/(a)utore/(c)ollegamento/(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Ordina al contrario per (d)ata/(t)itolo/(f)lag/(a)utore/(c)ollegamento/"
 "(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Flag aggiornate."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Errore: applicazione del filtro fallita: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Salvataggio annullato."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Articolo salvato su %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Errore: impossibile salvare l'articolo su %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Risultati della ricerca - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Feed interrogati - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista articoli - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Su"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Giù"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Feed: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Autore: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Data: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Collegamento: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "URL scaricamento podcast: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Su"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Giù"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Errore contrassegnando l'articolo come letto: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Aggiunto %s alla coda dei download."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "URL invalido: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Articolo salvato su %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Errore: impossibile scrivere l'articolo sul file %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Sto avviando il browser..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Errore contrassegnando l'articolo come non letto: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Vai a URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Apri nel browser"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Accoda"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Articolo - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Errore: espressione regolare non valida!"
 
@@ -1344,27 +1336,37 @@ msgstr "Spostati all'inizio della pagina/lista"
 msgid "Move to the end of page/list"
 msgstr "Spostati alla fine della pagina/lista"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' non è un contesto valido"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' non è una tasto di comando valido"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "l'attributo `%s' non è disponibile."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "l'espressione regolare `%s' non è valida: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: directory di configurazione '%s' non accessibile, uso '%s' al suo posto."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Errore fatale: impossibile determinare la directory home!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1372,18 +1374,18 @@ msgstr ""
 "Per favore, imposta la variabile d'ambiente HOME o aggiungi un utente valido "
 "per l'UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Errore fatale: impossibile creare la directory di configurazione `%s': (%i) "
 "%s"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Sto pulendo la coda..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1392,112 +1394,120 @@ msgstr ""
 "%s %s\n"
 "uso %s [-C <file>] [-q <file>] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<queuefile>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "usa <queuefile> come file cache"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "inizia download all'avvio"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u download paralleli"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Coda (%u download in corso, %u totali) - %.2f kb/s totale%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Errore: impossibile uscire: ci sono download in esecuzione."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Errore: il download deve finire prima che il file possa essere richiamato."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Errore: impossibile effettuare l'operazione: ci sono download incorso."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Scarica"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Elimina"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Pulisci terminati"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Attiva/Disattiva Download Automatico"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Avvia"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "Segna come completato"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' non è un tipo di schermata valida"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' non è un'espressione regolare valida: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sSto caricando %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Errore durante il recupero di %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Errore: feed non valido!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a, %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "parametri insufficienti"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' non è un'espressione regolare valida"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a, %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Errore: URL non supportato: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Seleziona Tag"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Seleziona Filtro"
 
@@ -1509,70 +1519,70 @@ msgstr "attributo non trovato"
 msgid "EOF found while reading XML tag"
 msgstr "EOF trovato durante la lettura del tag XML"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Nessun collegamento selezionato!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Salva Segnalibro"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URL"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Errore: il feed non contiene voci!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Nessun tag definito."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Aggiornamento interrogazione feed..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "Il nodo XML radice è NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "impossibile inizializzare libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "impossibile analizzare il buffer"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "impossibile analizzare il file"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "versione RSS non presente"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "versione RSS non valida"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "versione Atom non valida"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "versione Atom non presente"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "formato feed non supportato"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "nessun canale RSS trovato"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "formato feed non supportato"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/it.po
+++ b/po/it.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2018-06-11 14:47+0200\n"
 "Last-Translator: Francesco Ariis <fa-ml@ariis.it>\n"
 "Language-Team: Claudio M. Alessi <somppy@gmail.com>\n"
@@ -152,9 +152,9 @@ msgstr "Ricevuto newsboat::matcherexception con messaggio: %s"
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Ricevuto newsboat::exception con messaggio: %s"
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: livello loglevel non valido"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1380,6 +1380,11 @@ msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Errore fatale: impossibile creare la directory di configurazione `%s': (%i) "
 "%s"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: livello loglevel non valido"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/ja.po
+++ b/po/ja.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.9\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2015-04-26 05:55+0900\n"
 "Last-Translator: Grady Martin <GradyMartin@gmail.com>\n"
 "Language-Team: Japanese <GradyMartin@gmail.com>\n"
@@ -13,7 +13,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -24,95 +24,95 @@ msgstr ""
 "%s [-i <ファイル>|-e] [-u <URLファイル>] [-c <キャッシュ>] [-x <コマンド>…] "
 "[-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "OPMLフィードを標準出力に表示する"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "起動時にフィードを同期させる"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<ファイル>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "OPMLファイルの指定"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<URL>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "URLファイルの指定"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<キャッシュ>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "キャッシュの指定"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<設定>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "設定ファイルの指定"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<コマンド>…"
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "コマンドリストを実行する"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "出力を制御する"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "バージョン情報を表示する"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<ログレベル>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "1から6までの範囲でログレベルを指定する"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<ログ>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "ログの指定"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "既読記事のリストを<ファイル>に書き込む"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "既読記事の指定を<ファイル>から読み込む"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "読んでるよ"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, fuzzy, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -121,50 +121,50 @@ msgstr ""
 "newsboatはフリーソフトウェアでありMITあるいはXライセンスの下でご利用いただけ"
 "ます。"
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "「%s」は無効な色です。"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "「%s」は無効な書体です。"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr ""
@@ -174,622 +174,595 @@ msgstr ""
 msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr "newsboat: 同期完了 更新されたフィード%f部 新規記事%n件"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N%V %T %u/%t 未読 %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr ""
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N%V 全フィード %u/%t 未読%?T? %T?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr ""
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr ""
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N%V %T %u/%t 未読"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr ""
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr ""
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr ""
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr ""
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "「%s」を真偽値として認識できませんでした。"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "「%s」を整数値として認識できませんでした。"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr ""
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr ""
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr ""
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr ""
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr ""
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr ""
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr ""
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr ""
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr ""
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "%s%sを起動中…"
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "エラー：%sは既に起動中です（PID: %u）"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "設定を読み込み中…"
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "完了しました。"
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "キャッシュを読み込み中…"
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr ""
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "%sからURLを読み込み中…"
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr ""
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr ""
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "キャッシュから記事を読み込み中…"
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "キャッシュをより細かく整理中…"
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr ""
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr ""
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr ""
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "キャッシュを整理中…"
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr ""
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr ""
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr ""
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr ""
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr ""
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "見出し："
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "作者："
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "日付："
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "リンク："
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "コンテンツ："
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr ""
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr ""
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr ""
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr ""
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr ""
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr ""
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr ""
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr ""
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr ""
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr ""
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr ""
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr ""
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr ""
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr ""
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr ""
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr ""
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr ""
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr ""
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr ""
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr ""
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr ""
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr ""
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr ""
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "終了してもよろしいですか（y/n）"
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "閉じる"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "開く"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "次"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "同期"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "全フィードを同期"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "既読にする"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "全件を既読にする"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "検索"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "ヘルプ"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "検索中…"
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "検索結果がありませんでした。"
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "%sを上書きしてもよろしいですか（y/n）"
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "保存"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr ""
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr ""
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr ""
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr ""
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr ""
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr ""
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr ""
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr ""
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr ""
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr ""
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr ""
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "見出し："
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr ""
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 #, fuzzy
 msgid "Feed title: "
 msgstr "フィード："
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr ""
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
 msgstr ""
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr ""
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr ""
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr ""
 
@@ -817,197 +790,213 @@ msgstr ""
 msgid "unknown (bug)"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr ""
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+msgid "dtfalgr"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr ""
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr ""
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "フィード："
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "作者："
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "日付："
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "リンク："
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "コンテンツ："
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr ""
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr ""
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr ""
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%sのダウンロードを予約しました。"
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "%s…無効なURLです。"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr ""
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "ブラウザーを起動中…"
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "ブラウザーで開く"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "コンテンツをダウンロード"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr ""
 
@@ -1316,41 +1305,51 @@ msgstr ""
 msgid "Move to the end of page/list"
 msgstr ""
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr ""
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr ""
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr ""
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG設定ディレクトリ%sを読み込めませんでした。%sを使用します。"
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr ""
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr ""
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr ""
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1360,113 +1359,121 @@ msgstr ""
 "%s [-i <ファイル>|-e] [-u <URLファイル>] [-c <キャッシュ>] [-x <コマンド>…] "
 "[-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<ファイル>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "キャッシュの指定"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr ""
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr ""
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr ""
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr ""
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr ""
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr ""
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr ""
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr ""
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr ""
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr ""
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr ""
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr ""
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr ""
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%s%sにアクセス中…"
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr ""
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr ""
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr ""
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "「%s」は無効な色です。"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr ""
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr ""
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr ""
 
@@ -1478,69 +1485,69 @@ msgstr ""
 msgid "EOF found while reading XML tag"
 msgstr ""
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr ""
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr ""
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr ""
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "記事がありません！"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr ""
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr ""
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr ""
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr ""
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr ""
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr ""
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr ""
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr ""
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr ""
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr ""
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
+#: rss/rss09xparser.cpp:30
+msgid "no RSS channel found"
 msgstr ""
 
-#: rss/rss_09x_parser.cpp:39
-msgid "no RSS channel found"
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
 msgstr ""
 
 #, fuzzy

--- a/po/ja.po
+++ b/po/ja.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.9\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2015-04-26 05:55+0900\n"
 "Last-Translator: Grady Martin <GradyMartin@gmail.com>\n"
 "Language-Team: Japanese <GradyMartin@gmail.com>\n"
@@ -148,9 +148,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
+#: src/cliargsparser.cpp:145
 #, c-format
-msgid "%s: %d: invalid loglevel value"
+msgid "%s: %s: invalid loglevel value"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1343,6 +1343,11 @@ msgstr ""
 #: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
+msgstr ""
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
 #: src/pbcontroller.cpp:311

--- a/po/nb.po
+++ b/po/nb.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2012-08-08 20:07+0100\n"
 "Last-Translator: Daniel Aleksandersen <code@daniel.priv.no>\n"
 "Language-Team: \n"
@@ -15,7 +15,7 @@ msgstr ""
 "X-Poedit-Language: Norwegian Bokmal\n"
 "X-Poedit-Country: NORWAY\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -26,145 +26,145 @@ msgstr ""
 "bruk: %s [-i <fil>|-e] [-u <URL fil>] [-c <mellomlagerfil>] [-x "
 "<kommando> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "eksporter OPML strømmer til stdout"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "oppdater nyhetsstrømmer under oppstart"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<fil>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "importer OPML-fil"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<URL fil>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "les RSS-strømmer fra <URL-fil>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<mellomlagerfil>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "bruk <mellomlagerfil> som mellomlagerfil"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<oppsettsfil>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "les oppsettsfilen fra <oppsettsfil>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<kommando>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "utfør kommandoliste"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "stille oppstart"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "få versjonsinformasjon"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<loggnivå>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "skriv en logg med angitt loggskrivningsnivå mellom 1 og 6"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<loggfil>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "bruk <loggfil> som loggfil"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "eksporterer en liste med leste artikler til <fil>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "importer en liste med leste artikler fra <fil>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "denne hjelpen"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, fuzzy, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
 "see the full text.)"
 msgstr "newsboat er fri programvare lisensiert under MIT/X Consortium License."
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' er ikke en gyldig farge"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' er ikke en gyldig attributt"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' er ikke et gyldig oppsettselement"
@@ -176,76 +176,96 @@ msgstr ""
 "newsboat: fullførte oppdateringen, %f uleste nyhetsstrømmer (totalt %n "
 "uleste artikler)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr ""
 "%N %V - Artikler i nyhetsnyhetsstrømmen '%T' (%u ulest, %t totalt) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialoger"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr ""
 "%N %V - Nyhetsstrømmene dine (%u uleste, %t totalt)%?T? - etikett `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Åpne fil&Lagre fil? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Hjelp"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr ""
 "%N %V - Artikler i nyhetsnyhetsstrømmen '%T' (%u ulest, %t totalt) - %U"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Søkeresultater (%u ulest, %t totalt)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Velg filter"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Velg etikett"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URLer"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "forventet en boolsk verdi, fant `%s' istedenfor"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "forventet en heltallsverdi, fant `%s' i stedet"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "ugyldig oppsettsverdi `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "ugyldige parametere."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "for få parametere."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "ukjent kommando (programfeil)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "filen kunne ikke åpnes."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "ukjent feil (programfeil)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Feil under behandling av kommandoen `%s' (%s linje %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "ukjent kommando `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -254,51 +274,51 @@ msgstr ""
 "Vennligst sett miljøvariablen HOME eller legg til en gyldig bruker for UID "
 "%u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Starter %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Feil: en annen instans av %s kjører allerede (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Leser oppsett..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "utført."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Åpner mellomlager..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Feil: åpning av mellomlagerfilen `%s' feilet: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Laster inn URLer fra %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -307,7 +327,7 @@ msgstr ""
 "Feil: ingen URLer er satt opp. Vennligst fyll inn filen %s med RSS "
 "nyhetsstrømmer, eller importer fra en OPML-fil."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -316,7 +336,7 @@ msgstr ""
 "nyhetsstrømmer. Vennligst sørg for at den inneholder noen nyhetsstrømmer og "
 "prøv igjen."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -325,7 +345,7 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -334,7 +354,7 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -343,7 +363,7 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -352,226 +372,175 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Leser artikler fra mellomlageret..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Rydder grundig opp i mellomlageret..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Feil under innlesing av nyhetsstrømmer fra databasen: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Feil under innlastning av nyhetsstrømmen '%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Forhåndsutfyller spørringsstrømmer..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importerer liste over leste artikler..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Eksporterer liste over leste artikler..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Rydder opp i mellomlageret..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "feilet: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Feil: kunne ikke markere alle nyhetsstrømmene som lest: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "En feil oppsto under tolkningen av %s"
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Fullførte importeringen av %s."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u uleste artikler"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "ukjent kommando `%s'"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Tittel: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Forfatter: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Dato: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Lenke: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Podkastnedlastings-URL: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Feil: kunne ikke åpne oppsettsfilen `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Lukk"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Gå til dialogen"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Lukk dialogen"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Ingen innlegg merket!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Feil: du kan ikke fjerne nyhetsstrømlisten!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "ugyldig posisjon!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "lagt i køen"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "laster ned"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "avbrutt"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "slettet"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "fullført"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "feilet"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "ufullstendig"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr ""
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "avspilt"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "ukjent (programfeil)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "attributten `%s' er ikke tilgjengelig."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "det regulære uttrykket '%s' er ugyldig: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "ugyldige parametere."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "for få parametere."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "ukjent kommando (programfeil)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "filen kunne ikke åpnes."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "ukjent feil (programfeil)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "ugyldig strøminndeks (programfeil)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Folk du følger"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Favorittinnlegg"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Delte innlegg"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Ingen nyhetsstrømmer merket!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "ftaui"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -580,7 +549,7 @@ msgstr ""
 "Sorter stigende etter (f)ørste etikett/(t)ittel/antall (a)artikler/antall "
 "(u)leste artikler/(i)ngen?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -589,226 +558,230 @@ msgstr ""
 "Sorter synkende etter (f)ørste etikett/(t)ittel/antall (a)artikler/antall "
 "(u)leste artikler/(i)ngen?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Markerer nyhetsstrømmen som lest..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Feil: kunne ikke markere nyhetsstrømmen som lest: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Ingen nyhetsstrømmer med uleste innlegg."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Allerede i den siste nyhetsstrømmen."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Allerede i den første nyhetsstrømmen."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Markerer alle nyhetsstrømmer som lest..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Feil: kunne ikke tolke filterkommandoen `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Ingen angitte filtere."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Søk etter: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Vil du virkelig avslutte (j:Ja n:Nei)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "jn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "j"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Avslutt"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Åpne"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Neste uleste"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Oppdater"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Oppdater alle"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Merk som lest"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Marker alle som lest"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Søk"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Hjelp"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Feil: kunne ikke  tolke filterkommandoen!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Leter..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Feil under søket etter `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Ingen resultater."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Posisjonen er ikke synlig!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Nyhetsstrømliste  - %u uleste, %u totalt"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Vil du virkelig overskrive `%s' (j:Ja n:Nei)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "i"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Fil: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Lagre fil - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Lagre"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Lagre fil - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "kunne ikke tolke filteruttrykket `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "bruk: set <variabel>[=<verdi>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "bruk: source <fil> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "bruk: dumpconfig <fil>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Lagret oppsettsfilen til %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Ikke en kommando: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Lagrer bokmerke..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Lagret bokmerke."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Feil under lagring av bokmerke: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Tittel: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Beskrivelse: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 #, fuzzy
 msgid "Feed title: "
 msgstr "Fil: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "Lagrer bokmerke..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -816,15 +789,15 @@ msgstr ""
 "bokmerkestøtte er ikke satt opp. Vennligst sett valgvariabelen `bookmark-"
 "cmd' etter ønske."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Generelle bindinger:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Utilknyttede funksjoner:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Tøm"
 
@@ -852,201 +825,220 @@ msgstr "innbakt Flash-tillegg"
 msgid "unknown (bug)"
 msgstr "ukjent (programfeil)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 #, fuzzy
 msgid "Broadcast items"
 msgstr "Allerede på siste innlegg."
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 #, fuzzy
 msgid "Liked items"
 msgstr "Delte innlegg"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Setter lestflagg for artikkelen..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Feil under setting av lestflagg: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "URL-listen er tom."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Flagg: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Feil: ingen markerte innlegg!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Feil: du kan ikke oppdatere søkeresultater."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Ingen uleste innlegg."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Allerede på siste innlegg."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Allerede på første innlegg."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Ingen uleste nyhetsstrømmer."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Markerer alle nyhetsstrømmer som lest..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Send artikkel til kommando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfolg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Sorter etter (d)ato)/(t)ittel/(f)lagg/f(o)rfatter/(l)enke/(g)uide?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sorter synkende etter (d)ato)/(t)ittel/(f)lagg/f(o)rfatter/(l)enke/(g)uide?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Flagg oppdatert."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Feil: bruk av filteret feilet: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Avbrøt lagringen."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Lagret artikkelen til %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Feil: kunne ikke lagre artikkelen til %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Søkeresultater - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Spørringsstrøm - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikkelliste - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Toppen"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Bunnen"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Strøm: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Forfatter: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Dato: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Lenke: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Podkastnedlastings-URL: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "slag: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Toppen"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Bunnen"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Feil mens artikkelen ble markert som lest: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "La til %s til nedlastingskøen."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Ugyldig URL: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Lagret artikkel til %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Feil: kunne ikke skrive artikkelen til filen %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Åpner nettleseren..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Feil mens artikkelen ble markert som lest: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Gå til URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Åpne i nettleseren"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Legg til i køen"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Artikkel - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Feil: ugyldig regulært uttrykk!"
 
@@ -1357,26 +1349,36 @@ msgstr "Gå til starten av siden/listen"
 msgid "Move to the end of page/list"
 msgstr "Gå til slutten av siden/listen"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' er ikke en gyldig kontekst"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' er en ugyldig nøkkelkommando"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "attributten `%s' er ikke tilgjengelig."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "det regulære uttrykket '%s' er ugyldig: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Kraftig feil: kunne ikke finne hjemmemappen!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1384,16 +1386,16 @@ msgstr ""
 "Vennligst sett miljøvariablen HOME eller legg til en gyldig bruker for UID "
 "%u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Feil: kunne ikke åpne oppsettsfilen `%s'!"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Rydder opp i køen..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1403,114 +1405,122 @@ msgstr ""
 "bruk: %s [-i <fil>|-e] [-u <URL fil>] [-c <mellomlagerfil>] [-x "
 "<kommando> ...] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<fil>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "bruk <mellomlagerfil> som mellomlagerfil"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr ""
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u samtidige nedlastinger"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Kø (%u nedlastinger pågår, %u totalt) - %.2f kb/s totalt%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Feil: kan ikke avslutte: nedlasting(er) pågår."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Feil: nedlastinger må fullføres før filen kan spilles av."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Feil: klarte ikke å utføre oppgaven: nedlasting(er) pågår."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Last ned"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Slett"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Fjern fullførte"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Automatisk nedlasting [av/på]"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Spill av"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "Fjern fullførte"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' er en ugyldig dialogtype"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' er ikke et gyldig regulært utrykk: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sInnlasting%s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Feil under innhenting av %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Feil: ugyldig nyhetsstrøm!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "for få argumenter"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' er ikke et gyldig regulært utrykk: %s"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Feil: URLen støttes ikke: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Velg etikett"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Velg filter"
 
@@ -1522,70 +1532,70 @@ msgstr "attributten ble ikke funnet"
 msgid "EOF found while reading XML tag"
 msgstr "fant EOF mens XML-element ble lest inn"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Ingen lenke valgt!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Lagre bokmerke"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URLer"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Feil: nyhetsstrømmen inneholder ingen innlegg!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Ingen etiketter angitt."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Frisker opp spørringsstrømmen..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "XML-rotelementet er NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "kunne ikke initialisere libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "kunne ikke tolke bufferen"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "kunne ikke tolke filen"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "ingen RSS-versjon"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "ugyldig RSS-versjon"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "ugyldig Atom-versjon"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "ingen Atom-versjon"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "strømformatet støttes ikke"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "fant ingen RSS-kanal"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "strømformatet støttes ikke"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/nb.po
+++ b/po/nb.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2012-08-08 20:07+0100\n"
 "Last-Translator: Daniel Aleksandersen <code@daniel.priv.no>\n"
 "Language-Team: \n"
@@ -148,10 +148,10 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
-msgstr ""
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
+msgstr "`%s' er en ugyldig dialogtype"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
 #: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
@@ -1390,6 +1390,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Feil: kunne ikke åpne oppsettsfilen `%s'!"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr ""
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,9 +147,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
+#: src/cliargsparser.cpp:145
 #, c-format
-msgid "%s: %d: invalid loglevel value"
+msgid "%s: %s: invalid loglevel value"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1340,6 +1340,11 @@ msgstr ""
 #: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
+msgstr ""
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
 #: src/pbcontroller.cpp:311

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -25,145 +25,145 @@ msgid ""
 "[-h]\n"
 msgstr ""
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr ""
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr ""
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr ""
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr ""
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr ""
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr ""
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr ""
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr ""
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr ""
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr ""
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr ""
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr ""
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr ""
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr ""
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr ""
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr ""
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr ""
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr ""
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr ""
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr ""
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
 "see the full text.)"
 msgstr ""
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr ""
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr ""
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr ""
@@ -173,621 +173,594 @@ msgstr ""
 msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr ""
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr ""
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr ""
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr ""
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr ""
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr ""
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr ""
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr ""
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr ""
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr ""
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr ""
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr ""
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr ""
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr ""
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr ""
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr ""
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr ""
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr ""
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr ""
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr ""
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr ""
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr ""
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr ""
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr ""
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr ""
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr ""
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr ""
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr ""
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr ""
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr ""
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr ""
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr ""
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr ""
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr ""
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr ""
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr ""
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr ""
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr ""
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr ""
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr ""
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr ""
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr ""
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr ""
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr ""
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr ""
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr ""
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr ""
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr ""
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr ""
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr ""
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr ""
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr ""
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr ""
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr ""
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr ""
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr ""
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr ""
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr ""
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr ""
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr ""
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr ""
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr ""
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr ""
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr ""
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr ""
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr ""
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr ""
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr ""
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr ""
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr ""
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr ""
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr ""
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr ""
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr ""
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr ""
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr ""
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr ""
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr ""
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr ""
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr ""
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr ""
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr ""
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr ""
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr ""
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr ""
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr ""
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr ""
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
 msgstr ""
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr ""
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr ""
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr ""
 
@@ -815,197 +788,213 @@ msgstr ""
 msgid "unknown (bug)"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr ""
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+msgid "dtfalgr"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr ""
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr ""
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr ""
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr ""
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr ""
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr ""
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr ""
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr ""
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr ""
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr ""
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr ""
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr ""
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr ""
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr ""
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr ""
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr ""
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr ""
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr ""
 
@@ -1313,152 +1302,170 @@ msgstr ""
 msgid "Move to the end of page/list"
 msgstr ""
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr ""
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr ""
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr ""
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr ""
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr ""
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr ""
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
 "usage %s [-C <file>] [-q <file>] [-h]\n"
 msgstr ""
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr ""
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr ""
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr ""
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr ""
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr ""
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr ""
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr ""
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr ""
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr ""
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr ""
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr ""
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr ""
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr ""
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr ""
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr ""
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr ""
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr ""
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr ""
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr ""
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr ""
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr ""
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr ""
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr ""
 
@@ -1470,67 +1477,67 @@ msgstr ""
 msgid "EOF found while reading XML tag"
 msgstr ""
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr ""
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr ""
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr ""
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr ""
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr ""
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr ""
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr ""
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr ""
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr ""
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr ""
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr ""
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr ""
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr ""
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr ""
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
+#: rss/rss09xparser.cpp:30
+msgid "no RSS channel found"
 msgstr ""
 
-#: rss/rss_09x_parser.cpp:39
-msgid "no RSS channel found"
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2013-10-26 22:20+0100\n"
 "Last-Translator: Erwin Poeze <donnut@outlook.com>\n"
 "Language-Team: Dutch <vertalen@vrijschrift.org>\n"
@@ -149,9 +149,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: logniveau is ongeldig"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1384,6 +1384,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Fout: configuratiebestand ‘%s’ openen is mislukt!"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: logniveau is ongeldig"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2013-10-26 22:20+0100\n"
 "Last-Translator: Erwin Poeze <donnut@outlook.com>\n"
 "Language-Team: Dutch <vertalen@vrijschrift.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -26,95 +26,95 @@ msgstr ""
 "gebruik: %s [-i <bestand>|-e] [-u <urlbestand>] [-c <cachebestand>] [-x "
 "<opdracht> …] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "OPML-feed naar stdout exporteren"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "feeds bij opstarten vernieuwen"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<bestand>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "OPML-bestand importeren"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<bestand>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "URLs van RSS-feed uit <bestand> lezen"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<bestand>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "<bestand> als cachebestand gebruiken"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<bestand>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "configuratie uit <bestand> lezen"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<opdracht>…"
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "lijst van opdrachten uitvoeren"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "opstarten zonder opdrachtregeluitvoer"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "versie-informatie tonen"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<niveau>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "log op <niveau> wegschrijven (geldige waarden: 1 tot 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<bestand>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "<bestand> als logbestand gebruiken"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "exporteren lijst van gelezen artikelen naar <bestand>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "importeren lijst van gelezen artikelen uit <bestand>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "deze hulptekst"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, fuzzy, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -122,50 +122,50 @@ msgid ""
 msgstr ""
 "newsboat is vrije software en gelicenseerd onder de MIT/X Consortium License."
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: logniveau is ongeldig"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "kleur ‘%s’ is ongeldig"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "attribuut ‘%s’ is ongeldig"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "configuratie-element ‘%s’ is ongeldig"
@@ -177,72 +177,92 @@ msgstr ""
 "newsboat: klaar met vernieuwen, %f ongelezen feeds (%n ongelezen artikelen "
 "in totaal)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Artikelen in feed ‘%T’ (%u ongelezen, %t totaal) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialogen"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Uw feeds (%u ongelezen, %t totaal)%?T? - tag ‘%T’&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Open Bestand&Bestand opslaan? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Hulp"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artikel ‘%T’ (%u ongelezen, %t totaal)"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Zoekresultaten (%u ongelezen, %t totaal)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Filter selecteren"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Tag selecteren"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "verwachtte boolaanse waarden, maar ontving ‘%s'"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "verwachtte geheel getal, maar ontving ‘%s'"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "Configuratiewaarde ‘%s’ is ongeldig"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "ongeldige parameters."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "te weinig parameters"
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "onbekende opdracht (bug)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "bestand openen is mislukt."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "onbekende fout (bug)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Fout bij het uitvoeren van opdrachtregel ‘%s’ (%s regel %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "onbekende opdracht ‘%s’"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -251,51 +271,51 @@ msgstr ""
 "Stel de omgevingsvariabele HOME in of voeg een geldige gebruiker toe voor "
 "UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Starten van %s %s…"
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Fout: er draait al een instantie van %s (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Laden van de configuratie…"
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr " klaar"
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Openen van de cache…"
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Fout: openen van het cachebestand ‘%s’ is mislukt: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "URLs laden uit %s…"
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -304,7 +324,7 @@ msgstr ""
 "Fout: geen URLs geconfigureerd. Plaats URLs RSS-feed in het bestand %s of "
 "importeer een OPML-bestand."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -312,7 +332,7 @@ msgstr ""
 "Blijkbaar bevat de OPML-feed waar uw zich op heeft geabonneerd geen feeds. "
 "Vul het met feeds en probeer het dan opnieuw."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -321,7 +341,7 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw Google Reader-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -329,7 +349,7 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw Tiny Tiny RSS-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -338,7 +358,7 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw Google Reader-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -347,226 +367,175 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw Google Reader-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Laden van artikelen uit de cache…"
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Grondig opruimen van de cache…"
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Fout bij het laden van feeds uit de database: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Fout tijdens het laden van ‘%s’: %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Feedzoekopdrachten voorinvullen…"
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importeren van lijst van gelezen artikelen…"
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Exporteren van lijst van gelezen artikelen…"
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Opruimen van de cache…"
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "mislukt: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Fout: alle feeds als gelezen markeren is mislukt: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Het ontleden van %s is mislukt."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Klaar met importeren van %s."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u ongelezen artikelen"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: onbekende opdracht"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Titel: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Auteur: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Datum: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Koppeling: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Download-URL podcast: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fout: configuratiebestand ‘%s’ openen is mislukt!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Sluiten"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Ga naar dialoogvenster"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Sluit dialoogvenster"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Geen item geselecteerd!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Fout: feedlijst verwijderen is mislukt!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Ongeldige positie!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "in de wachtrij geplaatst"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "bezig met downloaden"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "geannuleerd"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "verwijderd"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "klaar"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "mislukt"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "onvolledig"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "klaar"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "afgespeeld"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "onbekend (bug)"
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "attribuut ‘%s’ is niet beschikbaar."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "reguliere expressie ‘%s’ is ongeldig: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "ongeldige parameters."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "te weinig parameters"
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "onbekende opdracht (bug)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "bestand openen is mislukt."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "onbekende fout (bug)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "ongeldige feed-index (bug)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Mensen die u volgt"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Favoriete items"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Gedeelde items"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Geen feeds geselecteerd!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "etaon"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -575,7 +544,7 @@ msgstr ""
 "Sorteren op (e)erste tag/(t)itel/(a)antal artikelen/aantal (o)ngelezen "
 "artikelen/(n)iets?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -584,225 +553,229 @@ msgstr ""
 "Omgekeerd sorteren op (e)erste tag/(t)itel/(a)antal artikelen/aantal "
 "(o)ngelezen artikelen/(n)iets?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Bezig met feed als gelezen te markeren…"
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Fout: feed als gelezen markeren is mislukt: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Geen feeds met ongelezen items"
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Dit is reeds de laatste feed."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Dit is reeds de eerste feed."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Bezig met alle feeds als gelezen te markeren…"
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Fout: filteropdracht ‘%s’ ontleden is mislukt: %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Geen filters gedefinieerd"
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Zoeken naar: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Zeker dat u wilt afsluiten (j:ja n:nee)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "jn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "j"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "afsluiten"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "openen"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "volgende ongelezen"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "vernieuwen"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "alles vernieuwen"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "gelezen"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "alles gelezen markeren"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "zoeken"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "hulp"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Fout: filteropdracht ontleden is mislukt!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Bezig met zoeken…"
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Fout tijdens het zoeken naar ‘%s’: %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Geen resultaten."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Positie niet zichtbaar!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Feedlijst - %u ongelezen, %u totaal"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Bent u zeker dat u ‘%s’ wilt overschrijven (j:ja n:nee)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Bestand: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Bestand opslaan - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "annuleren"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "opslaan"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Bestand opslaan - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "Fout: filterexpressie ‘%s’ ontleden is mislukt: %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "gebruik: set <variabele>[=<waarde>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "gebruik: bron <bestand> […]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "gebruik: dumpconfig <bestand>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuratie opgeslagen in %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Geen opdracht: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Bezig met opslaan van bladwijzer…"
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Bladwijzer opgeslagen."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Bladwijzer opslaan is mislukt: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Titel: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Omschrijving: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 #, fuzzy
 msgid "Feed title: "
 msgstr "Bestand: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "automatisch opslaan van bladwijzer…"
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -810,15 +783,15 @@ msgstr ""
 "bladwijzerondersteuning is niet geconfigureerd. Corrigeer de waarde van de "
 "configuratievariabele ‘bookmark-cmd’."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Algemene sneltoetsen:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Ongekoppelde functies"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Wissen"
 
@@ -846,200 +819,219 @@ msgstr "ingebedde flash"
 msgid "unknown (bug)"
 msgstr "onbekend (bug)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 #, fuzzy
 msgid "Broadcast items"
 msgstr "Dit is reeds het laatste item."
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 #, fuzzy
 msgid "Liked items"
 msgstr "Gedeelde items"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Gelezen-vlag van artikel omschakelen…"
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Gelezen-vlag omschakelen is mislukt: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "URL-lijst is leeg."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Vlaggen: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Fout: geen item geselecteerd!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Fout: zoekresultaten vernieuwen is mislukt."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Geen ongelezen items"
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Dit is reeds het laatste item."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Dit is reeds het eerste item."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Geen ongelezen feeds."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Bezig met alle feeds als gelezen te markeren…"
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Pipe artikel naar opdracht: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfalg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Sorteren op (d)datum/(t)itel/(a)uteur/(l)ink/(g)uid"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Omgekeerd sorteren op (d)datum/(t)itel/(a)uteur/koppe(l)ing/(g)uid"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Vlaggen zijn bijgewerkt."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Fout: toepassen van filter is mislukt: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Opslaan afgebroken."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artikel in %s opgeslagen"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fout: opslaan artikel in %s is mislukt"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Zoekresultaat - ‘%s’"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Feed-zoekopdracht - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikellijst - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Boven"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Onder"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Feed: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Auteur: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Datum: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Koppeling: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Download-URL podcast: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "type: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Boven"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Onder"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fout bij het als gelezen markeren van het artikel: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s toegevoegd aan de downloadwachtrij"
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Ongeldige URL: ‘%s’"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Artikel opgeslagen in %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Fout: artikel opslaan in bestand ‘%s’ is mislukt"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Bezig met starten van browser…"
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "als ongelezen markeren van het artikel ‘%s’ is mislukt"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "naar URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "openen in browser"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "aan wachtrij toevoegen"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Fout: ongeldige reguliere expressie!"
 
@@ -1350,27 +1342,37 @@ msgstr "naar begin van pagina/lijst"
 msgid "Move to the end of page/list"
 msgstr "naar einde van pagina/lijst"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "‘%s’ is een ongeldige context"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "‘%s’ is een ongeldige toetsopdracht"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "attribuut ‘%s’ is niet beschikbaar."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "reguliere expressie ‘%s’ is ongeldig: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: configuratiemap ‘%s’ is niet toegankelijk, daarom wordt ‘%s’ gebruikt."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Fatale fout: bepalen van de persoonlijke map is mislukt!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1378,16 +1380,16 @@ msgstr ""
 "Stel de omgevingsvariabele HOME in of voeg een geldige gebruiker toe voor "
 "UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Fout: configuratiebestand ‘%s’ openen is mislukt!"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Wachtrij opruimen…"
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1397,114 +1399,122 @@ msgstr ""
 "gebruik: %s [-i <bestand>|-e] [-u <urlbestand>] [-c <cachebestand>] [-x "
 "<opdracht> …] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<bestand>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "<bestand> als cachebestand gebruiken"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr ""
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u gelijktijdige downloads"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Wachtrij (%u download bezig, %u totaal) - %.2f kb/s totaal%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Fout: afsluiten is mislukt: download(s) zijn bezig."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Fout: download moet klaar zijn voordat het bestand afgespeeld kan worden."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Fout: opdracht uitvoeren is mislukt: download(s) zijn bezig."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Download"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Afgeronde download opruimen"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Automatisch downloaden omschakelen"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Afspelen"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "als afgerond markeren"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "‘%s’ is een ongelidg dialoogvenstertype"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "‘%s’ is ongeldige reguliere expressie: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sLaden van %s…"
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Ophalen van ‘%s’ is mislukt: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Fout: ongeldige feed!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "te weinig argumenten"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "‘%s’ is ongeldige reguliere expressie: %s"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Fout: niet ondersteunde URL: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Tag selecteren"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Filter selecteren"
 
@@ -1516,70 +1526,70 @@ msgstr "attribuut niet gevonden"
 msgid "EOF found while reading XML tag"
 msgstr "EOF gevonden tijdens het lezen van XML-tag"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Geen koppeling geselecteerd!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "bladwijzer opslaan"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Fout: feed bevat geen items!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Geen tags gedefinieerd"
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Feed-zoekopdracht bijwerken…"
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "XML-root-node is NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "libcurl initializeren is mislukt"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "buffer ontleden is mislukt"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "bestand ontleden is mislukt"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "RSS-versie ontbreekt"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "RSS-versie ongeldig"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "Atom-versie ongeldig"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "Atom-versie ongeldig"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "feed-type wordt niet ondersteund"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "RSS-kanaal niet gevonden"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "feed-type wordt niet ondersteund"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2019-01-09 20:42+0100\n"
 "Last-Translator: Michal Siemek <carnophage@dobramama.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -155,9 +155,9 @@ msgstr "Złapano wyjątek newsboat::matcherexception o treści: %s"
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Złapano wyjątek newsboat::dbexception o treści: %s"
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: nieprawidłowy poziom logowania"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1383,6 +1383,11 @@ msgstr ""
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Błąd krytyczny: nie można otworzyć pliku konfiguracyjnego `%s': (%i) %s"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: nieprawidłowy poziom logowania"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2019-01-09 20:42+0100\n"
 "Last-Translator: Michal Siemek <carnophage@dobramama.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.2\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -26,96 +26,96 @@ msgstr ""
 "Składnia: %s [-i <plik>|-e] [-u <plik url>] [-c <plik pamięci podręcznej>] [-"
 "x <polecenie> ...][-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "wyeksportuj kanał OPML na standardowe wyjście"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "odśwież kanały przy starcie"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<plik>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "zaimportuj plik OPML"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<plik z adresami url>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "wczytaj adresy URL kanałów z <plik z adresami url>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<plik pamięci podręcznej>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "użyj <plik pamięci podręcznej> jako pliku pamięci podręcznej"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<plik konfiguracyjny>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "wczytaj konfiguracje z <plik konfiguracyjny>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "kompaktowanie pamięci podręcznej"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<polecenie>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "wykonaj listę poleceń"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "cichy start"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "pobierz informacje o wersji"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<poziom logowania>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 "utwórz log używając wybranego poziomu logowania (poprawne wartości: 1 do 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<plik z logami>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "użyj <plik z logami> jako wyjściowy plik z logami"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "eksport listy przeczytanych artykułów do <plik>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "import listy przeczytanych artykułów z <plik>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "ta strona pomocy"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -124,7 +124,7 @@ msgstr ""
 "Newsboat jest wolnym oprogramowaniem na licencji MIT License (Użyj `%s -vv' "
 "aby zobaczyć pełny tekst licencji.)"
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
@@ -132,7 +132,7 @@ msgstr ""
 "Zawiera bibliotekę JSON for Modern C++ na licencji MIT License: https://"
 "github.com/nlohmann/json"
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
@@ -140,38 +140,38 @@ msgstr ""
 "Zawiera implementacje algorytmu alphanum na licencji MIT license: http://www."
 "davekoelle.com/alphanum.html"
 
-#: newsboat.cpp:186
-#, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+#: newsboat.cpp:192
+#, fuzzy, c-format
+msgid "Caught newsboat::DbException with message: %s"
 msgstr "Złapano wyjątek newsboat::dbexception o treści: %s"
 
-#: newsboat.cpp:193
-#, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+#: newsboat.cpp:199
+#, fuzzy, c-format
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Złapano wyjątek newsboat::matcherexception o treści: %s"
 
-#: newsboat.cpp:199 podboat.cpp:32
-#, c-format
-msgid "Caught newsboat::exception with message: %s"
+#: newsboat.cpp:205 podboat.cpp:37
+#, fuzzy, c-format
+msgid "Caught newsboat::Exception with message: %s"
 msgstr "Złapano wyjątek newsboat::dbexception o treści: %s"
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: nieprawidłowy poziom logowania"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' nie jest poprawnym kolorem"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' nie jest poprawnym atrybutem"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' nie jest poprawnym elementem konfiguracji"
@@ -183,74 +183,94 @@ msgstr ""
 "newsboat: odświeżanie zakończone, %f nieprzeczytanych kanałów(%n "
 "nieprzeczytanych artykułów)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr ""
 "%N %V - Artykuły w kanale '%T' (%u nieprzeczytanych, %t wszystkich) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Okna dialogowe"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr ""
 "%N %V - Twoje kanały (%u nieprzeczytanych, %t wszystkich)%?T? - tag '%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Otwórz plik&Zapisz plik? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Pomoc"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artykuł '%T' (%u nieprzeczytanych, %t wszystkich)"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Wynik wyszukiwania (%u nieprzeczytanych, %t wszystkich)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Wybierz filtr"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Wybierz tag"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - Odnośniki"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "oczekiwano wartości boolean, znaleziono `%s'"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "oczekiwano wartości integer, znaleziono `%s'"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "nieprawidłowa wartość konfiguracyjna `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "nieprawidłowe parametry."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "zbyt mało parametrów."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "nieznana komenda (bug)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "nie udało się otworzyć pliku."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "nieznany błąd (bug)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Błąd podczas przetwarzania komendy '%s' (%s linia %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "nieznana komenda '%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -260,51 +280,51 @@ msgstr ""
 "Proszę ustawić zmienną środowiskową HOME lub dodać prawidłowego użytkownika "
 "o UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Uruchamianie %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Błąd: inny proces %s jest już uruchomiony (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Czytanie konfiguracji..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "gotowe."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Otwieranie pamięci podręcznej..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Błąd: otwarcie pliku pamięci podręcznej '%s' nieudane: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "BŁĄD: Musisz ustawić `cookie-cache` aby korzystać z NewsBlur.\n"
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s jest niedostępny i nie może zostać utworzony\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Czytanie odnośników z %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -313,7 +333,7 @@ msgstr ""
 "Błąd: brak skonfigurowanych odnośników. Dodaj do pliku %s kilka odnośników "
 "do kanałów RSS lub zaimportuj plik OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -321,7 +341,7 @@ msgstr ""
 "Wygląda na to, że kanał OPML który subskrybujesz nie posiada żadnych kanałów."
 "Wypełnij go źródłami RSS i spróbuj ponownie."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -329,7 +349,7 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie The "
 "Old Reader. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -337,7 +357,7 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie Tiny "
 "Tiny RSS. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -345,7 +365,7 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie "
 "NewsBlur. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -353,225 +373,174 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie "
 "Inoreader. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Wczytywanie artykułów z pamięci podręcznej..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Dokładne czyszczenie pamięci podręcznej..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Błąd podczas wczytywania kanałów z bazy danych: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Błąd podczas ładowania kanału: '%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Wstępne wypełnianie kanałów zapytań..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importowanie listy przeczytanych artykułów..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Eksportowanie listy przeczytanych artykułów..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Czyszczenie pamięci podręcznej..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "nieudane: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Błąd: nie można zaznaczyć wszystkich kanałów jako przeczytanych: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Wystąpił błąd podczas przetwarzania %s."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Import z %s zakończony."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u nieprzeczytanych artykułów"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: nieznana komenda"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Tytuł: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Autor: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Data: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Odsyłacz: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Adres podcastu: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Błąd: nie można otworzyć pliku konfiguracyjnego `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Zamknij"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Idź do"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Zamknij okno"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Nie wybrano żadnej pozycji!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Błąd: nie możesz usunąć listy kanałów!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Błędna pozycja!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "zakolejkowany"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "pobieranie"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "anulowany"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "usunięty"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "zakończony"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "nieudany"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "niepełny"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "gotowy"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "odtworzony"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "nieznany (bug)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "atrybut '%s' nie jest dostępny."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "wyrażenie regularne: '%s' jest nieprawidłowe: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "nieprawidłowe parametry."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "zbyt mało parametrów."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "nieznana komenda (bug)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "nie udało się otworzyć pliku."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "nieznany błąd (bug)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "nieprawidłowy indeks kanału (bug)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Obserwowane osoby"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Pozycje oznaczone gwiazdką"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Pozycje współdzielone"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Nie wybrano żadnego kanału!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr "ptlnob"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -579,7 +548,7 @@ msgstr ""
 "Sortuj wg (p)ierwszego taga/(t)ytułu/(l)iczby artykułów/liczby "
 "(n)ieprzeczytanych artykułów/(o)statnio aktualizowane/(b)rak?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -587,224 +556,228 @@ msgstr ""
 "Sortuj odwrotnie wg (p)ierwszego taga/(t)ytułu/(l)iczby artykułów/liczby "
 "(n)ieprzeczytanych artykułów/(o)statnio aktualizowane/(b)rak?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr "Nie można otworzyć wybranych kanałów w przeglądarce!"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Oznaczam kanał jako przeczytany..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Błąd: nie udało się oznaczyć kanału jako przeczytanego: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Brak kanałów z nieprzeczytanymi artykułami."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "To już ostatni kanał."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "To już pierwszy kanał."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Oznaczam wszystkie kanały jako przeczytane..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Błąd składniowy komendy filtra `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Brak zdefiniowanych filtrów."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Szukaj: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filtr: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Czy na pewno chcesz wyjść (t:Tak n:Nie)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "tn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "t"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Wyjście"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Otwórz"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Następny nieprzeczytany"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Odśwież"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Odśwież wszystkie"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Oznacz jako przeczytane"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Oznacz wszystkie jako przeczytane"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Szukaj"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Pomoc"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Błąd składniowy komendy filtra!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Wyszukiwanie..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Błąd podczas wyszukiwania `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Brak wyników."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Pozycja niewidoczna!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista kanałów - %u nieprzeczytanych, %u wszystkich"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Czy na pewno chcesz nadpisać `%s' (t:Tak n:Nie)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Plik: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Zapisz plik - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Zapisz"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Zapisz plik - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "błąd składniowy komendy filtra `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "użycie: set <zmienna>[=<wartość>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "użycie: source <plik> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "użycie: dumpconfig <plik>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Zapisano konfiguracje do %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Nieznana komenda '%s'"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Zapisywanie zakładki..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Zakładka zapisana."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Błąd podczas zapisywania zakładki: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "Adres: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Tytuł: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Opis: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Tytuł kanału: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Automatyczne zapisywanie zakładki..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -812,15 +785,15 @@ msgstr ""
 "obsługa zakładek nie jest skonfigurowana. Proszę odpowiednio ustawić zmienną "
 "'bookmark-cmd' w pliku konfiguracyjnym."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Ogólne skróty:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Nieprzypisane funkcje:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Wyczyść"
 
@@ -848,198 +821,217 @@ msgstr "osadzony flash"
 msgid "unknown (bug)"
 msgstr "nieznany (bug)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "Roześlij pozycje"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "Polubione pozycje"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "Zapisane strony internetowe"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Przełączam znacznik przeczytania dla artykułu..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Błąd podczas przełączania znacznika przeczytania: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "Lista adresów jest pusta."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Flagi: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Błąd: nie wybrano żadnej pozycji!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Błąd: nie możesz odświeżyć wyników wyszukiwania."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Brak nieprzeczytanych pozycji."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "To już ostatnia pozycja."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "To już pierwsza pozycja."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Brak nieprzeczytanych kanałów."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 msgid "Marking all above as read..."
 msgstr "Oznaczam powyższe jako przeczytane..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Prześlij artykuł do polecenia: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfaog"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Sortuj wg (d)aty/(t)ytułu/(f)lag/(a)utora/(o)dnośnika/(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sortuj odwrotnie wg (d)aty/(t)ytułu/(f)lag/(a)utora/(o)dnośnika/(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Znaczniki uaktualnione."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Błąd: użycie filtra nie powiodło się: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Zapisywanie przerwane."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Zapisano artykuł do %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Błąd: nie można zapisać artykułu do %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Wyniki wyszukiwania - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Kanał zapytania - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista artykułów - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Góra"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Dół"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Kanał: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Autor: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Data: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Odsyłacz: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Adres podcastu: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Góra"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Dół"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Błąd podczas oznaczania artykułu jako przeczytanego: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Dodano %s do kolejki pobierania."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Niepoprawny adres URL: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Zapisano artykuł do %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Błąd: nie można zapisać artykułu do pliku %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Uruchamiam przeglądarkę..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Błąd podczas oznaczania artykułu jako nieprzeczytanego: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Idź do adresu URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Otwórz w przeglądarce"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Zakolejkuj"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Artykuł - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Błąd: nieprawidłowe wyrażenie regularne!"
 
@@ -1349,26 +1341,36 @@ msgstr "Przejdź do początku strony/listy"
 msgid "Move to the end of page/list"
 msgstr "Przejdź do końca strony/listy"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' nie jest dopuszczalnym kontekstem"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' nie jest dopuszczalnym poleceniem"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "atrybut '%s' nie jest dostępny."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "wyrażenie regularne: '%s' jest nieprawidłowe: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: folder z konfiguracją '%s' niedostępny, zostanie użyty '%s'."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Błąd krytyczny: nie mogę znaleźć katalogu domowego!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1376,17 +1378,17 @@ msgstr ""
 "Proszę ustawić zmienną środowiskową HOME lub dodać prawidłowego użytkownika "
 "o UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Błąd krytyczny: nie można otworzyć pliku konfiguracyjnego `%s': (%i) %s"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Czyszczenie kolejki..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1395,112 +1397,120 @@ msgstr ""
 "%s %s\n"
 "Składnia: %s [-C <plik>] [-q <plik>] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<plik kolejki>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "użyj <plik kolejki> jako pliku kolejki"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "rozpocznij pobieranie przy starcie"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u równoległych pobrań"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Kolejka (%u pobieranych plików, %u wszystkich) - %.2f kb/s całość%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Błąd: nie można wyjść, pobieranie w toku."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Błąd: pobieranie musi być zakończone zanim plik będzie mógł być odtworzony."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Błąd: nie można wykonać operacji: pobieranie w toku."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Pobierz"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Usuń"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Wyczyść zakończone"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Przełącz automatyczne pobieranie"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Odtwórz"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "Oznacz jako zakończone"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' nie jest dopuszczalnym typem dialogu"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' nie jest poprawnym wyrażeniem regularnym: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sWczytywanie %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Błąd podczas pobierania %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Błąd: nieprawidłowy kanał!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a, %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "zbyt mało parametrów"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' nie jest poprawnym filtrem"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a, %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Błąd: nieobsługiwany adres: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Wybierz tag"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Wybierz filtr"
 
@@ -1512,70 +1522,70 @@ msgstr "atrybut nie znaleziony"
 msgid "EOF found while reading XML tag"
 msgstr "Trafiono na koniec pliku podczas odczytu tagu XML"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Brak wybranego odnośnika!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Zapisz zakładkę"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "Adresy URL"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Błąd: kanał jest pusty!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Brak zdefiniowanych tagów."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Odświeżam kanał kolejki..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "Korzeń pliku XML ma wartość NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "nie udało się zainicjować libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "nie udało się przetworzyć bufora"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "nie udało się przetworzyć pliku"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "brak wersji RSS"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "błędna wersja RSS"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "błędna wersja Atom"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "brak wersji Atom"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "niewspierany format kanału"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "nie znaleziono żadnego kanału RSS"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "niewspierany format kanału"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.8\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2018-03-06 20:35-0300\n"
 "Last-Translator: Alexandre Erwin Ittner <alexandre@ittner.com.br>\n"
 "Language-Team: \n"
@@ -155,9 +155,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: nível de log inválido"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1386,6 +1386,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Erro: não foi possível abrir o arquivo de configuração '%s'!"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: nível de log inválido"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.8\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2018-03-06 20:35-0300\n"
 "Last-Translator: Alexandre Erwin Ittner <alexandre@ittner.com.br>\n"
 "Language-Team: \n"
@@ -16,7 +16,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -27,97 +27,97 @@ msgstr ""
 "uso: %s [-i <arquivo>|-e] [-u <arquivourl>] [-c <arquivocache>] [-x "
 "<comando> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "exportar fonte OPML para a saída padrão"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "recarregar fontes ao iniciar"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<arquivo>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "importar arquivo OPML"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<arquivourl>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "ler URLs de fontes RSS de <arquivourl>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<arquivocache>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "usar <arquivocache> como arquivo de cache"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<arquivoconfig>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "ler configurações de <arquivoconfig>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "compactar o cache"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<comando>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "executar lista de comandos"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "início silencioso"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "obter informações sobre a versão"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<nívellog>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 "escrever arquivo de log com um determinado nível de log (valores válidos: 1 "
 "a 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<arquivolog>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "usar <arquivolog> como arquivo de log"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "exportar lista de artigos lidos para <arquivo>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "importar lista de artigos lidos de <arquivo>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "esta ajuda"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -126,7 +126,7 @@ msgstr ""
 "O Newsboat é um software livre e está licenciado sob a MIT/X Consortium "
 "License. (Digite `%s -vv' para ver o texto completo.)"
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
@@ -134,44 +134,44 @@ msgstr ""
 "Ele inclui a biblioteca JSON for Modern C++, licenciada sob a MIT License: "
 "https://github.com/nlohmann/json"
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: nível de log inválido"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "'%s' não é uma cor válida"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "'%s' não é um atributo válido"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "'%s' não é um elemento de configuração válido"
@@ -183,72 +183,92 @@ msgstr ""
 "newsboat: recarregamento terminado, %f fontes não lidos (%n artigos não "
 "lidos no total)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Artigos na fonte '%T' (%u não lidos, %t no total) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Telas"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Suas fontes (%u não lidas, %t no total)%?T? - etiqueta '%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Abrir Arquivo&Salvar arquivo? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Ajuda"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artigo '%T' (%u não lidos, %t no total)"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Resultado da busca (%u não lidos, %t no total)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Selecione o Filtro"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Selecione a etiqueta"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "um valor booleano era esperado, mas '%s' foi encontrado"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "um valor inteiro era esperado, mas '%s' foi encontrado"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "Valer de configuração '%s' é inválido"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "parâmetros inválidos."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "poucos parâmetros."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "comando desconhecido (erro de software)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "o arquivo não pôde ser aberto."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "erro desconhecido (erro de software)"
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Erro ao processar o comando '%s' (%s linha %u). %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "comando desconhecido '%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -257,51 +277,51 @@ msgstr ""
 "Por favor defina a variável de ambiente HOME ou adicione um usuário válido "
 "para o UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Iniciando o %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Erro: uma instância de %s já está sendo executada (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Carregando configuração..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "pronto."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Abrindo o cache..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Erro: falha ao abrir o arquivo de cache '%s': %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s não está acessível e não pode ser criado\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Carregando URLS a partir de %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -310,7 +330,7 @@ msgstr ""
 "Erro: nenhuma URL configurada. Por favor preencha o arquivo %s com URLs de "
 "fontes RSS ou importe um arquivo OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -318,7 +338,7 @@ msgstr ""
 "Parece que a fonte OPML especificada não tem fontes RSS. Por favor, preencha-"
 "a com fontes RSS e tente novamente."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -326,7 +346,7 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta em The Old Reader. "
 "Faça isso, e tente novamente."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -334,7 +354,7 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta do Tiny Tiny RSS."
 "Faça isso, e tente novamente."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -342,7 +362,7 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta do NewsBlur. Faça "
 "isso, e tente novamente."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -350,226 +370,175 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta em Inoreader. Faça "
 "isso, e tente novamente."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Carregando artigos do cache..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Limpando o cache completamente..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Erro carregando as fontes do banco de dados: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Erro carregando fonte '%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Pré-povoando fontes de consulta..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importando lista de artigos lidos..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Exportando lista de artigos lidos..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Limpando o cache..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "falha: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Erro: não foi possível marcar todos artigos como lidos: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Um erro ocorreu durante a análise de %s."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importação de %s concluída."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u artigos não lidos"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: comando desconhecido"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Título: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Autor: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Data: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Link: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "URL para baixar Podcast: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Erro: não foi possível abrir o arquivo de configuração '%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Fechar"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Pular para Tela"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Fechar Tela"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Nenhum item selecionado!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Erro: você não pode remover a lista de fontes!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Posição inválida!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "na fila"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "baixando"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "cancelado"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "excluído"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "terminado"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "falhou"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "incompleto"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "pronto"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "tocado"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "desconhecido (erro de software)"
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "atributo '%s' não está disponível."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "a expressão regular '%s' é inválida: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "parâmetros inválidos."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "poucos parâmetros."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "comando desconhecido (erro de software)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "o arquivo não pôde ser aberto."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "erro desconhecido (erro de software)"
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "índice de fonte inválido (erro de software)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Pessoas que você segue"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Itens com estrela"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Itens compartilhados"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Nenhuma fonte RSS selecionada!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "ptqnm"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -578,7 +547,7 @@ msgstr ""
 "Classificar por (p)rimeiraetiqueta/(t)ítulo/(q)uantidadeartigos/"
 "quantidadeartigos(n)ãolidos/nenhu(m)?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -587,224 +556,228 @@ msgstr ""
 "Classificar inversamente por (p)rimeiraetiqueta/(t)ítulo/(q)uantidadeartigos/"
 "quantidadeartigos(n)ãolidos/nenhu(m)?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr "Não é possível abrir fontes de consulta no navegador!"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Marcando fonte como lida..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Erro: não foi possível marcar fonte como lida: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Nenhuma fonte RSS com artigos não lidos."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Já na última fonte"
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Já na primeira fonte"
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Marcando todas fontes RSS como lidas..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Erro: não foi possível analisar o comando de filtro '%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Nenhum filtro definido."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Procurar por: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Tem certeza que deseja sair (s: Sim n: Não)?"
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "sn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "s"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Sair"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Abrir"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Próxima Não Lida"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Recarregar"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Recarregar Todas"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Marcar como Lida"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Marcar Todos como Lidos"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Procurar"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Ajuda"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Erro: não foi possível analisar o comando de filtro!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Procurando..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Erro procurando por '%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Nenhum resultado."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "A posição não está visível!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista de Fontes - %u não lidas, %u no total"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Tem certeza que deseja sobrescrever '%s' (s: Sim n:Não)?"
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "m"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Arquivo: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Salvar arquivo - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Salvar"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Salvar Arquivo - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "não foi possível analisar a expressão de filtro '%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "uso: set <variável>[=<valor>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "uso: source <arquivo> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "uso: dumpconfig <arquivo>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuração salva em %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Não é um comando: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Salvando marcador..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Marcador salvo."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Erro ao salvar marcador: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Título: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Descrição: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Título da fonte: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Salvando marcador no autopilot..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -812,15 +785,15 @@ msgstr ""
 "o suporte a marcadores não está configurado. Por favor defina a variável de "
 "configuração 'bookmark-cmd' conforme necessário."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Ligações genéricas:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Funções sem ligações:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Limpar"
 
@@ -848,200 +821,219 @@ msgstr "flash embutido"
 msgid "unknown (bug)"
 msgstr "desconhecido (erro de software)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "Itens divulgados"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "Itens gostados"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "Páginas web salvas"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Alternando estado lido/não lido do artigo..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Erro ao alternar estado lido/não lido do artigo: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "A lista de URLs está vazia."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Sinalizações: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Erro: nenhum item selecionado!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Erro: você não pode recarregar os resultados da busca."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Nenhum artigo não lido."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Já no último item"
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Já no primeiro item"
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Nenhuma fonte não lida."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Marcando todas fontes RSS como lidas..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Passar o artigo por pipe ao comando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtsalg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Classificar por (d)ata/(t)ítulo/(s)inalizações/(a)utor/(l)ink/(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Classificar inversamente por (d)ata/(t)ítulo/(s)inalizações/(a)utor/(l)ink/"
 "(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Sinalizações atualizadas."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Erro: aplicação do filtro falhou: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Salvamento cancelado."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artigo salvo em %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Erro: não foi possível salvar artigo em %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado da Busca - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Fonte de Consulta - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista de Artigos - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Início"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Fim"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Fonte: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Autor: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Data: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Link: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "URL para baixar Podcast: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Início"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Fim"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Erro marcando artigo como lido: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s foi adicionado à fila para ser baixado."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "URL inválida: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Artigo salvo em %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Erro: não foi possível gravar o artigo no arquivo %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Iniciando navegador..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Erro marcando artigo como não lido: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Ir para a URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Abrir no Navegador"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Pôr na Fila"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Artigo - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Erro: expressão regular inválida!"
 
@@ -1353,26 +1345,36 @@ msgstr "Ir para o início da página/lista"
 msgid "Move to the end of page/list"
 msgstr "Ir para o fim da página/lista"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "'%s' não é um contexto válido"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "'%s' não é um comando de tecla válido"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "atributo '%s' não está disponível."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "a expressão regular '%s' é inválida: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: diretório de configuração '%s' inacessível, usando '%s' no lugar."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Erro fatal: não foi possível determinar o diretório do usuário!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1380,16 +1382,16 @@ msgstr ""
 "Por favor defina a variável de ambiente HOME ou adicione um usuário válido "
 "para o UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Erro: não foi possível abrir o arquivo de configuração '%s'!"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Limpando fila..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1398,113 +1400,121 @@ msgstr ""
 "%s %s\n"
 "uso: %s [-C <arquivo>] [-q <arquivo>] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<arquivofila>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "usar <arquivofila> como arquivo de fila"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "iniciar download ao abrir"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u transferências simultâneas"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Fila (%u transferências em progresso, %u no total) - %.2f kb/s total%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Erro: não é possível sair: transferência(s) em progresso"
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Erro: a transferência precisa ser concluída antes de o arquivo ser tocado."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr ""
 "Erro: não foi possível realizar a operação: transferência(s) em progresso."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Baixar"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Excluir"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Eliminar Concluídos"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Alternar Transferência Automática"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Tocar"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "Marcar como Concluído"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "'%s' é um tipo inválido de tela"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "'%s' não é uma expressão regular válida: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sCarregando %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Erro ao tentar obter %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Erro: fonte RSS inválida!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a, %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "poucos parâmetros"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' não é uma expressão de filtro válida"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a, %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Erro: URL não suportada: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Selecionar Etiqueta"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Selecionar Filtro"
 
@@ -1516,70 +1526,70 @@ msgstr "atributo não encontrado"
 msgid "EOF found while reading XML tag"
 msgstr "Fim de arquivo encontrado ao ler etiqueta XML"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Nenhum link selecionado!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Salvar Marcador"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Erro: fonte não possui nenhum item!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Nenhuma etiqueta definida."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Atualizando fonte de consulta..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "O nó raiz do XML é NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "não foi possível inicializar a libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "não foi possível analisar o buffer"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "não foi possível analisar o arquivo"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "RSS sem versão"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "versão de RSS inválida"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "versão de Atom inválida"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "Atom sem versão"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "formato de fonte não suportado"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "nenhum canal RSS encontrado"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "formato de fonte não suportado"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2018-08-03 22:54+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Konstantin Shakhnov <kastian@mail.ru>, Alexander Batischev "
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-Country: RUSSIAN FEDERATION\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -29,95 +29,95 @@ msgstr ""
 "Использование: %s [-i <файл>|-e] [-u <файл со cсылками>] [-c <файл кэша>] [-"
 "x <команда> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "экспорт ленты OPML в стандартный вывод"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "обновить ленты после запуска"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<файл>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "импортировать файл OPML"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<файл со ссылками>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "загрузить список ссылок на ленты RSS из <файла ссылок>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<файл кэша>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "использовать <файл кэша> как файл для кэша"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<файл настроек>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "считать настройки из <файла настроек>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "уплотнить кэш"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<команда>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "выполнить список команд"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "тихий запуск"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "получить информацию о версии"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<уровень>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "записывать в журнал сообщения определенного уровня (от 1 до 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<файл журнала>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "использовать <файл журнала> как файл вывода для журнала"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "экспорт прочитанных заметок в <файл>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "импорт списка прочитанных заметок из <файла>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "эта помощь"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -126,7 +126,7 @@ msgstr ""
 "Newsboat является свободным программным обеспечением под лицензией MIT. (Для "
 "просмотра полного текста наберите `%s -vv')."
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
@@ -134,46 +134,46 @@ msgstr ""
 "Программа включает в себя библиотеку «JSON for Modern C++» под лицензией "
 "MIT: https://github.com/nlohmann/json"
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
-"Программа включает в себя реализацию алгоритма alphanum под лицензией "
-"MIT: http://www.davekoelle.com/alphanum.html"
+"Программа включает в себя реализацию алгоритма alphanum под лицензией MIT: "
+"http://www.davekoelle.com/alphanum.html"
 
-#: newsboat.cpp:186
-#, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+#: newsboat.cpp:192
+#, fuzzy, c-format
+msgid "Caught newsboat::DbException with message: %s"
 msgstr "Поймали newsboat::dbexception с сообщением: %s"
 
-#: newsboat.cpp:193
-#, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+#: newsboat.cpp:199
+#, fuzzy, c-format
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Поймали newsboat::matcherexception с сообщением: %s"
 
-#: newsboat.cpp:199 podboat.cpp:32
-#, c-format
-msgid "Caught newsboat::exception with message: %s"
+#: newsboat.cpp:205 podboat.cpp:37
+#, fuzzy, c-format
+msgid "Caught newsboat::Exception with message: %s"
 msgstr "Поймали newsboat::exception с сообщением: %s"
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: некорректный уровень логирования"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "цвета `%s' не существует"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "атрибута `%s' не существует"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "элемента конфигурации `%s' не существует"
@@ -185,72 +185,92 @@ msgstr ""
 "newsboat: обновление завершено, %f не прочитанных лент (всего %n заметок не "
 "прочитано)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Заметок в ленте '%T' (непрочитанно %u, всего %t) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Ссылки"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Ваши ленты (непрочитанно %u, всего %t)%?T? - метка `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Открыть файл&Сохранить файл? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Помощь"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Заметок в ленте '%T' (непрочитанно %u, всего %t)"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Результаты поиска (непрочитанно %u, всего %t)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Выбрать Фильтр"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Выбрать Метку"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - Ссылки"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "ожидалось булево значение, обнаружилось `%s'"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "ожидалось целое число, обнаружилось `%s'"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "неверное значение конфигурации `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "неправильные параметры."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "слишком мало параметров."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "неизвестная команда (сбой)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "файл невозможно открыть."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "неизвестная ошибка (сбой)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Ошибка во время выполнения команды `%s' (%s строка %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "неизвестная команда `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -260,51 +280,51 @@ msgstr ""
 "Пожалуйста, задайте значение переменной окружения HOME или добавьте "
 "подходящего пользователя для UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Запускаю %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Ошибка: уже запущена копия %s (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Загружаю настройки..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "сделано."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Открываю кэш..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Ошибка: попытка открыть файл кэша `%s' завершилась неудачей: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "Ошибка: для пользования NewsBlur нужно задать `cookie-cache`.\n"
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s недоступен и не может быть создан\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Загружаю ссылки из %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -313,7 +333,7 @@ msgstr ""
 "Ошибка: не найдено ни одной ссылки. Пожалуйста, занесите в файл %s ссылки на "
 "RSS ленты или импортируйте файл OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -321,7 +341,7 @@ msgstr ""
 "Похоже что лента OPML, на которую вы подписались, не содержит лент новостей."
 "Пожалуйста заполните её лентами и попробуйте еще раз."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -329,7 +349,7 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "The Old Reader. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -337,7 +357,7 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "Tiny Tiny RSS. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -345,7 +365,7 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "NewsBlur. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -353,225 +373,174 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "Inoreader. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Загружаю заметки из кэша..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Тщательно очищаю кэш..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Ошибка во время загрузки лент новостей из базы: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Ошибка во время загрузки ленты '%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Заполняю динамические ленты..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Импортирую список прочитанных заметок..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Экспортирую список прочитанных заметок..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Очищаю кэш..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "не получилось: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Ошибка: невозможно отметить все ленты как прочитанные: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "При обработке %s возникла ошибка."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Импорт %s завершён."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u непрочитанных заметок"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: неизвестная команда"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Заголовок: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Автор: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Дата: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Ссылка: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Ссылка загрузки подкаста: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Ошибка: невозможно открыть конфигурационный файл `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Закрыть"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Открыть диалог"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Закрыть диалог"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Не выбранно ни одного элемента!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Ошибка: невозможно убрать список лент!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Неверная позиция!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "в очереди"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "загружается"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "отменено"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "удалено"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "завершено"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "неудачно"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "не полностью"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "готово"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "проиграно"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "неизвестно (сбой)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "атрибут `%s' недоступен."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "регулярное выражение '%s' неверно: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "неправильные параметры."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "слишком мало параметров."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "неизвестная команда (сбой)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "файл невозможно открыть."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "неизвестная ошибка (сбой)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "неверный индекс ленты (сбой)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Люди, которых Вы читаете"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Избранные элементы"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Опубликованные элементы"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Не выбрано ни одной ленты!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr "ftauln"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -579,7 +548,7 @@ msgstr ""
 "Сортировать по первой метке (f)/заголовку (t)/количеству записей (a)/"
 "непрочитанным (u)/времени последнего обновления (l)/никак (n)?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -587,224 +556,228 @@ msgstr ""
 "Сортировать в обратном порядке по первой метке (f)/заголовку (t)/количеству "
 "записей (a)/непрочитанным (u)/времени последнего обновления (l)/никак (n)?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr "Динамические ленты нельзя открывать в браузере!"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Отмечаю ленту как прочитанную..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Ошибка: невозможно отметить ленту как прочитанную: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Нет лент с непрочитанными элементами."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Уже на последней ленте."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Уже на первой ленте."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Отмечаю все ленты как прочитанные..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Ошибка: невозможно разобрать команду фильтрации `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Не определено ни одного фильтра."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Искать: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Фильтр: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Вы правда хотите выйти (y:Да n:Нет)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Выход"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Открыть"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Следующая непрочитанная"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Обновить"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Обновить все"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Отметить как прочитанную"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Отметить все как прочитанные"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Искать"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Помощь"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Ошибка: невозможно разобрать команду фильтрации!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Ищу..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Ошибка во время поиска `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Нет результатов."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Позицию не видно!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Список лент - %u непрочитанных, %u всего"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Вы правда хотите перезаписать `%s' (y:Да n:Нет)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Файл: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Сохранить файл - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Сохранить"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Сохранить файл - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "не удалось разобрать команду фильтрации `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "использование: set <переменная>[=<значение>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "использование: source <file> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "использование: dumpconfig <файл>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Конфигурация сохранена в %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Неизвестная команда: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Сохраняю закладку..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Сохранённая закладка."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Ошибка во время сохранения закладки: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "Источник: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Заголовок: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Описание: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Заголовок ленты: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Сохраняю закладку автоматически..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -812,15 +785,15 @@ msgstr ""
 "поддержка закладок не настроена. Пожалуйста, настройте переменную `bookmark-"
 "cmd'."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Общие привязки:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Отвязанные функции:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Чистый"
 
@@ -848,201 +821,220 @@ msgstr "встроенный flash:"
 msgid "unknown (bug)"
 msgstr "неизвестно (сбой)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "Разосланные статьи"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "Понравившиеся статьи"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "Сохранённые веб-страницы"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Переключение флага прочтения у заметки..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Ошибка во время переключения флага прочтения: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "Список ссылок пуст."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Флаги: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Ошибка: не выбранно ни одного элемента!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Ошибка: вы не можете обновить результаты поиска."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Непрочитанных элементов нет."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Уже на последней записи."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Уже на первой записи."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Непрочитанных лент нет."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 msgid "Marking all above as read..."
 msgstr "Отмечаю все, что выше, как прочитанные..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Обработать заметку командой: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfalg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Сортировать по дате (d)/заголовку (t)/флагам (f)/автору (a)/ссылке (l)/"
 "(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Сортировать в обратном порядке по дате (d)/заголовку (t)/флагам (f)/автору "
 "(a)/ссылке (l)/(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Флаги обновлены."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Ошибка: применение фильтра завершилось неудачей: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Прерванное сохранение."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Заметка сохранена в %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Ошибка: невозможно сохранить заметку в %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Результат поиска - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Динамическая лента - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Список заметок - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Верх"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Низ"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Лента: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Автор: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Дата: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Ссылка: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Ссылка загрузки подкаста: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "тип: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Верх"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Низ"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Ошибка во время пометки заметки как прочитанной: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Добавили %s в очередь загрузки."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Неверная ссылка: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Заметка сохранена в %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Ошибка: невозможно записать заметку в файл %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Запускаю браузер..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Ошибка во время пометки заметки как непрочитанной: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Открыть ссылку №"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Открыть в браузере"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Поставить в очередь"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Заметка - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Ошибка: неправильное регулярное выражение!"
 
@@ -1352,26 +1344,36 @@ msgstr "Перейти к началу страницы/списка"
 msgid "Move to the end of page/list"
 msgstr "Перейти к концу страницы/списка"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "контекста `%s' не существует"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "команда `%s' не поддерживается"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "атрибут `%s' недоступен."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "регулярное выражение '%s' неверно: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: конфигурационная директория '%s' недоступна, используем '%s'."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Фатальная ошибка: невозможно определить домашний каталог!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1379,16 +1381,16 @@ msgstr ""
 "Пожалуйста, задайте значение переменной окружения HOME или добавьте "
 "подходящего пользователя для UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Ошибка: невозможно создать конфигурационную директорию `%s': (%i) %s"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Очищаю очередь..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1397,112 +1399,120 @@ msgstr ""
 "%s %s\n"
 "использование: %s [-C <файл>] [-q <файл>] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<файл очереди>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "использовать <файл очереди> как файл очереди"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "начать загрузку сразу после запуска"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u параллельных загрузок"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Очередь (активных загрузок %u, всего %u) - %.2f кб/сек всего%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Ошибка: не могу выйти: загрузка(и) активна(ы)."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Ошибка: загрузка должна закончиться прежде чем файл может быть проигран."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Ошибка: невозможно выполнить действие: загрузка(и) активна(ы)."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Загрузить"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Удалить"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Очистить от завершённых"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Переключить автоматическую загрузку"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Проиграть"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "Отметить как завершенную"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' - неверный тип диалога"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' — неверное регулярное выражение:%s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sЗагружается %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Ошибка во время получения %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Ошибка: некорректная лента!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a, %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "слишком мало параметров"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' — неверный фильтр"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a, %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Ошибка: ссылка не поддерживается: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Выбрать метку"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Выбрать фильтр"
 
@@ -1514,67 +1524,67 @@ msgstr "атрибут не найден"
 msgid "EOF found while reading XML tag"
 msgstr "Во время чтения тега XML обнаружен конец файла"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Не выбрано ни одной ссылки!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Сохранить закладку"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "Источники"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Ошибка: лента не содержит ни одного элемента!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Не определено ни одной метки."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Обновляю динамическую ленту..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "Отсутствует корневой элемент XML документа"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "не удалось настроить libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "не удалось разобрать буффер"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "не удалось разобрать файл"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "нет версии RSS"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "неверная версия RSS"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "неверная версия Atom"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "нет версии Atom"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "неизвестный тип ленты"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "RSS-лента не найдена"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "неизвестный тип ленты"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2018-08-03 22:54+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Konstantin Shakhnov <kastian@mail.ru>, Alexander Batischev "
@@ -157,9 +157,9 @@ msgstr "Поймали newsboat::matcherexception с сообщением: %s"
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Поймали newsboat::exception с сообщением: %s"
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: некорректный уровень логирования"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1385,6 +1385,11 @@ msgstr ""
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Ошибка: невозможно создать конфигурационную директорию `%s': (%i) %s"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: некорректный уровень логирования"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/sk.po
+++ b/po/sk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.10.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2017-12-25 00:38+0100\n"
 "Last-Translator: František Hájik <ferko.hajik@gmail.com>\n"
 "Language-Team: František Hájik <ferko.hajik@gmail.com>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "X-Generator: Poedit 2.0.3\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -28,145 +28,145 @@ msgstr ""
 "usage: %s [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x <command> ...] "
 "[-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "export OPML kanálov do stdout"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "obnoviť kanály pri štarte"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<súbor>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "import OPML súboru"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<urlfile>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "načítať URL adresy RSS kanálov z <urlfile>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<cachefile>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "použiť <cachefile> ako cache súbor"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<configfile>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "načítať konfiguráciu z <configfile>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "stlačiť cache"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<command>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "vykonať zoznam príkazov"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "tichý startup"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "získať informácie o verzii"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<loglevel>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "napísať protokol (log) s určitým loglevelom (platné hodnoty: 1 až 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<logfile>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "použitie <logfile> ako výstupného log súboru"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "export zoznamu čítaných článkov do súboru <file>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "import zoznamu čítaných článkov zo súboru <file>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "tento pomocník"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, fuzzy, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
 "see the full text.)"
 msgstr "newsboat je slobodný softvér a licencovaný pod licenciou MIT."
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: \"loglevel\" hodnota je neplatná"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' nie je platná farba"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' nie je platný atribút"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' nie je platný prvok konfigurácie"
@@ -178,73 +178,93 @@ msgstr ""
 "newsboat: načítanie ukončené, %f neprečítaných kanálov s %n neprečítanými "
 "článkami celkom"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr ""
 "%N %V - Články v informačných kanáloch (%u neprečítané, %t celkom) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialógy"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Tvoje zdroje (%u neprečítané, %t celkom)%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Otvoriť Súbor&Uložiť Súbor? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Pomoc"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Article '%T' (%u neprečítané, %t celkom)"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Výsledok vyhľadávanie (%u nečítané, %t celkom)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Vyber Filter"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Vybraný Tag"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "očakávaná bolean hodnota, namiesto toho nájdené `%s"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "očakávaná \"integer\" hodnota, namiesto toho nájdené `%s"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "`%s' nie je platný prvok konfigurácie'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "chybné parametre."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "príliš málo parametrov."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "neznámy príkaz (bug)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "súbor nemôže byť otvorený."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "neznáma chyba (bug)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Chyba pri spracovaní príkazu `%s' (%s riadok %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "neznámy príkaz `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -253,51 +273,51 @@ msgstr ""
 "Prosím nastav premennú prostredia \"HOME\" alebo pridaj platného používateľa "
 "pre UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Spúšťanie %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Chyba: program %s už beží (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Načítanie konfigurácie..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "hotovo."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Otvorenie vyrovnávacej pamäte..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Chyba: otvorenie \"cache\" súboru `%s' zlyhalo: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s je nedostupný a nemôže byť vytvorený\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Načítanie adries URL z %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -306,7 +326,7 @@ msgstr ""
 "Chyba: nenakonfigurované žiadne URL adresy. Prosím vyplňte súbor% s pomocou "
 "URL adries RSS alebo importujte súbor OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -314,7 +334,7 @@ msgstr ""
 "Vyzerá to tak, že OPML zdroj, neobsahuje žiadne kanály. Vyplňte ho kanálmi a "
 "skúste to znova."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -322,7 +342,7 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte The Old Reader. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -330,7 +350,7 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte Tiny Tiny RSS. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -338,7 +358,7 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte NewsBlur. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -346,226 +366,175 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte Inoreader. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Načítanie článkov zo súboru \"cache\"..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Dokladné vyčistenie \"cahce\"..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Chyba pri načítavaní informačných kanálov z databázy: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Chyba pri načítaní informačného kanálu '%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Predvolené dopyty kanálov..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importovať zoznam čítaných článkov..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Exportovať zoznam čítaných článkov..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Vyčistenie \"cache\"..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "zlyhalo: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Chyba: nemožno označiť všetky prečítané informačné kanály: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Vyskytla sa chyba počas \"parsingu\" %s."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Import %s ukončený."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u neprečítaných článkov"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: neznámy príkaz"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Titulok: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Autor: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Dátum: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Odkaz: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Podcast Download URL: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Chyba: nemožno otvoriť konfiguračný súbor `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Zatvoriť"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Prejsť na dialóg"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Zatvoriť na dialóg"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Žiadna položka nebola označená!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Chyba: nemožno odstrániť zoznam informačných kanálov (feed list)!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Neplatná pozícia!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "vo fronte"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "sťahovanie"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "zrušené"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "zmazané"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "ukončené"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "zlyhalo"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "nekompletné"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "pripravený"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "prehrať"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "neznáma (chyba)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "atribút `%s' nie je k dispozícii."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "regulárny výraz '%s' je vadný: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "chybné parametre."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "príliš málo parametrov."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "neznámy príkaz (bug)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "súbor nemôže byť otvorený."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "neznáma chyba (bug)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "neplatný index kanála (bug)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Ľudia, ktorých sledujete"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Položky označené hviezdičkou"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Zdieľané položky"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Nebol vybraný žiadny kanál!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "ftpun"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -574,7 +543,7 @@ msgstr ""
 "Zotriediť podľa (f)prvého_tagu/(t)itulkov/(p)očtu_článkov/"
 "(u)neprečítaných_článkov/(n)etriediť?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -583,224 +552,228 @@ msgstr ""
 "Zotriediť spätne podľa (f)prvého_tagu/(t)itulkov/(p)očtu_článkov/"
 "(u)neprečítaných_článkov/(n)etriediť?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr "V prehliadači sa nedajú otvoriť požiadavky z kanálov!"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Označiť kanál za prečítaný..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Chyba: nemožno označiť čítanie kanála: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Žiaden kanál s neprečítanými položkami."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Celkom posledný kanál."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Celkom prvý kanál."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Označenie všetkých kanálov za prečítané..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Chyba: príkaz filtra nedá analyzovať `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Neboli definované žiadne filtre."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Vyhľadať: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Skutočne skončiť (a:Áno n:Nie)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "an"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "a"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Ukončiť"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Otvoriť"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Ďalší neprečítaný"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Obnoviť"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Obnoviť všetko"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Označiť ako prečítané"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Označiť všetko ako prečítané"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Hľadať"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Pomocník"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Chyba: nebolo možné analyzovať príkaz filtra!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Vyhľadávanie..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Chyba pri vyhľadávaní `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Žiadny výsledok."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Pozícia nie je viditeľná!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Zoznam informačných kanálov - %u neprečítané, %u celkom"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Naozaj chcete prepísať `%s' (a:Áno n:Nie)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Súbor: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Uložiť súbor - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Uložiť"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Uložiť súbor - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "nemožno analyzovať výraz filtra `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "použitie: set <variable>[=<value>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "použitie: zdrojový súbor <file> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "použítie: dumpconfig <file>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Konfigurácia uložená do %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Nie je príkaz: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Záložka sa ukladá..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Záložka uložená."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Chyba pri ukladaní záložky: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Titulok: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Popis: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Názov titulu: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Ukladanie záložiek na \"autopilota\"..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -808,15 +781,15 @@ msgstr ""
 "podpora záložiek nie je nakonfigurovaná. Nastavte prosím adekvátne premennú "
 "`bookmark-cmd' v konfigurácii."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Zabudované príkazy:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Neviazané funkcie:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Vyčistiť"
 
@@ -844,202 +817,221 @@ msgstr "vstavaný flash"
 msgid "unknown (bug)"
 msgstr "neznáme (chyba)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "Vysielanie položiek"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "Obľúbené položky"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "Web stránka uložená"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Prepínanie príznaku čítania článku..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Chyba pri prepínaní príznaku čítania: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "Zoznam URL je prázdny."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Príznaky (flags): "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Chyba: žiadna položka nebola vybratá!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Chyba: nemožno načítať výsledky vyhľadávania."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Všetky položky prečítané."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Celkom posledná položka."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Celkom prvá položka."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Všetko prečítané."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Označenie všetkých kanálov za prečítané..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Odoslať (Pipe) článok do príkazu: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dnpaoi"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Zotriedenie podľa (d)átumu/(n)ázvu/(p)ríznaku/(a)utora/(o)dkazu/"
 "(i)dentifikátora?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Zotriediť spätne podľa (d)átumu/(n)ázvu/(p)ríznaku/(a)utora/(o)dkazu/"
 "(i)dentifikátora?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Príznaky aktualizované."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Chyba: použitie filtra zlyhalo: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Ukladanie bolo prerušené."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Článok bol uložený do %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Chyba: článok nemožno uložiť do %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Výsledok vyhľadávania - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Dotaz informačného kanála - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Zoznam článkov - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Vrch"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Spodok"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Kanál: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Autor: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Dátum: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Odkaz: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Podcast Download URL: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Vrch"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Spodok"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Chyba pri označovaní článku za prečítaný: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s pridaný do fronty sťahovania."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Nesprávna URL: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Článok uložený do %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Chyba: nemožno zapísať článok do súboru %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Spustenie prehliadača..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Chyba pri označovaní článku ako neprečítaného: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Choď na URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Otvoriť v prehliadači"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Do fronty"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Článok - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Chyba: neplatný regulárny výraz!"
 
@@ -1353,28 +1345,38 @@ msgstr "Prejsť na začiatok stránky / zoznamu"
 msgid "Move to the end of page/list"
 msgstr "Prejsť na koniec stránky/zoznamu"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' nie je platný kontext"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' nie je platný príkaz kľúča"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "atribút `%s' nie je k dispozícii."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "regulárny výraz '%s' je vadný: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: konfiguračný adresár '% s' nie je prístupný, namiesto toho používa "
 "'% s'."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Fatálna chyba: nedá sa určiť \"home\" adresár!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1382,16 +1384,16 @@ msgstr ""
 "Prosím nastav premennú prostredia \"HOME\" alebo pridaj platného používateľa "
 "pre UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Chyba: nemožno otvoriť konfiguračný súbor `%s'!"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Čistenie fronty..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1400,111 +1402,119 @@ msgstr ""
 "%s %s\n"
 "použitie %s [-C <file>] [-q <file>] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<queuefile>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "použiť <queuefile> ako \"queue\" súbor"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "spustiť sťahovanie pri štarte"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u paralelné sťahovanie"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Fronta (%u prebieha sťahovanie, %u celkom) - %.2f kb/s celkom%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Chyba: nemožno ukončiť preberanie (sťahovanie)."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Chyba: sťahovanie musí byť dokončené pred prehrávaním súboru."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Chyba: nemožno vykonať operáciu: Prebieha sťahovanie."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Stiahnuť"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Zmazať"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Čistenie dokončené"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Prepnúť automatické stiahnutie"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Prehrať"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "Označiť ako ukončené"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' je chybný dialógový typ"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' nie je platný regulárny výraz: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sNačítanie %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Chyba pri načítaní %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Chyba: vadný kanál!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a, %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "príliš málo parametrov"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' nie je platný prvok konfigurácie"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a, %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Chyba: nepodporovaná URL: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Vyber Tag"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Vyber Filter"
 
@@ -1516,70 +1526,70 @@ msgstr "atribút nebol nájdený"
 msgid "EOF found while reading XML tag"
 msgstr "Bol nájdený \"EOF\" pri načítaní XML tagu"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Link nebol vybraný!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Uložiť záložku"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Chyba: informačný kanál neobsahuje žiadne položky!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Neboli definované žiadne \"tagy\"."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Aktualizácia dopytu informačného kanála..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "Koreňový uzol jazyka XML je NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "nebolo možné inicializovať libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "nebolo možné analyzovať vyrovnávaciu pamäť (buffer)"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "nebolo možné analyzovať súbor"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "verzia pre RSS neexistuje"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "neplatná verzia pre RSS"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "neplatná verzia pre ATOM"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "verzia pre ATOM neexistuje"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "nepodporovaný \"feed\" formát"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "žiadny RSS kanál sa nenašiel"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "nepodporovaný \"feed\" formát"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/sk.po
+++ b/po/sk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.10.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2017-12-25 00:38+0100\n"
 "Last-Translator: František Hájik <ferko.hajik@gmail.com>\n"
 "Language-Team: František Hájik <ferko.hajik@gmail.com>\n"
@@ -150,9 +150,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: \"loglevel\" hodnota je neplatná"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1388,6 +1388,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Chyba: nemožno otvoriť konfiguračný súbor `%s'!"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: \"loglevel\" hodnota je neplatná"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/sv.po
+++ b/po/sv.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat-2.12\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2018-08-08 10:17+0200\n"
 "Last-Translator: Dennis Öberg <contact@dennisoberg.se>\n"
 "Language-Team: Niklas Grahn <terra.unknown@yahoo.com>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.1.1\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -26,95 +26,95 @@ msgstr ""
 "användning: %s [-i <fil>|-e] [-u <url-fil>] [-c <cache-fil>] [-x "
 "<kommando> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "exportera OPML-flöde till stdout"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "uppdatera webbflöden vid uppstart"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<fil>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "importera OPML-fil"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<url-fil>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "läs in URL:er till RSS-webbflöden från <url-fil>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<cache-fil>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "använd <cache-fil> som cache-fil"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<konfigurationsfil>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "läs in konfiguration från <konfigurationsfil>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "komprimera cachen"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<kommando>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "exekvera lista över kommandon"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "tyst uppstart"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "hämta versionsinformation"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<loggnivå>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "skriv en logg med en särskild loggnivå (giltiga värden: 1 till 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<loggfil>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "använd <loggfil> som loggfil"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "exportera lista över lästa artiklar till <fil>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "importera lista över lästa artiklar till <fil>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "denna hjälp"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -123,7 +123,7 @@ msgstr ""
 "Newsboat är fri programvara licensierad under MIT-licensen. (Ange `%s -vv' "
 "för att se hela texten.)"
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
@@ -131,44 +131,44 @@ msgstr ""
 "Det inkluderar biblioteket JSON for Modern C++, licensierat under MIT-"
 "licensen: https://github.com/nlohmann/json"
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
-#, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+#: newsboat.cpp:192
+#, fuzzy, c-format
+msgid "Caught newsboat::DbException with message: %s"
 msgstr "Fångade newsboat::dbexception med meddelande: %s"
 
-#: newsboat.cpp:193
-#, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+#: newsboat.cpp:199
+#, fuzzy, c-format
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Fångade newsboat::matcherexception med meddelande: %s"
 
-#: newsboat.cpp:199 podboat.cpp:32
-#, c-format
-msgid "Caught newsboat::exception with message: %s"
+#: newsboat.cpp:205 podboat.cpp:37
+#, fuzzy, c-format
+msgid "Caught newsboat::Exception with message: %s"
 msgstr "Fångade newsboat::exception med meddelande: %s"
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: ogiltigt loggnivåvärde"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' är inte en giltig färg"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' är inte ett giltigt attribut"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' är inte ett giltigt konfigurationselement"
@@ -179,72 +179,92 @@ msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr ""
 "newsboat: omläsning färdig, %f olästa webbflöden (%n olästa artiklar totalt)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - Artiklar i webbflöden '%T' (%u olästa, %t totalt) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialogrutor"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Dina webbflöden (%u olästa, %t totalt)%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Öppna fil&Spara fil? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Hjälp"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artikel '%T' (%u olästa, %t totalt)"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Sökresultat (%u olästa, %t totalt)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Välj filter"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Välj tagg"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URL:er"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "boolean-värde förväntades, hittade `%s' istället"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "integer-värde förväntades, hittade `%s' istället"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "ogiltigt konfigurationsvärde `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "ogiltiga parametrar."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "för få parametrar."
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "okänt kommando (bugg)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "fil kunde inte öppnas."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "okänt fel (bugg)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Fel vid behandling av kommando `%s' (%s rad %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "okänt kommando `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -254,51 +274,51 @@ msgstr ""
 "Var god ställ in HOME-miljövariabeln eller lägg till en giltig användare för "
 "UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Startar %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Fel: en instans av %s körs redan (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Läser in konfiguration..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "färdig."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Öppnar cache..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Fel: öppnande av cache-fil `%s' misslyckades: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "FEL: Du måste sätta 'cookie-cache' till att använda NewsBlur.\n"
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s är oåtkomlig och kan inte skapas\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Läser in URL:er från %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -307,7 +327,7 @@ msgstr ""
 "Fel: inga URL:er konfigurerade. Var god fyll filen %s med URL:er till RSS-"
 "kanaler eller importera en OPML-fil."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -315,7 +335,7 @@ msgstr ""
 "Det ser ut som om OPML-flödet som du valde att prenumerera på inte "
 "innehåller några webbflöden. Var god fyll den med webbflöden och prova igen."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -323,7 +343,7 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt The Old "
 "Reader-konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -331,7 +351,7 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt Tiny Tiny "
 "RSS-konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -339,7 +359,7 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt NewsBlur-"
 "konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -347,225 +367,174 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt Inoreader-"
 "konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Läser in artiklar från cache..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Tömmer noggrant cache..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Fel vid inläsning av webbflöden från databasen: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Fel vid inläsning av webbflöde `%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Förbefolkar förfrågansflöden..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Importerar lista över lästa artiklar..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Exporterar lista över lästa artiklar..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Tömmer cache..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "misslyckades: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Fel: kunde inte markera alla webbflödeer som lästa: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ett fel inträffade vid tolkning av %s."
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importering av %s färdig."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u olästa artiklar"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: okänt kommando"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Titel: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Författare: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Datum: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Länk: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Hämtnings-URL för poddsändning: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fel: kunde inte öppna konfigurationsfil `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Stäng"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Gå till-dialogruta"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Stäng dialogruta"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Ingen post markerad!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Fel: du kan inte ta bort listan över webbflöden!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Ogiltig position!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "kölagd"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "hämtar"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "avbruten"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "borttagen"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "färdig"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "misslyckad"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "ofullständig"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "redo"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "uppspelad"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "okänt (bugg)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "attribut `%s' är inte tillgängligt."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "reguljärt uttryck '%s' är ogiltigt: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "ogiltiga parametrar."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "för få parametrar."
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "okänt kommando (bugg)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "fil kunde inte öppnas."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "okänt fel (bugg)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "ogiltigt webbflödesindex (bugg)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Personer du följer"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Stjärnmarkerade poster"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Delade poster"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Ingen kanal markerad!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr "ftaosi"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -573,7 +542,7 @@ msgstr ""
 "Sortera utifrån (f)örstatagg/(t)itel/(a)rtikelmängd/(o)lästartikelmängd/"
 "(s)enastuppdaterad/(i)nget?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -581,224 +550,228 @@ msgstr ""
 "Sortera omvänt utifrån (f)örstatagg/(t)itel/(a)rtikelmängd/"
 "(o)lästartikelmängd/(s)enastuppdaterad/(i)nget?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr "Kan inte öppna query feeds i webbläsaren!"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Markerar webbflöde som läst..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Fel: kunde inte markera webbflöde som läst: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Inga webbflöden med olästa poster."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Redan på sista webbflödet."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Redan på första webbflödet."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Markerar alla webbflöden som lästa..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Fel: kunde inte tolka filterkommando `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Inga filter definierade."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Sök efter: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Vill du verkligen avsluta (j:Ja n:Nej)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "jn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "j"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Avsluta"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Öppna"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Nästa olästa"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Läs om"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Läs om alla"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Markera som läst"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Markera alla som lästa"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Sök"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Hjälp"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Fel: kunde inte tolka filterkommando!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Söker..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Fel vid sökning efter `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Inga resultat."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Position inte synlig!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista över webbflöden - %u olästa, %u totalt"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Vill du verkligen skriva över %s' (j:Ja n:Nej)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Fil: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Spara fil - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Spara"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Spara fil - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "kunde inte tolka filteruttryck `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "användning: set <variabel>[=<värde>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "användning: source <fil> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "användning: dumpconfig <fil>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Sparade konfiguration till %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Inte ett kommando: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Sparar bokmärke..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Sparade bokmärke."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Fel vid sparande av bokmärke: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Titel: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Beskrivning: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Webbflödestitel: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Sparar bokmärke på autopilot..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -806,15 +779,15 @@ msgstr ""
 "stöd för bokmarkering är inte konfigurerat. Var god ställ in "
 "konfigurationsvariablen `bookmark-cdm' korrekt."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Allmänna bindningar:"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Icke-bundna funktioner:"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Töm"
 
@@ -842,198 +815,217 @@ msgstr "inbäddat flash"
 msgid "unknown (bug)"
 msgstr "okänt (bugg)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "Utsända poster"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "Gillade poster"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "Sparade webbsidor"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Växlar läsflagga för artikel..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Fel vid växling av läsflagga: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "URL-lista tom."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Flaggor: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Fel: ingen post markerad!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Fel: du kan inte läsa om sökresultat."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Inga olästa poster."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Redan på sista posten."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Redan på första posten."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Inga olästa webbflöden."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 msgid "Marking all above as read..."
 msgstr "Markerar allt ovanför som läst..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Skicka artikel genom pipe till kommando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtFflg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Sortera utifrån (d)atum/(t)itel/(F)laggor/(f)örfattare/(l)änk/(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sortera omvänt utifrån (d)atum/(t)itel/(F)laggor/(f)örfattare/(l)änk/(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Flaggor uppdaterade."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Fel: verkställande av filtret misslyckades: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Avbröt sparande."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Sparade artikel till %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fel: kunde inte spara artikel till %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Sökresultat - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Förfrågansflöde - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikellista - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Överkant"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Nederkant"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Webbflöde: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Författare: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Datum: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Länk: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Hämtnings-URL för poddsändning: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Överkant"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Nederkant"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fel vid markering av artikel som läst: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Lade till %s i hämtningskö."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Ogiltig URL: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Sparade artikel till %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Fel: kunde inte skriva artikel till fil %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Startar webbläsare..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Fel vid markering av artikel som oläst: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Gå till URL #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Öppna i webbläsare"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Kölägg"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Fel: ogiltigt reguljärt uttryck!"
 
@@ -1344,26 +1336,36 @@ msgstr "Flytta till början av sida/lista"
 msgid "Move to the end of page/list"
 msgstr "Flytta till slutet av sida/lista"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' är inte en giltig kontext"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' är inte ett giltigt tangentkommando"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "attribut `%s' är inte tillgängligt."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "reguljärt uttryck '%s' är ogiltigt: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: konfigurationskatalog '%s' inte åtkomlig, använder '%s' istället."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Fatalt fel: kunde inte fastställa hemkatalog!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1371,16 +1373,16 @@ msgstr ""
 "Var god ställ in HOME-miljövariabeln eller lägg till en giltig användare för "
 "UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Fatalt fel: kunde inte skapa konfigurationskatalog `%s': (%i) %s"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Tömmer kö..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1389,111 +1391,119 @@ msgstr ""
 "%s %s\n"
 "användning: %s [-C <fil>] [-q <fil>] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<köfil>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "använd <köfil> som köfil"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "påbörja hämtning vid uppstart"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u parallella hämtningar"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Kölista (%u pågående hämtningar, %u totalt) - %.2f kb/s totalt%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Fel: kan inte avsluta: hämtning(ar) pågår."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Fel: hämtning måste vara klar innan filen kan spelas upp."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Fel: kan inte utföra åtgärd: hämtning(ar) pågår."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Hämta"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Ta bort"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Rensa färdiga"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Växla automatisk hämtning"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Spela upp"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "Markera som klar"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' är en ogiltig typ av dialogruta"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' är inte ett giltigt reguljärt uttryck: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sLäser in %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Fel vid hämtning av %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Fel: ogiltigt webbflöde!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a, %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "för få parametrar"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' är inte ett giltigt filteruttryck"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a, %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Fel: URL stöds inte: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Välj tagg"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Välj filter"
 
@@ -1505,70 +1515,70 @@ msgstr "attribut hittades inte"
 msgid "EOF found while reading XML tag"
 msgstr "EOF hittades vid inläsning av XML-tagg"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Ingen länk markerad!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Spara bokmärke"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URL:er"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Fel: webbflöde innehåller inga poster!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Inga taggar definierade."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Uppdaterar query feed..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "XML root node är NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "kunde inte initialisera libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "kunde inte tolka buffer"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "kunde inte tolka fil"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "ingen RSS-version"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "ogiltig RSS-version"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "ogiltig Atom-version"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "ingen Atom-version"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "format på webbflödet stöds inte"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "ingen RSS-kanal hittades"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "format på webbflödet stöds inte"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat-2.12\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2018-08-08 10:17+0200\n"
 "Last-Translator: Dennis Öberg <contact@dennisoberg.se>\n"
 "Language-Team: Niklas Grahn <terra.unknown@yahoo.com>\n"
@@ -152,9 +152,9 @@ msgstr "Fångade newsboat::matcherexception med meddelande: %s"
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Fångade newsboat::exception med meddelande: %s"
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: ogiltigt loggnivåvärde"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1377,6 +1377,11 @@ msgstr ""
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Fatalt fel: kunde inte skapa konfigurationskatalog `%s': (%i) %s"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: ogiltigt loggnivåvärde"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/tr.po
+++ b/po/tr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2008-11-18 14:41+0200\n"
 "Last-Translator: H.Gökhan SARI <hsa2@difuzyon.net>\n"
 "Language-Team: Türkçe <en@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Language: tr_TR\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -25,145 +25,145 @@ msgstr ""
 "kullanım: %s [-i <dosya>|-e] [-u <url_dosyası>] [-c <önbellek_dosyası>] [-x "
 "<komut> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "beslemeleri OPML olarak çıktıla"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "beslemeleri başlangıçta yenile"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<dosya>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "OPML dosyasını içe aktar"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<url_dosyası>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "RSS beslemeleri adreslerini <url_dosyası>ndan oku"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<önbellek_dosyası>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "<önbellek_dosyası>nı önbellek dosyası olarak kullan"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<ayar_dosyası>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "ayarları <ayar_dosyası>ndan oku"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<komut>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "bir dizi komut çalıştır"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr ""
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "sürüm bilgisini al"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<kayıt_seviyesi>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "kayıt tutarken seviye belirle (geçerli seviyeler: 1 - 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<kayıt_dosyası>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "<kayıt_dosyası>nı çıktı kaydı için kullan"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "okunmuş yazıların listesini <dosya>ya aktar"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "okunmuş yazıları <dosya>dan aktar"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "bu yardım"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
 "see the full text.)"
 msgstr ""
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' geçerli bir renk değil"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' geçersiz bir özellik"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr ""
@@ -175,73 +175,93 @@ msgstr ""
 "newsboat: yeniden yükleme tamamlandı, %f okunmamış besleme (%n okunmamış "
 "toplam yazı)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - '%T' yazı (%u okunmamış, %t toplam) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Diyalog"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Beslemeler (%u okunmamış, %t toplam)%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Aç&Kaydet? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Yardım"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - '%T' yazı (%u okunmamış, %t toplam) - %U"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Arama sonucu (%u okunmamış, %t toplam)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Filtre Seç"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Etiket Seç"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - Adres"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr ""
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr ""
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, fuzzy, c-format
 msgid "invalid configuration value `%s'"
 msgstr "Ayarlar %s 'e kaydedildi"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "Geçersiz parametre."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "yetersiz parametre"
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "bilinmeyen komut (bug)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "dosya açılamadı."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "bilinmeyen hata (bug)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "`%s' komutu çalıştırılırken hata (%s %u. satır): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "bilinmeyen komut `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -250,51 +270,51 @@ msgstr ""
 "Ev dizini değişkenini ayarlayın ya da %u UID'i için geçerli bir kullanıcı "
 "ekleyin!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "%s %s başlatılıyor..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Hata: %s zaten çalışıyor (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Ayarlar yükleniyor..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "tamamlandı."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Önbellek açılıyor..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Hata: `%s' önbellek dosyası açılamadı: %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "%s kaynağından adresler yükleniyor..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -303,7 +323,7 @@ msgstr ""
 "Hata: hiçbir adres ayarlanmamış. Lütfen %s içine RSS besleme kaynakları "
 "ekleyin ya da bir OPML dosyasını içeri aktarın."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -311,7 +331,7 @@ msgstr ""
 "Belirttiğiniz OPML dosyası herhangi bir kaynak içermiyor. Lütfen besleme "
 "kaynaklarını doğru biçimde bu dosyaya ekleyin ve tekrar deneyin."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -320,7 +340,7 @@ msgstr ""
 "Bloglines hesabınızda herhangi bir besleme ayarlamamışsınız. Lütfen gerekli "
 "ayarlamayı yaptıktan sonra tekrar deneyin."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -329,7 +349,7 @@ msgstr ""
 "Bloglines hesabınızda herhangi bir besleme ayarlamamışsınız. Lütfen gerekli "
 "ayarlamayı yaptıktan sonra tekrar deneyin."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -338,7 +358,7 @@ msgstr ""
 "Bloglines hesabınızda herhangi bir besleme ayarlamamışsınız. Lütfen gerekli "
 "ayarlamayı yaptıktan sonra tekrar deneyin."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -347,458 +367,411 @@ msgstr ""
 "Bloglines hesabınızda herhangi bir besleme ayarlamamışsınız. Lütfen gerekli "
 "ayarlamayı yaptıktan sonra tekrar deneyin."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Yazılar önbellekten yükleniyor..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Önbellek boşaltılıyor..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Veritabanından beslemeler alınırken hata oluştu: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, fuzzy, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "`%s' aranırken hata: %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Sorgu beslemesi güncelleniyor..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Okunmuş yazıların listesi içe aktarılıyor..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Okunmuş yazıların listesi dışa aktarılıyor..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Önbellek temizleniyor..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "başarız: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Hata: tüm beslemeler okundu olarak işaretlenemedi: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s'in içeri aktarımı tamamlandı."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u okunmamış yazı"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "bilinmeyen komut `%s'"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Başlık: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Yazar: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Tarih: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Bağlantı: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Podcast İndirme Adresi: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Hata: ayar dosyası `%s' kaydedilemedi!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Hiçbiri seçilmedi!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Hata: besleme listesini silemezsiniz!"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Geçersiz konum!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "kuyruğa eklendi"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "indiriliyor"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "iptal edildi"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "silindi"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "tamamlandı"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "tamamlanamadı"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "eksik"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr ""
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "oynatıldı"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "bilinmiyor (bug) "
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "`%s' özelliği mevcut değil."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr ""
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "Geçersiz parametre."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "yetersiz parametre"
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "bilinmeyen komut (bug)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "dosya açılamadı."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "bilinmeyen hata (bug)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "geçersiz besleme indeksi (bug)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr ""
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 #, fuzzy
 msgid "Starred items"
 msgstr "Okunmamış yok."
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 #, fuzzy
 msgid "Shared items"
 msgstr "Okunmamış yok."
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Hiçbir besleme seçilmedi!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Besleme okundu olarak işaretleniyor..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Hata: besleme okundu olarak işaretlenemedi: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Okunmamış besleme yok."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Tüm beslemeler okundu olarak işaretleniyor..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Hata: filtre komutu `%s' ayrıştırılamadı: %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Hiçbir filtre tanımlanmadı."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Ara: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Filtre: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Çıkmak istediğinize emin misiniz (e:Evet h:Hayır)? "
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "eh"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "e"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Çık"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Aç"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Sonraki Okunmamış"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Yeniden Yükle"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Tümünü Yeniden Yükle"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Okundu olarak işaretle"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Tümünü Okundu Olarak İşaretle"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Ara"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Yardım"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Hata: filtre komutu ayrıştırılamadı!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Aranıyor..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "`%s' aranırken hata: %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Sonuç yok."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Konum görünür değil!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Besleme Listesi %u okunmamuş, %u toplam"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "`%s'in üzerine yazmak istediğinize emin misiniz (e:Evet h:Hayır)? "
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "h"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Dosya: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Dosya Kaydet - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Kaydet"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Kaydet - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "filtre ifadesi `%s' ayrıştırılamadı: %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "kullanım: set <variable>[=<value>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr ""
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "kullanım: dumpconfig <dosya>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Ayarlar %s 'e kaydedildi"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "bilinmeyen komut: %s"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Yerimi kaydediliyor..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Yerimi kaydedildi."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Yerimi kaydedilirken hata oluştu: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "Adres: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Başlık: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Açıklama: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 #, fuzzy
 msgid "Feed title: "
 msgstr "Dosya: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "Yerimi kaydediliyor..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -806,15 +779,15 @@ msgstr ""
 "yer imleme desteği ayarlanmadı. Ayar değişkenini `bookmark-cmd'ye göre "
 "ayarlayın."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr ""
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr ""
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Temizle"
 
@@ -842,199 +815,216 @@ msgstr "gömülmüş flash"
 msgid "unknown (bug)"
 msgstr "bilinmiyor (bug)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 #, fuzzy
 msgid "Liked items"
 msgstr "Okunmamış yok."
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Bayrak okuma açılıyor/kapatılıyor..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Hata: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "Adres listesi boş."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Bayraklar: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Hata: hiçbiri seçilmedi!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Hata: arama sonuçlarını yeniden yükleyemezsiniz."
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Okunmamış yok."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Okunmamış besleme yok."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Tüm beslemeler okundu olarak işaretleniyor..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfalg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Bayraklar güncellendi."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Hata: filtre uygulanırken hata oluştu: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Kayıt işlemi iptal edildi."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Yazı %s'e kaydedildi"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Hata: yazı %s'e kaydedilemedi"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Yazı Listesi - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Yukarı"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Aşağı"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Besleme: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Yazar: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Tarih: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Bağlantı: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Podcast İndirme Adresi: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "biçim: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Yukarı"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Aşağı"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Yazı okundu olarak işaretlenirken hata oluştu: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s indirme kuyruğuna eklendi."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr ""
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Yazı %s'e kaydedildi."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Hata: yazı %s'e kaydedilemedi"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Tarayıcı başlatılıyor..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Yazı yeni olarak işaretlenirken hata oluştu: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Tarayıcıda Görüntüle"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Kuyruktan Çıkar"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Yazı - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Hata: geçersiz düzenli ifade!"
 
@@ -1352,26 +1342,36 @@ msgstr "Sonraki sayfaya taşı"
 msgid "Move to the end of page/list"
 msgstr "Sonraki sayfaya taşı"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr ""
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "`%s' özelliği mevcut değil."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr ""
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Ölümcül hata: ev dizini tanımlanamadı!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1379,16 +1379,16 @@ msgstr ""
 "Ev dizini değişkenini ayarlayın ya da %u UID'i için geçerli bir kullanıcı "
 "ekleyin!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Hata: ayar dosyası `%s' kaydedilemedi!"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Kuyruk temizleniyor..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1398,116 +1398,124 @@ msgstr ""
 "kullanım: %s [-i <dosya>|-e] [-u <url_dosyası>] [-c <önbellek_dosyası>] [-x "
 "<komut> ...] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<dosya>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "<önbellek_dosyası>nı önbellek dosyası olarak kullan"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr ""
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u paralel indirme"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Kuyruk (%u indirme sürüyor, %u toplam) - %.2f kb/s toplam%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Hata: çıkılamadı: devam eden indirme(ler) var."
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Hata: dosya oynatılmadan önce indirme işleminin tamamlanması gerekiyor."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Hata: işlem gerçekleştirilemedi: devam eden indirme(ler) var."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "İndir"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Sil"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Tamamlananları Temizle"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Otomatik İndirmeyi Aç/Kapat"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Oynat"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "Tamamlananları Temizle"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr ""
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' geçerli bir düzenli ifade değil: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sYükleniyor %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "%s alınırken hata oluştu: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Hata: geçersiz besleme!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 #, fuzzy
 msgid "too few arguments"
 msgstr "yetersiz parametre"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' geçerli bir düzenli ifade değil: %s"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Hata: desteklenmeyen adres: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Etiket Seç"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Filtre Seç"
 
@@ -1519,69 +1527,69 @@ msgstr "özellik bulunamadı"
 msgid "EOF found while reading XML tag"
 msgstr "XML etiketi okunurken EOF (dosya sonu) bulundu"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Hiçbir bağlantı seçilmedi!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Yerimlerine Ekle"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "Adresler"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Hata: besleme boş!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Hiçbir etiket tanımlanmadı."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Sorgu beslemesi güncelleniyor..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr ""
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr ""
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr ""
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "dosya ayrıştırılamadı"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr ""
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "geçersiz RSS sürümü"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "geçersiz Atom sürümü"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr ""
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
+#: rss/rss09xparser.cpp:30
+msgid "no RSS channel found"
 msgstr ""
 
-#: rss/rss_09x_parser.cpp:39
-msgid "no RSS channel found"
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
 msgstr ""
 
 #, fuzzy

--- a/po/tr.po
+++ b/po/tr.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2008-11-18 14:41+0200\n"
 "Last-Translator: H.Gökhan SARI <hsa2@difuzyon.net>\n"
 "Language-Team: Türkçe <en@li.org>\n"
@@ -147,9 +147,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
+#: src/cliargsparser.cpp:145
 #, c-format
-msgid "%s: %d: invalid loglevel value"
+msgid "%s: %s: invalid loglevel value"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1383,6 +1383,11 @@ msgstr ""
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Hata: ayar dosyası `%s' kaydedilemedi!"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr ""
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2018-08-01 22:39+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Ivan Kovnatsky <sevenfourk@gmail.com>, Alexander Batischev "
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -26,95 +26,95 @@ msgstr ""
 "використання: %s [-i <файл>|-e] [-u <файлпосилання>] [-c <файлкешу>] [-x "
 "<команда> ...] [-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "експорт теми OPML до стандартного виводу"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "оновити теми при старті"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<файл>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "імпортувати файл OPML"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<файлпосилання>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "читати посилання на RSS теми з <файлпосилання>"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<файлкешу>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "використайте <файлкешу> як файл кешу"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<файлналаштування>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "читати налаштування з <файлналаштування>"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr "стиснути кеш"
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<команда>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "виконати список команд"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr "мовчазний запуск"
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "отримати інформацію про версію"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<рівеньлогу>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "записувати лог з визначеним рівнем (дійсні значення: від 1 до 6)"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<файллогу>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "використовуйте <файллогу> як вихідний файл логу"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "експортувати список прочитаних статей у <файл>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "імпортувати список прочитаних статей з <файл>"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "ця довідка"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
@@ -123,7 +123,7 @@ msgstr ""
 "Newsboat є вільним програмним забезпеченням за ліцензією MIT. (Наберіть `%s -"
 "vv', щоб переглянути повний текст)."
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
@@ -131,7 +131,7 @@ msgstr ""
 "Програма включає в себе бібліотеку «JSON for Modern C++» за ліцензією MIT: "
 "https://github.com/nlohmann/json"
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
@@ -139,38 +139,38 @@ msgstr ""
 "Програма включає в себе реалізацію алгоритму alphanum за ліцензією MIT: "
 "http://www.davekoelle.com/alphanum.html"
 
-#: newsboat.cpp:186
-#, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+#: newsboat.cpp:192
+#, fuzzy, c-format
+msgid "Caught newsboat::DbException with message: %s"
 msgstr "Впіймали newsboat::dbexception із повідомленням: %s"
 
-#: newsboat.cpp:193
-#, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+#: newsboat.cpp:199
+#, fuzzy, c-format
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Впіймали newsboat::matcherexception із повідомленням: %s"
 
-#: newsboat.cpp:199 podboat.cpp:32
-#, c-format
-msgid "Caught newsboat::exception with message: %s"
+#: newsboat.cpp:205 podboat.cpp:37
+#, fuzzy, c-format
+msgid "Caught newsboat::Exception with message: %s"
 msgstr "Впіймали newsboat::exception із повідомленням: %s"
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: неправильний рівень логування"
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' недійсний колір"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "атрибут `%s' не доступний."
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' недійсний елемент конфігурації"
@@ -182,72 +182,92 @@ msgstr ""
 "newsboat: завантаження завершено, %f непрочитаних тем (%n всього "
 "непрочитаних статей)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - '%T' Статей у темі (%u непрочитано, всього %t) - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Діалоги"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - Ваші новини (%u непрочитано, всього %t)%?T? - мітка `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Відкрити Файл&Зберегти Файл? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - Довідка"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Стаття '%T' (%u непрочитано, всього %t)"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - Результат пошуку (%u непрочитано, всього %t)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Вибрати Фільтер"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Вибрати Мітку"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "потрібно вказати boolean тип, натомість `%s'"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "потрібно вказати integer тип, натомість `%s'"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "невірне значення налаштунку %s"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "Параметри невірні."
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "замало параметрів"
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "невідома команда (помилка)."
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "файл неможливо відкрити."
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "невідома помилка (помилка)."
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "Помилка при виконанні команди `%s' (%s рядок %u): %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "невідома команда `%s'"
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -257,52 +277,52 @@ msgstr ""
 "Будь ласка, налаштуйте змінну HOME, або додайте користувача, що відповідає "
 "UID %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Запускаю %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Помилка: вже працює копія %s (PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Завантаження налаштувань..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "готово."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "Відкриваю кеш..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Помилка: при відкритті файлу кеша `%s' виникла %s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 "Помилка: для выкористання NewsBlur потрібно налаштувати `cookie-cache`.\n"
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s недоступний і не може бути створеним\n"
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Завантажую URLs з %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -311,7 +331,7 @@ msgstr ""
 "Помилка: не вказано URLs. Будь ласка, додайте RSS URLs у файл %s чи "
 "імпортуйте файл OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -319,7 +339,7 @@ msgstr ""
 "Схоже на те, що OPML тема, на яку ви підписалися не містить тем. Будь ласка, "
 "заповніть її темами та спробуйте знову."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -327,7 +347,7 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті The Old Reader."
 "Будь ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -335,7 +355,7 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті Tiny Tiny RSS."
 "Будь ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -343,7 +363,7 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті NewsBlur.Будь "
 "ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -351,225 +371,174 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті Inoreader.Будь "
 "ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "Завантаження статей з кешу..."
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "Ретельне очищення кешу..."
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "Помилка при завантаженні тем з бази даних: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Помилка при завантаженні теми `%s': %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "Підготовлюю динамічні теми..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "Імпортую список прочитаних статей..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "Зберігаю список прочитаних статей..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "Очищення кешу..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "невдало: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Помилка: не можу позначити всі теми як прочитані: %s "
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Виникла помилка при парсуванні %s"
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "Імпорт %s завершено."
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u непрочитаних статей"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: невідома команда"
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "Назва: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "Автор: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "Дата: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "Посилання: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Посилання на завантаження Podcast: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Помилка: не можу відкрити файл конфігурації `%s'!"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "Закрити"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "Перейти до Діалогу"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "Закрити Діалог"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "Не вибрано нічого!"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "Помилка: ви не можете видаляти список тем"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "Непрацездатна позиція!"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "у черзі"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "завантажую"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "відмінено"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "видалено"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "закінчено"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "невдало"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "незавершено"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr "готово"
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "програно"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "невідомо (помилка)."
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "атрибут `%s' не доступний."
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "вживаний вираз '%s' неправильний %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "Параметри невірні."
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "замало параметрів"
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "невідома команда (помилка)."
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "файл неможливо відкрити."
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "невідома помилка (помилка)."
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "непрацездатний індекс теми (помилка)"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "Люди, котрих ви читаєте"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "Відмічені статті."
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "Загальні статті."
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "Не вибрано тем!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr "ftauln"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -577,7 +546,7 @@ msgstr ""
 "Сортувати за (f)першимТаґом/(t)назвою/(a)кількістьСтатей/"
 "(u)кількістьНепрочитанихСтатей/(l)останнімОновленням/(n)ніяк?"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -585,224 +554,228 @@ msgstr ""
 "Сортувати реверсно за (f)першимТаґом/(t)назвою/(a)кількістьСтатей/"
 "(u)кількістьНепрочитанихСтатей/(l)останнімОновленням/(n)ніяк?"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr "Динамічні теми не можна відкрити у браузері!"
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "Позначаю теми як прочитані..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Помилка: не можу позначити тему: %s як прочитану"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "Немає тем з непрочитаними статтями."
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr "Вже на останній темі."
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr "Вже на першій темі."
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "Позначаю всі теми як прочитані..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Помилка: неможливо парсувати команду фільтра `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "Не визначено фільтри."
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "Шукати: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "Фільтр: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Ви впевнені, що хочете вийти (y:Так n:Ні)?"
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "Вихід"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "Відкрити"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "Наступна непрочитана"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "Перезавантажити"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "Перезавантажити усі"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "Позначити як прочитано"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "Позначити всі як прочитані"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "Пошук"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "Довідка"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "Помилка: неможливо розібрати помилку фільтра!"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "Шукаю..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Помилка при пошуку `%s': %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "Безрезультатно."
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "Не видно позицію!"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Список Тем - %u непрочитано, загалом - %u"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Ви впевнені, що хочете перезаписати `%s' (y:Так n:Ні)?"
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "Файл: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - Зберегти файл - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "Відміна"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "Зберегти"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "Зберегти Файл - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "неможливо парсувати вираз фільра `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "використання: set <змінна>[=<значення>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "використання: <файл> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "використання: конфігурація дампу <файл>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Конфігурацію збережено у %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "Не є командою: `%s'"
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "Зберігаю закладки..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "Збережені закладки."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "Помилка при зберіганні закладок: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "Назва: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "Опис: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 msgid "Feed title: "
 msgstr "Назва теми: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 msgid "Saving bookmark on autopilot..."
 msgstr "Зберігаю закладку на автоматі..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -810,15 +783,15 @@ msgstr ""
 "підтримка закладок не налаштована. Будь ласка, встановіть змінну `bookmark-"
 "cmd' відповідно."
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "Загальні клавіші"
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "Незастосовані функції"
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "Очистити"
 
@@ -846,200 +819,219 @@ msgstr "вбудований флеш"
 msgid "unknown (bug)"
 msgstr "невідомо (помилка)"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr "Розіслані статті"
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 msgid "Liked items"
 msgstr "Вподобані статті"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr "Збережені веб-сторінки"
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "Переключення флагу прочитано для статей..."
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Помилка при переключенні флагу прочитано: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "Список URL пустий."
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "Флаги: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "Помилка: нічого не вибрано!"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "Помилка: ви не можете перезавантажувати результати пошуку"
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "Немає непрочитаних статей."
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr "Вже на останній статті."
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr "Вже на першій статті."
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "Немає непрочитаних тем."
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 msgid "Marking all above as read..."
 msgstr "Позначаю все, що вище, як прочитані..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Пайпувати статтю до каманди: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfalg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Сортувати за (d)датою/(t)назвою/(f)флагами/(a)автором/(l)посиланням/(g)uid?"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Сортувати реверсно за (d)датою/(t)назвою/(f)флагами/(a)автором/(l)посиланням/"
 "(g)uid?"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "Флаги поновлено."
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Помилка: примінення фільтру невдале: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "Збереження перервано."
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "Стаття збережена у %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Помилка: не можу зберегти у %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Результати Пошуку - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Динамічна тема - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "Список Статей - %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "Вершина"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "Низ"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "Тема: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "Автор: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "Дата: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "Посилання: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Посилання на завантаження Podcast: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "тип: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "Вершина"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "Низ"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Помилка при позначенні статті як прочитано: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Додано %s до черги завантаження."
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Некоректний URL: '%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "Збережено статтю у %s."
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Помилка: не можу записати статтю у файл %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "Запускаю браузер..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Помилка при позначенні статті як непрочитано: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "Перейти за посиланням №"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "Відкрити у браузері"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "Поставити у чергу"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "Стаття - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "Помилка: неправильний вираз!"
 
@@ -1349,26 +1341,36 @@ msgstr "Перемістити до початку сторінки/списку
 msgid "Move to the end of page/list"
 msgstr "Перемістити до кінця сторінки/списку"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' недійсний контекст"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' недійсна ключова команда"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "атрибут `%s' не доступний."
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "вживаний вираз '%s' неправильний %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: конфігураційна директорія '%s' недоступна, використовуємо '%s'."
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Критична помилка: неможливо визначити домашню директорію!"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1376,16 +1378,16 @@ msgstr ""
 "Будь ласка, налаштуйте змінну HOME, або додайте користувача, що відповідає "
 "UID %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Помилка: не можу створити конфігураційну директорію `%s': (%i) %s"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "Очищую чергу..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1394,112 +1396,120 @@ msgstr ""
 "%s %s\n"
 "використання: %s [-C <файл>] [-q <файл>|-e] [-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 msgid "<queuefile>"
 msgstr "<файл черги>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 msgid "use <queuefile> as queue file"
 msgstr "використовувати <файл черги> як файл черги"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr "починати завантаження при запуску"
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u паралельних завантажень"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "Черга (%u активних завантажень, всього %u) - %.2f kb/s всього%s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Помилка: неможливо вийти: активне(і) завантаження"
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Помилка: для того, щоб програти файл, завантаження повинні бути завершені."
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Помилка: неможливо виконати операцію: активне(і) завантаження."
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "Завантаження"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "Видалити"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "Очищення закінчено"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "Увімкнути автоматичне завантаження"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "Програти"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 msgid "Mark as Finished"
 msgstr "Позначити як завершене"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' недійсний тип діалогу"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' не є правильним регулярним виразом: %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sЗавантаження %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Помилка при стягненні %s: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "Помилка: непрацездатна тема!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr "%a, %d %b %Y %T %z"
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "замало параметрів"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' не є правильним фільтром"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr "%a, %d %b %Y %T %z"
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Помилка: посилання не підтримується: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "Виберіть мітку"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "Виберіть фільтр"
 
@@ -1511,67 +1521,67 @@ msgstr "атрибут не знайдено"
 msgid "EOF found while reading XML tag"
 msgstr "При читанні мітки з XML був виявлений кінець файлу"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "Не вибрано посилання!"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "Зберегти закладку"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "URLs: "
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "Помилка: теми не містять елементів!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "Не визначено жодної мітки."
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "Оновлюю динамічну тему..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "XML root node is NULL"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "не можу ініціялізувати libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "не можу парсувати буфер"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "не можу парсувати файл"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "нема версії RSS"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "недійсна версія RSS"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "недійсна версія Atom"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "нема версії Atom"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "формат теми не підтримується"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "не знайдено каналу RSS"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "формат теми не підтримується"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2018-08-01 22:39+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Ivan Kovnatsky <sevenfourk@gmail.com>, Alexander Batischev "
@@ -154,9 +154,9 @@ msgstr "Впіймали newsboat::matcherexception із повідомленн�
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Впіймали newsboat::exception із повідомленням: %s"
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: неправильний рівень логування"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1382,6 +1382,11 @@ msgstr ""
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Помилка: не можу створити конфігураційну директорію `%s': (%i) %s"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr "%s: %d: неправильний рівень логування"
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/zh.po
+++ b/po/zh.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2007-11-21 22:51+0100\n"
 "Last-Translator: josh yu <joshyupeng@gmail.com>\n"
 "Language-Team: Chinese <joshyupeng@gmail.com>\n"
@@ -146,9 +146,9 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
+#: src/cliargsparser.cpp:145
 #, c-format
-msgid "%s: %d: invalid loglevel value"
+msgid "%s: %s: invalid loglevel value"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
@@ -1380,6 +1380,11 @@ msgstr "请设置主目录的环境变量，或者添加一个有效的用户其
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "错误：无法将文章写至 %s"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr ""
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/po/zh.po
+++ b/po/zh.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2007-11-21 22:51+0100\n"
 "Last-Translator: josh yu <joshyupeng@gmail.com>\n"
 "Language-Team: Chinese <joshyupeng@gmail.com>\n"
@@ -13,7 +13,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -24,145 +24,145 @@ msgstr ""
 "用法: %s [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x <command> ...] [-"
 "h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "导出OPML种子列表到控制台"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "在本软件启动之初刷新种子列表"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "文件"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "导入opml文件"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<超链文件>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "从超链文件里读取RSS种子列表"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "缓存文件"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "使用<cachefile>作为保存缓存数据的文件"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<配置文件>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "从<配置文件>里读取配置信息"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "命令 ..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "执行一系列命令"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr ""
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "获得版本信息"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "记录等级"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "以某一等级做记录（有效值：1 - 6）"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<记录文件>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "使用<记录文件>作为导出记录的文件"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "将已阅读文章导出到<文件>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "从<文件>里导入阅读的文章列表"
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "该帮助"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
 "see the full text.)"
 msgstr ""
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr ""
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, fuzzy, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "无效的属性索引"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr ""
@@ -172,138 +172,158 @@ msgstr ""
 msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr "newsboat:重新加载完毕, %f个种子含未读文章(共有 %n 篇未读文章)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - 种子 '%T' 里的文章（%u 未读, 共有 %t 篇） - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 #, fuzzy
 msgid "%N %V - Dialogs"
 msgstr "%N %V - 链接"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - 你的种子 (%u 篇未读, 共有 %t 篇)%?T? - 标签 `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?打开文件&保存文件? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - 帮助"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - 种子 '%T' 里的文章（%u 未读, 共有 %t 篇） - %U"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - 查找结果 (%u 未读, 共有 %t)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - 选择过滤器"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - 选择标签"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - 链接"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr ""
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr ""
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, fuzzy, c-format
 msgid "invalid configuration value `%s'"
 msgstr "把文章保存到 %s"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "无效参数"
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "参数太少"
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "未知的命令（bug）"
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "无法打开文件"
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "未知的错误（bug）"
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "当处理命令`%s'(%s 第 %u 行)时出错: %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "未知的命令 `%s' "
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr "请设置主目录的环境变量，或者添加一个有效的用户其UID为 %u!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "启动 %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "错误：%s的一个进程已经在运行中（PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "加载配置文件..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "完毕."
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "打开缓存..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "错误:打开缓存文件`%s' 失败:%s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "从 %s 文件加载链接..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr "错误：没有配置链接。请用RSS种子的链接替换 %s 或者导入一个OPML文件."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr "看起来你订阅的OPML种子没有包含任何种子请更正之后再尝试一下。"
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -311,7 +331,7 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -319,7 +339,7 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -327,7 +347,7 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -335,475 +355,428 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "从缓存中加载文章"
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "彻底清除缓存"
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "当从数据库中加载种子的时候出错: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, fuzzy, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "当调用`%s'的时候出错: %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 #, fuzzy
 msgid "Prepopulating query feeds..."
 msgstr "更新查询种子..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "导入阅读文章列表"
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "导出阅读文章列表"
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "清空缓存..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "失败: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "错误:无法将所有种子都标记为已读: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s 导入完毕"
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u 篇未读文章"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "未知的命令 `%s' "
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "标题: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "作者: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "日期: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "链接: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "播客下载的地址: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, fuzzy, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "错误：无法将文章写至 %s"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr ""
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "没有选择任何项目"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 #, fuzzy
 msgid "Error: you can't remove the feed list!"
 msgstr "错误：你不能重新加载所选项目"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "无效位置！"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "队列"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "下载中"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "已取消"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "已删除"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "已完毕"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "已失败"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "未完毕"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr ""
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "已播放"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "未知（bug）"
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "无效属性 `%s'"
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr ""
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "无效参数"
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "参数太少"
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "未知的命令（bug）"
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "无法打开文件"
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "未知的错误（bug）"
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "无效的种子索引(bug）"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr ""
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 #, fuzzy
 msgid "Starred items"
 msgstr "没有未读的文章"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 #, fuzzy
 msgid "Shared items"
 msgstr "没有未读的文章"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "没有选择种子"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 msgid "ftauln"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "标记该种子已读"
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "错误：无法将种子标记为已读: %s"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "任何种子里都没有未读的文章"
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "将所有种子都标记为已读..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, fuzzy, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "错误：无法分析过滤器（filter）命令"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "没有定义任何过滤器（filter）"
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "查找: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "过滤器: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "你真的想离开么（y:是的 n:不是)?"
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "放弃"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "打开"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "下一篇未读"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "重新加载当前种子"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "重新加载所有种子"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "标记为已读"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "将所有都标记为已读"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "查找"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "帮助"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "错误：无法分析过滤器（filter）命令"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "查找..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "当查找 `%s'的时候出错: %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "没有结果"
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "找不到这个位置"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, fuzzy, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "%N %V - 查找结果 (%u 未读, 共有 %t)"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "你真的想覆盖 `%s'么(y:是的  n:不是)?"
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "文件: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - 保存文件 - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "取消"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "保存"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, fuzzy, c-format
 msgid "Save File - %s"
 msgstr "%s %s - 保存文件 - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, fuzzy, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "错误：无法分析过滤器（filter）命令"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "用法: set <变量>[=<值>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr ""
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 #, fuzzy
 msgid "usage: dumpconfig <file>"
 msgstr "<配置文件>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, fuzzy, c-format
 msgid "Saved configuration to %s"
 msgstr "把文章保存到 %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, fuzzy, c-format
 msgid "Not a command: %s"
 msgstr "未知的命令 `%s' "
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "保存书签..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "已保存的书签."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "当保存书签时出错: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "链接: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "标题: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "描述: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 #, fuzzy
 msgid "Feed title: "
 msgstr "文件: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "保存书签..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
 msgstr "书签支持尚未配置，请在配置文件里设置相应变量 `bookmark-cmd' "
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr ""
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr ""
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "清空"
 
@@ -831,200 +804,216 @@ msgstr "内嵌flash"
 msgid "unknown (bug)"
 msgstr "未知（bug）"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 #, fuzzy
 msgid "Liked items"
 msgstr "没有未读的文章"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "切换文章阅读标记（已读/未读）"
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "当切换阅读标记（已读/未读）时出错: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "空空如也的链接列表"
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "标记: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "错误：没有选择任何项目！"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "错误：你不能重新加载所选项目"
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "没有未读的文章"
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "没有未读的种子"
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "将所有种子都标记为已读..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
 #, fuzzy
-msgid "dtfalg"
+msgid "dtfalgr"
 msgstr "编辑标记"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "标记已更新"
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "错误: 应用过滤器失败: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "放弃保存"
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "错误：无法保存文章到 %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, fuzzy, c-format
 msgid "Article List - %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "顶部"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "底部"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "种子: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "作者: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "日期: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "链接: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "播客下载的地址: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "类型: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "顶部"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "底部"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "当标记文章为已读的时候出错: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "将 %s 加入下载队列"
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr ""
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "将文章保存至 %s "
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "错误：无法将文章写至 %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "启动浏览器..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "当标记文章为未读的时候出错: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "在浏览器里打开"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "加入队列"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, fuzzy, c-format
 msgid "Article - %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 #, fuzzy
 msgid "Error: invalid regular expression!"
 msgstr "错误:无效的种子!"
@@ -1352,41 +1341,51 @@ msgstr "转到下一篇未读文章"
 msgid "Move to the end of page/list"
 msgstr "转到下一篇未读文章"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr ""
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "无效属性 `%s'"
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr ""
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "致命错误:无法确定主目录！"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr "请设置主目录的环境变量，或者添加一个有效的用户其UID为 %u!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "错误：无法将文章写至 %s"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "清空队列..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1396,115 +1395,123 @@ msgstr ""
 "用法: %s [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x <command> ...] [-"
 "h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 #, fuzzy
 msgid "<queuefile>"
 msgstr "文件"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "使用<cachefile>作为保存缓存数据的文件"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr ""
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u 个并行下载"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "队列 (%u 个下载项目在进行，共有 %u 个下载项目) - 总共 %.2f kb/s %s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "错误: 无法取消: 还有项目在下载"
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "错误：下载项目必须下载完毕才可以播放"
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "错误：无法执行操作：有项目在下载中"
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "下载"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "删除"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "清除完毕的项目"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "切换自动下载"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "播放"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "清除完毕的项目"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr ""
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, fuzzy, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "错误:无效的种子!"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%s加载中 %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "当抓取%s的时候出错: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "错误:无效的种子!"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 #, fuzzy
 msgid "too few arguments"
 msgstr "参数太少"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "错误:无效的种子!"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "错误：不支持的链接: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "选择标签"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "选择过滤器"
 
@@ -1516,73 +1523,73 @@ msgstr "属性没有发现"
 msgid "EOF found while reading XML tag"
 msgstr "当读取XML标签时遇到EOF标记"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "没有选择任何链接！"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "保存书签"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 #, fuzzy
 msgid "URLs"
 msgstr "链接: "
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "错误: 种子里没有包含任何项目!"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "没有定义任何标签"
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "更新查询种子..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr ""
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr ""
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr ""
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 #, fuzzy
 msgid "could not parse file"
 msgstr "错误：无法分析过滤器（filter）命令"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr ""
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 #, fuzzy
 msgid "invalid RSS version"
 msgstr "无效位置！"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 #, fuzzy
 msgid "invalid Atom version"
 msgstr "无效位置！"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr ""
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
+#: rss/rss09xparser.cpp:30
+msgid "no RSS channel found"
 msgstr ""
 
-#: rss/rss_09x_parser.cpp:39
-msgid "no RSS channel found"
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
 msgstr ""
 
 #, fuzzy

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2018-09-29 19:11+0300\n"
+"POT-Creation-Date: 2019-05-26 15:49+0300\n"
 "PO-Revision-Date: 2010-03-03 16:55+0800\n"
 "Last-Translator: Aeglos <aeglos.lin@gmail.com>\n"
 "Language-Team: Traditional Chinese <aeglos.lin@gmail.com>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "X-Poedit-Country: Taiwan\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: newsboat.cpp:24
+#: newsboat.cpp:29
 #, c-format
 msgid ""
 "%s %s\n"
@@ -27,145 +27,145 @@ msgstr ""
 "使用方法: %s [-i <file>|-e] [-u <網址檔案>] [-c <快取檔案>] [-x <命令> ...] "
 "[-h]\n"
 
-#: newsboat.cpp:39
+#: newsboat.cpp:44
 msgid "export OPML feed to stdout"
 msgstr "匯出OPML來源到標準輸出"
 
-#: newsboat.cpp:40
+#: newsboat.cpp:45
 msgid "refresh feeds on start"
 msgstr "啟動時更新文件"
 
-#: newsboat.cpp:41 newsboat.cpp:73 newsboat.cpp:77
+#: newsboat.cpp:46 newsboat.cpp:78 newsboat.cpp:82
 msgid "<file>"
 msgstr "<檔案>"
 
-#: newsboat.cpp:41
+#: newsboat.cpp:46
 msgid "import OPML file"
 msgstr "匯入OPML檔案"
 
-#: newsboat.cpp:44
+#: newsboat.cpp:49
 msgid "<urlfile>"
 msgstr "<網址檔案>"
 
-#: newsboat.cpp:45
+#: newsboat.cpp:50
 msgid "read RSS feed URLs from <urlfile>"
 msgstr "從<網址檔案>讀取RSS來源的網址"
 
-#: newsboat.cpp:48
+#: newsboat.cpp:53
 msgid "<cachefile>"
 msgstr "<快取檔案>"
 
-#: newsboat.cpp:49
+#: newsboat.cpp:54
 msgid "use <cachefile> as cache file"
 msgstr "使用<快取檔案>作為快取檔案"
 
-#: newsboat.cpp:52 src/pb_controller.cpp:339
+#: newsboat.cpp:57 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<組態檔案>"
 
-#: newsboat.cpp:53 src/pb_controller.cpp:340
+#: newsboat.cpp:58 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "從<組態檔案>讀取組態"
 
-#: newsboat.cpp:54
+#: newsboat.cpp:59
 msgid "compact the cache"
 msgstr ""
 
-#: newsboat.cpp:57
+#: newsboat.cpp:62
 msgid "<command>..."
 msgstr "<命令>..."
 
-#: newsboat.cpp:58
+#: newsboat.cpp:63
 msgid "execute list of commands"
 msgstr "執行列出的命令"
 
-#: newsboat.cpp:59
+#: newsboat.cpp:64
 msgid "quiet startup"
 msgstr ""
 
-#: newsboat.cpp:60
+#: newsboat.cpp:65
 msgid "get version information"
 msgstr "取得版本資訊"
 
-#: newsboat.cpp:63 src/pb_controller.cpp:348
+#: newsboat.cpp:68 src/pbcontroller.cpp:350
 msgid "<loglevel>"
 msgstr "<記錄層級>"
 
-#: newsboat.cpp:64 src/pb_controller.cpp:349
+#: newsboat.cpp:69 src/pbcontroller.cpp:351
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "依記錄層級(有效值：1到6)進行記錄"
 
-#: newsboat.cpp:69 src/pb_controller.cpp:354
+#: newsboat.cpp:74 src/pbcontroller.cpp:356
 msgid "<logfile>"
 msgstr "<記錄檔案>"
 
-#: newsboat.cpp:70 src/pb_controller.cpp:355
+#: newsboat.cpp:75 src/pbcontroller.cpp:357
 msgid "use <logfile> as output log file"
 msgstr "使用<記錄檔案>作為輸出的記錄檔"
 
-#: newsboat.cpp:74
+#: newsboat.cpp:79
 msgid "export list of read articles to <file>"
 msgstr "匯出已閱讀文章列表至<檔案>"
 
-#: newsboat.cpp:78
+#: newsboat.cpp:83
 msgid "import list of read articles from <file>"
 msgstr "由<檔案>匯入閱讀文章列表..."
 
-#: newsboat.cpp:79 src/pb_controller.cpp:356
+#: newsboat.cpp:84 src/pbcontroller.cpp:358
 msgid "this help"
 msgstr "這份說明"
 
-#: newsboat.cpp:113
+#: newsboat.cpp:118
 #, fuzzy, c-format
 msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
 "see the full text.)"
 msgstr "newsboat是基於MIT/X Consortium License發佈的自由軟體"
 
-#: newsboat.cpp:118
+#: newsboat.cpp:123
 msgid ""
 "It bundles JSON for Modern C++ library, licensed under the MIT License: "
 "https://github.com/nlohmann/json"
 msgstr ""
 
-#: newsboat.cpp:122
+#: newsboat.cpp:127
 msgid ""
 "It bundles an alphanum algorithm implementation licensed under the MIT "
 "license: http://www.davekoelle.com/alphanum.html"
 msgstr ""
 
-#: newsboat.cpp:186
+#: newsboat.cpp:192
 #, c-format
-msgid "Caught newsboat::dbexception with message: %s"
+msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:193
+#: newsboat.cpp:199
 #, c-format
-msgid "Caught newsboat::matcherexception with message: %s"
+msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:199 podboat.cpp:32
+#: newsboat.cpp:205 podboat.cpp:37
 #, c-format
-msgid "Caught newsboat::exception with message: %s"
+msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:144 src/pb_controller.cpp:231
+#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:72
-#: src/regexmanager.cpp:84 src/regexmanager.cpp:155 src/regexmanager.cpp:165
+#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
+#: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s'不是有效的顏色"
 
-#: src/colormanager.cpp:64 src/regexmanager.cpp:98 src/regexmanager.cpp:178
+#: src/colormanager.cpp:65 src/regexmanager.cpp:100 src/regexmanager.cpp:180
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' 不是有效的屬性"
 
-#: src/colormanager.cpp:81
+#: src/colormanager.cpp:82
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s'不是一個有效的組態項目"
@@ -175,137 +175,157 @@ msgstr "`%s'不是一個有效的組態項目"
 msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr "newsboat:重新載入完成, %f個來源含未讀文章(共有 %n 篇未讀文章)"
 
-#: src/configcontainer.cpp:217
+#: src/configcontainer.cpp:220
 msgid "%N %V - Articles in feed '%T' (%u unread, %t total) - %U"
 msgstr "%N %V - 來源 '%T' 裡的文章（%u 未讀, 共有 %t 篇） - %U"
 
-#: src/configcontainer.cpp:222
+#: src/configcontainer.cpp:225
 msgid "%N %V - Dialogs"
 msgstr "%N %V - 對話窗"
 
-#: src/configcontainer.cpp:224
+#: src/configcontainer.cpp:227
 msgid "%N %V - Your feeds (%u unread, %t total)%?T? - tag `%T'&?"
 msgstr "%N %V - 你的來源 (%u 篇未讀, 共有 %t 篇)%?T? - 標籤 `%T'&?"
 
-#: src/configcontainer.cpp:229
+#: src/configcontainer.cpp:232
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?打開檔案&儲存檔案? - %f"
 
-#: src/configcontainer.cpp:232
+#: src/configcontainer.cpp:235
 msgid "%N %V - Help"
 msgstr "%N %V - 說明"
 
-#: src/configcontainer.cpp:234
+#: src/configcontainer.cpp:237
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - 來源 '%T' 裡的文章（%u 未讀, 共有 %t 篇） - %U"
 
-#: src/configcontainer.cpp:238
+#: src/configcontainer.cpp:241
 msgid "%N %V - Search result (%u unread, %t total)"
 msgstr "%N %V - 搜尋結果 (%u 未讀, 共有 %t)"
 
-#: src/configcontainer.cpp:242
+#: src/configcontainer.cpp:245
 msgid "%N %V - Select Filter"
 msgstr "%N %V - 選擇過濾器"
 
-#: src/configcontainer.cpp:245
+#: src/configcontainer.cpp:248
 msgid "%N %V - Select Tag"
 msgstr "%N %V - 選擇標籤"
 
-#: src/configcontainer.cpp:248
+#: src/configcontainer.cpp:251
 msgid "%N %V - URLs"
 msgstr "%N %V - 網址"
 
-#: src/configcontainer.cpp:294
+#: src/configcontainer.cpp:297
 #, c-format
 msgid "expected boolean value, found `%s' instead"
 msgstr "預期的布林變數被`%s'取代"
 
-#: src/configcontainer.cpp:302
+#: src/configcontainer.cpp:305
 #, c-format
 msgid "expected integer value, found `%s' instead"
 msgstr "預期的整數變數被`%s'取代"
 
-#: src/configcontainer.cpp:311
+#: src/configcontainer.cpp:314
 #, c-format
 msgid "invalid configuration value `%s'"
 msgstr "無效的組態值 `%s'"
 
-#: src/configparser.cpp:97
+#: src/confighandlerexception.cpp:16
+msgid "invalid parameters."
+msgstr "無效參數"
+
+#: src/confighandlerexception.cpp:18
+msgid "too few parameters."
+msgstr "參數過少"
+
+#: src/confighandlerexception.cpp:20
+msgid "unknown command (bug)."
+msgstr "未知的命令（bug）"
+
+#: src/confighandlerexception.cpp:22
+msgid "file couldn't be opened."
+msgstr "無法打開檔案"
+
+#: src/confighandlerexception.cpp:24
+msgid "unknown error (bug)."
+msgstr "未知的錯誤（bug）"
+
+#: src/configparser.cpp:105
 #, c-format
 msgid "Error while processing command `%s' (%s line %u): %s"
 msgstr "在處理命令`%s'(%s 第 %u 行)時發生錯誤: %s"
 
-#: src/configparser.cpp:107
+#: src/configparser.cpp:115
 #, c-format
 msgid "unknown command `%s'"
 msgstr "未知的命令 `%s' "
 
-#: src/configpaths.cpp:30
+#: src/configpaths.cpp:32
 #, fuzzy, c-format
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr "請設定主目錄的環境變數，或者增加一個UID為 %u的有效使用者!"
 
-#: src/controller.cpp:152 src/pb_controller.cpp:246
+#: src/controller.cpp:157 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr "啟動 %s %s..."
 
-#: src/controller.cpp:162 src/controller.cpp:218 src/pb_controller.cpp:253
+#: src/controller.cpp:167 src/controller.cpp:223 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "錯誤：已有一個%s程序在執行中（PID: %u)"
 
-#: src/controller.cpp:174 src/pb_controller.cpp:261
+#: src/controller.cpp:179 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "載入設定檔..."
 
-#: src/controller.cpp:208 src/controller.cpp:252 src/controller.cpp:316
-#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
-#: src/controller.cpp:420 src/controller.cpp:438 src/controller.cpp:449
-#: src/controller.cpp:491 src/pb_controller.cpp:298 src/pb_controller.cpp:315
+#: src/controller.cpp:213 src/controller.cpp:257 src/controller.cpp:323
+#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
+#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
+#: src/controller.cpp:500 src/pbcontroller.cpp:300 src/pbcontroller.cpp:317
 msgid "done."
 msgstr "完成。"
 
-#: src/controller.cpp:228 src/controller.cpp:363
+#: src/controller.cpp:233 src/controller.cpp:370
 msgid "Opening cache..."
 msgstr "打開快取中..."
 
-#: src/controller.cpp:235 src/controller.cpp:243
+#: src/controller.cpp:240 src/controller.cpp:248
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "錯誤:打開快取檔案`%s' 失敗:%s"
 
-#: src/controller.cpp:271
+#: src/controller.cpp:279
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:279
+#: src/controller.cpp:287
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:312
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "從 %s 中載入鏈結..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:331
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr "錯誤：沒有設置鏈結。請用RSS來源的鏈結替換 %s 或者匯入一個OPML檔案"
 
-#: src/controller.cpp:330
+#: src/controller.cpp:337
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr "看起來你訂閱的OPML沒有任何來源。請先加入來源，然後再試一次。"
 
-#: src/controller.cpp:335
+#: src/controller.cpp:342
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -313,7 +333,7 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:340
+#: src/controller.cpp:347
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -321,7 +341,7 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:345
+#: src/controller.cpp:352
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -329,7 +349,7 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:350
+#: src/controller.cpp:357
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -337,473 +357,426 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:361
+#: src/controller.cpp:368
 msgid "Loading articles from cache..."
 msgstr "從快取中載入文章"
 
-#: src/controller.cpp:368
+#: src/controller.cpp:375
 msgid "Cleaning up cache thoroughly..."
 msgstr "徹底清空快取"
 
-#: src/controller.cpp:388
+#: src/controller.cpp:395
 msgid "Error while loading feeds from database: "
 msgstr "從資料庫中載入來源時發生錯誤: "
 
-#: src/controller.cpp:394
+#: src/controller.cpp:401
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "載入 `%s'的時候發生錯誤: %s"
 
-#: src/controller.cpp:413
+#: src/controller.cpp:420
 msgid "Prepopulating query feeds..."
 msgstr "更新查詢來源..."
 
-#: src/controller.cpp:435
+#: src/controller.cpp:442
 msgid "Importing list of read articles..."
 msgstr "匯入已閱讀文章列表..."
 
-#: src/controller.cpp:446
+#: src/controller.cpp:453
 msgid "Exporting list of read articles..."
 msgstr "匯出已閱讀文章列表..."
 
-#: src/controller.cpp:484
+#: src/controller.cpp:493
 msgid "Cleaning up cache..."
 msgstr "清空快取..."
 
-#: src/controller.cpp:496
+#: src/controller.cpp:505
 msgid "failed: "
 msgstr "失敗: "
 
-#: src/controller.cpp:522
+#: src/controller.cpp:531
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "錯誤:無法將所有來源標為已讀: %s"
 
-#: src/controller.cpp:615
+#: src/controller.cpp:627
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "在分析%s時發生錯誤"
 
-#: src/controller.cpp:620
+#: src/controller.cpp:633
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s 匯入完畢"
 
-#: src/controller.cpp:774
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u篇未讀文章"
 
-#: src/controller.cpp:779
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "未知的命令 `%s' "
 
-#: src/controller.cpp:825 src/formaction.cpp:417 src/formaction.cpp:419
-#: src/itemview_formaction.cpp:94
-msgid "Title: "
-msgstr "標題: "
-
-#: src/controller.cpp:829 src/itemview_formaction.cpp:101
-msgid "Author: "
-msgstr "作者: "
-
-#: src/controller.cpp:833 src/itemview_formaction.cpp:114
-msgid "Date: "
-msgstr "日期: "
-
-#: src/controller.cpp:837 src/itemview_formaction.cpp:108
-msgid "Link: "
-msgstr "鏈結: "
-
-#: src/controller.cpp:842 src/itemview_formaction.cpp:125
-msgid "Podcast Download URL: "
-msgstr "Pocast下載網址: "
-
-#: src/controller.cpp:1017
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "錯誤：無法開啟組態檔案`%s'！"
 
-#: src/dialogs_formaction.cpp:66
+#: src/dialogsformaction.cpp:67
 msgid "Close"
 msgstr "關閉"
 
-#: src/dialogs_formaction.cpp:67
+#: src/dialogsformaction.cpp:68
 msgid "Goto Dialog"
 msgstr "前往對話窗"
 
-#: src/dialogs_formaction.cpp:68
+#: src/dialogsformaction.cpp:69
 msgid "Close Dialog"
 msgstr "關閉對話窗"
 
-#: src/dialogs_formaction.cpp:83 src/dialogs_formaction.cpp:99
-#: src/itemlist_formaction.cpp:72 src/itemlist_formaction.cpp:94
-#: src/itemlist_formaction.cpp:142 src/itemlist_formaction.cpp:157
-#: src/itemlist_formaction.cpp:284 src/itemlist_formaction.cpp:318
-#: src/itemlist_formaction.cpp:343 src/itemlist_formaction.cpp:550
-#: src/itemlist_formaction.cpp:774
+#: src/dialogsformaction.cpp:84 src/dialogsformaction.cpp:100
+#: src/itemlistformaction.cpp:82 src/itemlistformaction.cpp:104
+#: src/itemlistformaction.cpp:157 src/itemlistformaction.cpp:172
+#: src/itemlistformaction.cpp:296 src/itemlistformaction.cpp:330
+#: src/itemlistformaction.cpp:355 src/itemlistformaction.cpp:577
+#: src/itemlistformaction.cpp:795
 msgid "No item selected!"
 msgstr "沒有選擇任何項目"
 
-#: src/dialogs_formaction.cpp:95
+#: src/dialogsformaction.cpp:96
 msgid "Error: you can't remove the feed list!"
 msgstr "錯誤：你不能移除來源列表！"
 
-#: src/dialogs_formaction.cpp:122 src/feedlist_formaction.cpp:944
-#: src/itemlist_formaction.cpp:1197 src/urlview_formaction.cpp:146
+#: src/dialogsformaction.cpp:123 src/feedlistformaction.cpp:954
+#: src/itemlistformaction.cpp:1212 src/urlviewformaction.cpp:147
 msgid "Invalid position!"
 msgstr "無效位置！"
 
-#: src/download.cpp:55
+#: src/download.cpp:65
 msgid "queued"
 msgstr "隊列"
 
-#: src/download.cpp:57
+#: src/download.cpp:67
 msgid "downloading"
 msgstr "下載中"
 
-#: src/download.cpp:59
+#: src/download.cpp:69
 msgid "cancelled"
 msgstr "已取消"
 
-#: src/download.cpp:61
+#: src/download.cpp:71
 msgid "deleted"
 msgstr "已刪除"
 
-#: src/download.cpp:63
+#: src/download.cpp:73
 msgid "finished"
 msgstr "已完畢"
 
-#: src/download.cpp:65
+#: src/download.cpp:75
 msgid "failed"
 msgstr "已失敗"
 
-#: src/download.cpp:67
+#: src/download.cpp:77
 msgid "incomplete"
 msgstr "未完畢"
 
-#: src/download.cpp:69
+#: src/download.cpp:79
 msgid "ready"
 msgstr ""
 
-#: src/download.cpp:71
+#: src/download.cpp:81
 msgid "played"
 msgstr "已播放"
 
-#: src/download.cpp:73
+#: src/download.cpp:83
 msgid "unknown (bug)."
 msgstr "未知（bug）"
 
-#: src/exception.cpp:31
-#, c-format
-msgid "attribute `%s' is not available."
-msgstr "無效屬性 `%s'"
-
-#: src/exception.cpp:35
-#, c-format
-msgid "regular expression '%s' is invalid: %s"
-msgstr "正規表示式 '%s' 是無效的: %s"
-
-#: src/exception.cpp:52
-msgid "invalid parameters."
-msgstr "無效參數"
-
-#: src/exception.cpp:54
-msgid "too few parameters."
-msgstr "參數過少"
-
-#: src/exception.cpp:56
-msgid "unknown command (bug)."
-msgstr "未知的命令（bug）"
-
-#: src/exception.cpp:58
-msgid "file couldn't be opened."
-msgstr "無法打開檔案"
-
-#: src/exception.cpp:60
-msgid "unknown error (bug)."
-msgstr "未知的錯誤（bug）"
-
-#: src/feedcontainer.cpp:105
+#: src/feedcontainer.cpp:106
 msgid "invalid feed index (bug)"
 msgstr "無效的來源索引(bug）"
 
-#: src/feedhq_urlreader.cpp:49 src/oldreader_urlreader.cpp:50
+#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
 msgid "People you follow"
 msgstr "你追蹤的人"
 
-#: src/feedhq_urlreader.cpp:51 src/inoreader_urlreader.cpp:51
-#: src/oldreader_urlreader.cpp:52
+#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
+#: src/oldreaderurlreader.cpp:55
 msgid "Starred items"
 msgstr "星號的文章"
 
-#: src/feedhq_urlreader.cpp:52 src/oldreader_urlreader.cpp:53
+#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
 msgid "Shared items"
 msgstr "分享的文章"
 
-#: src/feedlist_formaction.cpp:119 src/feedlist_formaction.cpp:133
-#: src/feedlist_formaction.cpp:230 src/feedlist_formaction.cpp:247
-#: src/feedlist_formaction.cpp:303
+#: src/feedlistformaction.cpp:125 src/feedlistformaction.cpp:139
+#: src/feedlistformaction.cpp:244 src/feedlistformaction.cpp:261
+#: src/feedlistformaction.cpp:317
 msgid "No feed selected!"
 msgstr "沒有選擇的來源！"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlist_formaction.cpp:146 src/feedlist_formaction.cpp:178
+#: src/feedlistformaction.cpp:152 src/feedlistformaction.cpp:182
 #, fuzzy
 msgid "ftauln"
 msgstr "ftaun"
 
-#: src/feedlist_formaction.cpp:148
+#: src/feedlistformaction.cpp:154
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
 msgstr "排序依照：(f)第一項Tag/(t)標題/(a)文章數量/(u)未讀文章數量/(n)無？"
 
-#: src/feedlist_formaction.cpp:180
+#: src/feedlistformaction.cpp:184
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
 msgstr "排序依照：(f)第一項Tag/(t)標題/(a)文章數量/(u)未讀文章數量/(n)無？"
 
-#: src/feedlist_formaction.cpp:225
+#: src/feedlistformaction.cpp:239
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlist_formaction.cpp:287 src/itemlist_formaction.cpp:458
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:470
 msgid "Marking feed read..."
 msgstr "將來源標為已讀..."
 
-#: src/feedlist_formaction.cpp:298 src/itemlist_formaction.cpp:490
+#: src/feedlistformaction.cpp:312 src/itemlistformaction.cpp:520
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "錯誤：無法將來源%s標記為已讀"
 
-#: src/feedlist_formaction.cpp:325 src/feedlist_formaction.cpp:333
-#: src/feedlist_formaction.cpp:356
+#: src/feedlistformaction.cpp:339 src/feedlistformaction.cpp:347
+#: src/feedlistformaction.cpp:370
 msgid "No feeds with unread items."
 msgstr "沒有含未讀文章的來源"
 
-#: src/feedlist_formaction.cpp:340 src/itemlist_formaction.cpp:448
+#: src/feedlistformaction.cpp:354 src/itemlistformaction.cpp:460
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:348 src/itemlist_formaction.cpp:453
+#: src/feedlistformaction.cpp:362 src/itemlistformaction.cpp:465
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlist_formaction.cpp:361
+#: src/feedlistformaction.cpp:375
 msgid "Marking all feeds read..."
 msgstr "將所有來源標為已讀..."
 
-#: src/feedlist_formaction.cpp:410 src/itemlist_formaction.cpp:591
+#: src/feedlistformaction.cpp:422 src/itemlistformaction.cpp:616
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "錯誤：無法分析過濾的命令 `%s': %s"
 
-#: src/feedlist_formaction.cpp:424 src/itemlist_formaction.cpp:606
+#: src/feedlistformaction.cpp:436 src/itemlistformaction.cpp:631
 msgid "No filters defined."
 msgstr "沒有定義任何過濾器(filter)"
 
-#: src/feedlist_formaction.cpp:438 src/help_formaction.cpp:39
-#: src/itemlist_formaction.cpp:562 src/itemview_formaction.cpp:289
+#: src/feedlistformaction.cpp:450 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:589 src/itemviewformaction.cpp:241
 msgid "Search for: "
 msgstr "搜尋: "
 
-#: src/feedlist_formaction.cpp:457 src/itemlist_formaction.cpp:619
+#: src/feedlistformaction.cpp:469 src/itemlistformaction.cpp:644
 msgid "Filter: "
 msgstr "過濾器: "
 
-#: src/feedlist_formaction.cpp:475 src/view.cpp:226
+#: src/feedlistformaction.cpp:486 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "你確定要離開嗎(y:是的 n:不是)？"
 
-#: src/feedlist_formaction.cpp:476 src/filebrowser_formaction.cpp:135
-#: src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/filebrowserformaction.cpp:136
+#: src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlist_formaction.cpp:476 src/view.cpp:228
+#: src/feedlistformaction.cpp:487 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlist_formaction.cpp:574 src/help_formaction.cpp:217
-#: src/itemlist_formaction.cpp:1174 src/itemview_formaction.cpp:469
-#: src/pb_view.cpp:336 src/pb_view.cpp:343 src/urlview_formaction.cpp:134
+#: src/feedlistformaction.cpp:584 src/helpformaction.cpp:216
+#: src/itemlistformaction.cpp:1189 src/itemviewformaction.cpp:421
+#: src/pbview.cpp:332 src/pbview.cpp:339 src/urlviewformaction.cpp:135
 msgid "Quit"
 msgstr "放棄"
 
-#: src/feedlist_formaction.cpp:575 src/itemlist_formaction.cpp:1175
+#: src/feedlistformaction.cpp:585 src/itemlistformaction.cpp:1190
 msgid "Open"
 msgstr "打開"
 
-#: src/feedlist_formaction.cpp:576 src/itemlist_formaction.cpp:1178
-#: src/itemview_formaction.cpp:471
+#: src/feedlistformaction.cpp:586 src/itemlistformaction.cpp:1193
+#: src/itemviewformaction.cpp:423
 msgid "Next Unread"
 msgstr "下一篇未讀"
 
-#: src/feedlist_formaction.cpp:577 src/itemlist_formaction.cpp:1177
+#: src/feedlistformaction.cpp:587 src/itemlistformaction.cpp:1192
 msgid "Reload"
 msgstr "重新載入"
 
-#: src/feedlist_formaction.cpp:578
+#: src/feedlistformaction.cpp:588
 msgid "Reload All"
 msgstr "全部重新載入"
 
-#: src/feedlist_formaction.cpp:579
+#: src/feedlistformaction.cpp:589
 msgid "Mark Read"
 msgstr "標為已讀"
 
-#: src/feedlist_formaction.cpp:580 src/itemlist_formaction.cpp:1179
+#: src/feedlistformaction.cpp:590 src/itemlistformaction.cpp:1194
 msgid "Mark All Read"
 msgstr "標記全部為已讀"
 
-#: src/feedlist_formaction.cpp:581 src/help_formaction.cpp:218
-#: src/itemlist_formaction.cpp:1180
+#: src/feedlistformaction.cpp:591 src/helpformaction.cpp:217
+#: src/itemlistformaction.cpp:1195
 msgid "Search"
 msgstr "搜尋"
 
-#: src/feedlist_formaction.cpp:582 src/help_formaction.cpp:248
-#: src/itemlist_formaction.cpp:1181 src/itemview_formaction.cpp:474
-#: src/pb_view.cpp:275 src/pb_view.cpp:351
+#: src/feedlistformaction.cpp:592 src/helpformaction.cpp:247
+#: src/itemlistformaction.cpp:1196 src/itemviewformaction.cpp:426
+#: src/pbview.cpp:271 src/pbview.cpp:347
 msgid "Help"
 msgstr "說明"
 
-#: src/feedlist_formaction.cpp:888 src/itemlist_formaction.cpp:760
+#: src/feedlistformaction.cpp:898 src/itemlistformaction.cpp:781
 msgid "Error: couldn't parse filter command!"
 msgstr "錯誤：無法分析過濾器(filter)命令"
 
-#: src/feedlist_formaction.cpp:906 src/itemlist_formaction.cpp:795
+#: src/feedlistformaction.cpp:916 src/itemlistformaction.cpp:816
 msgid "Searching..."
 msgstr "搜尋中..."
 
-#: src/feedlist_formaction.cpp:916 src/itemlist_formaction.cpp:810
+#: src/feedlistformaction.cpp:926 src/itemlistformaction.cpp:828
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "在搜尋 `%s'的時候出錯: %s"
 
-#: src/feedlist_formaction.cpp:928 src/itemlist_formaction.cpp:817
+#: src/feedlistformaction.cpp:938 src/itemlistformaction.cpp:835
 msgid "No results."
 msgstr "沒有結果"
 
-#: src/feedlist_formaction.cpp:939 src/itemlist_formaction.cpp:1192
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:1207
 msgid "Position not visible!"
 msgstr "找不到這個位置"
 
-#: src/feedlist_formaction.cpp:1011
+#: src/feedlistformaction.cpp:1021
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "來源列表 - %u 未讀, 總共 %u"
 
-#: src/filebrowser_formaction.cpp:130
+#: src/filebrowserformaction.cpp:131
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "你確定要覆蓋 `%s'嗎(y:是的  n:不是)?"
 
-#: src/filebrowser_formaction.cpp:135
+#: src/filebrowserformaction.cpp:136
 msgid "n"
 msgstr "n"
 
-#: src/filebrowser_formaction.cpp:225
+#: src/filebrowserformaction.cpp:226
 msgid "File: "
 msgstr "檔案: "
 
-#: src/filebrowser_formaction.cpp:250
+#: src/filebrowserformaction.cpp:250
 #, c-format
 msgid "%s %s - Save File - %s"
 msgstr "%s %s - 儲存檔案 - %s"
 
-#: src/filebrowser_formaction.cpp:258 src/pb_view.cpp:345
-#: src/select_formaction.cpp:166 src/select_formaction.cpp:169
+#: src/filebrowserformaction.cpp:258 src/pbview.cpp:341
+#: src/selectformaction.cpp:167 src/selectformaction.cpp:170
 msgid "Cancel"
 msgstr "取消"
 
-#: src/filebrowser_formaction.cpp:259 src/itemlist_formaction.cpp:1176
-#: src/itemview_formaction.cpp:470
+#: src/filebrowserformaction.cpp:259 src/itemlistformaction.cpp:1191
+#: src/itemviewformaction.cpp:422
 msgid "Save"
 msgstr "儲存"
 
-#: src/filebrowser_formaction.cpp:381
+#: src/filebrowserformaction.cpp:381
 #, c-format
 msgid "Save File - %s"
 msgstr "儲存檔案 - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:188 src/rss.cpp:406
+#: src/filtercontainer.cpp:29 src/regexmanager.cpp:190 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "無法分析過濾的表示式 `%s': %s"
 
-#: src/formaction.cpp:250 src/formaction.cpp:281
+#: src/formaction.cpp:253 src/formaction.cpp:284
 msgid "usage: set <variable>[=<value>]"
 msgstr "用法: set <變數>[=<值>]"
 
-#: src/formaction.cpp:289
+#: src/formaction.cpp:292
 msgid "usage: source <file> [...]"
 msgstr "使用方式：source <檔案> [...]"
 
-#: src/formaction.cpp:304
+#: src/formaction.cpp:307
 msgid "usage: dumpconfig <file>"
 msgstr "使用方式： dumpconfig <檔案>"
 
-#: src/formaction.cpp:309
+#: src/formaction.cpp:312
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "把組態儲存到 %s"
 
-#: src/formaction.cpp:316
+#: src/formaction.cpp:319
 #, c-format
 msgid "Not a command: %s"
 msgstr "未知的命令： `%s' "
 
-#: src/formaction.cpp:366
+#: src/formaction.cpp:369
 msgid "Saving bookmark..."
 msgstr "儲存書籤..."
 
-#: src/formaction.cpp:372 src/formaction.cpp:446
+#: src/formaction.cpp:375 src/formaction.cpp:449
 msgid "Saved bookmark."
 msgstr "已儲存的書籤."
 
-#: src/formaction.cpp:375 src/formaction.cpp:449
+#: src/formaction.cpp:378 src/formaction.cpp:452
 msgid "Error while saving bookmark: "
 msgstr "在儲存書籤時發生錯誤: "
 
-#: src/formaction.cpp:412
+#: src/formaction.cpp:415
 msgid "URL: "
 msgstr "鏈結: "
 
-#: src/formaction.cpp:421
+#: src/formaction.cpp:420 src/formaction.cpp:422 src/itemrenderer.cpp:49
+msgid "Title: "
+msgstr "標題: "
+
+#: src/formaction.cpp:424
 msgid "Description: "
 msgstr "描述: "
 
-#: src/formaction.cpp:422
+#: src/formaction.cpp:425
 #, fuzzy
 msgid "Feed title: "
 msgstr "檔案: "
 
-#: src/formaction.cpp:440
+#: src/formaction.cpp:443
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "儲存書籤..."
 
-#: src/formaction.cpp:553
+#: src/formaction.cpp:555
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
 msgstr "書籤功能還未設定，請在設定檔中設定變數 `bookmark-cmd' "
 
-#: src/help_formaction.cpp:188
+#: src/helpformaction.cpp:187
 msgid "Generic bindings:"
 msgstr "一般的綁定方式："
 
-#: src/help_formaction.cpp:196
+#: src/helpformaction.cpp:195
 msgid "Unbound functions:"
 msgstr "未綁定的功能："
 
-#: src/help_formaction.cpp:219
+#: src/helpformaction.cpp:218
 msgid "Clear"
 msgstr "清除"
 
@@ -831,199 +804,218 @@ msgstr "內嵌的flash"
 msgid "unknown (bug)"
 msgstr "未知（bug）"
 
-#: src/inoreader_urlreader.cpp:53
+#: src/inoreaderurlreader.cpp:56
 msgid "Broadcast items"
 msgstr ""
 
-#: src/inoreader_urlreader.cpp:54
+#: src/inoreaderurlreader.cpp:57
 #, fuzzy
 msgid "Liked items"
 msgstr "分享的文章"
 
-#: src/inoreader_urlreader.cpp:56
+#: src/inoreaderurlreader.cpp:59
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlist_formaction.cpp:184 src/itemview_formaction.cpp:396
+#: src/itemlistformaction.cpp:199 src/itemviewformaction.cpp:348
 msgid "Toggling read flag for article..."
 msgstr "切換文章閱讀標記（已讀/未讀）"
 
-#: src/itemlist_formaction.cpp:228
+#: src/itemlistformaction.cpp:241
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "當切換閱讀標記（已讀/未讀）時出錯: %s"
 
-#: src/itemlist_formaction.cpp:274 src/itemview_formaction.cpp:329
+#: src/itemlistformaction.cpp:286 src/itemviewformaction.cpp:281
 msgid "URL list empty."
 msgstr "空白的鏈結列表"
 
-#: src/itemlist_formaction.cpp:334 src/itemview_formaction.cpp:119
-#: src/itemview_formaction.cpp:317
+#: src/itemlistformaction.cpp:346 src/itemrenderer.cpp:53
+#: src/itemviewformaction.cpp:269
 msgid "Flags: "
 msgstr "標記: "
 
-#: src/itemlist_formaction.cpp:364 src/itemlist_formaction.cpp:1224
+#: src/itemlistformaction.cpp:376 src/itemlistformaction.cpp:1239
 msgid "Error: no item selected!"
 msgstr "錯誤：沒有選擇任何項目！"
 
-#: src/itemlist_formaction.cpp:378
+#: src/itemlistformaction.cpp:390
 msgid "Error: you can't reload search results."
 msgstr "錯誤：你不能重新載入所選項目"
 
-#: src/itemlist_formaction.cpp:399 src/itemlist_formaction.cpp:408
-#: src/itemlist_formaction.cpp:432 src/itemview_formaction.cpp:350
-#: src/itemview_formaction.cpp:361 src/itemview_formaction.cpp:390
-#: src/view.cpp:773 src/view.cpp:849
+#: src/itemlistformaction.cpp:411 src/itemlistformaction.cpp:420
+#: src/itemlistformaction.cpp:444 src/itemviewformaction.cpp:302
+#: src/itemviewformaction.cpp:313 src/itemviewformaction.cpp:342
+#: src/view.cpp:779 src/view.cpp:855
 msgid "No unread items."
 msgstr "沒有未讀的文章"
 
-#: src/itemlist_formaction.cpp:416 src/itemview_formaction.cpp:370
-#: src/view.cpp:923
+#: src/itemlistformaction.cpp:428 src/itemviewformaction.cpp:322
+#: src/view.cpp:928
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:425 src/itemview_formaction.cpp:380
-#: src/view.cpp:887
+#: src/itemlistformaction.cpp:437 src/itemviewformaction.cpp:332
+#: src/view.cpp:893
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlist_formaction.cpp:438 src/itemlist_formaction.cpp:443
+#: src/itemlistformaction.cpp:450 src/itemlistformaction.cpp:455
 msgid "No unread feeds."
 msgstr "沒有未讀的來源"
 
-#: src/itemlist_formaction.cpp:497
+#: src/itemlistformaction.cpp:527
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "將所有來源標為已讀..."
 
-#: src/itemlist_formaction.cpp:545 src/itemview_formaction.cpp:304
+#: src/itemlistformaction.cpp:572 src/itemviewformaction.cpp:256
 msgid "Pipe article to command: "
 msgstr "Pipe article to command: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlist_formaction.cpp:633 src/itemlist_formaction.cpp:664
-msgid "dtfalg"
+#: src/itemlistformaction.cpp:658 src/itemlistformaction.cpp:686
+#, fuzzy
+msgid "dtfalgr"
 msgstr "dtfalg"
 
-#: src/itemlist_formaction.cpp:635
-msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:660
+#, fuzzy
+msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "排序依照：(d)日期/(t)標題/(f)"
 
-#: src/itemlist_formaction.cpp:666
-msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid?"
+#: src/itemlistformaction.cpp:688
+#, fuzzy
+msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "反向排序依(d)日期/(t)標題/(f)標誌/(a)作者/(l)連結/(g)用戶號碼"
 
-#: src/itemlist_formaction.cpp:782 src/itemview_formaction.cpp:571
+#: src/itemlistformaction.cpp:803 src/itemviewformaction.cpp:497
 msgid "Flags updated."
 msgstr "標記已更新"
 
-#: src/itemlist_formaction.cpp:880 src/view.cpp:431 src/view.cpp:457
+#: src/itemlistformaction.cpp:898 src/view.cpp:434 src/view.cpp:460
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "錯誤: 套用過濾器失敗: %s"
 
-#: src/itemlist_formaction.cpp:1264 src/itemview_formaction.cpp:247
-#: src/itemview_formaction.cpp:539
+#: src/itemlistformaction.cpp:1279 src/itemviewformaction.cpp:199
+#: src/itemviewformaction.cpp:467
 msgid "Aborted saving."
 msgstr "放棄儲存"
 
-#: src/itemlist_formaction.cpp:1269 src/itemview_formaction.cpp:545
+#: src/itemlistformaction.cpp:1284 src/itemviewformaction.cpp:473
 #, c-format
 msgid "Saved article to %s"
 msgstr "把文章儲存到 %s"
 
-#: src/itemlist_formaction.cpp:1272 src/itemview_formaction.cpp:549
+#: src/itemlistformaction.cpp:1287 src/itemviewformaction.cpp:477
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "錯誤：無法儲存文章到 %s"
 
-#: src/itemlist_formaction.cpp:1366
+#: src/itemlistformaction.cpp:1381
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "搜尋結果 - '%s'"
 
-#: src/itemlist_formaction.cpp:1369
+#: src/itemlistformaction.cpp:1384
 #, c-format
 msgid "Query Feed - %s"
 msgstr "查詢來源 - %s"
 
-#: src/itemlist_formaction.cpp:1376
+#: src/itemlistformaction.cpp:1391
 #, c-format
 msgid "Article List - %s"
 msgstr "文章列表 %s"
 
-#: src/itemview_formaction.cpp:48 src/itemview_formaction.cpp:682
-msgid "Top"
-msgstr "頂端"
-
-#: src/itemview_formaction.cpp:49 src/itemview_formaction.cpp:684
-msgid "Bottom"
-msgstr "底端"
-
-#: src/itemview_formaction.cpp:88
+#: src/itemrenderer.cpp:48
 msgid "Feed: "
 msgstr "來源: "
 
-#: src/itemview_formaction.cpp:129
+#: src/itemrenderer.cpp:50
+msgid "Author: "
+msgstr "作者: "
+
+#: src/itemrenderer.cpp:51
+msgid "Date: "
+msgstr "日期: "
+
+#: src/itemrenderer.cpp:52
+msgid "Link: "
+msgstr "鏈結: "
+
+#: src/itemrenderer.cpp:58
+msgid "Podcast Download URL: "
+msgstr "Pocast下載網址: "
+
+#: src/itemrenderer.cpp:63
 msgid "type: "
 msgstr "類型: "
 
-#: src/itemview_formaction.cpp:211 src/view.cpp:568
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:572
+msgid "Top"
+msgstr "頂端"
+
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:574
+msgid "Bottom"
+msgstr "底端"
+
+#: src/itemviewformaction.cpp:166 src/view.cpp:574
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "當標記文章為已讀的時候發生錯誤: %s"
 
-#: src/itemview_formaction.cpp:229
+#: src/itemviewformaction.cpp:181
 #, c-format
 msgid "Added %s to download queue."
 msgstr "將 %s 加入下載隊列"
 
-#: src/itemview_formaction.cpp:233
+#: src/itemviewformaction.cpp:185
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "無效的網址：'%s'"
 
-#: src/itemview_formaction.cpp:252
+#: src/itemviewformaction.cpp:204
 #, c-format
 msgid "Saved article to %s."
 msgstr "將文章保存至 %s "
 
-#: src/itemview_formaction.cpp:255
+#: src/itemviewformaction.cpp:207
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "錯誤：無法將文章寫至 %s"
 
-#: src/itemview_formaction.cpp:263 src/itemview_formaction.cpp:436
-#: src/itemview_formaction.cpp:595 src/urlview_formaction.cpp:42
-#: src/urlview_formaction.cpp:74
+#: src/itemviewformaction.cpp:215 src/itemviewformaction.cpp:388
+#: src/itemviewformaction.cpp:521 src/urlviewformaction.cpp:44
+#: src/urlviewformaction.cpp:76
 msgid "Starting browser..."
 msgstr "啟動瀏覽器..."
 
-#: src/itemview_formaction.cpp:402
+#: src/itemviewformaction.cpp:354
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "將文章標為未讀時發生錯誤: %s"
 
-#: src/itemview_formaction.cpp:450 src/keymap.cpp:140
+#: src/itemviewformaction.cpp:402 src/keymap.cpp:140
 msgid "Goto URL #"
 msgstr "前往網址 #"
 
-#: src/itemview_formaction.cpp:472 src/urlview_formaction.cpp:135
+#: src/itemviewformaction.cpp:424 src/urlviewformaction.cpp:136
 msgid "Open in Browser"
 msgstr "在瀏覽器裡打開"
 
-#: src/itemview_formaction.cpp:473
+#: src/itemviewformaction.cpp:425
 msgid "Enqueue"
 msgstr "加入隊列"
 
-#: src/itemview_formaction.cpp:696
+#: src/itemviewformaction.cpp:585
 #, c-format
 msgid "Article - %s"
 msgstr "文章 - %s"
 
-#: src/itemview_formaction.cpp:745
+#: src/itemviewformaction.cpp:634
 msgid "Error: invalid regular expression!"
 msgstr "錯誤:無效的正規表示式！"
 
@@ -1339,41 +1331,51 @@ msgstr "跳到頁面/列表的開始"
 msgid "Move to the end of page/list"
 msgstr "跳到頁面/列表的最後"
 
-#: src/keymap.cpp:576
+#: src/keymap.cpp:589
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' 不是有效的內容"
 
-#: src/keymap.cpp:580 src/keymap.cpp:619
+#: src/keymap.cpp:593 src/keymap.cpp:638
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' 不是有效的按鍵命令"
 
-#: src/pb_controller.cpp:82
+#: src/matcherexception.cpp:14
+#, c-format
+msgid "attribute `%s' is not available."
+msgstr "無效屬性 `%s'"
+
+#: src/matcherexception.cpp:18
+#, c-format
+msgid "regular expression '%s' is invalid: %s"
+msgstr "正規表示式 '%s' 是無效的: %s"
+
+#: src/pbcontroller.cpp:84
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pb_controller.cpp:145
+#: src/pbcontroller.cpp:147
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "嚴重錯誤:無法確認主目錄！"
 
-#: src/pb_controller.cpp:149
+#: src/pbcontroller.cpp:151
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr "請設定主目錄的環境變數，或者增加一個UID為 %u的有效使用者!"
 
-#: src/pb_controller.cpp:169
+#: src/pbcontroller.cpp:171
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "錯誤：無法開啟組態檔案`%s'！"
 
-#: src/pb_controller.cpp:309
+#: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."
 msgstr "清空隊列..."
 
-#: src/pb_controller.cpp:323
+#: src/pbcontroller.cpp:325
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1383,114 +1385,122 @@ msgstr ""
 "使用方法: %s [-i <file>|-e] [-u <網址檔案>] [-c <快取檔案>] [-x <命令> ...] "
 "[-h]\n"
 
-#: src/pb_controller.cpp:343
+#: src/pbcontroller.cpp:345
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<檔案>"
 
-#: src/pb_controller.cpp:344
+#: src/pbcontroller.cpp:346
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "使用<快取檔案>作為快取檔案"
 
-#: src/pb_controller.cpp:345
+#: src/pbcontroller.cpp:347
 msgid "start download on startup"
 msgstr ""
 
-#: src/pb_view.cpp:53
+#: src/pbview.cpp:55
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u 個平行下載"
 
-#: src/pb_view.cpp:60
+#: src/pbview.cpp:62
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f kb/s total%s"
 msgstr "隊列 (%u 個下載在進行中，共有 %u 個下載項目) - 總共 %.2f kb/s %s"
 
-#: src/pb_view.cpp:133
+#: src/pbview.cpp:129
 msgid "Error: can't quit: download(s) in progress."
 msgstr "錯誤: 無法取消: 還有下載在進行中"
 
-#: src/pb_view.cpp:176
+#: src/pbview.cpp:172
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "錯誤：必須下載完畢才可以播放"
 
-#: src/pb_view.cpp:222
+#: src/pbview.cpp:218
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "錯誤：無法執行操作：還有下載在進行中"
 
-#: src/pb_view.cpp:344
+#: src/pbview.cpp:340
 msgid "Download"
 msgstr "下載"
 
-#: src/pb_view.cpp:346
+#: src/pbview.cpp:342
 msgid "Delete"
 msgstr "刪除"
 
-#: src/pb_view.cpp:347
+#: src/pbview.cpp:343
 msgid "Purge Finished"
 msgstr "清除完畢的項目"
 
-#: src/pb_view.cpp:348
+#: src/pbview.cpp:344
 msgid "Toggle Automatic Download"
 msgstr "切換自動下載"
 
-#: src/pb_view.cpp:349
+#: src/pbview.cpp:345
 msgid "Play"
 msgstr "播放"
 
-#: src/pb_view.cpp:350
+#: src/pbview.cpp:346
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "清除完畢的項目"
 
-#: src/regexmanager.cpp:52
+#: src/queueloader.cpp:87
+#, c-format
+msgid ""
+"WARNING: Comment found in %s. The queue file is regenerated when podboat "
+"exits and comments will be deleted. Press enter to continue or Ctrl+C to "
+"abort"
+msgstr ""
+
+#: src/regexmanager.cpp:54
 #, c-format
 msgid "`%s' is an invalid dialog type"
 msgstr "`%s' 不是有效的對話類別"
 
-#: src/regexmanager.cpp:63
+#: src/regexmanager.cpp:65
 #, c-format
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' 不是一個有效的正規表示式： %s"
 
-#: src/reloader.cpp:61
+#: src/reloader.cpp:66
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%s載入中 %s..."
 
-#: src/reloader.cpp:90 src/reloader.cpp:95 src/reloader.cpp:100
+#: src/reloader.cpp:95 src/reloader.cpp:100 src/reloader.cpp:105
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "在抓取%s的時候發生錯誤: %s"
 
-#: src/reloader.cpp:110
+#: src/reloader.cpp:115
 msgid "Error: invalid feed!"
 msgstr "錯誤:無效的來源！"
 
-#: src/rss.cpp:152
-msgid "%a, %d %b %Y %T %z"
-msgstr ""
-
-#: src/rss.cpp:555
+#: src/rssfeed.cpp:223
 msgid "too few arguments"
 msgstr "參數過少"
 
-#: src/rss.cpp:570
+#: src/rssfeed.cpp:238
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' 不是一個有效的正規表示式： %s"
 
-#: src/rss_parser.cpp:174
+#: src/rssitem.cpp:123
+msgid "%a, %d %b %Y %T %z"
+msgstr ""
+
+#: src/rssparser.cpp:177
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "錯誤：不支持的鏈結: %s"
 
-#: src/select_formaction.cpp:167 src/select_formaction.cpp:185
+#: src/selectformaction.cpp:168 src/selectformaction.cpp:186
 msgid "Select Tag"
 msgstr "選擇標籤"
 
-#: src/select_formaction.cpp:170 src/select_formaction.cpp:187
+#: src/selectformaction.cpp:171 src/selectformaction.cpp:188
 msgid "Select Filter"
 msgstr "選擇過濾器"
 
@@ -1502,70 +1512,70 @@ msgstr "未發現屬性"
 msgid "EOF found while reading XML tag"
 msgstr "當讀取XML標籤時遇到EOF標記"
 
-#: src/urlview_formaction.cpp:46 src/urlview_formaction.cpp:58
+#: src/urlviewformaction.cpp:48 src/urlviewformaction.cpp:60
 msgid "No link selected!"
 msgstr "沒有選擇任何鏈結！"
 
-#: src/urlview_formaction.cpp:136
+#: src/urlviewformaction.cpp:137
 msgid "Save Bookmark"
 msgstr "儲存書籤"
 
-#: src/urlview_formaction.cpp:157
+#: src/urlviewformaction.cpp:158
 msgid "URLs"
 msgstr "網址"
 
-#: src/view.cpp:486 src/view.cpp:511
+#: src/view.cpp:490 src/view.cpp:516
 msgid "Error: feed contains no items!"
 msgstr "錯誤: 來源裡沒有任何項目！"
 
-#: src/view.cpp:634
+#: src/view.cpp:641
 msgid "No tags defined."
 msgstr "沒有定義任何標籤"
 
-#: src/view.cpp:983
+#: src/view.cpp:988
 msgid "Updating query feed..."
 msgstr "更新查詢的來源..."
 
-#: rss/atom_parser.cpp:13 rss/parser.cpp:364 rss/rss_09x_parser.cpp:15
-#: rss/rss_09x_parser.cpp:30 rss/rss_10_parser.cpp:14
+#: rss/atomparser.cpp:17 rss/parser.cpp:367 rss/rss09xparser.cpp:21
+#: rss/rss10parser.cpp:19 rss/rss20parser.cpp:21
 msgid "XML root node is NULL"
 msgstr "XML的根節點為無效"
 
-#: rss/parser.cpp:110
+#: rss/parser.cpp:113
 msgid "couldn't initialize libcurl"
 msgstr "無法初始化libcurl"
 
-#: rss/parser.cpp:250
+#: rss/parser.cpp:253
 msgid "could not parse buffer"
 msgstr "無法分析緩衝區"
 
-#: rss/parser.cpp:274
+#: rss/parser.cpp:277
 msgid "could not parse file"
 msgstr "無法分析檔案"
 
-#: rss/parser.cpp:298
+#: rss/parser.cpp:301
 msgid "no RSS version"
 msgstr "沒有RSS版本"
 
-#: rss/parser.cpp:314
+#: rss/parser.cpp:317
 msgid "invalid RSS version"
 msgstr "無效的RSS版本！"
 
-#: rss/parser.cpp:334 rss/parser.cpp:345
+#: rss/parser.cpp:337 rss/parser.cpp:348
 msgid "invalid Atom version"
 msgstr "無效的Atom版本！"
 
-#: rss/parser.cpp:350
+#: rss/parser.cpp:353
 msgid "no Atom version"
 msgstr "沒有Atom版本"
 
-#: rss/parser_factory.cpp:25
-msgid "unsupported feed format"
-msgstr "不支援的來源格式"
-
-#: rss/rss_09x_parser.cpp:39
+#: rss/rss09xparser.cpp:30
 msgid "no RSS channel found"
 msgstr "找不到RSS頻道"
+
+#: rss/rssparserfactory.cpp:31
+msgid "unsupported feed format"
+msgstr "不支援的來源格式"
 
 #, fuzzy
 #~ msgid "'%s' is not a valid key command"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2019-05-26 15:49+0300\n"
+"POT-Creation-Date: 2019-05-26 15:56+0300\n"
 "PO-Revision-Date: 2010-03-03 16:55+0800\n"
 "Last-Translator: Aeglos <aeglos.lin@gmail.com>\n"
 "Language-Team: Traditional Chinese <aeglos.lin@gmail.com>\n"
@@ -149,10 +149,10 @@ msgstr ""
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/cliargsparser.cpp:145 src/pbcontroller.cpp:233
-#, c-format
-msgid "%s: %d: invalid loglevel value"
-msgstr ""
+#: src/cliargsparser.cpp:145
+#, fuzzy, c-format
+msgid "%s: %s: invalid loglevel value"
+msgstr "`%s' 不是有效的對話類別"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:74
 #: src/regexmanager.cpp:86 src/regexmanager.cpp:157 src/regexmanager.cpp:167
@@ -1370,6 +1370,11 @@ msgstr "請設定主目錄的環境變數，或者增加一個UID為 %u的有效
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "錯誤：無法開啟組態檔案`%s'！"
+
+#: src/pbcontroller.cpp:233
+#, c-format
+msgid "%s: %d: invalid loglevel value"
+msgstr ""
 
 #: src/pbcontroller.cpp:311
 msgid "Cleaning up queue..."

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -136,7 +136,7 @@ pub extern "C" fn rs_cliargsparser_silent(object: *mut c_void) -> bool {
 
 #[no_mangle]
 pub extern "C" fn rs_cliargsparser_using_nonstandard_configs(object: *mut c_void) -> bool {
-    with_cliargsparser(object, |o| o.using_nonstandard_configs, false)
+    with_cliargsparser(object, |o| o.using_nonstandard_configs(), false)
 }
 
 #[no_mangle]

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -111,17 +111,22 @@ pub extern "C" fn rs_cliargsparser_importfile(object: *mut c_void) -> *mut c_cha
 
 #[no_mangle]
 pub extern "C" fn rs_cliargsparser_do_read_import(object: *mut c_void) -> bool {
-    with_cliargsparser(object, |o| o.do_read_import, false)
+    with_cliargsparser(object, |o| o.readinfo_import_file.is_some(), false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_readinfo_import_file(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_opt_str(object, |o| &o.readinfo_import_file)
 }
 
 #[no_mangle]
 pub extern "C" fn rs_cliargsparser_do_read_export(object: *mut c_void) -> bool {
-    with_cliargsparser(object, |o| o.do_read_export, false)
+    with_cliargsparser(object, |o| o.readinfo_export_file.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_readinfofile(object: *mut c_void) -> *mut c_char {
-    with_cliargsparser_str(object, |o| &o.readinfofile)
+pub extern "C" fn rs_cliargsparser_readinfo_export_file(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_opt_str(object, |o| &o.readinfo_export_file)
 }
 
 #[no_mangle]

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -86,7 +86,7 @@ where
 
 #[no_mangle]
 pub extern "C" fn rs_cliargsparser_do_import(object: *mut c_void) -> bool {
-    with_cliargsparser(object, |o| o.do_import, false)
+    with_cliargsparser(object, |o| o.importfile.is_some(), false)
 }
 
 #[no_mangle]
@@ -106,7 +106,7 @@ pub extern "C" fn rs_cliargsparser_program_name(object: *mut c_void) -> *mut c_c
 
 #[no_mangle]
 pub extern "C" fn rs_cliargsparser_importfile(object: *mut c_void) -> *mut c_char {
-    with_cliargsparser_str(object, |o| &o.importfile)
+    with_cliargsparser_opt_str(object, |o| &o.importfile)
 }
 
 #[no_mangle]

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -1,0 +1,234 @@
+use abort_on_panic;
+use libc::{c_char, c_void};
+use libnewsboat::cliargsparser::CliArgsParser;
+use std::ffi::{CStr, CString};
+use std::mem;
+use std::panic::{RefUnwindSafe, UnwindSafe};
+use std::ptr;
+use std::slice;
+
+#[no_mangle]
+pub extern "C" fn create_rs_cliargsparser(argc: isize, argv: *mut *const c_char) -> *mut c_void {
+    abort_on_panic(|| {
+        assert!(!argv.is_null());
+        assert!(argc >= 0);
+        let argv = unsafe { slice::from_raw_parts(argv, argc as usize) };
+
+        let args = argv
+            .iter()
+            .map(|s_ptr| unsafe { CStr::from_ptr(*s_ptr).to_string_lossy().into_owned() })
+            .collect::<Vec<String>>();
+        Box::into_raw(Box::new(CliArgsParser::new(args))) as *mut c_void
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn destroy_rs_cliargsparser(object: *mut c_void) {
+    abort_on_panic(|| {
+        if object.is_null() {
+            return;
+        }
+        unsafe {
+            Box::from_raw(object);
+        }
+    })
+}
+
+fn with_cliargsparser<F, T>(object: *mut c_void, action: F, default: T) -> T
+where
+    F: RefUnwindSafe + Fn(&Box<CliArgsParser>) -> T,
+    T: UnwindSafe,
+{
+    abort_on_panic(|| {
+        if object.is_null() {
+            return default;
+        }
+        // TODO: use abort_on_panic here
+        let object = unsafe { Box::from_raw(object as *mut CliArgsParser) };
+        let result = action(&object);
+        // Don't destroy the object when the function finishes
+        mem::forget(object);
+        result
+    })
+}
+
+fn with_cliargsparser_str<F>(object: *mut c_void, action: F) -> *mut c_char
+where
+    F: RefUnwindSafe + Fn(&Box<CliArgsParser>) -> &String,
+{
+    with_cliargsparser(
+        object,
+        |o| CString::new(action(o).clone()).unwrap().into_raw(),
+        ptr::null_mut(),
+    )
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_do_import(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.do_import, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_do_export(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.do_export, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_do_vacuum(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.do_vacuum, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_program_name(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_str(object, |o| &o.program_name)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_importfile(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_str(object, |o| &o.importfile)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_do_read_import(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.do_read_import, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_do_read_export(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.do_read_export, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_readinfofile(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_str(object, |o| &o.readinfofile)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_show_version(object: *mut c_void) -> usize {
+    with_cliargsparser(object, |o| o.show_version, 0)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_silent(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.silent, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_using_nonstandard_configs(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.using_nonstandard_configs, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_should_return(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.should_return, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_return_code(object: *mut c_void) -> isize {
+    with_cliargsparser(object, |o| o.return_code as isize, 0)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_display_msg(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_str(object, |o| &o.display_msg)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_should_print_usage(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.should_print_usage, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_refresh_on_start(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.refresh_on_start, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_set_url_file(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.set_url_file, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_url_file(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_str(object, |o| &o.url_file)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_set_lock_file(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.set_lock_file, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_lock_file(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_str(object, |o| &o.lock_file)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_set_cache_file(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.set_cache_file, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_cache_file(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_str(object, |o| &o.cache_file)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_set_config_file(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.set_config_file, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_config_file(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_str(object, |o| &o.config_file)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_execute_cmds(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.execute_cmds, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_cmds_to_execute_count(object: *mut c_void) -> usize {
+    with_cliargsparser(object, |o| o.cmds_to_execute.len(), 0)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_cmd_to_execute_n(object: *mut c_void, n: usize) -> *mut c_char {
+    if object.is_null() {
+        return ptr::null_mut();
+    }
+    abort_on_panic(|| {
+        let object = unsafe { Box::from_raw(object as *mut CliArgsParser) };
+        let result = if n < object.cmds_to_execute.len() {
+            CString::new(object.cmds_to_execute[n].clone())
+                .unwrap()
+                .into_raw()
+        } else {
+            ptr::null_mut()
+        };
+        // Don't destroy the object when the function finishes
+        mem::forget(object);
+        result
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_set_log_file(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.set_log_file, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_log_file(object: *mut c_void) -> *mut c_char {
+    with_cliargsparser_str(object, |o| &o.log_file)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_set_log_level(object: *mut c_void) -> bool {
+    with_cliargsparser(object, |o| o.set_log_level, false)
+}
+
+#[no_mangle]
+pub extern "C" fn rs_cliargsparser_log_level(object: *mut c_void) -> u8 {
+    with_cliargsparser(object, |o| o.log_level as u8, 0)
+}

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -6,6 +6,7 @@ use std::ffi::CString;
 use std::panic::{catch_unwind, UnwindSafe};
 use std::process::abort;
 
+pub mod cliargsparser;
 pub mod fmtstrformatter;
 pub mod human_panic;
 pub mod logger;

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -15,10 +15,22 @@ unicode-width = "0.1.5"
 nom = "^4.1"
 unicode-segmentation = "1"
 curl-sys = "0.4.5"
+libc = "0.2"
 
 # We don't use the following crates, but we pin their versions to make sure
 # that Newsboat builds with Rust 1.25 and later.
 libz-sys = "= 1.0.17"
+
+[dependencies.clap]
+version = "2.33"
+# This disables three features, for the following reasons:
+# - "suggestions" and "color" features: we provide our own help text, so don't
+#   need those
+# - "vec_map": this provides "a slight performance improvement" at the cost of
+#   an additional dependency. At the time of writing Rust is still a new kid on
+#   the block, distros are still figuring out the ways to package crates, so
+#   I want as little dependencies as practically possible.
+default-features = false
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -4,6 +4,8 @@ version = "2.15.0"
 authors = ["Alexander Batischev <eual.jp@gmail.com>"]
 
 [dependencies]
+strprintf = { path="../strprintf" }
+
 chrono = "0.4"
 rand = "0.5"
 once_cell = "0.1.6"

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -18,6 +18,7 @@ nom = "^4.1"
 unicode-segmentation = "1"
 curl-sys = "0.4.5"
 libc = "0.2"
+gettext-rs = "0.4.1"
 
 # We don't use the following crates, but we pin their versions to make sure
 # that Newsboat builds with Rust 1.25 and later.
@@ -33,6 +34,12 @@ version = "2.33"
 #   the block, distros are still figuring out the ways to package crates, so
 #   I want as little dependencies as practically possible.
 default-features = false
+
+[dependencies.gettext-sys]
+version = "0.19.8"
+# Don't let the crate build its own copy of gettext; force it to use the one
+# built into glibc.
+features = [ "gettext-system" ]
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -1,0 +1,833 @@
+use clap::{App, Arg};
+use libc::{EXIT_FAILURE, EXIT_SUCCESS};
+
+use logger::Level;
+
+#[derive(Default)]
+pub struct CliArgsParser {
+    pub do_import: bool,
+    pub do_export: bool,
+    pub do_vacuum: bool,
+    pub importfile: String,
+    pub do_read_import: bool,
+    pub do_read_export: bool,
+    pub program_name: String,
+    pub readinfofile: String,
+    pub show_version: usize,
+    pub silent: bool,
+    pub using_nonstandard_configs: bool,
+
+    /// If `should_return` is `true`, the creator of `CliArgsParser` object
+    /// should call `exit(return_code)`.
+    pub should_return: bool,
+    pub return_code: i32,
+
+    /// If `display_msg` is not empty, the creator of `CliArgsParser` should
+    /// print its contents to stderr.
+    ///
+    /// \note The contents of this string should be checked before
+    /// processing `should_return`.
+    pub display_msg: String,
+
+    /// If `should_print_usage` is `true`, the creator of `CliArgsParser`
+    /// object should print usage information.
+    ///
+    /// \note This field should be checked before processing
+    /// `should_return`.
+    pub should_print_usage: bool,
+
+    pub refresh_on_start: bool,
+
+    /// The value of `url_file` should only be used if `set_url_file` is
+    /// `true`.
+    pub set_url_file: bool,
+    pub url_file: String,
+
+    /// The value of `lock_file` should only be used if `set_lock_file` is
+    /// `true`.
+    pub set_lock_file: bool,
+    pub lock_file: String,
+
+    /// The value of `cache_file` should only be used if `set_cache_file` is
+    /// `true`.
+    pub set_cache_file: bool,
+    pub cache_file: String,
+
+    /// The value of `config_file` should only be used if `set_config_file`
+    /// is `true`.
+    pub set_config_file: bool,
+    pub config_file: String,
+
+    /// If 'execute_cmds' is true, the 'CliArgsParser' object holds commands
+    /// that should be executed in cmds_to_execute vector.
+    ///
+    /// \note The parser does not check if the passed commands are valid.
+    pub execute_cmds: bool,
+    pub cmds_to_execute: Vec<String>,
+
+    /// The value of `log_file` should only be used if `set_log_file` is
+    /// `true`.
+    pub set_log_file: bool,
+    pub log_file: String,
+
+    /// The value of `log_level` should only be used if `set_log_level` is
+    /// `true`.
+    pub set_log_level: bool,
+    pub log_level: Level,
+}
+
+impl CliArgsParser {
+    pub fn new(opts: Vec<String>) -> CliArgsParser {
+        const CACHE_FILE: &str = "cache-file";
+        const CONFIG_FILE: &str = "config-file";
+        const EXECUTE: &str = "execute";
+        const EXPORT_TO_FILE: &str = "export-to-file";
+        const EXPORT_TO_OPML: &str = "export-to-opml";
+        const HELP: &str = "help";
+        const IMPORT_FROM_FILE: &str = "import-from-file";
+        const IMPORT_FROM_OPML: &str = "import-from-opml";
+        const LOG_FILE: &str = "log-file";
+        const LOG_LEVEL: &str = "log-level";
+        const QUIET: &str = "quiet";
+        const REFRESH_ON_START: &str = "refresh-on-start";
+        const URL_FILE: &str = "url-file";
+        const VACUUM: &str = "vacuum";
+        const VERSION: &str = "version";
+        const VERSION_V: &str = "-V";
+
+        let app = App::new("Newsboat")
+            .arg(
+                Arg::with_name(IMPORT_FROM_OPML)
+                    .short("i")
+                    .long(IMPORT_FROM_OPML)
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name(EXPORT_TO_OPML)
+                    .short("e")
+                    .long(EXPORT_TO_OPML),
+            )
+            .arg(
+                Arg::with_name(REFRESH_ON_START)
+                    .short("r")
+                    .long(REFRESH_ON_START),
+            )
+            .arg(Arg::with_name(HELP).short("h").long(HELP))
+            .arg(
+                Arg::with_name(URL_FILE)
+                    .short("u")
+                    .long(URL_FILE)
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name(CACHE_FILE)
+                    .short("c")
+                    .long(CACHE_FILE)
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name(CONFIG_FILE)
+                    .short("C")
+                    .long(CONFIG_FILE)
+                    .takes_value(true),
+            )
+            .arg(Arg::with_name(VACUUM).short("X").long(VACUUM))
+            .arg(
+                Arg::with_name(VERSION)
+                    .short("v")
+                    .long(VERSION)
+                    .multiple(true),
+            )
+            .arg(Arg::with_name(VERSION_V).short("V").multiple(true))
+            .arg(
+                Arg::with_name(EXECUTE)
+                    .short("x")
+                    .long(EXECUTE)
+                    .takes_value(true)
+                    .multiple(true),
+            )
+            .arg(Arg::with_name(QUIET).short("q").long(QUIET))
+            .arg(
+                Arg::with_name(IMPORT_FROM_FILE)
+                    .short("I")
+                    .long(IMPORT_FROM_FILE)
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name(EXPORT_TO_FILE)
+                    .short("E")
+                    .long(EXPORT_TO_FILE)
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name(LOG_FILE)
+                    .short("d")
+                    .long(LOG_FILE)
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name(LOG_LEVEL)
+                    .short("l")
+                    .long(LOG_LEVEL)
+                    .takes_value(true),
+            );
+
+        let matches = match app.get_matches_from_safe(opts) {
+            Ok(matches) => matches,
+            Err(_) => {
+                return CliArgsParser {
+                    should_print_usage: true,
+                    should_return: true,
+                    return_code: EXIT_FAILURE,
+                    ..CliArgsParser::default()
+                };
+            }
+        };
+
+        let mut args = CliArgsParser::default();
+
+        if matches.is_present(EXPORT_TO_OPML) {
+            if args.do_import {
+                args.should_print_usage = true;
+                args.should_return = true;
+                args.return_code = EXIT_FAILURE;
+            } else {
+                args.do_export = true;
+                args.silent = true;
+            }
+        }
+
+        args.refresh_on_start = matches.is_present(REFRESH_ON_START);
+
+        if matches.is_present(HELP) {
+            args.should_print_usage = true;
+            args.should_return = true;
+            args.return_code = EXIT_SUCCESS;
+        }
+
+        args.do_vacuum = matches.is_present(VACUUM);
+
+        args.silent = args.silent || matches.is_present(QUIET);
+
+        if let Some(importfile) = matches.value_of(IMPORT_FROM_OPML) {
+            if args.do_export {
+                args.should_print_usage = true;
+                args.should_return = true;
+                args.return_code = EXIT_FAILURE;
+            } else {
+                args.do_import = true;
+                args.importfile = importfile.to_string();
+            }
+        }
+
+        if let Some(url_file) = matches.value_of(URL_FILE) {
+            args.set_url_file = true;
+            args.url_file = url_file.to_string();
+            args.using_nonstandard_configs = true;
+        }
+
+        if let Some(cache_file) = matches.value_of(CACHE_FILE) {
+            args.set_cache_file = true;
+            args.cache_file = cache_file.to_string();
+            args.set_lock_file = true;
+            // TODO: append a lock suffix to this name
+            args.lock_file = cache_file.to_string();
+            args.using_nonstandard_configs = true;
+        }
+
+        if let Some(config_file) = matches.value_of(CONFIG_FILE) {
+            args.set_config_file = true;
+            args.config_file = config_file.to_string();
+            args.using_nonstandard_configs = true;
+        }
+
+        // Casting u64 to usize. Highly unlikely that the user will hit the limit, even if we were
+        // running on an 8-bit platform.
+        //
+        // There are three "version" options, two of which (-v and --version) are grouped into
+        // VERSION, and the other one (-V) is under VERSION_V. This is because Clap won't let us
+        // have short aliases.
+        args.show_version =
+            (matches.occurrences_of(VERSION) + matches.occurrences_of(VERSION_V)) as usize;
+
+        if let Some(mut commands) = matches.values_of_lossy(EXECUTE) {
+            args.silent = true;
+            args.execute_cmds = true;
+            args.cmds_to_execute.append(&mut commands);
+        }
+
+        if let Some(importfile) = matches.value_of(IMPORT_FROM_FILE) {
+            if args.do_read_export {
+                args.should_print_usage = true;
+                args.should_return = true;
+                args.return_code = EXIT_FAILURE;
+            } else {
+                args.do_read_import = true;
+                args.readinfofile = importfile.to_string();
+            }
+        }
+
+        if let Some(exportfile) = matches.value_of(EXPORT_TO_FILE) {
+            if args.do_read_import {
+                args.should_print_usage = true;
+                args.should_return = true;
+                args.return_code = EXIT_FAILURE;
+            } else {
+                args.do_read_export = true;
+                args.readinfofile = exportfile.to_string();
+            }
+        }
+
+        if let Some(log_file) = matches.value_of(LOG_FILE) {
+            args.set_log_file = true;
+            args.log_file = log_file.to_string();
+        }
+
+        if let Some(log_level_str) = matches.value_of(LOG_LEVEL) {
+            match log_level_str.parse::<u8>() {
+                Ok(1) => {
+                    args.set_log_level = true;
+                    args.log_level = Level::UserError;
+                }
+                Ok(2) => {
+                    args.set_log_level = true;
+                    args.log_level = Level::Critical;
+                }
+                Ok(3) => {
+                    args.set_log_level = true;
+                    args.log_level = Level::Error;
+                }
+                Ok(4) => {
+                    args.set_log_level = true;
+                    args.log_level = Level::Warn;
+                }
+                Ok(5) => {
+                    args.set_log_level = true;
+                    args.log_level = Level::Info;
+                }
+                Ok(6) => {
+                    args.set_log_level = true;
+                    args.log_level = Level::Debug;
+                }
+                _ => {
+                    args.display_msg = "Uh-oh!".to_string();
+                    args.should_return = true;
+                    args.return_code = EXIT_FAILURE;
+                }
+            };
+        }
+
+        args
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn t_asks_to_print_usage_info_and_exit_with_failure_on_unknown_option() {
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+            assert!(args.should_print_usage);
+            assert!(args.should_return);
+            assert_eq!(args.return_code, EXIT_FAILURE);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "--some-unknown-option".to_string(),
+        ]);
+
+        check(vec!["newsboat".to_string(), "-s".to_string()]);
+        check(vec!["newsboat".to_string(), "-s".to_string()]);
+        check(vec!["newsboat".to_string(), "-m ix".to_string()]);
+        check(vec!["newsboat".to_string(), "-wtf".to_string()]);
+    }
+
+    #[test]
+    fn t_sets_do_import_and_importfile_if_dash_i_is_provided() {
+        let filename = "blogroll.opml".to_string();
+
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.do_import);
+            assert_eq!(args.importfile, filename);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-i".to_string(),
+            filename.clone(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "--import-from-opml=".to_string() + &filename,
+        ]);
+    }
+
+    #[test]
+    fn t_asks_to_print_usage_and_exit_with_failure_if_both_import_and_export_are_provided() {
+        let importf = "import.opml".to_string();
+        let exportf = "export.opml".to_string();
+
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.should_print_usage);
+            assert!(args.should_return);
+            assert_eq!(args.return_code, EXIT_FAILURE);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-i".to_string(),
+            importf.clone(),
+            "-e".to_string(),
+            exportf.to_string(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "-e".to_string(),
+            exportf.clone(),
+            "-i".to_string(),
+            importf.to_string(),
+        ]);
+    }
+
+    #[test]
+    fn t_sets_refresh_on_start_if_dash_r_is_provided() {
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.refresh_on_start);
+        };
+
+        check(vec!["newsboat".to_string(), "-r".to_string()]);
+        check(vec![
+            "newsboat".to_string(),
+            "--refresh-on-start".to_string(),
+        ]);
+    }
+
+    #[test]
+    fn t_requests_silent_mode_if_dash_e_is_provided() {
+        let check = |args| {
+            let args = CliArgsParser::new(args);
+
+            assert!(args.silent);
+        };
+
+        check(vec!["newsboat".to_string(), "-e".to_string()]);
+        check(vec!["newsboat".to_string(), "--export-to-opml".to_string()]);
+    }
+
+    #[test]
+    fn t_sets_do_export_if_dash_e_is_provided() {
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.do_export);
+        };
+
+        check(vec!["newsboat".to_string(), "-e".to_string()]);
+        check(vec!["newsboat".to_string(), "--export-to-opml".to_string()]);
+    }
+
+    #[test]
+    fn t_asks_to_print_usage_and_exit_with_success_if_dash_h_is_provided() {
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.should_print_usage);
+            assert!(args.should_return);
+            assert_eq!(args.return_code, EXIT_SUCCESS);
+        };
+
+        check(vec!["newsboat".to_string(), "-h".to_string()]);
+        check(vec!["newsboat".to_string(), "--help".to_string()]);
+    }
+
+    #[test]
+    fn t_sets_url_file_set_url_file_and_using_nonstandard_configs_if_dash_u_is_provided() {
+        let filename = "urlfile".to_string();
+
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.set_url_file);
+            assert_eq!(args.url_file, filename);
+            assert!(args.using_nonstandard_configs);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-u".to_string(),
+            filename.clone(),
+        ]);
+
+        check(vec![
+            "newsboat".to_string(),
+            "--url-file=".to_string() + &filename,
+        ]);
+    }
+
+    #[test]
+    fn t_sets_proper_fields_when_dash_c_is_provided() {
+        let filename = "cache.db".to_string();
+
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.set_cache_file);
+            assert_eq!(args.cache_file, filename);
+            assert!(args.set_lock_file);
+            // TODO: check that the name is different from the cache's name, and ends with a lock
+            // file suffix
+            assert!(args.lock_file.starts_with(&filename));
+            assert!(args.using_nonstandard_configs);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-c".to_string(),
+            filename.clone(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "--cache-file=".to_string() + &filename,
+        ]);
+    }
+
+    #[test]
+    fn t_sets_config_file_if_dash_capital_c_is_provided() {
+        let filename = "config file".to_string();
+
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.set_config_file);
+            assert_eq!(args.config_file, filename);
+            assert!(args.using_nonstandard_configs);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-C".to_string(),
+            filename.clone(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "--config-file=".to_string() + &filename,
+        ]);
+    }
+
+    #[test]
+    fn t_sets_do_vacuum_if_dash_capital_x_is_provided() {
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.do_vacuum);
+        };
+
+        check(vec!["newsboat".to_string(), "-X".to_string()]);
+        check(vec!["newsboat".to_string(), "--vacuum".to_string()]);
+    }
+
+    #[test]
+    fn t_increases_show_version_with_each_dash_v_provided() {
+        let check = |opts, expected_version| {
+            let args = CliArgsParser::new(opts);
+
+            assert_eq!(args.show_version, expected_version);
+        };
+
+        check(vec!["newsboat".to_string(), "-v".to_string()], 1);
+        check(vec!["newsboat".to_string(), "-V".to_string()], 1);
+        check(vec!["newsboat".to_string(), "--version".to_string()], 1);
+        check(vec!["newsboat".to_string(), "-vvvv".to_string()], 4);
+        check(vec!["newsboat".to_string(), "-vV".to_string()], 2);
+        check(
+            vec![
+                "newsboat".to_string(),
+                "--version".to_string(),
+                "-v".to_string(),
+            ],
+            2,
+        );
+        check(
+            vec![
+                "newsboat".to_string(),
+                "-V".to_string(),
+                "--version".to_string(),
+                "-v".to_string(),
+            ],
+            3,
+        );
+        check(vec!["newsboat".to_string(), "-VvVVvvvvV".to_string()], 9);
+    }
+
+    #[test]
+    fn t_requests_silent_mode_if_dash_x_is_provided() {
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.silent);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-x".to_string(),
+            "reload".to_string(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "--execute".to_string(),
+            "reload".to_string(),
+        ]);
+    }
+
+    #[test]
+    fn t_sets_execute_cmds_if_dash_x_is_provided() {
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.execute_cmds);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-x".to_string(),
+            "reload".to_string(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "--execute".to_string(),
+            "reload".to_string(),
+        ]);
+    }
+
+    #[test]
+    fn t_inserts_commands_to_cmds_to_execute_if_dash_x_is_provided() {
+        let check = |opts, cmds| {
+            let args = CliArgsParser::new(opts);
+
+            assert_eq!(args.cmds_to_execute, cmds);
+        };
+
+        check(
+            vec![
+                "newsboat".to_string(),
+                "-x".to_string(),
+                "reload".to_string(),
+            ],
+            vec!["reload".to_string()],
+        );
+        check(
+            vec![
+                "newsboat".to_string(),
+                "--execute".to_string(),
+                "reload".to_string(),
+            ],
+            vec!["reload".to_string()],
+        );
+        check(
+            vec![
+                "newsboat".to_string(),
+                "-x".to_string(),
+                "reload".to_string(),
+                "print-unread".to_string(),
+            ],
+            vec!["reload".to_string(), "print-unread".to_string()],
+        );
+        check(
+            vec![
+                "newsboat".to_string(),
+                "--execute".to_string(),
+                "reload".to_string(),
+                "print-unread".to_string(),
+            ],
+            vec!["reload".to_string(), "print-unread".to_string()],
+        );
+        check(
+            vec![
+                "newsboat".to_string(),
+                "-x".to_string(),
+                "print-unread".to_string(),
+                "--execute".to_string(),
+                "reload".to_string(),
+            ],
+            vec!["print-unread".to_string(), "reload".to_string()],
+        );
+    }
+
+    #[test]
+    fn t_requests_silent_mode_if_dash_q_is_provided() {
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.silent);
+        };
+
+        check(vec!["newsboat".to_string(), "-q".to_string()]);
+        check(vec!["newsboat".to_string(), "--quiet".to_string()]);
+    }
+
+    #[test]
+    fn t_sets_do_read_import_and_readinfofile_if_dash_capital_i_is_provided() {
+        let filename = "filename".to_string();
+
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.do_read_import);
+            assert_eq!(args.readinfofile, filename);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-I".to_string(),
+            filename.to_string(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "--import-from-file=".to_string() + &filename,
+        ]);
+    }
+
+    #[test]
+    fn t_sets_do_read_export_and_readinfofile_if_dash_capital_e_is_provided() {
+        let filename = "filename".to_string();
+
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.do_read_export);
+            assert_eq!(args.readinfofile, filename);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-E".to_string(),
+            filename.to_string(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "--export-to-file=".to_string() + &filename,
+        ]);
+    }
+
+    #[test]
+    fn t_asks_to_print_usage_and_exit_with_failure_if_both_capital_e_and_capital_i_are_provided() {
+        let importf = "import.opml".to_string();
+        let exportf = "export.opml".to_string();
+
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.should_print_usage);
+            assert!(args.should_return);
+            assert_eq!(args.return_code, EXIT_FAILURE);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-I".to_string(),
+            importf.clone(),
+            "-E".to_string(),
+            exportf.to_string(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "-E".to_string(),
+            exportf.clone(),
+            "-I".to_string(),
+            importf.to_string(),
+        ]);
+    }
+
+    #[test]
+    fn t_sets_set_log_file_and_log_file_if_dash_d_is_provided() {
+        let filename = "log file.txt".to_string();
+
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.set_log_file);
+            assert_eq!(args.log_file, filename);
+        };
+
+        check(vec![
+            "newsboat".to_string(),
+            "-d".to_string(),
+            filename.clone(),
+        ]);
+        check(vec![
+            "newsboat".to_string(),
+            "--log-file=".to_string() + &filename,
+        ]);
+    }
+
+    #[test]
+    fn t_sets_set_log_level_and_log_level_if_argument_to_dash_l_is_1_to_6() {
+        let check = |opts, expected_level| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(args.set_log_level);
+            assert_eq!(args.log_level, expected_level);
+        };
+
+        // --log-level=1 means UserError
+        check(
+            vec!["newsboat".to_string(), "--log-level=1".to_string()],
+            Level::UserError,
+        );
+
+        // --log-level=2 means Critical
+        check(
+            vec!["newsboat".to_string(), "--log-level=2".to_string()],
+            Level::Critical,
+        );
+
+        // -l3 means Error
+        check(
+            vec!["newsboat".to_string(), "-l3".to_string()],
+            Level::Error,
+        );
+
+        // --log-level=4 means Warn
+        check(
+            vec!["newsboat".to_string(), "--log-level=4".to_string()],
+            Level::Warn,
+        );
+
+        // -l5 means Info
+        check(vec!["newsboat".to_string(), "-l5".to_string()], Level::Info);
+
+        // -l6 means Debug
+        check(
+            vec!["newsboat".to_string(), "-l6".to_string()],
+            Level::Debug,
+        );
+    }
+
+    #[test]
+    fn t_sets_display_msg_and_asks_to_exit_with_failure_if_argument_to_dash_l_is_outside_1_to_6_range(
+    ) {
+        let check = |opts| {
+            let args = CliArgsParser::new(opts);
+
+            assert!(!args.display_msg.is_empty());
+            assert!(args.should_return);
+            assert_eq!(args.return_code, EXIT_FAILURE);
+        };
+
+        check(vec!["newsboat".to_string(), "-l0".to_string()]);
+        check(vec!["newsboat".to_string(), "--log-level=7".to_string()]);
+        check(vec![
+            "newsboat".to_string(),
+            "--log-level=90001".to_string(),
+        ]);
+    }
+}

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -174,7 +174,7 @@ impl CliArgsParser {
                     .takes_value(true),
             );
 
-        let matches = match app.get_matches_from_safe(opts) {
+        let matches = match app.get_matches_from_safe(&opts) {
             Ok(matches) => matches,
             Err(_) => {
                 return CliArgsParser {
@@ -311,7 +311,10 @@ impl CliArgsParser {
                     args.log_level = Level::Debug;
                 }
                 _ => {
-                    args.display_msg = "Uh-oh!".to_string();
+                    // TODO: use gettext to i18n this string. Note that I changed %d to %s because
+                    // there is actually no guarantee that the user passed us a number
+                    args.display_msg =
+                        fmt!("%s: %s: invalid loglevel value", &opts[0], log_level_str);
                     args.should_return = true;
                     args.return_code = EXIT_FAILURE;
                 }

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -1,4 +1,5 @@
 use clap::{App, Arg};
+use gettextrs::gettext;
 use libc::{EXIT_FAILURE, EXIT_SUCCESS};
 
 use logger::Level;
@@ -311,10 +312,11 @@ impl CliArgsParser {
                     args.log_level = Level::Debug;
                 }
                 _ => {
-                    // TODO: use gettext to i18n this string. Note that I changed %d to %s because
-                    // there is actually no guarantee that the user passed us a number
-                    args.display_msg =
-                        fmt!("%s: %s: invalid loglevel value", &opts[0], log_level_str);
+                    args.display_msg = fmt!(
+                        &gettext("%s: %s: invalid loglevel value"),
+                        &opts[0],
+                        log_level_str
+                    );
                     args.should_return = true;
                     args.return_code = EXIT_FAILURE;
                 }

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -9,14 +9,19 @@ pub struct CliArgsParser {
     pub do_export: bool,
     pub do_vacuum: bool,
     pub program_name: String,
-    pub do_read_import: bool,
-    pub do_read_export: bool,
-    pub readinfofile: String,
     pub show_version: usize,
     pub silent: bool,
 
     /// If this contains some value, it's the path to the OPML file that should be imported.
     pub importfile: Option<String>,
+
+    /// If this contains some value, it's the path to the file from which the list of read articles
+    /// should be imported.
+    pub readinfo_import_file: Option<String>,
+
+    /// If this contains some value, it's the path to the file to which the list of read articles
+    /// should be exported.
+    pub readinfo_export_file: Option<String>,
 
     /// If this contains some value, the creator of `CliArgsParser` object should call
     /// `exit(return_code)`.
@@ -233,22 +238,20 @@ impl CliArgsParser {
         }
 
         if let Some(importfile) = matches.value_of(IMPORT_FROM_FILE) {
-            if args.do_read_export {
+            if args.readinfo_export_file.is_some() {
                 args.should_print_usage = true;
                 args.return_code = Some(EXIT_FAILURE);
             } else {
-                args.do_read_import = true;
-                args.readinfofile = importfile.to_string();
+                args.readinfo_import_file = Some(importfile.to_string());
             }
         }
 
         if let Some(exportfile) = matches.value_of(EXPORT_TO_FILE) {
-            if args.do_read_import {
+            if args.readinfo_import_file.is_some() {
                 args.should_print_usage = true;
                 args.return_code = Some(EXIT_FAILURE);
             } else {
-                args.do_read_export = true;
-                args.readinfofile = exportfile.to_string();
+                args.readinfo_export_file = Some(exportfile.to_string());
             }
         }
 
@@ -619,14 +622,13 @@ mod tests {
     }
 
     #[test]
-    fn t_sets_do_read_import_and_readinfofile_if_dash_capital_i_is_provided() {
+    fn t_sets_readinfo_import_file_if_dash_capital_i_is_provided() {
         let filename = "filename".to_string();
 
         let check = |opts| {
             let args = CliArgsParser::new(opts);
 
-            assert!(args.do_read_import);
-            assert_eq!(args.readinfofile, filename);
+            assert_eq!(args.readinfo_import_file, Some(filename.clone()));
         };
 
         check(vec![
@@ -641,14 +643,13 @@ mod tests {
     }
 
     #[test]
-    fn t_sets_do_read_export_and_readinfofile_if_dash_capital_e_is_provided() {
+    fn t_sets_readinfo_export_file_if_dash_capital_e_is_provided() {
         let filename = "filename".to_string();
 
         let check = |opts| {
             let args = CliArgsParser::new(opts);
 
-            assert!(args.do_read_export);
-            assert_eq!(args.readinfofile, filename);
+            assert_eq!(args.readinfo_export_file, Some(filename.clone()));
         };
 
         check(vec![

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -6,16 +6,17 @@ use logger::Level;
 
 #[derive(Default)]
 pub struct CliArgsParser {
-    pub do_import: bool,
     pub do_export: bool,
     pub do_vacuum: bool,
     pub program_name: String,
-    pub importfile: String,
     pub do_read_import: bool,
     pub do_read_export: bool,
     pub readinfofile: String,
     pub show_version: usize,
     pub silent: bool,
+
+    /// If this contains some value, it's the path to the OPML file that should be imported.
+    pub importfile: Option<String>,
 
     /// If this contains some value, the creator of `CliArgsParser` object should call
     /// `exit(return_code)`.
@@ -175,7 +176,7 @@ impl CliArgsParser {
         };
 
         if matches.is_present(EXPORT_TO_OPML) {
-            if args.do_import {
+            if args.importfile.is_some() {
                 args.should_print_usage = true;
                 args.return_code = Some(EXIT_FAILURE);
             } else {
@@ -200,8 +201,7 @@ impl CliArgsParser {
                 args.should_print_usage = true;
                 args.return_code = Some(EXIT_FAILURE);
             } else {
-                args.do_import = true;
-                args.importfile = importfile.to_string();
+                args.importfile = Some(importfile.to_string());
             }
         }
 
@@ -325,8 +325,7 @@ mod tests {
         let check = |opts| {
             let args = CliArgsParser::new(opts);
 
-            assert!(args.do_import);
-            assert_eq!(args.importfile, filename);
+            assert_eq!(args.importfile, Some(filename.clone()));
         };
 
         check(vec![

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -16,7 +16,6 @@ pub struct CliArgsParser {
     pub readinfofile: String,
     pub show_version: usize,
     pub silent: bool,
-    pub using_nonstandard_configs: bool,
 
     /// If this contains some value, the creator of `CliArgsParser` object should call
     /// `exit(return_code)`.
@@ -208,18 +207,15 @@ impl CliArgsParser {
 
         if let Some(url_file) = matches.value_of(URL_FILE) {
             args.url_file = Some(url_file.to_string());
-            args.using_nonstandard_configs = true;
         }
 
         if let Some(cache_file) = matches.value_of(CACHE_FILE) {
             args.cache_file = Some(cache_file.to_string());
             args.lock_file = Some(cache_file.to_string() + LOCK_SUFFIX);
-            args.using_nonstandard_configs = true;
         }
 
         if let Some(config_file) = matches.value_of(CONFIG_FILE) {
             args.config_file = Some(config_file.to_string());
-            args.using_nonstandard_configs = true;
         }
 
         // Casting u64 to usize. Highly unlikely that the user will hit the limit, even if we were
@@ -292,6 +288,10 @@ impl CliArgsParser {
         }
 
         args
+    }
+
+    pub fn using_nonstandard_configs(&self) -> bool {
+        self.url_file.is_some() || self.cache_file.is_some() || self.config_file.is_some()
     }
 }
 
@@ -428,7 +428,7 @@ mod tests {
             let args = CliArgsParser::new(opts);
 
             assert_eq!(args.url_file, Some(filename.clone()));
-            assert!(args.using_nonstandard_configs);
+            assert!(args.using_nonstandard_configs());
         };
 
         check(vec![
@@ -452,7 +452,7 @@ mod tests {
 
             assert_eq!(args.cache_file, Some(filename.clone()));
             assert_eq!(args.lock_file, Some(filename.clone() + ".lock"));
-            assert!(args.using_nonstandard_configs);
+            assert!(args.using_nonstandard_configs());
         };
 
         check(vec![
@@ -474,7 +474,7 @@ mod tests {
             let args = CliArgsParser::new(opts);
 
             assert_eq!(args.config_file, Some(filename.clone()));
-            assert!(args.using_nonstandard_configs);
+            assert!(args.using_nonstandard_configs());
         };
 
         check(vec![

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -9,10 +9,10 @@ pub struct CliArgsParser {
     pub do_import: bool,
     pub do_export: bool,
     pub do_vacuum: bool,
+    pub program_name: String,
     pub importfile: String,
     pub do_read_import: bool,
     pub do_read_export: bool,
-    pub program_name: String,
     pub readinfofile: String,
     pub show_version: usize,
     pub silent: bool,
@@ -175,19 +175,21 @@ impl CliArgsParser {
                     .takes_value(true),
             );
 
+        let mut args = CliArgsParser::default();
+
+        if let Some(program_name) = opts.get(0).and_then(|s| Some(s.clone())) {
+            args.program_name = program_name;
+        }
+
         let matches = match app.get_matches_from_safe(&opts) {
             Ok(matches) => matches,
             Err(_) => {
-                return CliArgsParser {
-                    should_print_usage: true,
-                    should_return: true,
-                    return_code: EXIT_FAILURE,
-                    ..CliArgsParser::default()
-                };
+                args.should_print_usage = true;
+                args.should_return = true;
+                args.return_code = EXIT_FAILURE;
+                return args;
             }
         };
-
-        let mut args = CliArgsParser::default();
 
         if matches.is_present(EXPORT_TO_OPML) {
             if args.do_import {

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -836,4 +836,32 @@ mod tests {
             "--log-level=90001".to_string(),
         ]);
     }
+
+    #[test]
+    fn t_sets_program_name_to_the_first_string_of_the_options_list() {
+        let check = |opts, expected| {
+            let args = CliArgsParser::new(opts);
+
+            assert_eq!(args.program_name, expected);
+        };
+
+        check(vec!["newsboat".to_string()], "newsboat".to_string());
+        check(
+            vec!["podboat".to_string(), "-h".to_string()],
+            "podboat".to_string(),
+        );
+        check(
+            vec![
+                "something else entirely".to_string(),
+                "--foo".to_string(),
+                "--bar".to_string(),
+                "--baz".to_string(),
+            ],
+            "something else entirely".to_string(),
+        );
+        check(
+            vec!["/usr/local/bin/app-with-a-path".to_string()],
+            "/usr/local/bin/app-with-a-path".to_string(),
+        );
+    }
 }

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -76,6 +76,8 @@ pub struct CliArgsParser {
     pub log_level: Level,
 }
 
+const LOCK_SUFFIX: &str = ".lock";
+
 impl CliArgsParser {
     pub fn new(opts: Vec<String>) -> CliArgsParser {
         const CACHE_FILE: &str = "cache-file";
@@ -230,8 +232,7 @@ impl CliArgsParser {
             args.set_cache_file = true;
             args.cache_file = cache_file.to_string();
             args.set_lock_file = true;
-            // TODO: append a lock suffix to this name
-            args.lock_file = cache_file.to_string();
+            args.lock_file = cache_file.to_string() + LOCK_SUFFIX;
             args.using_nonstandard_configs = true;
         }
 
@@ -483,9 +484,7 @@ mod tests {
             assert!(args.set_cache_file);
             assert_eq!(args.cache_file, filename);
             assert!(args.set_lock_file);
-            // TODO: check that the name is different from the cache's name, and ends with a lock
-            // file suffix
-            assert!(args.lock_file.starts_with(&filename));
+            assert_eq!(args.lock_file, filename.clone() + ".lock");
             assert!(args.using_nonstandard_configs);
         };
 

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate strprintf;
+
 extern crate backtrace;
 #[macro_use]
 extern crate nom;

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -9,6 +9,7 @@ extern crate once_cell;
 #[macro_use]
 extern crate proptest;
 extern crate clap;
+extern crate gettextrs;
 extern crate libc;
 
 // This module must be declared before the others because it exports a `log!` macro that everyone

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -5,6 +5,8 @@ extern crate once_cell;
 #[cfg(test)]
 #[macro_use]
 extern crate proptest;
+extern crate clap;
+extern crate libc;
 
 // This module must be declared before the others because it exports a `log!` macro that everyone
 // else uses.
@@ -14,4 +16,5 @@ pub mod logger;
 pub mod human_panic;
 pub mod utils;
 
+pub mod cliargsparser;
 pub mod fmtstrformatter;

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 /// "Importance levels" for log messages.
 ///
 /// Each message is assigned a level. set_loglevel instructs Logger to only store messages at and
@@ -68,6 +68,12 @@ impl fmt::Display for Level {
             Level::Info => write!(f, "INFO"),
             Level::Debug => write!(f, "DEBUG"),
         }
+    }
+}
+
+impl Default for Level {
+    fn default() -> Level {
+        Level::None
     }
 }
 

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -142,10 +142,10 @@ CliArgsParser::CliArgsParser(int argc, char* argv[])
 				log_level = l;
 			} else {
 				display_msg =
-					strprintf::fmt(_("%s: %d: invalid "
+					strprintf::fmt(_("%s: %s: invalid "
 							 "loglevel value"),
 						argv[0],
-						static_cast<int>(l));
+						optarg);
 
 				should_return = true;
 				return_code = EXIT_FAILURE;

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -6,299 +6,235 @@
 #include "globals.h"
 #include "strprintf.h"
 
+#include "rs_utils.h"
+
+extern "C" {
+	void* create_rs_cliargsparser(int argc, char* argv[]);
+
+	void destroy_rs_cliargsparser(void*);
+
+	bool rs_cliargsparser_do_import(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_do_export(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_do_vacuum(void* rs_cliargsparser);
+
+	char* rs_cliargsparser_importfile(void* rs_cliargsparser);
+
+	char* rs_cliargsparser_program_name(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_do_read_import(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_do_read_export(void* rs_cliargsparser);
+
+	char* rs_cliargsparser_readinfofile(void* rs_cliargsparser);
+
+	unsigned int rs_cliargsparser_show_version(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_silent(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_using_nonstandard_configs(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_should_return(void* rs_cliargsparser);
+
+	int rs_cliargsparser_return_code(void* rs_cliargsparser);
+
+	char* rs_cliargsparser_display_msg(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_should_print_usage(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_refresh_on_start(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_set_url_file(void* rs_cliargsparser);
+
+	char* rs_cliargsparser_url_file(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_set_lock_file(void* rs_cliargsparser);
+
+	char* rs_cliargsparser_lock_file(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_set_cache_file(void* rs_cliargsparser);
+
+	char* rs_cliargsparser_cache_file(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_set_config_file(void* rs_cliargsparser);
+
+	char* rs_cliargsparser_config_file(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_execute_cmds(void* rs_cliargsparser);
+
+	unsigned int rs_cliargsparser_cmds_to_execute_count(void* rs_cliargsparser);
+	char* rs_cliargsparser_cmd_to_execute_n(void* rs_cliargsparser, unsigned int n);
+
+	bool rs_cliargsparser_set_log_file(void* rs_cliargsparser);
+
+	char* rs_cliargsparser_log_file(void* rs_cliargsparser);
+
+	bool rs_cliargsparser_set_log_level(void* rs_cliargsparser);
+
+	unsigned char rs_cliargsparser_log_level(void* rs_cliargsparser);
+}
+
+#define GET_VALUE(NAME, DEFAULT) \
+	if (rs_cliargsparser) { \
+		return rs_cliargsparser_ ## NAME (rs_cliargsparser); \
+	} else { \
+		return DEFAULT; \
+	}
+
+#define GET_STRING(NAME) \
+	if (rs_cliargsparser) { \
+		return RustString(rs_cliargsparser_ ## NAME (rs_cliargsparser)); \
+	} else { \
+		return {}; \
+	}
+
 namespace newsboat {
 
 CliArgsParser::CliArgsParser(int argc, char* argv[])
 {
-	int c;
+	rs_cliargsparser = create_rs_cliargsparser(argc, argv);
+}
 
-	m_program_name = argv[0];
-
-	static const char getopt_str[] = "i:erhqu:c:C:d:l:vVx:XI:E:";
-	static const struct option longopts[] = {
-		{"cache-file", required_argument, 0, 'c'},
-		{"config-file", required_argument, 0, 'C'},
-		{"execute", required_argument, 0, 'x'},
-		{"export-to-file", required_argument, 0, 'E'},
-		{"export-to-opml", no_argument, 0, 'e'},
-		{"help", no_argument, 0, 'h'},
-		{"import-from-file", required_argument, 0, 'I'},
-		{"import-from-opml", required_argument, 0, 'i'},
-		{"log-file", required_argument, 0, 'd'},
-		{"log-level", required_argument, 0, 'l'},
-		{"quiet", no_argument, 0, 'q'},
-		{"refresh-on-start", no_argument, 0, 'r'},
-		{"url-file", required_argument, 0, 'u'},
-		{"vacuum", no_argument, 0, 'X'},
-		{"version", no_argument, 0, 'v'},
-		{0, 0, 0, 0}};
-
-	// Ask getopt to re-initialize itself.
-	//
-	// This isn't necessary for real-world use, because we parse arguments
-	// only once; but this is *very* important in tests, where CliArgsParser
-	// is ran dozens of times.
-	//
-	// Note we use 0, not 1. getopt(3) says that the value of 0 forces
-	// getopt() to re-initialize some more internal stuff. This shouldn't
-	// make a difference in our case, but somehow it does - if we use 1,
-	// tests start to fail.
-	optind = 0;
-
-	while ((c = ::getopt_long(argc, argv, getopt_str, longopts, nullptr)) !=
-		-1) {
-		switch (c) {
-		case ':': /* fall-through */
-		case '?': /* missing option */
-			m_should_print_usage = true;
-
-			m_should_return = true;
-			m_return_code = EXIT_FAILURE;
-
-			break;
-		case 'i':
-			if (m_do_export) {
-				m_should_print_usage = true;
-
-				m_should_return = true;
-				m_return_code = EXIT_FAILURE;
-
-				break;
-			}
-			m_do_import = true;
-			m_importfile = optarg;
-			break;
-		case 'r':
-			m_refresh_on_start = true;
-			break;
-		case 'e':
-			// disable logging of newsboat's startup progress to
-			// stdout, because the OPML export will be printed to
-			// stdout.
-			m_silent = true;
-			if (m_do_import) {
-				m_should_print_usage = true;
-
-				m_should_return = true;
-				m_return_code = EXIT_FAILURE;
-
-				break;
-			}
-			m_do_export = true;
-			break;
-		case 'h':
-			m_should_print_usage = true;
-			m_should_return = true;
-			m_return_code = EXIT_SUCCESS;
-			break;
-		case 'u':
-			m_set_url_file = true;
-			m_url_file = optarg;
-			m_using_nonstandard_configs = true;
-			break;
-		case 'c':
-			m_set_cache_file = true;
-			m_cache_file = optarg;
-			m_set_lock_file = true;
-			m_lock_file = std::string(m_cache_file) + LOCK_SUFFIX;
-			m_using_nonstandard_configs = true;
-			break;
-		case 'C':
-			m_set_config_file = true;
-			m_config_file = optarg;
-			m_using_nonstandard_configs = true;
-			break;
-		case 'X':
-			m_do_vacuum = true;
-			break;
-		case 'v':
-		case 'V':
-			m_show_version++;
-			break;
-		case 'x':
-			// disable logging of newsboat's startup progress to
-			// stdout, because the command execution result will be
-			// printed to stdout
-			m_silent = true;
-
-			m_execute_cmds = true;
-			m_cmds_to_execute.push_back(optarg);
-			while (optind < argc && *argv[optind] != '-') {
-				m_cmds_to_execute.push_back(argv[optind]);
-				optind++;
-			}
-			break;
-		case 'q':
-			m_silent = true;
-			break;
-		case 'd':
-			m_set_log_file = true;
-			m_log_file = optarg;
-			break;
-		case 'l': {
-			Level l = static_cast<Level>(atoi(optarg));
-			if (l > Level::NONE && l <= Level::DEBUG) {
-				m_set_log_level = true;
-				m_log_level = l;
-			} else {
-				m_display_msg =
-					strprintf::fmt(_("%s: %s: invalid "
-							 "loglevel value"),
-						argv[0],
-						optarg);
-
-				m_should_return = true;
-				m_return_code = EXIT_FAILURE;
-
-				break;
-			}
-		} break;
-		case 'I':
-			if (m_do_read_export) {
-				m_should_print_usage = true;
-
-				m_should_return = true;
-				m_return_code = EXIT_FAILURE;
-
-				break;
-			}
-			m_do_read_import = true;
-			m_readinfofile = optarg;
-			break;
-		case 'E':
-			if (m_do_read_import) {
-				m_should_print_usage = true;
-
-				m_should_return = true;
-				m_return_code = EXIT_FAILURE;
-
-				break;
-			}
-			m_do_read_export = true;
-			m_readinfofile = optarg;
-			break;
-		}
-	};
+CliArgsParser::~CliArgsParser() {
+	if (rs_cliargsparser) {
+		destroy_rs_cliargsparser(rs_cliargsparser);
+	}
 }
 
 bool CliArgsParser::do_import() const {
-	return m_do_import;
+	GET_VALUE(do_import, false);
 }
 
 bool CliArgsParser::do_export() const {
-	return m_do_export;
+	GET_VALUE(do_export, false);
 }
 
 bool CliArgsParser::do_vacuum() const {
-	return m_do_vacuum;
+	GET_VALUE(do_vacuum, false);
 }
 
 std::string CliArgsParser::importfile() const {
-	return m_importfile;
+	GET_STRING(importfile);
 }
 
 bool CliArgsParser::do_read_import() const {
-	return m_do_read_import;
+	GET_VALUE(do_read_import, false);
 }
 
 bool CliArgsParser::do_read_export() const {
-	return m_do_read_export;
+	GET_VALUE(do_read_export, false);
 }
 
 std::string CliArgsParser::readinfofile() const {
-	return m_readinfofile;
+	GET_STRING(readinfofile);
 }
 
 std::string CliArgsParser::program_name() const {
-	return m_program_name;
+	GET_STRING(program_name);
 }
 
 unsigned int CliArgsParser::show_version() const {
-	return m_show_version;
+	GET_VALUE(show_version, 0);
 }
 
 bool CliArgsParser::silent() const {
-	return m_silent;
+	GET_VALUE(silent, false);
 }
 
 bool CliArgsParser::using_nonstandard_configs() const {
-	return m_using_nonstandard_configs;
+	GET_VALUE(using_nonstandard_configs, false);
 }
 
 bool CliArgsParser::should_return() const {
-	return m_should_return;
+	GET_VALUE(should_return, false);
 }
 
 int CliArgsParser::return_code() const {
-	return m_return_code;
+	GET_VALUE(return_code, 0);
 }
 
 std::string CliArgsParser::display_msg() const {
-	return m_display_msg;
+	GET_STRING(display_msg);
 }
 
 bool CliArgsParser::should_print_usage() const {
-	return m_should_print_usage;
+	GET_VALUE(should_print_usage, false);
 }
 
 bool CliArgsParser::refresh_on_start() const {
-	return m_refresh_on_start;
+	GET_VALUE(refresh_on_start, false);
 }
 
 bool CliArgsParser::set_url_file() const {
-	return m_set_url_file;
+	GET_VALUE(set_url_file, false);
 }
 
 std::string CliArgsParser::url_file() const {
-	return m_url_file;
+	GET_STRING(url_file);
 }
 
 bool CliArgsParser::set_lock_file() const {
-	return m_set_lock_file;
+	GET_VALUE(set_lock_file, false);
 }
 
 std::string CliArgsParser::lock_file() const {
-	return m_lock_file;
+	GET_STRING(lock_file);
 }
 
 bool CliArgsParser::set_cache_file() const {
-	return m_set_cache_file;
+	GET_VALUE(set_cache_file, false);
 }
 
 std::string CliArgsParser::cache_file() const {
-	return m_cache_file;
+	GET_STRING(cache_file);
 }
 
 bool CliArgsParser::set_config_file() const {
-	return m_set_config_file;
+	GET_VALUE(set_config_file, false);
 }
 
 std::string CliArgsParser::config_file() const {
-	return m_config_file;
+	GET_STRING(config_file);
 }
 
 bool CliArgsParser::execute_cmds() const {
-	return m_execute_cmds;
+	GET_VALUE(execute_cmds, false);
 }
 
 std::vector<std::string> CliArgsParser::cmds_to_execute() const {
-	return m_cmds_to_execute;
+	if (rs_cliargsparser) {
+		std::vector<std::string> result;
+
+		const auto count = rs_cliargsparser_cmds_to_execute_count(rs_cliargsparser);
+		for (unsigned int i = 0; i < count; ++i) {
+			result.push_back(RustString(rs_cliargsparser_cmd_to_execute_n(rs_cliargsparser, i)));
+		}
+
+		return result;
+	} else {
+		return {};
+	}
 }
 
 bool CliArgsParser::set_log_file() const {
-	return m_set_log_file;
+	GET_VALUE(set_log_file, false);
 }
 
 std::string CliArgsParser::log_file() const {
-	return m_log_file;
+	GET_STRING(log_file);
 }
 
 bool CliArgsParser::set_log_level() const {
-	return m_set_log_level;
+	GET_VALUE(set_log_level, false);
 }
 
 Level CliArgsParser::log_level() const {
-	return m_log_level;
+	if (rs_cliargsparser) {
+		return static_cast<Level>(rs_cliargsparser_log_level(rs_cliargsparser));
+	} else {
+		return Level::NONE;
+	}
 }
 
 } // namespace newsboat

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -12,7 +12,7 @@ CliArgsParser::CliArgsParser(int argc, char* argv[])
 {
 	int c;
 
-	program_name = argv[0];
+	m_program_name = argv[0];
 
 	static const char getopt_str[] = "i:erhqu:c:C:d:l:vVx:XI:E:";
 	static const struct option longopts[] = {
@@ -50,135 +50,256 @@ CliArgsParser::CliArgsParser(int argc, char* argv[])
 		switch (c) {
 		case ':': /* fall-through */
 		case '?': /* missing option */
-			should_print_usage = true;
+			m_should_print_usage = true;
 
-			should_return = true;
-			return_code = EXIT_FAILURE;
+			m_should_return = true;
+			m_return_code = EXIT_FAILURE;
 
 			break;
 		case 'i':
-			if (do_export) {
-				should_print_usage = true;
+			if (m_do_export) {
+				m_should_print_usage = true;
 
-				should_return = true;
-				return_code = EXIT_FAILURE;
+				m_should_return = true;
+				m_return_code = EXIT_FAILURE;
 
 				break;
 			}
-			do_import = true;
-			importfile = optarg;
+			m_do_import = true;
+			m_importfile = optarg;
 			break;
 		case 'r':
-			refresh_on_start = true;
+			m_refresh_on_start = true;
 			break;
 		case 'e':
 			// disable logging of newsboat's startup progress to
 			// stdout, because the OPML export will be printed to
 			// stdout.
-			silent = true;
-			if (do_import) {
-				should_print_usage = true;
+			m_silent = true;
+			if (m_do_import) {
+				m_should_print_usage = true;
 
-				should_return = true;
-				return_code = EXIT_FAILURE;
+				m_should_return = true;
+				m_return_code = EXIT_FAILURE;
 
 				break;
 			}
-			do_export = true;
+			m_do_export = true;
 			break;
 		case 'h':
-			should_print_usage = true;
-			should_return = true;
-			return_code = EXIT_SUCCESS;
+			m_should_print_usage = true;
+			m_should_return = true;
+			m_return_code = EXIT_SUCCESS;
 			break;
 		case 'u':
-			set_url_file = true;
-			url_file = optarg;
-			using_nonstandard_configs = true;
+			m_set_url_file = true;
+			m_url_file = optarg;
+			m_using_nonstandard_configs = true;
 			break;
 		case 'c':
-			set_cache_file = true;
-			cache_file = optarg;
-			set_lock_file = true;
-			lock_file = std::string(cache_file) + LOCK_SUFFIX;
-			using_nonstandard_configs = true;
+			m_set_cache_file = true;
+			m_cache_file = optarg;
+			m_set_lock_file = true;
+			m_lock_file = std::string(m_cache_file) + LOCK_SUFFIX;
+			m_using_nonstandard_configs = true;
 			break;
 		case 'C':
-			set_config_file = true;
-			config_file = optarg;
-			using_nonstandard_configs = true;
+			m_set_config_file = true;
+			m_config_file = optarg;
+			m_using_nonstandard_configs = true;
 			break;
 		case 'X':
-			do_vacuum = true;
+			m_do_vacuum = true;
 			break;
 		case 'v':
 		case 'V':
-			show_version++;
+			m_show_version++;
 			break;
 		case 'x':
 			// disable logging of newsboat's startup progress to
 			// stdout, because the command execution result will be
 			// printed to stdout
-			silent = true;
+			m_silent = true;
 
-			execute_cmds = true;
-			cmds_to_execute.push_back(optarg);
+			m_execute_cmds = true;
+			m_cmds_to_execute.push_back(optarg);
 			while (optind < argc && *argv[optind] != '-') {
-				cmds_to_execute.push_back(argv[optind]);
+				m_cmds_to_execute.push_back(argv[optind]);
 				optind++;
 			}
 			break;
 		case 'q':
-			silent = true;
+			m_silent = true;
 			break;
 		case 'd':
-			set_log_file = true;
-			log_file = optarg;
+			m_set_log_file = true;
+			m_log_file = optarg;
 			break;
 		case 'l': {
 			Level l = static_cast<Level>(atoi(optarg));
 			if (l > Level::NONE && l <= Level::DEBUG) {
-				set_log_level = true;
-				log_level = l;
+				m_set_log_level = true;
+				m_log_level = l;
 			} else {
-				display_msg =
+				m_display_msg =
 					strprintf::fmt(_("%s: %s: invalid "
 							 "loglevel value"),
 						argv[0],
 						optarg);
 
-				should_return = true;
-				return_code = EXIT_FAILURE;
+				m_should_return = true;
+				m_return_code = EXIT_FAILURE;
 
 				break;
 			}
 		} break;
 		case 'I':
-			if (do_read_export) {
-				should_print_usage = true;
+			if (m_do_read_export) {
+				m_should_print_usage = true;
 
-				should_return = true;
-				return_code = EXIT_FAILURE;
+				m_should_return = true;
+				m_return_code = EXIT_FAILURE;
 
 				break;
 			}
-			do_read_import = true;
-			readinfofile = optarg;
+			m_do_read_import = true;
+			m_readinfofile = optarg;
 			break;
 		case 'E':
-			if (do_read_import) {
-				should_print_usage = true;
+			if (m_do_read_import) {
+				m_should_print_usage = true;
 
-				should_return = true;
-				return_code = EXIT_FAILURE;
+				m_should_return = true;
+				m_return_code = EXIT_FAILURE;
 
 				break;
 			}
-			do_read_export = true;
-			readinfofile = optarg;
+			m_do_read_export = true;
+			m_readinfofile = optarg;
 			break;
 		}
 	};
 }
 
+bool CliArgsParser::do_import() const {
+	return m_do_import;
+}
+
+bool CliArgsParser::do_export() const {
+	return m_do_export;
+}
+
+bool CliArgsParser::do_vacuum() const {
+	return m_do_vacuum;
+}
+
+std::string CliArgsParser::importfile() const {
+	return m_importfile;
+}
+
+bool CliArgsParser::do_read_import() const {
+	return m_do_read_import;
+}
+
+bool CliArgsParser::do_read_export() const {
+	return m_do_read_export;
+}
+
+std::string CliArgsParser::readinfofile() const {
+	return m_readinfofile;
+}
+
+std::string CliArgsParser::program_name() const {
+	return m_program_name;
+}
+
+unsigned int CliArgsParser::show_version() const {
+	return m_show_version;
+}
+
+bool CliArgsParser::silent() const {
+	return m_silent;
+}
+
+bool CliArgsParser::using_nonstandard_configs() const {
+	return m_using_nonstandard_configs;
+}
+
+bool CliArgsParser::should_return() const {
+	return m_should_return;
+}
+
+int CliArgsParser::return_code() const {
+	return m_return_code;
+}
+
+std::string CliArgsParser::display_msg() const {
+	return m_display_msg;
+}
+
+bool CliArgsParser::should_print_usage() const {
+	return m_should_print_usage;
+}
+
+bool CliArgsParser::refresh_on_start() const {
+	return m_refresh_on_start;
+}
+
+bool CliArgsParser::set_url_file() const {
+	return m_set_url_file;
+}
+
+std::string CliArgsParser::url_file() const {
+	return m_url_file;
+}
+
+bool CliArgsParser::set_lock_file() const {
+	return m_set_lock_file;
+}
+
+std::string CliArgsParser::lock_file() const {
+	return m_lock_file;
+}
+
+bool CliArgsParser::set_cache_file() const {
+	return m_set_cache_file;
+}
+
+std::string CliArgsParser::cache_file() const {
+	return m_cache_file;
+}
+
+bool CliArgsParser::set_config_file() const {
+	return m_set_config_file;
+}
+
+std::string CliArgsParser::config_file() const {
+	return m_config_file;
+}
+
+bool CliArgsParser::execute_cmds() const {
+	return m_execute_cmds;
+}
+
+std::vector<std::string> CliArgsParser::cmds_to_execute() const {
+	return m_cmds_to_execute;
+}
+
+bool CliArgsParser::set_log_file() const {
+	return m_set_log_file;
+}
+
+std::string CliArgsParser::log_file() const {
+	return m_log_file;
+}
+
+bool CliArgsParser::set_log_level() const {
+	return m_set_log_level;
+}
+
+Level CliArgsParser::log_level() const {
+	return m_log_level;
+}
+
 } // namespace newsboat
+

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -25,9 +25,11 @@ extern "C" {
 
 	bool rs_cliargsparser_do_read_import(void* rs_cliargsparser);
 
+	char* rs_cliargsparser_readinfo_import_file(void* rs_cliargsparser);
+
 	bool rs_cliargsparser_do_read_export(void* rs_cliargsparser);
 
-	char* rs_cliargsparser_readinfofile(void* rs_cliargsparser);
+	char* rs_cliargsparser_readinfo_export_file(void* rs_cliargsparser);
 
 	unsigned int rs_cliargsparser_show_version(void* rs_cliargsparser);
 
@@ -122,12 +124,16 @@ bool CliArgsParser::do_read_import() const {
 	GET_VALUE(do_read_import, false);
 }
 
+std::string CliArgsParser::readinfo_import_file() const {
+	GET_STRING(readinfo_import_file);
+}
+
 bool CliArgsParser::do_read_export() const {
 	GET_VALUE(do_read_export, false);
 }
 
-std::string CliArgsParser::readinfofile() const {
-	GET_STRING(readinfofile);
+std::string CliArgsParser::readinfo_export_file() const {
+	GET_STRING(readinfo_export_file);
 }
 
 std::string CliArgsParser::program_name() const {

--- a/src/configpaths.cpp
+++ b/src/configpaths.cpp
@@ -133,24 +133,24 @@ bool ConfigPaths::find_dirs_xdg()
 
 void ConfigPaths::process_args(const CliArgsParser& args)
 {
-	if (args.set_url_file) {
-		m_url_file = args.url_file;
+	if (args.set_url_file()) {
+		m_url_file = args.url_file();
 	}
 
-	if (args.set_cache_file) {
-		m_cache_file = args.cache_file;
+	if (args.set_cache_file()) {
+		m_cache_file = args.cache_file();
 	}
 
-	if (args.set_lock_file) {
-		m_lock_file = args.lock_file;
+	if (args.set_lock_file()) {
+		m_lock_file = args.lock_file();
 	}
 
-	if (args.set_config_file) {
-		m_config_file = args.config_file;
+	if (args.set_config_file()) {
+		m_config_file = args.config_file();
 	}
 
-	m_silent = args.silent;
-	m_using_nonstandard_configs = args.using_nonstandard_configs;
+	m_silent = args.silent();
+	m_using_nonstandard_configs = args.using_nonstandard_configs();
 }
 
 bool ConfigPaths::try_migrate_from_newsbeuter()

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -109,22 +109,22 @@ int Controller::run(const CliArgsParser& args)
 		return EXIT_FAILURE;
 	}
 
-	refresh_on_start = args.refresh_on_start;
+	refresh_on_start = args.refresh_on_start();
 
-	if (args.set_log_file) {
-		Logger::set_logfile(args.log_file);
+	if (args.set_log_file()) {
+		Logger::set_logfile(args.log_file());
 	}
 
-	if (args.set_log_level) {
-		Logger::set_loglevel(args.log_level);
+	if (args.set_log_level()) {
+		Logger::set_loglevel(args.log_level());
 	}
 
-	if (!args.display_msg.empty()) {
-		std::cerr << args.display_msg << std::endl;
+	if (!args.display_msg().empty()) {
+		std::cerr << args.display_msg() << std::endl;
 	}
 
-	if (args.should_return) {
-		return args.return_code;
+	if (args.should_return()) {
+		return args.return_code();
 	}
 
 	configpaths.process_args(args);
@@ -140,20 +140,20 @@ int Controller::run(const CliArgsParser& args)
 		return EXIT_FAILURE;
 	}
 
-	if (args.do_import) {
+	if (args.do_import()) {
 		LOG(Level::INFO,
 			"Importing OPML file from %s",
-			args.importfile);
+			args.importfile());
 		urlcfg = new FileUrlReader(configpaths.url_file());
 		urlcfg->reload();
-		import_opml(args.importfile);
+		import_opml(args.importfile());
 		return EXIT_SUCCESS;
 	}
 
 	LOG(Level::INFO, "nl_langinfo(CODESET): %s", nl_langinfo(CODESET));
 
-	if (!args.do_export) {
-		if (!args.silent)
+	if (!args.do_export()) {
+		if (!args.silent())
 			std::cout << strprintf::fmt(_("Starting %s %s..."),
 					     PROGRAM_NAME,
 					     PROGRAM_VERSION)
@@ -162,7 +162,7 @@ int Controller::run(const CliArgsParser& args)
 		fslock = std::unique_ptr<FsLock>(new FsLock());
 		pid_t pid;
 		if (!fslock->try_lock(configpaths.lock_file(), pid)) {
-			if (!args.execute_cmds) {
+			if (!args.execute_cmds()) {
 				std::cout << strprintf::fmt(
 						     _("Error: an instance of "
 						       "%s is already running "
@@ -175,7 +175,7 @@ int Controller::run(const CliArgsParser& args)
 		}
 	}
 
-	if (!args.silent)
+	if (!args.silent())
 		std::cout << _("Loading configuration...");
 	std::cout.flush();
 
@@ -209,12 +209,12 @@ int Controller::run(const CliArgsParser& args)
 
 	update_config();
 
-	if (!args.silent)
+	if (!args.silent())
 		std::cout << _("done.") << std::endl;
 
 	// create cache object
 	std::string cachefilepath = cfg.get_configvalue("cache-file");
-	if (cachefilepath.length() > 0 && !args.set_cache_file) {
+	if (cachefilepath.length() > 0 && !args.set_cache_file()) {
 		configpaths.set_cache_file(cachefilepath);
 		fslock = std::unique_ptr<FsLock>(new FsLock());
 		pid_t pid;
@@ -229,7 +229,7 @@ int Controller::run(const CliArgsParser& args)
 		}
 	}
 
-	if (!args.silent) {
+	if (!args.silent()) {
 		std::cout << _("Opening cache...");
 		std::cout.flush();
 	}
@@ -253,7 +253,7 @@ int Controller::run(const CliArgsParser& args)
 		return EXIT_FAILURE;
 	}
 
-	if (!args.silent) {
+	if (!args.silent()) {
 		std::cout << _("done.") << std::endl;
 	}
 
@@ -307,7 +307,7 @@ int Controller::run(const CliArgsParser& args)
 			urlcfg->get_source());
 	}
 
-	if (!args.do_export && !args.silent) {
+	if (!args.do_export() && !args.silent()) {
 		std::cout << strprintf::fmt(
 			_("Loading URLs from %s..."), urlcfg->get_source());
 		std::cout.flush();
@@ -319,7 +319,7 @@ int Controller::run(const CliArgsParser& args)
 		}
 	}
 	urlcfg->reload();
-	if (!args.do_export && !args.silent) {
+	if (!args.do_export() && !args.silent()) {
 		std::cout << _("done.") << std::endl;
 	}
 
@@ -364,13 +364,13 @@ int Controller::run(const CliArgsParser& args)
 		return EXIT_FAILURE;
 	}
 
-	if (!args.do_export && !args.do_vacuum && !args.silent)
+	if (!args.do_export() && !args.do_vacuum() && !args.silent())
 		std::cout << _("Loading articles from cache...");
-	if (args.do_vacuum)
+	if (args.do_vacuum())
 		std::cout << _("Opening cache...");
 	std::cout.flush();
 
-	if (args.do_vacuum) {
+	if (args.do_vacuum()) {
 		std::cout << _("done.") << std::endl;
 		std::cout << _("Cleaning up cache thoroughly...");
 		std::cout.flush();
@@ -410,49 +410,49 @@ int Controller::run(const CliArgsParser& args)
 
 	std::vector<std::string> tags = urlcfg->get_alltags();
 
-	if (!args.do_export && !args.silent)
+	if (!args.do_export() && !args.silent())
 		std::cout << _("done.") << std::endl;
 
 	// if configured, we fill all query feeds with some data; no need to
 	// sort it, it will be refilled when actually opening it.
 	if (cfg.get_configvalue_as_bool("prepopulate-query-feeds")) {
-		if (!args.do_export && !args.silent) {
+		if (!args.do_export() && !args.silent()) {
 			std::cout << _("Prepopulating query feeds...");
 			std::cout.flush();
 		}
 
 		feedcontainer.populate_query_feeds();
 
-		if (!args.do_export && !args.silent) {
+		if (!args.do_export() && !args.silent()) {
 			std::cout << _("done.") << std::endl;
 		}
 	}
 
 	feedcontainer.sort_feeds(cfg.get_feed_sort_strategy());
 
-	if (args.do_export) {
+	if (args.do_export()) {
 		export_opml();
 		return EXIT_SUCCESS;
 	}
 
-	if (args.do_read_import) {
+	if (args.do_read_import()) {
 		LOG(Level::INFO,
 			"Importing read information file from %s",
-			args.readinfofile);
+			args.readinfofile());
 		std::cout << _("Importing list of read articles...");
 		std::cout.flush();
-		import_read_information(args.readinfofile);
+		import_read_information(args.readinfofile());
 		std::cout << _("done.") << std::endl;
 		return EXIT_SUCCESS;
 	}
 
-	if (args.do_read_export) {
+	if (args.do_read_export()) {
 		LOG(Level::INFO,
 			"Exporting read information file to %s",
-			args.readinfofile);
+			args.readinfofile());
 		std::cout << _("Exporting list of read articles...");
 		std::cout.flush();
-		export_read_information(args.readinfofile);
+		export_read_information(args.readinfofile());
 		std::cout << _("done.") << std::endl;
 		return EXIT_SUCCESS;
 	}
@@ -464,8 +464,8 @@ int Controller::run(const CliArgsParser& args)
 	v->set_cache(rsscache);
 	v->set_filters(&filters);
 
-	if (args.execute_cmds) {
-		execute_commands(args.cmds_to_execute);
+	if (args.execute_cmds()) {
+		execute_commands(args.cmds_to_execute());
 		return EXIT_SUCCESS;
 	}
 
@@ -489,19 +489,19 @@ int Controller::run(const CliArgsParser& args)
 		configpaths.cmdline_file(),
 		history_limit);
 
-	if (!args.silent) {
+	if (!args.silent()) {
 		std::cout << _("Cleaning up cache...");
 		std::cout.flush();
 	}
 	try {
 		std::lock_guard<std::mutex> feedslock(feeds_mutex);
 		rsscache->cleanup_cache(feedcontainer.feeds);
-		if (!args.silent) {
+		if (!args.silent()) {
 			std::cout << _("done.") << std::endl;
 		}
 	} catch (const DbException& e) {
 		LOG(Level::USERERROR, "Cleaning up cache failed: %s", e.what());
-		if (!args.silent) {
+		if (!args.silent()) {
 			std::cout << _("failed: ") << e.what() << std::endl;
 			ret = EXIT_FAILURE;
 		}

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -438,10 +438,10 @@ int Controller::run(const CliArgsParser& args)
 	if (args.do_read_import()) {
 		LOG(Level::INFO,
 			"Importing read information file from %s",
-			args.readinfofile());
+			args.readinfo_import_file());
 		std::cout << _("Importing list of read articles...");
 		std::cout.flush();
-		import_read_information(args.readinfofile());
+		import_read_information(args.readinfo_import_file());
 		std::cout << _("done.") << std::endl;
 		return EXIT_SUCCESS;
 	}
@@ -449,10 +449,10 @@ int Controller::run(const CliArgsParser& args)
 	if (args.do_read_export()) {
 		LOG(Level::INFO,
 			"Exporting read information file to %s",
-			args.readinfofile());
+			args.readinfo_export_file());
 		std::cout << _("Exporting list of read articles...");
 		std::cout.flush();
-		export_read_information(args.readinfofile());
+		export_read_information(args.readinfo_export_file());
 		std::cout << _("done.") << std::endl;
 		return EXIT_SUCCESS;
 	}

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -205,8 +205,7 @@ TEST_CASE(
 		REQUIRE(args.set_cache_file);
 		REQUIRE(args.cache_file == filename);
 		REQUIRE(args.set_lock_file);
-		REQUIRE_THAT(
-			args.lock_file, Catch::Matchers::StartsWith(filename));
+		REQUIRE(args.lock_file == filename + ".lock");
 		REQUIRE(args.using_nonstandard_configs);
 	};
 

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -415,7 +415,7 @@ TEST_CASE(
 		CliArgsParser args(opts.argc(), opts.argv());
 
 		REQUIRE(args.do_read_import());
-		REQUIRE(args.readinfofile() == filename);
+		REQUIRE(args.readinfo_import_file() == filename);
 	};
 
 	SECTION("-I")
@@ -440,7 +440,7 @@ TEST_CASE(
 		CliArgsParser args(opts.argc(), opts.argv());
 
 		REQUIRE(args.do_read_export());
-		REQUIRE(args.readinfofile() == filename);
+		REQUIRE(args.readinfo_export_file() == filename);
 	};
 
 	SECTION("-E")

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -575,3 +575,20 @@ TEST_CASE(
 		check({"newsboat", "--log-level=90001"});
 	}
 }
+
+TEST_CASE("Sets `program_name` to the first string of the options list",
+		"[CliArgsParser]")
+{
+	auto check = [](TestHelpers::Opts opts, std::string expected) {
+		CliArgsParser args(opts.argc(), opts.argv());
+
+		REQUIRE(args.program_name() == expected);
+	};
+
+	check({"newsboat"}, "newsboat");
+	check({"podboat", "-h"}, "podboat");
+	check({"something else entirely", "--foo", "--bar", "--baz"},
+			"something else entirely");
+	check({"/usr/local/bin/app-with-a-path"},
+			"/usr/local/bin/app-with-a-path");
+}

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -15,9 +15,9 @@ TEST_CASE(
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.should_print_usage);
-		REQUIRE(args.should_return);
-		REQUIRE(args.return_code == EXIT_FAILURE);
+		REQUIRE(args.should_print_usage());
+		REQUIRE(args.should_return());
+		REQUIRE(args.return_code() == EXIT_FAILURE);
 	};
 
 	SECTION("Example No.1")
@@ -51,8 +51,8 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.do_import);
-		REQUIRE(args.importfile == filename);
+		REQUIRE(args.do_import());
+		REQUIRE(args.importfile() == filename);
 	};
 
 	SECTION("-i")
@@ -77,9 +77,9 @@ TEST_CASE(
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.should_print_usage);
-		REQUIRE(args.should_return);
-		REQUIRE(args.return_code == EXIT_FAILURE);
+		REQUIRE(args.should_print_usage());
+		REQUIRE(args.should_return());
+		REQUIRE(args.return_code() == EXIT_FAILURE);
 	};
 
 	SECTION("-i first")
@@ -99,7 +99,7 @@ TEST_CASE("Sets `refresh_on_start` if -r/--refresh-on-start is provided",
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.refresh_on_start);
+		REQUIRE(args.refresh_on_start());
 	};
 
 	SECTION("-r")
@@ -120,7 +120,7 @@ TEST_CASE("Requests silent mode if -e/--export-to-opml is provided",
 
 	CliArgsParser args(opts.argc(), opts.argv());
 
-	REQUIRE(args.silent);
+	REQUIRE(args.silent());
 }
 
 TEST_CASE("Sets `do_export` if -e/--export-to-opml is provided",
@@ -129,7 +129,7 @@ TEST_CASE("Sets `do_export` if -e/--export-to-opml is provided",
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.do_export);
+		REQUIRE(args.do_export());
 	};
 
 	SECTION("-e")
@@ -149,9 +149,9 @@ TEST_CASE("Asks to print usage and exit with success if -h/--help is provided",
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.should_print_usage);
-		REQUIRE(args.should_return);
-		REQUIRE(args.return_code == EXIT_SUCCESS);
+		REQUIRE(args.should_print_usage());
+		REQUIRE(args.should_return());
+		REQUIRE(args.return_code() == EXIT_SUCCESS);
 	};
 
 	SECTION("-h")
@@ -175,9 +175,9 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_url_file);
-		REQUIRE(args.url_file == filename);
-		REQUIRE(args.using_nonstandard_configs);
+		REQUIRE(args.set_url_file());
+		REQUIRE(args.url_file() == filename);
+		REQUIRE(args.using_nonstandard_configs());
 	};
 
 	SECTION("-u")
@@ -202,11 +202,11 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_cache_file);
-		REQUIRE(args.cache_file == filename);
-		REQUIRE(args.set_lock_file);
-		REQUIRE(args.lock_file == filename + ".lock");
-		REQUIRE(args.using_nonstandard_configs);
+		REQUIRE(args.set_cache_file());
+		REQUIRE(args.cache_file() == filename);
+		REQUIRE(args.set_lock_file());
+		REQUIRE(args.lock_file() == filename + ".lock");
+		REQUIRE(args.using_nonstandard_configs());
 	};
 
 	SECTION("-c")
@@ -230,9 +230,9 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_config_file);
-		REQUIRE(args.config_file == filename);
-		REQUIRE(args.using_nonstandard_configs);
+		REQUIRE(args.set_config_file());
+		REQUIRE(args.config_file() == filename);
+		REQUIRE(args.using_nonstandard_configs());
 	};
 
 	SECTION("-C")
@@ -251,7 +251,7 @@ TEST_CASE("Sets `do_vacuum` if -X/--vacuum is provided", "[CliArgsParser]")
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.do_vacuum);
+		REQUIRE(args.do_vacuum());
 	};
 
 	SECTION("-X")
@@ -271,7 +271,7 @@ TEST_CASE("Increases `show_version` with each -v/-V/--version provided",
 	auto check = [](TestHelpers::Opts opts, int expected_version) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.show_version == expected_version);
+		REQUIRE(args.show_version() == expected_version);
 	};
 
 	SECTION("-v => 1")
@@ -315,7 +315,7 @@ TEST_CASE("Requests silent mode if -x/--execute is provided", "[CliArgsParser]")
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.silent);
+		REQUIRE(args.silent());
 	};
 
 	SECTION("-x")
@@ -334,7 +334,7 @@ TEST_CASE("Sets `execute_cmds` if -x/--execute is provided", "[CliArgsParser]")
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.execute_cmds);
+		REQUIRE(args.execute_cmds());
 	};
 
 	SECTION("-x")
@@ -354,7 +354,7 @@ TEST_CASE("Inserts commands to cmds_to_execute if -x/--execute is provided",
 	auto check = [](TestHelpers::Opts opts, const std::vector<std::string>& cmds) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.cmds_to_execute == cmds);
+		REQUIRE(args.cmds_to_execute() == cmds);
 	};
 
 	SECTION("-x reload")
@@ -390,7 +390,7 @@ TEST_CASE("Requests silent mode if -q/--quiet is provided", "[CliArgsParser]")
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.silent);
+		REQUIRE(args.silent());
 	};
 
 	SECTION("-q")
@@ -414,8 +414,8 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.do_read_import);
-		REQUIRE(args.readinfofile == filename);
+		REQUIRE(args.do_read_import());
+		REQUIRE(args.readinfofile() == filename);
 	};
 
 	SECTION("-I")
@@ -439,8 +439,8 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.do_read_export);
-		REQUIRE(args.readinfofile == filename);
+		REQUIRE(args.do_read_export());
+		REQUIRE(args.readinfofile() == filename);
 	};
 
 	SECTION("-E")
@@ -465,9 +465,9 @@ TEST_CASE(
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.should_print_usage);
-		REQUIRE(args.should_return);
-		REQUIRE(args.return_code == EXIT_FAILURE);
+		REQUIRE(args.should_print_usage());
+		REQUIRE(args.should_return());
+		REQUIRE(args.return_code() == EXIT_FAILURE);
 	};
 
 	SECTION("-I first")
@@ -489,8 +489,8 @@ TEST_CASE("Sets `set_log_file` and `log_file` if -d/--log-file is provided",
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_log_file);
-		REQUIRE(args.log_file == filename);
+		REQUIRE(args.set_log_file());
+		REQUIRE(args.log_file() == filename);
 	};
 
 	SECTION("-d")
@@ -512,8 +512,8 @@ TEST_CASE(
 	auto check = [](TestHelpers::Opts opts, Level expected) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_log_level);
-		REQUIRE(args.log_level == expected);
+		REQUIRE(args.set_log_level());
+		REQUIRE(args.log_level() == expected);
 	};
 
 	SECTION("--log-level=1 means USERERROR")
@@ -555,9 +555,9 @@ TEST_CASE(
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE_FALSE(args.display_msg.empty());
-		REQUIRE(args.should_return);
-		REQUIRE(args.return_code == EXIT_FAILURE);
+		REQUIRE_FALSE(args.display_msg().empty());
+		REQUIRE(args.should_return());
+		REQUIRE(args.return_code() == EXIT_FAILURE);
 	};
 
 	SECTION("-l0")

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -379,6 +379,11 @@ TEST_CASE("Inserts commands to cmds_to_execute if -x/--execute is provided",
 		check({"newsboat", "--execute", "reload", "print-unread"},
 			{"reload", "print-unread"});
 	}
+
+	SECTION("Multiple occurrences of the option") {
+		check({"newsboat", "-x", "print-unread", "--execute", "reload"},
+			{"print-unread", "reload"});
+	}
 }
 
 TEST_CASE("Requests silent mode if -q/--quiet is provided", "[CliArgsParser]")


### PR DESCRIPTION
Fixes #525. Also closes #443, since one of the commits here finally employ gettext-rs and our own strprintf to internationalize a string.

Don't be put off by big added/removed counts: most of those changes are generated automatically, and are isolated to a single commit.

As usual, reviews are welcome! If nobody comments, I'll merge this in three days.