### PR TITLE
Fix out-of-bounds access on empty author tag in RSS 0.9x

### DIFF
--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -88,8 +88,8 @@ Item Rss09xParser::parse_item(xmlNode* itemNode)
 		} else if (node_is(node, "date", DC_URI)) {
 			dc_date = w3cdtf_to_rfc822(get_content(node));
 		} else if (node_is(node, "author", ns)) {
-			std::string authorfield = get_content(node);
-			if (authorfield[authorfield.length() - 1] == ')') {
+			const std::string authorfield = get_content(node);
+			if (authorfield.length() > 2 && authorfield.back() == ')') {
 				it.author_email =
 					utils::tokenize(authorfield, " ")[0];
 				unsigned int start, end;

--- a/test/data/rss_091_with_empty_author.xml
+++ b/test/data/rss_091_with_empty_author.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<!DOCTYPE rss
+  SYSTEM 'http://my.netscape.com/publish/formats/rss-0.91.dtd'>
+<rss version="0.91">
+	<channel>
+		<title>A Channel with Unnamed Authors</title>
+		<link>http://example.com/</link>
+		<description>an example feed</description>
+		<language>en</language>
+
+		<item>
+			<title>This one has en empty author tag</title>
+			<link>http://example.com/test_1.html</link>
+            <author></author>
+            <description>It doesn't matter.</description>
+		</item>
+
+		<item>
+			<title>This one has en empty author tag as well</title>
+			<link>http://example.com/test_2.html</link>
+            <author/>
+			<description>Non-empty description though.</description>
+		</item>
+	</channel>
+</rss>

--- a/test/data/rss_092_with_empty_author.xml
+++ b/test/data/rss_092_with_empty_author.xml
@@ -1,0 +1,22 @@
+<rss version="0.92" xml:base="http://example.com/feed/rss_testing.html">
+	<channel>
+		<title>A Channel with Unnamed Authors</title>
+		<link>http://example.com/</link>
+		<description>an example feed</description>
+		<language>en</language>
+
+		<item>
+			<title>This one has en empty author tag</title>
+			<link>http://example.com/test_1.html</link>
+            <author></author>
+            <description>It doesn't matter.</description>
+		</item>
+
+		<item>
+			<title>This one has en empty author tag as well</title>
+			<link>http://example.com/test_2.html</link>
+            <author/>
+			<description>Non-empty description though.</description>
+		</item>
+	</channel>
+</rss>

--- a/test/data/rss_094_with_empty_author.xml
+++ b/test/data/rss_094_with_empty_author.xml
@@ -1,0 +1,22 @@
+<rss version="0.94" xml:base="http://example.com/feed/rss_testing.html">
+	<channel>
+		<title>A Channel with Unnamed Authors</title>
+		<link>http://example.com/</link>
+		<description>an example feed</description>
+		<language>en</language>
+
+		<item>
+			<title>This one has en empty author tag</title>
+			<link>http://example.com/test_1.html</link>
+            <author></author>
+            <description>It doesn't matter.</description>
+		</item>
+
+		<item>
+			<title>This one has en empty author tag as well</title>
+			<link>http://example.com/test_2.html</link>
+            <author/>
+			<description>Non-empty description though.</description>
+		</item>
+	</channel>
+</rss>

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -49,6 +49,48 @@ TEST_CASE("Extracts data from RSS 0.91", "[rsspp::Parser]")
 	REQUIRE(f.items[0].guid == "");
 }
 
+TEST_CASE("Doesn't crash or garble data if an item in RSS 0.9x contains "
+		"an empty author tag",
+		"[rsspp::Parser][issue542]")
+{
+	rsspp::Parser p;
+	rsspp::Feed f;
+
+	SECTION("RSS 0.91") {
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_091_with_empty_author.xml"));
+		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_91);
+	}
+
+	SECTION("RSS 0.92") {
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_092_with_empty_author.xml"));
+		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_92);
+	}
+
+	SECTION("RSS 0.94") {
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_094_with_empty_author.xml"));
+		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_94);
+	}
+
+	REQUIRE(f.title == "A Channel with Unnamed Authors");
+	REQUIRE(f.description == "an example feed");
+	REQUIRE(f.link == "http://example.com/");
+	REQUIRE(f.language == "en");
+
+	REQUIRE(f.items.size() == 2u);
+
+	REQUIRE(f.items[0].title == "This one has en empty author tag");
+	REQUIRE(f.items[0].link == "http://example.com/test_1.html");
+	REQUIRE(f.items[0].description == "It doesn't matter.");
+	REQUIRE(f.items[0].author == "");
+	REQUIRE(f.items[0].guid == "");
+
+	REQUIRE(f.items[1].title == "This one has en empty author tag as well");
+	REQUIRE(f.items[1].link == "http://example.com/test_2.html");
+	REQUIRE(f.items[1].description == "Non-empty description though.");
+	REQUIRE(f.items[1].author == "");
+	REQUIRE(f.items[1].guid == "");
+}
+
 TEST_CASE("Extracts data from RSS 0.92", "[rsspp::Parser]")
 {
 	rsspp::Parser p;


### PR DESCRIPTION
Fixes #542.