### PR TITLE
Build Newsboat on FreeBSD 11.2 and 12.0 with Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,5 +4,9 @@ freebsd_task:
             - image: freebsd-11-2-release-amd64
             - image: freebsd-12-0-release-amd64
     install_script: pkg install -y rust gmake asciidoc pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools
-    compile_script: RUST_BACKTRACE=1 gmake all test
+    # CI builds take a while to provision, install dependencies and compile our
+    # stuff. To maximize the benefits, we ask Make to process as many rules as
+    # possible before failing. This enables developers to fix more errors before
+    # re-submitting the code to CI, which should increase throughput.
+    compile_script: RUST_BACKTRACE=1 gmake --keep-going all test
     test_script: cargo test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,13 +3,13 @@ freebsd_task:
         matrix:
             - image: freebsd-11-2-release-amd64
             - image: freebsd-12-0-release-amd64
-        cpu: 8
-        memory: 8G
 
     install_script: pkg install -y rust gmake asciidoc pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools
     # CI builds take a while to provision, install dependencies and compile our
     # stuff. To maximize the benefits, we ask Make to process as many rules as
     # possible before failing. This enables developers to fix more errors before
     # re-submitting the code to CI, which should increase throughput.
-    compile_script: RUST_BACKTRACE=1 gmake --jobs=9 --keep-going all test
+    #
+    # Running three jobs because by default, VMs have 2 cores.
+    compile_script: RUST_BACKTRACE=1 gmake --jobs=3 --keep-going all test
     test_script: cargo test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,5 +4,5 @@ freebsd_task:
             - image: freebsd-11-2-release-amd64
             - image: freebsd-12-0-release-amd64
     install_script: pkg install -y rust gmake asciidoc pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools
-    script: RUST_BACKTRACE=1 gmake all test
+    compile_script: RUST_BACKTRACE=1 gmake all test
     test_script: cargo test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,8 @@
-freebsd_instance:
-    image: freebsd-11-2-release-amd64
-
-task:
+freebsd_task:
+    freebsd_instance:
+        matrix:
+            - image: freebsd-11-2-release-amd64
+            - image: freebsd-12-0-release-amd64
     install_script: pkg install -y rust gmake asciidoc pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools
     script: RUST_BACKTRACE=1 gmake all test
     test_script: cargo test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,4 +3,5 @@ freebsd_instance:
 
 task:
     install_script: pkg install -y rust gmake asciidoc pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools
-    script: RUST_BACKTRACE=1 gmake
+    script: RUST_BACKTRACE=1 gmake all test
+    test_script: cargo test

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,6 @@
+freebsd_instance:
+    image: freebsd-11-2-release-amd64
+
+task:
+    install_script: pkg install -y rust gmake asciidoc pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools
+    script: RUST_BACKTRACE=1 gmake

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,10 +3,13 @@ freebsd_task:
         matrix:
             - image: freebsd-11-2-release-amd64
             - image: freebsd-12-0-release-amd64
+        cpu: 8
+        memory: 8G
+
     install_script: pkg install -y rust gmake asciidoc pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools
     # CI builds take a while to provision, install dependencies and compile our
     # stuff. To maximize the benefits, we ask Make to process as many rules as
     # possible before failing. This enables developers to fix more errors before
     # re-submitting the code to CI, which should increase throughput.
-    compile_script: RUST_BACKTRACE=1 gmake --keep-going all test
+    compile_script: RUST_BACKTRACE=1 gmake --jobs=9 --keep-going all test
     test_script: cargo test

--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,10 @@ uninstall-mo:
 
 # tests and coverage reports
 
