### PR TITLE
Add i386 pipeline to CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,6 @@ freebsd_task:
     allow_failures: true
 
     container:
-        dockerfile: docker/ubuntu_16.04-i686.dockerfile
+        dockerfile: docker/ubuntu_18.04-i686.dockerfile
     build_script: make -j3 --keep-going all test
     test_script: ( cd test && ./test --order rand ); ret=$?; (cargo test) && sh -c "exit $ret"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,3 +13,9 @@ freebsd_task:
     # Running three jobs because by default, VMs have 2 cores.
     compile_script: RUST_BACKTRACE=1 gmake --jobs=3 --keep-going all test
     test_script: cargo test
+
+32bit_ubuntu_task:
+    container:
+        dockerfile: docker/ubuntu_16.04-i686.dockerfile
+    build_script: make -j3 --keep-going all test
+    test_script: ( cd test && ./test --order rand ); ret=$?; (cargo test) && sh -c "exit $ret"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,6 +15,10 @@ freebsd_task:
     test_script: cargo test
 
 32bit_ubuntu_task:
+    # We broke 32-bit builds (https://github.com/newsboat/newsboat/issues/555),
+    # so let this fail until we fix it.
+    allow_failures: true
+
     container:
         dockerfile: docker/ubuntu_16.04-i686.dockerfile
     build_script: make -j3 --keep-going all test

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ slows them down if `TMPDIR` is on HDD or even SSD.
 
 We check the formatting of the Rust code during CI using
 [rust-fmt](https://github.com/rust-lang/rustfmt).  To make sure your code is
-properly formated install and run rust-fmt:
+properly formatted, install and run rust-fmt:
 
 	$ rustup component add rustfmt
 	$ cargo fmt

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ properly formatted, install and run rust-fmt:
 	$ rustup component add rustfmt
 	$ cargo fmt
 
+Newsboat can also be [built in Docker](doc/internal/docker.md).
+
 License
 -------
 

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -47,9 +47,6 @@ your host source directory:
     $ docker run \
         --rm \
         --mount type=bind,source=$(pwd),target=/home/builder/src \
-        --user <UID>:<GID> \
+        --user $(id -u):$(id -g) \
         newsboat-ubuntu18.04-i686 \
         make -j9
-
-Substitute `<UID>` and `<GID>` with your host user ID and group ID, they can
-be determined using the `id` commmand locally.

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -1,0 +1,2 @@
+Building Newsboat with Docker
+=============================

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -30,6 +30,7 @@ using your favourite tools to edit the files. Let's build Newsboat this way:
     $ docker run \
         --rm \
         --mount type=bind,source=$(pwd),target=/home/builder/src \
+        --user $(id -u):$(id -g) \
         newsboat-ubuntu18.04-i686 \
         make -j9
 
@@ -37,16 +38,8 @@ using your favourite tools to edit the files. Let's build Newsboat this way:
 just litter up your system.
 `--mount` links your current directory to "/home/builder" inside the container,
 and `--workdir=/home/builder` makes the container switch to that dir.
+`--user` specifies the user and the group that will own the newly created files
+(object files, docs, and the final executable); `id` determines your current
+user and group IDs.
 "newsboat-ubuntu18.04-i686" is the image from which we're creating the
 container, and `make -j9` is the command we're running inside of it.
-
-If your host's user or group ID are not 1000, then you have to adjust the run
-command in order to avoid permission errors when generating the artifacts in
-your host source directory:
-
-    $ docker run \
-        --rm \
-        --mount type=bind,source=$(pwd),target=/home/builder/src \
-        --user $(id -u):$(id -g) \
-        newsboat-ubuntu18.04-i686 \
-        make -j9

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -28,10 +28,13 @@ system*. This way, you can have an isolated, controlled build environment, while
 using your favourite tools to edit the files. Let's build Newsboat this way:
 
     $ docker run \
+        --rm \
         --mount type=bind,source=$(pwd),target=/home/builder/src \
         newsboat-ubuntu18.04-i686 \
         make -j9
 
+`--rm` deletes the container once it finished, by default it is kept and will
+just litter up your system.
 `--mount` links your current directory to "/home/builder" inside the container,
 and `--workdir=/home/builder` makes the container switch to that dir.
 "newsboat-ubuntu18.04-i686" is the image from which we're creating the
@@ -42,6 +45,7 @@ command in order to avoid permission errors when generating the artifacts in
 your host source directory:
 
     $ docker run \
+        --rm \
         --mount type=bind,source=$(pwd),target=/home/builder/src \
         --user <UID>:<GID> \
         --env HOME=/home/builder \

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -7,8 +7,8 @@ environments, with all the necessary tools and libraries already installed.
 These containers can be used for continuous testing, and also locally if you
 feel like it.
 
-Each Docker container is described by a "Dockerfile". We keep ours in "docker"
-directory.
+Each Docker container is described by a "Dockerfile". We keep ours in the
+"docker" directory.
 
 To use a container, you need to build its image first. For example, let's create
 one that we use for cross-compiling from amd64 to i686:
@@ -33,7 +33,7 @@ using your favourite tools to edit the files. Let's build Newsboat this way:
         newsboat-ubuntu16.04-i686 \
         make -j9
 
-`--mount` links your current directory to "/home/builer" inside the container,
+`--mount` links your current directory to "/home/builder" inside the container,
 and `--workdir=/home/builder` makes the container switch to that dir.
 "newsboat-ubuntu16.04-i686" is the image from which we're creating the
 container, and `make -j9` is the command we're running inside of it.

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -35,10 +35,9 @@ using your favourite tools to edit the files. Let's build Newsboat this way:
         make -j9
 
 `--rm` deletes the container once it finished, by default it is kept and will
-just litter up your system.
-`--mount` links your current directory to "/home/builder/src" inside the container.
-`--user` specifies the user and the group that will own the newly created files
-(object files, docs, and the final executable); `id` determines your current
-user and group IDs.
+just litter up your system. `--mount` links your current directory to
+"/home/builder/src" inside the container. `--user` specifies the user and the
+group that will own the newly created files (object files, docs, and the final
+executable); `id` determines your current user and group IDs.
 "newsboat-ubuntu18.04-i686" is the image from which we're creating the
 container, and `make -j9` is the command we're running inside of it.

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -15,12 +15,12 @@ one that we use for cross-compiling from amd64 to i686:
 
     # In the root of Newsboat's repository
     $ docker build \
-        --tag=newsboat-ubuntu16.04-i686 \
-        --file=docker/ubuntu_16.04-i686.dockerfile \
+        --tag=newsboat-ubuntu18.04-i686 \
+        --file=docker/ubuntu_18.04-i686.dockerfile \
         docker
 
-This will use the description from "docker/ubuntu_16.04-i686.dockerfile" to
-build an image named "newsboat-ubuntu16.04-i686".
+This will use the description from "docker/ubuntu_18.04-i686.dockerfile" to
+build an image named "newsboat-ubuntu18.04-i686".
 
 You can now create a container from that image, and run commands inside it. But
 the coolest thing is: you can run those commands *on the files in your host
@@ -30,10 +30,10 @@ using your favourite tools to edit the files. Let's build Newsboat this way:
     $ docker run \
         --mount type=bind,source=$(pwd),target=/home/builder \
         --workdir=/home/builder \
-        newsboat-ubuntu16.04-i686 \
+        newsboat-ubuntu18.04-i686 \
         make -j9
 
 `--mount` links your current directory to "/home/builder" inside the container,
 and `--workdir=/home/builder` makes the container switch to that dir.
-"newsboat-ubuntu16.04-i686" is the image from which we're creating the
+"newsboat-ubuntu18.04-i686" is the image from which we're creating the
 container, and `make -j9` is the command we're running inside of it.

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -48,11 +48,8 @@ your host source directory:
         --rm \
         --mount type=bind,source=$(pwd),target=/home/builder/src \
         --user <UID>:<GID> \
-        --env HOME=/home/builder \
         newsboat-ubuntu18.04-i686 \
         make -j9
 
 Substitute `<UID>` and `<GID>` with your host user ID and group ID, they can
-be determined using the `id` commmand locally. As the home directory of your
-newly passed in user is unknown, it needs to be set properly using the
-environment variable via `--env`.
+be determined using the `id` commmand locally.

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -1,2 +1,39 @@
 Building Newsboat with Docker
 =============================
+
+[Docker](https://www.docker.com/) is a program that builds Linux containers
+according to the spec provided by the user. We use Docker to create development
+environments, with all the necessary tools and libraries already installed.
+These containers can be used for continuous testing, and also locally if you
+feel like it.
+
+Each Docker container is described by a "Dockerfile". We keep ours in "docker"
+directory.
+
+To use a container, you need to build its image first. For example, let's create
+one that we use for cross-compiling from amd64 to i686:
+
+    # In the root of Newsboat's repository
+    $ docker build \
+        --tag=newsboat-ubuntu16.04-i686 \
+        --file=docker/ubuntu_16.04-i686.dockerfile \
+        docker
+
+This will use the description from "docker/ubuntu_16.04-i686.dockerfile" to
+build an image named "newsboat-ubuntu16.04-i686".
+
+You can now create a container from that image, and run commands inside it. But
+the coolest thing is: you can run those commands *on the files in your host
+system*. This way, you can have an isolated, controlled build environment, while
+using your favourite tools to edit the files. Let's build Newsboat this way:
+
+    $ docker run \
+        --mount type=bind,source=$(pwd),target=/home/builder \
+        --workdir=/home/builder \
+        newsboat-ubuntu16.04-i686 \
+        make -j9
+
+`--mount` links your current directory to "/home/builer" inside the container,
+and `--workdir=/home/builder` makes the container switch to that dir.
+"newsboat-ubuntu16.04-i686" is the image from which we're creating the
+container, and `make -j9` is the command we're running inside of it.

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -36,8 +36,7 @@ using your favourite tools to edit the files. Let's build Newsboat this way:
 
 `--rm` deletes the container once it finished, by default it is kept and will
 just litter up your system.
-`--mount` links your current directory to "/home/builder" inside the container,
-and `--workdir=/home/builder` makes the container switch to that dir.
+`--mount` links your current directory to "/home/builder/src" inside the container.
 `--user` specifies the user and the group that will own the newly created files
 (object files, docs, and the final executable); `id` determines your current
 user and group IDs.

--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -28,8 +28,7 @@ system*. This way, you can have an isolated, controlled build environment, while
 using your favourite tools to edit the files. Let's build Newsboat this way:
 
     $ docker run \
-        --mount type=bind,source=$(pwd),target=/home/builder \
-        --workdir=/home/builder \
+        --mount type=bind,source=$(pwd),target=/home/builder/src \
         newsboat-ubuntu18.04-i686 \
         make -j9
 
@@ -37,3 +36,19 @@ using your favourite tools to edit the files. Let's build Newsboat this way:
 and `--workdir=/home/builder` makes the container switch to that dir.
 "newsboat-ubuntu18.04-i686" is the image from which we're creating the
 container, and `make -j9` is the command we're running inside of it.
+
+If your host's user or group ID are not 1000, then you have to adjust the run
+command in order to avoid permission errors when generating the artifacts in
+your host source directory:
+
+    $ docker run \
+        --mount type=bind,source=$(pwd),target=/home/builder/src \
+        --user <UID>:<GID> \
+        --env HOME=/home/builder \
+        newsboat-ubuntu18.04-i686 \
+        make -j9
+
+Substitute `<UID>` and `<GID>` with your host user ID and group ID, they can
+be determined using the `id` commmand locally. As the home directory of your
+newly passed in user is unknown, it needs to be set properly using the
+environment variable via `--env`.

--- a/docker/ubuntu_16.04-i686.dockerfile
+++ b/docker/ubuntu_16.04-i686.dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PATH /root/.cargo/bin:$PATH
+ENV CXXFLAGS -m32
+ENV CARGO_BUILD_TARGET i686-unknown-linux-gnu
+ENV PKG_CONFIG_ALLOW_CROSS 1
+
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get upgrade --assume-yes
+
+RUN apt-get install --assume-yes \
+        build-essential g++-multilib pkg-config:i386 libsqlite3-0:i386 \
+        libsqlite3-dev:i386 libcurl4-openssl-dev:i386 libxml2-dev:i386 \
+        libstfl-dev:i386 libjson-c-dev:i386 libssl-dev:i386 gettext \
+        # `curl` would be enough for our needs, but it pulls in amd64 versions
+        # of libraries we use, interfering with the build environment. So
+        # `wget` it is.
+        wget \
+    && apt-get install --assume-yes --no-install-recommends \
+        asciidoc docbook-xml docbook-xsl xsltproc libxml2-utils \
+    && apt-get autoremove \
+    && apt-get clean
+
+RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
+    && chmod +x $HOME/rustup.sh \
+    && $HOME/rustup.sh -y --default-host i686-unknown-linux-gnu --default-toolchain stable

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -36,3 +36,5 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y --default-host i686-unknown-linux-gnu --default-toolchain stable \
     && chmod a+w $HOME/.cargo
+
+ENV HOME /home/builder

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH /root/.cargo/bin:$PATH

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV PATH /root/.cargo/bin:$PATH
+ENV PATH /home/builder/.cargo/bin:$PATH
 ENV CXXFLAGS -m32
 ENV CARGO_BUILD_TARGET i686-unknown-linux-gnu
 ENV PKG_CONFIG_ALLOW_CROSS 1
@@ -23,6 +23,16 @@ RUN apt-get install --assume-yes \
     && apt-get autoremove \
     && apt-get clean
 
+RUN addgroup --gid 1000 builder \
+    && adduser --home /home/builder --uid 1000 --ingroup builder \
+        --disabled-password --shell /bin/bash builder \
+    && mkdir -p /home/builder/src \
+    && chown -R builder:builder /home/builder
+
+USER builder
+WORKDIR /home/builder/src
+
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
-    && $HOME/rustup.sh -y --default-host i686-unknown-linux-gnu --default-toolchain stable
+    && $HOME/rustup.sh -y --default-host i686-unknown-linux-gnu --default-toolchain stable \
+    && chmod a+w $HOME/.cargo


### PR DESCRIPTION
This fixes #556. The short of that issue (and what predates it) is:
- we broke i386 compatibility somewhere between 2.15 and 2.16;
- we never noticed because we don't build for i386 on CI. (Snap builds every commit for a number of architectures, but they don't send us emails if something breaks);
- Travis CI doesn't have native 32-bit machines; nor do Drone, Circle, Cirrus, and AppVeyor CIs;
- cross-compiling to i386 on an amd64 host works fine, so that's what I went with;
- adding this job to Travis required some boring work on .travis.yml, so I added it to another CI we recently started using—Cirrus CI;
- to make it easier to test locally, I wrapped the whole job in a Docker image. It is used by Cirrus CI, and anyone can use it locally to test i386.

Anyone with Docker knowledge is welcome to poke holes in my Dockerfile. It's my first, but please don't hold anything back :)

@der-lyse, you seem to keep an eye on our docs, so can you please take a look at doc/internal/docker.md? Does it make sense? Is it even readable? Any loose ends or unanswered questions? It's targeted at developers, so it doesn't have to explain *everything*, but it shouldn't be impenetrable either. I'd like your opinion of how well I managed that :)