### PR TITLE
Suggest sharing ~/.cargo with the container

### DIFF
--- a/doc/internal/docker.md
+++ b/doc/internal/docker.md
@@ -30,14 +30,17 @@ using your favourite tools to edit the files. Let's build Newsboat this way:
     $ docker run \
         --rm \
         --mount type=bind,source=$(pwd),target=/home/builder/src \
+        --mount type=bind,source=$HOME/.cargo,target=/home/builder/.cargo \
         --user $(id -u):$(id -g) \
         newsboat-ubuntu18.04-i686 \
         make -j9
 
 `--rm` deletes the container once it finished, by default it is kept and will
-just litter up your system. `--mount` links your current directory to
-"/home/builder/src" inside the container. `--user` specifies the user and the
-group that will own the newly created files (object files, docs, and the final
-executable); `id` determines your current user and group IDs.
-"newsboat-ubuntu18.04-i686" is the image from which we're creating the
-container, and `make -j9` is the command we're running inside of it.
+just litter up your system. The first `--mount` links your current directory to
+"/home/builder/src" inside the container. The other `--mount` shares your local
+crate cache with the container, letting it avoid re-downloading everything all
+the time. `--user` specifies the user and the group that will own the newly
+created files (object files, docs, and the final executable); `id` determines
+your current user and group IDs. "newsboat-ubuntu18.04-i686" is the image from
+which we're creating the container, and `make -j9` is the command we're running
+inside of it.


### PR DESCRIPTION
Docker containers are ephemeral and don't retain `.cargo` between runs. This means that every `docker run` updates Cargo index and re-downloads all the crates we require—even if none of our code changed and nothing needs to be re-built. Sharing your local ~/.cargo with the container is harmless because that directory only contains the index and a cache of downloaded crates; no build artifacts, no project-specific configs, nothing like that.

@der-lyse, if you have a spare minute, please take a look at the wording. Reviews from everyone else are welcome as well.