### PR TITLE
Add Rust tests for utils::getcwd and utils::remove_soft_hyphens

### DIFF
--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -917,4 +917,43 @@ mod tests {
             Path::new("/baz")
         );
     }
+
+    #[test]
+    fn t_remove_soft_hyphens_removes_all_00ad_unicode_chars_from_a_string() {
+        {
+            // Does nothing if input has no soft hyphens in it
+            let mut input1 = "hello world!".to_string();
+            remove_soft_hyphens(&mut input1);
+            assert_eq!(input1, "hello world!");
+        }
+
+        {
+            // Removes *all* soft hyphens
+            let mut data = "hy\u{00AD}phen\u{00AD}a\u{00AD}tion".to_string();
+            remove_soft_hyphens(&mut data);
+            assert_eq!(data, "hyphenation");
+        }
+
+        {
+            // Removes consecutive soft hyphens
+            let mut data = "don't know why any\u{00AD}\u{00AD}one would do that".to_string();
+            remove_soft_hyphens(&mut data);
+            assert_eq!(data, "don't know why anyone would do that");
+        }
+
+        {
+            // Removes soft hyphen at the beginning of the line
+            let mut data = "\u{00AD}tion".to_string();
+            remove_soft_hyphens(&mut data);
+            assert_eq!(data, "tion");
+        }
+
+        {
+            // Removes soft hyphen at the end of the line
+            let mut data = "over\u{00AD}".to_string();
+            remove_soft_hyphens(&mut data);
+            assert_eq!(data, "over");
+        }
+    }
+
 }

--- a/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
+++ b/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
@@ -1,0 +1,19 @@
+extern crate libnewsboat;
+extern crate tempfile;
+
+use self::tempfile::TempDir;
+use libnewsboat::utils;
+use std::env;
+
+#[test]
+fn t_getcwd_returns_an_error_if_current_directory_doesnt_exist() {
+    {
+        let tmp = TempDir::new().unwrap();
+        let chdir_result = env::set_current_dir(&tmp.path());
+        assert!(chdir_result.is_ok());
+    }
+
+    // `tmp` went out of scope and removed the directory, but we're still in it
+
+    assert!(utils::getcwd().is_err());
+}

--- a/rust/libnewsboat/tests/getcwd_returns_non-empty_string.rs
+++ b/rust/libnewsboat/tests/getcwd_returns_non-empty_string.rs
@@ -1,0 +1,11 @@
+extern crate libnewsboat;
+
+use libnewsboat::utils;
+use std::path::Path;
+
+#[test]
+fn t_getcwd_returns_non_empty_string() {
+    let result = utils::getcwd();
+    assert!(result.is_ok());
+    assert_ne!(result.unwrap(), Path::new(""));
+}

--- a/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
+++ b/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
@@ -7,16 +7,17 @@ use std::env;
 
 #[test]
 fn t_getcwd_value_depends_on_current_directory() {
-    let initial_dir = utils::getcwd();
-    assert!(initial_dir.is_ok());
+    let initial_dir = utils::getcwd().unwrap();
 
     let tmp = TempDir::new().unwrap();
-    assert_ne!(initial_dir.unwrap(), tmp.path());
+    assert_ne!(&initial_dir, tmp.path());
     let chdir_result = env::set_current_dir(&tmp.path());
     assert!(chdir_result.is_ok());
 
-    let new_dir = utils::getcwd();
-    assert!(new_dir.is_ok());
+    let new_dir = utils::getcwd().unwrap();
 
-    assert_eq!(new_dir.unwrap(), tmp.path());
+    // We cannot assert that newdir == tmp.path() because the latter might contain symlinks, which
+    // getcwd() resolves. So we have to test a slightly weaker property: changing the current
+    // directory changes the return value of getcwd
+    assert_ne!(initial_dir, new_dir);
 }

--- a/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
+++ b/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
@@ -1,0 +1,22 @@
+extern crate libnewsboat;
+extern crate tempfile;
+
+use self::tempfile::TempDir;
+use libnewsboat::utils;
+use std::env;
+
+#[test]
+fn t_getcwd_value_depends_on_current_directory() {
+    let initial_dir = utils::getcwd();
+    assert!(initial_dir.is_ok());
+
+    let tmp = TempDir::new().unwrap();
+    assert_ne!(initial_dir.unwrap(), tmp.path());
+    let chdir_result = env::set_current_dir(&tmp.path());
+    assert!(chdir_result.is_ok());
+
+    let new_dir = utils::getcwd();
+    assert!(new_dir.is_ok());
+
+    assert_eq!(new_dir.unwrap(), tmp.path());
+}


### PR DESCRIPTION
I slipped while reviewing #576 and #580, merging those PRs even though they didn't port tests to Rust. This pull request fixes that.

Everyone are welcome to review. I'll merge this in three days if no-one stops me!