### PR TITLE
Travis: harden compilation the way Fedora and Ubuntu do

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ newsboat_brew_commands: &osx_deps
   - pip3 install cpp-coveralls
   - pyenv rehash
 
+env:
+  - CXXFLAGS='-fstack-clash-protection -D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2'
+
 matrix:
   fast_finish: true
   include:
@@ -90,7 +93,7 @@ matrix:
         - COMPILER=g++-8
         - GCOV=/usr/bin/gcov-8
       script: &release_build_script
-        - CXXFLAGS="-O3" make -j2 --keep-going all test
+        - CXXFLAGS="$CXXFLAGS -O3" make -j2 --keep-going all test
         - ( cd test && ./test --order rand ); ret=$?; (cargo test) && sh -c "exit $ret"
     - compiler: clang-8
       os: linux


### PR DESCRIPTION
Fedora and Ubuntu use these options to turn some bugs into compilation
failures and runtime crashes:
- https://fedoraproject.org/wiki/Changes/HardeningFlags28
- https://fedoraproject.org/wiki/Changes/HardenedCompiler
- https://wiki.ubuntu.com/ToolChain/CompilerFlags

I might add "-Wformat -Wformat-security" to the Makefile, because
they're only affecting the compilation. The rest are runtime checks, and
I'm on the fence about enabling them for all downstream users. Let's
keep deferring the decision to distributions for now.

This commit is inspired by #542.