### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -1,6 +1,7 @@
 #ifndef NEWSBOAT_FILEBROWSERFORMACTION_H_
 #define NEWSBOAT_FILEBROWSERFORMACTION_H_
 
+#include <sys/stat.h>
 #include <grp.h>
 
 #include "configcontainer.h"

--- a/include/scopemeasure.h
+++ b/include/scopemeasure.h
@@ -1,6 +1,7 @@
 #ifndef NEWSBOAT_SCOPEMEASURE_H_
 #define NEWSBOAT_SCOPEMEASURE_H_
 
+#include <sys/time.h>
 #include <string>
 
 #include "logger.h"

--- a/rss/item.h
+++ b/rss/item.h
@@ -1,6 +1,7 @@
 #ifndef NEWSBOAT_RSSPPITEM_H_
 #define NEWSBOAT_RSSPPITEM_H_
 
+#include <ctime>
 #include <string>
 #include <vector>
 

--- a/rss/rssparser.cpp
+++ b/rss/rssparser.cpp
@@ -1,6 +1,7 @@
 #include "rssparser.h"
 
 #include <cstring>
+#include <ctime>
 #include <libxml/tree.h>
 
 #include "exception.h"

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -1,5 +1,5 @@
 use abort_on_panic;
-use libc::c_char;
+use libc::{c_char,c_ulong};
 use libnewsboat::utils;
 use std::ffi::{CStr, CString};
 use std::ptr;
@@ -229,7 +229,7 @@ pub extern "C" fn rs_get_random_value(rs_max: u32) -> u32 {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_get_auth_method(input: *const c_char) -> u64 {
+pub extern "C" fn rs_get_auth_method(input: *const c_char) -> c_ulong {
     abort_on_panic(|| {
         let rs_input = unsafe { CStr::from_ptr(input) };
         let rs_input = rs_input.to_string_lossy().into_owned();

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -1,5 +1,5 @@
 use abort_on_panic;
-use libc::{c_char,c_ulong};
+use libc::{c_char, c_ulong};
 use libnewsboat::utils;
 use std::ffi::{CStr, CString};
 use std::ptr;

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -1,5 +1,6 @@
 extern crate curl_sys;
 extern crate dirs;
+extern crate libc;
 extern crate rand;
 extern crate regex;
 extern crate unicode_segmentation;
@@ -11,6 +12,7 @@ use self::unicode_segmentation::UnicodeSegmentation;
 use self::unicode_width::UnicodeWidthStr;
 use self::url::percent_encoding::*;
 use self::url::Url;
+use libc::c_ulong;
 use logger::{self, Level};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -290,7 +292,7 @@ pub fn is_valid_podcast_type(mimetype: &str) -> bool {
     matches || found
 }
 
-pub fn get_auth_method(method: &str) -> u64 {
+pub fn get_auth_method(method: &str) -> c_ulong {
     match method {
         "basic" => curl_sys::CURLAUTH_BASIC,
         "digest" => curl_sys::CURLAUTH_DIGEST,


### PR DESCRIPTION
```
In file included from src/scopemeasure.cpp:1:
include/scopemeasure.h:18:17: error: field has incomplete type 'struct timeval'
        struct timeval tv1, tv2;
                       ^
include/scopemeasure.h:18:9: note: forward declaration of 'newsboat::timeval'
        struct timeval tv1, tv2;
               ^
include/scopemeasure.h:18:22: error: field has incomplete type 'struct timeval'
        struct timeval tv1, tv2;
                            ^
include/scopemeasure.h:18:9: note: forward declaration of 'newsboat::timeval'
        struct timeval tv1, tv2;
               ^
2 errors generated.
[...]
In file included from src/filebrowserformaction.cpp:1:
include/filebrowserformaction.h:43:20: error: unknown type name 'mode_t'; did you mean '__mode_t'?
        char get_filetype(mode_t mode);
                          ^~~~~~
                          __mode_t
/usr/include/sys/_types.h:51:20: note: '__mode_t' declared here
typedef __uint16_t      __mode_t;       /* permissions */
                        ^
In file included from src/filebrowserformaction.cpp:1:
include/filebrowserformaction.h:44:24: error: unknown type name 'uid_t'; did you mean 'gid_t'?
        std::string get_owner(uid_t uid);
                              ^~~~~
                              gid_t
/usr/include/grp.h:49:18: note: 'gid_t' declared here
typedef __gid_t         gid_t;
                        ^
In file included from src/filebrowserformaction.cpp:1:
include/filebrowserformaction.h:47:59: error: unknown type name 'mode_t'; did you mean '__mode_t'?
        get_formatted_filename(std::string filename, char ftype, mode_t mode);
                                                                 ^~~~~~
                                                                 __mode_t
/usr/include/sys/_types.h:51:20: note: '__mode_t' declared here
typedef __uint16_t      __mode_t;       /* permissions */
                        ^
3 errors generated.
[...]
In file included from src/newsblururlreader.cpp:1:
In file included from include/newsblururlreader.h:4:
In file included from ./rss/feed.h:7:
rss/item.h:43:2: error: unknown type name 'time_t'
        time_t pubDate_ts;
        ^
1 error generated.
[...]
rss/rssparser.cpp:91:12: error: variable has incomplete type 'struct tm'
        struct tm stm;
                  ^
/usr/include/wchar.h:111:8: note: forward declaration of 'tm'
struct tm;
       ^
rss/rssparser.cpp:135:2: error: unknown type name 'time_t'
        time_t gmttime = mktime(&stm) + offs;
        ^
2 errors generated.
```

Also unbreak on 32-bit archs (probably also on Linux):
```
error[E0308]: mismatched types
   --> rust/libnewsboat/src/utils.rs:295:20
    |
293 | pub fn get_auth_method(method: &str) -> u64 {
    |                                         --- expected `u64` because of return type
294 |     match method {
295 |         "basic" => curl_sys::CURLAUTH_BASIC,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ expected u64, found u32
help: you can cast an `u32` to `u64`, which will zero-extend the source value
    |
295 |         "basic" => curl_sys::CURLAUTH_BASIC.into(),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> rust/libnewsboat/src/utils.rs:308:13
    |
293 | pub fn get_auth_method(method: &str) -> u64 {
    |                                         --- expected `u64` because of return type
...
308 |             curl_sys::CURLAUTH_ANY
    |             ^^^^^^^^^^^^^^^^^^^^^^ expected u64, found u32
help: you can cast an `u32` to `u64`, which will zero-extend the source value
    |
308 |             curl_sys::CURLAUTH_ANY.into()
    |
```