### PR TITLE
Crash when opening a url (#189)

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1069,7 +1069,6 @@ void ItemListFormAction::prepare()
 				datetime_format);
 			listfmt.set_line(itempos, line, item.second);
 		}
-		invalidated_itempos.clear();
 	} else {
 		LOG(Level::ERROR,
 			"invalidation_mode is neither COMPLETE nor "
@@ -1080,6 +1079,7 @@ void ItemListFormAction::prepare()
 		"replace_inner",
 		listfmt.format_list(rxman, "articlelist"));
 
+	invalidated_itempos.clear();
 	invalidated = false;
 
 	set_head(feed->title(),


### PR DESCRIPTION
Caused by heap-use-after-free in ItemListFormAction::prepare().

The complete invalidation mode repopulates the listfmt vector, thus it's
not enough to clear the invalidated_itempos only in case of partial
invalidation mode. The fix is to clear the invalidated_itempos vector
also in case of complete invalidation mode.