### PR TITLE
Strip comments before the backticks are evaluated

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -14,6 +14,7 @@
 namespace newsboat {
 
 namespace utils {
+	std::string strip_comments(const std::string& line);
 	std::vector<std::string> tokenize(const std::string& str,
 		std::string delimiters = " \r\n\t");
 	std::vector<std::string> tokenize_spaced(const std::string& str,

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -91,7 +91,11 @@ bool ConfigParser::parse(const std::string& tmp_filename)
 		getline(f, line);
 		++linecounter;
 		LOG(Level::DEBUG, "ConfigParser::parse: tokenizing %s", line);
-		std::vector<std::string> tokens = utils::tokenize_quoted(evaluate_backticks(line));
+
+		auto stripped = utils::strip_comments(line);
+		auto evaluated = evaluate_backticks(std::move(stripped));
+		std::vector<std::string> tokens = utils::tokenize_quoted(std::move(evaluated));
+
 		if (!tokens.empty()) {
 			std::string cmd = tokens[0];
 			ConfigActionHandler* handler = action_handlers[cmd];

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -78,6 +78,18 @@ void append_escapes(std::string& str, char c)
 }
 }
 
+std::string utils::strip_comments(const std::string& line)
+{
+	/*
+	 * This functions returns only the non-comment part of the line,
+	 * which can then be safely evaluated and tokenized.
+	 *
+	 * If no comments are present on the line, the whole line is returned.
+	 */
+	auto hash_pos = line.find_first_of("#");
+	return line.substr(0, hash_pos);
+}
+
 std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 	std::string delimiters)
 {

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -194,7 +194,7 @@ TEST_CASE("tokenize_nl() split a string into delimiters and fields", "[utils]")
 }
 
 TEST_CASE(
-	"strip_comments returns correct part of the line",
+	"strip_comments returns only the part of the line before first # character",
 	"[utils]")
 {
 	SECTION("no comments in line")

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -194,6 +194,32 @@ TEST_CASE("tokenize_nl() split a string into delimiters and fields", "[utils]")
 }
 
 TEST_CASE(
+	"strip_comments returns correct part of the line",
+	"[utils]")
+{
+	SECTION("no comments in line")
+	{
+		REQUIRE(utils::strip_comments("") == "");
+		REQUIRE(utils::strip_comments("\t\n") == "\t\n");
+		REQUIRE(utils::strip_comments("some directive ") == "some directive ");
+	}
+
+	SECTION("fully commented line")
+	{
+		REQUIRE(utils::strip_comments("#") == "");
+		REQUIRE(utils::strip_comments("# #") == "");
+		REQUIRE(utils::strip_comments("# comment") == "");
+	}
+
+	SECTION("partially commented line")
+	{
+		REQUIRE(utils::strip_comments("directive # comment") == "directive ");
+		REQUIRE(utils::strip_comments("directive # comment # another") == "directive ");
+		REQUIRE(utils::strip_comments("directive#comment") == "directive");
+	}
+}
+
+TEST_CASE(
 	"consolidate_whitespace replaces multiple consecutive"
 	"whitespace with a single space",
 	"[utils]")


### PR DESCRIPTION
Since the backticks should be evaluated before tokenizing (see https://github.com/newsboat/newsboat/pull/493 for discussion), the comments need to be stripped even before that, so that backticks can be safely used for quoting.

Not doing so can cause various unexpected issues (such as having `` `yes` `` in commented line causing newsboat to crash with out-of-memory errors, as the `/usr/bin/yes` command produces infinite output).

The `/usr/bin/yes` issue was encountered when running newsboat on the example configuration file, which contains several instances of commented `` `yes` `` strings. See https://bugzilla.redhat.com/show_bug.cgi?id=1731224 for the original bug report.

---

As this is my first (code) contribution to newsboat, please have patience if I have put code/tests in wrong place or broke similar contribution rule 😉. I will happily amend any mistakes pointed to me.