### PR TITLE
add color scheme based on Adapta-Maia GTK theme

### DIFF
--- a/contrib/colorschemes/kinda-maia
+++ b/contrib/colorschemes/kinda-maia
@@ -1,0 +1,13 @@
+#a theme inspired by the GTK Adapta-Maia theme.
+#works really well on a stock Manjaro.
+#
+#for "info" field, both "color35" and "color36" match well.
+
+color listfocus         color192 default
+color listfocus_unread  color155 default
+color info              color35 default reverse 
+
+# highlights
+highlight article "https?://[^ ]+" 		color117 default
+highlight article "^(Title):.*$"		color117 default
+highlight article "\\[image\\ [0-9]+\\]" 	color117 default


### PR DESCRIPTION
I created a color scheme based on my current computer's theme
(almost stock Manjaro), and wanted to share it.

it is mostly green with small touches of light blue.

comments and improvements would be much appreciated :)
![cap_nb1](https://user-images.githubusercontent.com/24274639/59136904-6d5d5680-8985-11e9-9f80-e6beffe21993.png)
![cap_nb2](https://user-images.githubusercontent.com/24274639/59136906-70584700-8985-11e9-8247-aa4d24cd1fff.png)
![cap_nb3](https://user-images.githubusercontent.com/24274639/59136911-74846480-8985-11e9-984b-2d5e42a4af65.png)

