### PR TITLE
Do not use GIT_HASH if git-describe failed

### DIFF
--- a/rust/libnewsboat/build.rs
+++ b/rust/libnewsboat/build.rs
@@ -6,9 +6,11 @@ fn main() {
         .args(&["describe", "--abbrev=4", "--dirty", "--always", "--tags"])
         .output()
     {
-        let hash = String::from_utf8_lossy(&hash_output.stdout);
-        println!("cargo:rustc-env=GIT_HASH={}", hash);
-        // Re-build this crate when Git HEAD changes. Idea lifted from vergen crate.
-        println!("cargo:rebuild-if-changed=.git/HEAD");
+        if hash_output.status.success() {
+            let hash = String::from_utf8_lossy(&hash_output.stdout);
+            println!("cargo:rustc-env=GIT_HASH={}", hash);
+            // Re-build this crate when Git HEAD changes. Idea lifted from vergen crate.
+            println!("cargo:rebuild-if-changed=.git/HEAD");
+        }
     }
 }

--- a/rust/libnewsboat/build.rs
+++ b/rust/libnewsboat/build.rs
@@ -2,15 +2,22 @@ use std::process::Command;
 
 fn main() {
     // Code lifted from https://stackoverflow.com/a/44407625/2350060
-    if let Ok(hash_output) = Command::new("git")
+    let command_output = Command::new("git")
         .args(&["describe", "--abbrev=4", "--dirty", "--always", "--tags"])
-        .output()
-    {
-        if hash_output.status.success() {
+        .output();
+    match command_output {
+        Ok(ref hash_output) if hash_output.status.success() => {
             let hash = String::from_utf8_lossy(&hash_output.stdout);
-            println!("cargo:rustc-env=GIT_HASH={}", hash);
+            println!("cargo:rustc-env=NEWSBOAT_VERSION={}", hash);
             // Re-build this crate when Git HEAD changes. Idea lifted from vergen crate.
             println!("cargo:rebuild-if-changed=.git/HEAD");
         }
+
+        _ => println!(
+            "cargo:rustc-env=NEWSBOAT_VERSION={}.{}.{}",
+            env!("CARGO_PKG_VERSION_MAJOR"),
+            env!("CARGO_PKG_VERSION_MINOR"),
+            env!("CARGO_PKG_VERSION_PATCH")
+        ),
     }
 }

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -486,17 +486,8 @@ pub fn take_graphemes(input: &str, n: usize) -> String {
 /// The tag and Git commit ID the program was built from, or a pre-defined value from config.h if
 /// there is no Git directory.
 pub fn program_version() -> String {
-    // GIT_HASH is set by this crate's build script, "build.rs"
-    if let Some(version_str) = option_env!("GIT_HASH") {
-        version_str.to_string()
-    } else {
-        format!(
-            "{}.{}.{}",
-            env!("CARGO_PKG_VERSION_MAJOR"),
-            env!("CARGO_PKG_VERSION_MINOR"),
-            env!("CARGO_PKG_VERSION_PATCH")
-        )
-    }
+    // NEWSBOAT_VERSION is set by this crate's build script, "build.rs"
+    env!("NEWSBOAT_VERSION").to_string()
 }
 
 /// Newsboat's major version number.


### PR DESCRIPTION
`if let Some(_) = Command::new().output()` only checks if the command *started*. We also need to check if it *finished*, otherwise we can't trust the output.

Fixes #579.