-test: test/test
+test: test/test rust-test
+
+rust-test:
+	cargo test --no-run
 
 TEST_SRCS:=$(wildcard test/*.cpp)
 TEST_OBJS:=$(patsubst %.cpp,%.o,$(TEST_SRCS))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Newsboat [![Build Status](https://travis-ci.org/newsboat/newsboat.svg?branch=master)](https://travis-ci.org/newsboat/newsboat) [![Coverage Status](https://coveralls.io/repos/github/newsboat/newsboat/badge.svg?branch=master)](https://coveralls.io/github/newsboat/newsboat?branch=master) [![Coverity Scan Build Status](https://scan.coverity.com/projects/15567/badge.svg)](https://scan.coverity.com/projects/newsboat-newsboat)
+Newsboat [![Travis CI Build Status](https://travis-ci.org/newsboat/newsboat.svg?branch=master)](https://travis-ci.org/newsboat/newsboat) [![Cirrus CI Build Status](https://api.cirrus-ci.com/github/newsboat/newsboat.svg)](https://cirrus-ci.com/github/newsboat/newsboat) [![Coverage Status](https://coveralls.io/repos/github/newsboat/newsboat/badge.svg?branch=master)](https://coveralls.io/github/newsboat/newsboat?branch=master) [![Coverity Scan Build Status](https://scan.coverity.com/projects/15567/badge.svg)](https://scan.coverity.com/projects/newsboat-newsboat)
 ========
 
 Newsboat is a fork of Newsbeuter, an RSS/Atom feed reader for the text console.

--- a/rust/libnewsboat/build.rs
+++ b/rust/libnewsboat/build.rs
@@ -2,13 +2,13 @@ use std::process::Command;
 
 fn main() {
     // Code lifted from https://stackoverflow.com/a/44407625/2350060
-    // Panics in build script stop the build, which is fine by us - let's use unwrap() freely here.
-    let hash_output = Command::new("git")
+    if let Ok(hash_output) = Command::new("git")
         .args(&["describe", "--abbrev=4", "--dirty", "--always", "--tags"])
         .output()
-        .unwrap();
-    let hash = String::from_utf8_lossy(&hash_output.stdout);
-    println!("cargo:rustc-env=GIT_HASH={}", hash);
-    // Re-build this crate when Git HEAD changes. Idea lifted from vergen crate.
-    println!("cargo:rebuild-if-changed=.git/HEAD");
+    {
+        let hash = String::from_utf8_lossy(&hash_output.stdout);
+        println!("cargo:rustc-env=GIT_HASH={}", hash);
+        // Re-build this crate when Git HEAD changes. Idea lifted from vergen crate.
+        println!("cargo:rebuild-if-changed=.git/HEAD");
+    }
 }

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -12,16 +12,18 @@ namespace newsboat {
 std::string item_renderer::get_feedtitle(std::shared_ptr<RssItem> item) {
 	const std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
 
+	if (!feedptr) {
+		return {};
+	}
+
 	std::string feedtitle;
-	if (feedptr) {
-		if (!feedptr->title().empty()) {
-			feedtitle = feedptr->title();
-			utils::remove_soft_hyphens(feedtitle);
-		} else if (!feedptr->link().empty()) {
-			feedtitle = feedptr->link();
-		} else if (!feedptr->rssurl().empty()) {
-			feedtitle = feedptr->rssurl();
-		}
+	if (!feedptr->title().empty()) {
+		feedtitle = feedptr->title();
+		utils::remove_soft_hyphens(feedtitle);
+	} else if (!feedptr->link().empty()) {
+		feedtitle = feedptr->link();
+	} else if (!feedptr->rssurl().empty()) {
+		feedtitle = feedptr->rssurl();
 	}
 
 	return feedtitle;

--- a/test/configpaths.cpp
+++ b/test/configpaths.cpp
@@ -1352,6 +1352,8 @@ TEST_CASE("create_dirs() returns false if XDG config dir exists but data dir "
 	SECTION("XDG_DATA_HOME redefined") {
 		const auto data_home = tmp.get_path() + "xdg-data/";
 		xdg_data.set(data_home);
+		// It's important to set the variable, but *not* create the directory
+		// - it's the pre-condition of the test that the data dir doesn't exist
 
 		const auto data_dir = data_home + "newsboat/";
 		REQUIRE(utils::mkdir_parents(data_dir, 0700) == 0);
@@ -1364,13 +1366,12 @@ TEST_CASE("create_dirs() returns false if XDG config dir exists but data dir "
 		xdg_config.set(config_home);
 
 		const auto config_dir = config_home + "newsboat/";
-		::mkdir(config_dir.c_str(), 0700);
+		REQUIRE(utils::mkdir_parents(config_dir, 0700) == 0);
 
 		const auto data_home = tmp.get_path() + "xdg-data/";
 		xdg_data.set(data_home);
-
-		const auto data_dir = data_home + "newsboat/";
-		::mkdir(data_dir.c_str(), 0700);
+		// It's important to set the variable, but *not* create the directory
+		// - it's the pre-condition of the test that the data dir doesn't exist
 
 		verify_create_dirs_returns_false(tmp);
 	}

--- a/test/configpaths.cpp
+++ b/test/configpaths.cpp
@@ -411,7 +411,7 @@ void mock_newsbeuter_dotdir(
 		const FileSentries& sentries)
 {
 	const auto dotdir_path = tmp.get_path() + ".newsbeuter/";
-	::mkdir(dotdir_path.c_str(), 0700);
+	REQUIRE(::mkdir(dotdir_path.c_str(), 0700) == 0);
 	REQUIRE(create_file(dotdir_path + "config", sentries.config));
 	REQUIRE(create_file(dotdir_path + "urls", sentries.urls));
 	REQUIRE(create_file(dotdir_path + "cache.db", sentries.cache));
@@ -425,11 +425,11 @@ void mock_newsbeuter_xdg_dirs(
 		const std::string& data_dir_path,
 		const FileSentries& sentries)
 {
-	utils::mkdir_parents(config_dir_path, 0700);
+	REQUIRE(utils::mkdir_parents(config_dir_path, 0700) == 0);
 	REQUIRE(create_file(config_dir_path + "config", sentries.config));
 	REQUIRE(create_file(config_dir_path + "urls", sentries.urls));
 
-	utils::mkdir_parents(data_dir_path, 0700);
+	REQUIRE(utils::mkdir_parents(data_dir_path, 0700) == 0);
 	REQUIRE(create_file(data_dir_path + "cache.db", sentries.cache));
 	REQUIRE(create_file(data_dir_path + "queue", sentries.queue));
 	REQUIRE(create_file(data_dir_path + "history.search", sentries.search));
@@ -450,7 +450,7 @@ void mock_newsboat_dotdir(
 		const FileSentries& sentries)
 {
 	const auto dotdir_path = tmp.get_path() + ".newsboat/";
-	::mkdir(dotdir_path.c_str(), 0700);
+	REQUIRE(::mkdir(dotdir_path.c_str(), 0700) == 0);
 
 	const auto urls_file = dotdir_path + "urls";
 	REQUIRE(create_file(urls_file, sentries.urls));
@@ -461,7 +461,7 @@ void mock_newsboat_xdg_dirs(
 		const std::string& /*data_dir_path*/,
 		const FileSentries& sentries)
 {
-	utils::mkdir_parents(config_dir_path, 0700);
+	REQUIRE(utils::mkdir_parents(config_dir_path, 0700) == 0);
 
 	const auto urls_file = config_dir_path + "urls";
 	REQUIRE(create_file(urls_file, sentries.urls));
@@ -589,7 +589,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate if urls file "
 
 			SECTION("XDG_CONFIG_HOME redefined") {
 				const auto config_dir = tmp.get_path() + "xdg-conf/";
-				::mkdir(config_dir.c_str(), 0700);
+				REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 				xdg_config.set(config_dir);
 				const auto newsboat_config_dir = config_dir + "newsboat/";
 				mock_newsboat_xdg_dirs(
@@ -601,7 +601,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate if urls file "
 
 			SECTION("XDG_DATA_HOME redefined") {
 				const auto data_dir = tmp.get_path() + "xdg-data/";
-				::mkdir(data_dir.c_str(), 0700);
+				REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 				xdg_data.set(data_dir);
 				const auto newsboat_config_dir =
 						tmp.get_path() + ".config/newsboat/";
@@ -615,11 +615,11 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate if urls file "
 
 			SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
 				const auto config_dir = tmp.get_path() + "xdg-conf/";
-				::mkdir(config_dir.c_str(), 0700);
+				REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 				xdg_config.set(config_dir);
 
 				const auto data_dir = tmp.get_path() + "xdg-data/";
-				::mkdir(data_dir.c_str(), 0700);
+				REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 				xdg_data.set(data_dir);
 
 				const auto newsboat_config_dir = config_dir + "newsboat/";
@@ -652,7 +652,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate if urls file "
 
 		SECTION("XDG_CONFIG_HOME redefined") {
 			const auto config_dir = tmp.get_path() + "xdg-conf/";
-			::mkdir(config_dir.c_str(), 0700);
+			REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 			xdg_config.set(config_dir);
 			mock_newsbeuter_xdg_dirs(
 					config_dir + "newsbeuter/",
@@ -676,7 +676,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate if urls file "
 
 		SECTION("XDG_DATA_HOME redefined") {
 			const auto data_dir = tmp.get_path() + "xdg-data/";
-			::mkdir(data_dir.c_str(), 0700);
+			REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 			xdg_data.set(data_dir);
 			mock_newsbeuter_xdg_dirs(
 					tmp.get_path() + ".config/newsbeuter/",
@@ -701,11 +701,11 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate if urls file "
 
 		SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
 			const auto config_dir = tmp.get_path() + "xdg-conf/";
-			::mkdir(config_dir.c_str(), 0700);
+			REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 			xdg_config.set(config_dir);
 
 			const auto data_dir = tmp.get_path() + "xdg-data/";
-			::mkdir(data_dir.c_str(), 0700);
+			REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 			xdg_data.set(data_dir);
 
 			mock_newsbeuter_xdg_dirs(
@@ -813,7 +813,7 @@ TEST_CASE("try_migrate_from_newsbeuter() migrates Newsbeuter XDG dirs from "
 
 	SECTION("XDG_CONFIG_HOME redefined") {
 		const auto config_dir = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_dir.c_str(), 0700);
+		REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 		xdg_config.set(config_dir);
 		mock_newsbeuter_xdg_dirs(
 				config_dir + "newsbeuter/",
@@ -826,7 +826,7 @@ TEST_CASE("try_migrate_from_newsbeuter() migrates Newsbeuter XDG dirs from "
 
 	SECTION("XDG_DATA_HOME redefined") {
 		const auto data_dir = tmp.get_path() + "xdg-data/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		xdg_data.set(data_dir);
 		mock_newsbeuter_xdg_dirs(
 				tmp.get_path() + ".config/newsbeuter/",
@@ -839,11 +839,11 @@ TEST_CASE("try_migrate_from_newsbeuter() migrates Newsbeuter XDG dirs from "
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
 		const auto config_dir = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_dir.c_str(), 0700);
+		REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 		xdg_config.set(config_dir);
 
 		const auto data_dir = tmp.get_path() + "xdg-data/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		xdg_data.set(data_dir);
 
 		mock_newsbeuter_xdg_dirs(
@@ -897,7 +897,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 		mock_newsbeuter_xdg_dirs(tmp, sentries);
 
 		const auto config_dir = tmp.get_path() + ".config/newsboat/";
-		::mkdir(config_dir.c_str(), 0700);
+		REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 
 		const auto data_dir = tmp.get_path() + ".local/share/newsboat/";
 		verify_xdg_not_migrated(config_dir, data_dir);
@@ -905,7 +905,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 
 	SECTION("XDG_CONFIG_HOME redefined") {
 		const auto config_home = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_home.c_str(), 0700);
+		REQUIRE(::mkdir(config_home.c_str(), 0700) == 0);
 		xdg_config.set(config_home);
 		mock_newsbeuter_xdg_dirs(
 				config_home + "newsbeuter/",
@@ -913,13 +913,13 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 				sentries);
 
 		const auto config_dir = config_home + "newsboat/";
-		::mkdir(config_dir.c_str(), 0700);
+		REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 		verify_xdg_not_migrated(config_dir, tmp.get_path() + ".local/share/newsboat/");
 	}
 
 	SECTION("XDG_DATA_HOME redefined") {
 		const auto data_dir = tmp.get_path() + "xdg-data/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		xdg_data.set(data_dir);
 		mock_newsbeuter_xdg_dirs(
 				tmp.get_path() + ".config/newsbeuter/",
@@ -927,17 +927,17 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 				sentries);
 
 		const auto config_dir = tmp.get_path() + ".config/newsboat/";
-		::mkdir(config_dir.c_str(), 0700);
+		REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 		verify_xdg_not_migrated(config_dir, data_dir + "newsboat/");
 	}
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
 		const auto config_home = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_home.c_str(), 0700);
+		REQUIRE(::mkdir(config_home.c_str(), 0700) == 0);
 		xdg_config.set(config_home);
 
 		const auto data_dir = tmp.get_path() + "xdg-data/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		xdg_data.set(data_dir);
 
 		mock_newsbeuter_xdg_dirs(
@@ -946,7 +946,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 				sentries);
 
 		const auto config_dir = config_home + "newsboat/";
-		::mkdir(config_dir.c_str(), 0700);
+		REQUIRE(::mkdir(config_dir.c_str(), 0700) == 0);
 		verify_xdg_not_migrated(config_dir, data_dir + "newsboat/");
 	}
 }
@@ -975,13 +975,13 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 
 		const auto config_dir = tmp.get_path() + ".config/newsboat/";
 		const auto data_dir = tmp.get_path() + ".local/share/newsboat/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		verify_xdg_not_migrated(config_dir, data_dir);
 	}
 
 	SECTION("XDG_CONFIG_HOME redefined") {
 		const auto config_home = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_home.c_str(), 0700);
+		REQUIRE(::mkdir(config_home.c_str(), 0700) == 0);
 		xdg_config.set(config_home);
 		mock_newsbeuter_xdg_dirs(
 				config_home + "newsbeuter/",
@@ -989,13 +989,13 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 				sentries);
 
 		const auto data_dir = tmp.get_path() + ".local/share/newsboat/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		verify_xdg_not_migrated(config_home + "newsboat/", data_dir);
 	}
 
 	SECTION("XDG_DATA_HOME redefined") {
 		const auto data_home = tmp.get_path() + "xdg-data/";
-		::mkdir(data_home.c_str(), 0700);
+		REQUIRE(::mkdir(data_home.c_str(), 0700) == 0);
 		xdg_data.set(data_home);
 		mock_newsbeuter_xdg_dirs(
 				tmp.get_path() + ".config/newsbeuter/",
@@ -1003,17 +1003,17 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 				sentries);
 
 		const auto data_dir = data_home + "newsboat/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		verify_xdg_not_migrated(tmp.get_path() + ".config/newsboat/", data_dir);
 	}
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
 		const auto config_home = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_home.c_str(), 0700);
+		REQUIRE(::mkdir(config_home.c_str(), 0700) == 0);
 		xdg_config.set(config_home);
 
 		const auto data_home = tmp.get_path() + "xdg-data/";
-		::mkdir(data_home.c_str(), 0700);
+		REQUIRE(::mkdir(data_home.c_str(), 0700) == 0);
 		xdg_data.set(data_home);
 
 		mock_newsbeuter_xdg_dirs(
@@ -1022,7 +1022,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 				sentries);
 
 		const auto data_dir = data_home + "newsboat/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		verify_xdg_not_migrated(config_home + "newsboat/", data_dir);
 	}
 }
@@ -1061,7 +1061,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 
 	SECTION("XDG_CONFIG_HOME redefined") {
 		const auto config_home = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_home.c_str(), 0700);
+		REQUIRE(::mkdir(config_home.c_str(), 0700) == 0);
 		xdg_config.set(config_home);
 		mock_newsbeuter_xdg_dirs(
 				config_home + "newsbeuter/",
@@ -1079,7 +1079,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 
 	SECTION("XDG_DATA_HOME redefined") {
 		const auto data_dir = tmp.get_path() + "xdg-data/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		xdg_data.set(data_dir);
 		mock_newsbeuter_xdg_dirs(
 				tmp.get_path() + ".config/newsbeuter/",
@@ -1098,11 +1098,11 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
 		const auto config_home = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_home.c_str(), 0700);
+		REQUIRE(::mkdir(config_home.c_str(), 0700) == 0);
 		xdg_config.set(config_home);
 
 		const auto data_dir = tmp.get_path() + "xdg-data/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(::mkdir(data_dir.c_str(), 0700) == 0);
 		xdg_data.set(data_dir);
 
 		mock_newsbeuter_xdg_dirs(
@@ -1154,7 +1154,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 
 	SECTION("XDG_CONFIG_HOME redefined") {
 		const auto config_home = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_home.c_str(), 0700);
+		REQUIRE(::mkdir(config_home.c_str(), 0700) == 0);
 		xdg_config.set(config_home);
 		mock_newsbeuter_xdg_dirs(
 				config_home + "newsbeuter/",
@@ -1173,7 +1173,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 
 	SECTION("XDG_DATA_HOME redefined") {
 		const auto data_home = tmp.get_path() + "xdg-data/";
-		::mkdir(data_home.c_str(), 0700);
+		REQUIRE(::mkdir(data_home.c_str(), 0700) == 0);
 		xdg_data.set(data_home);
 		mock_newsbeuter_xdg_dirs(
 				tmp.get_path() + ".config/newsbeuter/",
@@ -1191,11 +1191,11 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
 		const auto config_home = tmp.get_path() + "xdg-conf/";
-		::mkdir(config_home.c_str(), 0700);
+		REQUIRE(::mkdir(config_home.c_str(), 0700) == 0);
 		xdg_config.set(config_home);
 
 		const auto data_home = tmp.get_path() + "xdg-data/";
-		::mkdir(data_home.c_str(), 0700);
+		REQUIRE(::mkdir(data_home.c_str(), 0700) == 0);
 		xdg_data.set(data_home);
 
 		mock_newsbeuter_xdg_dirs(
@@ -1252,7 +1252,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 	mock_newsbeuter_dotdir(tmp, sentries);
 
 	const auto dotdir = tmp.get_path() + ".newsboat/";
-	::mkdir(dotdir.c_str(), 0700);
+	REQUIRE(::mkdir(dotdir.c_str(), 0700) == 0);
 
 	verify_dotdir_not_migrated(dotdir);
 }
@@ -1334,7 +1334,7 @@ TEST_CASE("create_dirs() returns false if XDG config dir exists but data dir "
 
 	SECTION("Default XDG locations") {
 		const auto config_dir = tmp.get_path() + ".config/newsboat/";
-		::mkdir(config_dir.c_str(), 0700);
+		REQUIRE(utils::mkdir_parents(config_dir, 0700) == 0);
 
 		verify_create_dirs_returns_false(tmp);
 	}
@@ -1344,7 +1344,7 @@ TEST_CASE("create_dirs() returns false if XDG config dir exists but data dir "
 		xdg_config.set(config_home);
 
 		const auto config_dir = config_home + "newsboat/";
-		::mkdir(config_dir.c_str(), 0700);
+		REQUIRE(utils::mkdir_parents(config_dir, 0700) == 0);
 
 		verify_create_dirs_returns_false(tmp);
 	}
@@ -1354,7 +1354,7 @@ TEST_CASE("create_dirs() returns false if XDG config dir exists but data dir "
 		xdg_data.set(data_home);
 
 		const auto data_dir = data_home + "newsboat/";
-		::mkdir(data_dir.c_str(), 0700);
+		REQUIRE(utils::mkdir_parents(data_dir, 0700) == 0);
 
 		verify_create_dirs_returns_false(tmp);
 	}

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -482,16 +482,20 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed title without "
 	std::shared_ptr<RssFeed> feed;
 	std::tie(item, feed) = create_test_item(&rsscache);
 
+	const auto check = [&]() {
+		const auto result = item_renderer::get_feedtitle(item);
+		REQUIRE(result == "Welcome, lovely strangers!");
+	};
+
 	SECTION("Title without soft hyphens") {
 		feed->set_title("Welcome, lovely strangers!");
+		check();
 	}
 
 	SECTION("Title containing soft hyphens") {
 		feed->set_title("Wel\u00ADcome, lo\u00ADve\u00ADly stran\u00ADgers!");
+		check();
 	}
-
-	const auto result = item_renderer::get_feedtitle(item);
-	REQUIRE(result == "Welcome, lovely strangers!");
 }
 
 TEST_CASE("item_renderer::get_feedtitle() returns item's feed self-link "

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -56,39 +56,44 @@ TEST_CASE("Doesn't crash or garble data if an item in RSS 0.9x contains "
 	rsspp::Parser p;
 	rsspp::Feed f;
 
+	const auto check = [&]() {
+		REQUIRE(f.title == "A Channel with Unnamed Authors");
+		REQUIRE(f.description == "an example feed");
+		REQUIRE(f.link == "http://example.com/");
+		REQUIRE(f.language == "en");
+
+		REQUIRE(f.items.size() == 2u);
+
+		REQUIRE(f.items[0].title == "This one has en empty author tag");
+		REQUIRE(f.items[0].link == "http://example.com/test_1.html");
+		REQUIRE(f.items[0].description == "It doesn't matter.");
+		REQUIRE(f.items[0].author == "");
+		REQUIRE(f.items[0].guid == "");
+
+		REQUIRE(f.items[1].title == "This one has en empty author tag as well");
+		REQUIRE(f.items[1].link == "http://example.com/test_2.html");
+		REQUIRE(f.items[1].description == "Non-empty description though.");
+		REQUIRE(f.items[1].author == "");
+		REQUIRE(f.items[1].guid == "");
+	};
+
 	SECTION("RSS 0.91") {
 		REQUIRE_NOTHROW(f = p.parse_file("data/rss_091_with_empty_author.xml"));
 		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_91);
+		check();
 	}
 
 	SECTION("RSS 0.92") {
 		REQUIRE_NOTHROW(f = p.parse_file("data/rss_092_with_empty_author.xml"));
 		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_92);
+		check();
 	}
 
 	SECTION("RSS 0.94") {
 		REQUIRE_NOTHROW(f = p.parse_file("data/rss_094_with_empty_author.xml"));
 		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_94);
+		check();
 	}
-
-	REQUIRE(f.title == "A Channel with Unnamed Authors");
-	REQUIRE(f.description == "an example feed");
-	REQUIRE(f.link == "http://example.com/");
-	REQUIRE(f.language == "en");
-
-	REQUIRE(f.items.size() == 2u);
-
-	REQUIRE(f.items[0].title == "This one has en empty author tag");
-	REQUIRE(f.items[0].link == "http://example.com/test_1.html");
-	REQUIRE(f.items[0].description == "It doesn't matter.");
-	REQUIRE(f.items[0].author == "");
-	REQUIRE(f.items[0].guid == "");
-
-	REQUIRE(f.items[1].title == "This one has en empty author tag as well");
-	REQUIRE(f.items[1].link == "http://example.com/test_2.html");
-	REQUIRE(f.items[1].description == "Non-empty description though.");
-	REQUIRE(f.items[1].author == "");
-	REQUIRE(f.items[1].guid == "");
 }
 
 TEST_CASE("Extracts data from RSS 0.92", "[rsspp::Parser]")

--- a/test/test-helpers.cpp
+++ b/test/test-helpers.cpp
@@ -270,6 +270,17 @@ TEST_CASE("EnvVar's destructor runs a function (set by on_change()) after "
 
 	const auto expected = std::string("let's try this out, shall we?");
 
+	const auto check = [&]() {
+		auto counter = unsigned{};
+
+		{
+			TestHelpers::EnvVar envVar(var);
+			envVar.on_change([&counter](){ counter++; });
+		}
+
+		REQUIRE(counter == 1);
+	};
+
 	SECTION("Variable wasn't even set") {
 		// Intentionally left empty.
 		//
@@ -280,21 +291,16 @@ TEST_CASE("EnvVar's destructor runs a function (set by on_change()) after "
 		// in two different situations: once when the environment variable is
 		// already present, and once when it's absent. The point of the test is
 		// that this wouldn't matter: EnvVar will behave the same regardless.
+
+		check();
 	}
 
 	SECTION("Variable was set before EnvVar is created") {
 		const auto overwrite = true;
 		::setenv(var, expected.c_str(), overwrite);
+
+		check();
 	}
-
-	auto counter = unsigned{};
-
-	{
-		TestHelpers::EnvVar envVar(var);
-		envVar.on_change([&counter](){ counter++; });
-	}
-
-	REQUIRE(counter == 1);
 
 	// It's a no-op if the variable is absent from the environment, so we don't
 	// need to put this inside a conditional to match SECTIONs above.

--- a/test/textformatter.cpp
+++ b/test/textformatter.cpp
@@ -201,7 +201,7 @@ TEST_CASE("Lines marked as non-wrappable are always returned verbatim",
  * second line and it would make the text look jagged with a bigger input. Thus
  * spaces at the beginning of lines after wrapping should be dropped.
  */
-TEST_CASE("ignore whitespace that's going to be wrapped onto the next line",
+TEST_CASE("Ignore whitespace that's going to be wrapped onto the next line",
 	"[TextFormatter]")
 {
 	TextFormatter fmt;

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1049,7 +1049,7 @@ TEST_CASE("mkdir_parents() creates all paths components and returns 0 if "
 	TestHelpers::TempDir tmp;
 
 	const auto require_return_zero = [](const std::string& path) {
-		REQUIRE(utils::mkdir_parents(path.c_str(), 0700) == 0);
+		REQUIRE(utils::mkdir_parents(path, 0700) == 0);
 		REQUIRE(::access(path.c_str(), R_OK | X_OK) == 0);
 	};
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -307,15 +307,12 @@ TEST_CASE("run_command() doesn't wait for the command to finish",
 
 TEST_CASE("resolve_tilde() replaces ~ with the path to the $HOME directory", "[utils]")
 {
-	SECTION("prefix-tilde replaced")
-	{
-		TestHelpers::EnvVar envVar("HOME");
-		envVar.set("test");
-		REQUIRE(utils::resolve_tilde("~") == "test");
-		REQUIRE(utils::resolve_tilde("~/") == "test/");
-		REQUIRE(utils::resolve_tilde("~/dir") == "test/dir");
-		REQUIRE(utils::resolve_tilde("/home/~") == "/home/~");
-	}
+	TestHelpers::EnvVar envVar("HOME");
+	envVar.set("test");
+	REQUIRE(utils::resolve_tilde("~") == "test");
+	REQUIRE(utils::resolve_tilde("~/") == "test/");
+	REQUIRE(utils::resolve_tilde("~/dir") == "test/dir");
+	REQUIRE(utils::resolve_tilde("/home/~") == "/home/~");
 }
 
 TEST_CASE("resolve_relative() returns an absolute file path relative to another", "[utils]")


### PR DESCRIPTION
CI builds Newsboat, and runs Rust tests. Some C++ tests for `ConfigPaths` fail, and since we're rewriting this component at the moment, I'm not fixing them. This will be done later, when `ConfigPaths` is moved to Rust completely (see #413, #561).