### PR TITLE
Speed up Cache::internalize_rssfeed

### DIFF
--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -130,6 +130,7 @@ public:
 	std::string get_attribute(const std::string& attribname) override;
 
 	void set_feedptr(std::shared_ptr<RssFeed> ptr);
+	void set_feedptr(const std::weak_ptr<RssFeed>& ptr);
 	std::shared_ptr<RssFeed> get_feedptr()
 	{
 		return feedptr_.lock();

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -607,9 +607,10 @@ std::shared_ptr<RssFeed> Cache::internalize_rssfeed(std::string rssurl,
 			items.end());
 	}
 
+	auto feed_weak_ptr = std::weak_ptr<RssFeed>(feed);
 	for (const auto& item : feed->items()) {
 		item->set_cache(this);
-		item->set_feedptr(feed);
+		item->set_feedptr(feed_weak_ptr);
 		item->set_feedurl(feed->rssurl());
 	}
 

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -584,8 +584,7 @@ std::shared_ptr<RssFeed> Cache::internalize_rssfeed(std::string rssurl,
 		"feedurl, enclosure_url, enclosure_type, enqueued, flags, base "
 		"FROM rss_item "
 		"WHERE feedurl = '%q' "
-		"AND deleted = 0 "
-		"ORDER BY pubDate DESC, id DESC;",
+		"AND deleted = 0;",
 		rssurl);
 	run_sql(query, rssitem_callback, &feed);
 

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -261,8 +261,8 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 	case ArtSortMethod::TITLE:
 		std::stable_sort(items_.begin(),
 			items_.end(),
-			[&](std::shared_ptr<RssItem> a,
-				std::shared_ptr<RssItem> b) {
+			[&](const std::shared_ptr<RssItem>& a,
+				const std::shared_ptr<RssItem>& b) {
 				return sort_strategy.sd ==
 						SortDirection::DESC
 					? (utils::strnaturalcmp(a->title().c_str(),
@@ -274,8 +274,8 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 	case ArtSortMethod::FLAGS:
 		std::stable_sort(items_.begin(),
 			items_.end(),
-			[&](std::shared_ptr<RssItem> a,
-				std::shared_ptr<RssItem> b) {
+			[&](const std::shared_ptr<RssItem>& a,
+				const std::shared_ptr<RssItem>& b) {
 				return sort_strategy.sd ==
 						SortDirection::DESC
 					? (strcmp(a->flags().c_str(),
@@ -287,8 +287,8 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 	case ArtSortMethod::AUTHOR:
 		std::stable_sort(items_.begin(),
 			items_.end(),
-			[&](std::shared_ptr<RssItem> a,
-				std::shared_ptr<RssItem> b) {
+			[&](const std::shared_ptr<RssItem>& a,
+				const std::shared_ptr<RssItem>& b) {
 				return sort_strategy.sd ==
 						SortDirection::DESC
 					? (strcmp(a->author().c_str(),
@@ -300,8 +300,8 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 	case ArtSortMethod::LINK:
 		std::stable_sort(items_.begin(),
 			items_.end(),
-			[&](std::shared_ptr<RssItem> a,
-				std::shared_ptr<RssItem> b) {
+			[&](const std::shared_ptr<RssItem>& a,
+				const std::shared_ptr<RssItem>& b) {
 				return sort_strategy.sd ==
 						SortDirection::DESC
 					? (strcmp(a->link().c_str(),
@@ -313,8 +313,8 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 	case ArtSortMethod::GUID:
 		std::stable_sort(items_.begin(),
 			items_.end(),
-			[&](std::shared_ptr<RssItem> a,
-				std::shared_ptr<RssItem> b) {
+			[&](const std::shared_ptr<RssItem>& a,
+				const std::shared_ptr<RssItem>& b) {
 				return sort_strategy.sd ==
 						SortDirection::DESC
 					? (strcmp(a->guid().c_str(),
@@ -326,8 +326,8 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 	case ArtSortMethod::DATE:
 		std::stable_sort(items_.begin(),
 			items_.end(),
-			[&](std::shared_ptr<RssItem> a,
-				std::shared_ptr<RssItem> b) {
+			[&](const std::shared_ptr<RssItem>& a,
+				const std::shared_ptr<RssItem>& b) {
 				// date is descending by default
 				return sort_strategy.sd == SortDirection::ASC
 					? (a->pubDate_timestamp() >

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -241,4 +241,9 @@ void RssItem::set_feedptr(std::shared_ptr<RssFeed> ptr)
 	feedptr_ = std::weak_ptr<RssFeed>(ptr);
 }
 
+void RssItem::set_feedptr(const std::weak_ptr<RssFeed>& ptr)
+{
+	feedptr_ = ptr;
+}
+
 } // namespace newsboat


### PR DESCRIPTION
These changes decrease startup time by about 6%. I wanted to get more precise measurements, but found that e.g. stddev increases after each optimization, and I'm not sure what value I should be comparing—the median, the average, some percentile, or maybe something else entirely. So I just ran old and new version on a 1.4 Gb cache.db stored on tmpfs, and the difference is about half a second, which is 6%.