### PR TITLE
Fix crash on unread toggle in empty feed

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -197,7 +197,7 @@ void ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO,
 			"ItemListFormAction: toggling item read at pos `%s'",
 			itemposname);
-		if (itemposname.length() > 0) {
+		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			v->set_status(_("Toggling read flag for article..."));
 			try {
 				if (automatic && args->size() > 0) {


### PR DESCRIPTION
To reproduce the crash:
* Enter a feed with no unread items
* Press `l` to hide all items
* Press N

Edit: I did a quick pass on other operations in the litemlist and feedlist and didn't find any similar bugs - but I didn't take a very close look.