### PR TITLE
Clean up other FFI modules

### DIFF
--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -9,33 +9,34 @@ use std::ptr;
 use std::slice;
 
 #[no_mangle]
-pub extern "C" fn create_rs_cliargsparser(argc: isize, argv: *mut *const c_char) -> *mut c_void {
+pub unsafe extern "C" fn create_rs_cliargsparser(
+    argc: isize,
+    argv: *mut *const c_char,
+) -> *mut c_void {
     abort_on_panic(|| {
         assert!(!argv.is_null());
         assert!(argc >= 0);
-        let argv = unsafe { slice::from_raw_parts(argv, argc as usize) };
+        let argv = slice::from_raw_parts(argv, argc as usize);
 
         let args = argv
             .iter()
-            .map(|s_ptr| unsafe { CStr::from_ptr(*s_ptr).to_string_lossy().into_owned() })
+            .map(|s_ptr| CStr::from_ptr(*s_ptr).to_string_lossy().into_owned())
             .collect::<Vec<String>>();
         Box::into_raw(Box::new(CliArgsParser::new(args))) as *mut c_void
     })
 }
 
 #[no_mangle]
-pub extern "C" fn destroy_rs_cliargsparser(object: *mut c_void) {
+pub unsafe extern "C" fn destroy_rs_cliargsparser(object: *mut c_void) {
     abort_on_panic(|| {
         if object.is_null() {
             return;
         }
-        unsafe {
-            Box::from_raw(object as *mut CliArgsParser);
-        }
+        Box::from_raw(object as *mut CliArgsParser);
     })
 }
 
-fn with_cliargsparser<F, T>(object: *mut c_void, action: F, default: T) -> T
+unsafe fn with_cliargsparser<F, T>(object: *mut c_void, action: F, default: T) -> T
 where
     F: RefUnwindSafe + Fn(&CliArgsParser) -> T,
     T: UnwindSafe,
@@ -44,8 +45,7 @@ where
         if object.is_null() {
             return default;
         }
-        // TODO: use abort_on_panic here
-        let object = unsafe { Box::from_raw(object as *mut CliArgsParser) };
+        let object = Box::from_raw(object as *mut CliArgsParser);
         let result = action(&object);
         // Don't destroy the object when the function finishes
         mem::forget(object);
@@ -53,7 +53,7 @@ where
     })
 }
 
-fn with_cliargsparser_str<F>(object: *mut c_void, action: F) -> *mut c_char
+unsafe fn with_cliargsparser_str<F>(object: *mut c_void, action: F) -> *mut c_char
 where
     F: RefUnwindSafe + Fn(&CliArgsParser) -> &str,
 {
@@ -64,7 +64,7 @@ where
     )
 }
 
-fn with_cliargsparser_opt_str<F>(object: *mut c_void, action: F) -> *mut c_char
+unsafe fn with_cliargsparser_opt_str<F>(object: *mut c_void, action: F) -> *mut c_char
 where
     F: RefUnwindSafe + Fn(&CliArgsParser) -> &Option<String>,
 {
@@ -85,147 +85,150 @@ where
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_do_import(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_do_import(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.importfile.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_do_export(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_do_export(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.do_export, false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_do_vacuum(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_do_vacuum(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.do_vacuum, false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_program_name(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_program_name(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_str(object, |o| &o.program_name)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_importfile(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_importfile(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_opt_str(object, |o| &o.importfile)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_do_read_import(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_do_read_import(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.readinfo_import_file.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_readinfo_import_file(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_readinfo_import_file(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_opt_str(object, |o| &o.readinfo_import_file)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_do_read_export(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_do_read_export(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.readinfo_export_file.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_readinfo_export_file(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_readinfo_export_file(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_opt_str(object, |o| &o.readinfo_export_file)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_show_version(object: *mut c_void) -> usize {
+pub unsafe extern "C" fn rs_cliargsparser_show_version(object: *mut c_void) -> usize {
     with_cliargsparser(object, |o| o.show_version, 0)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_silent(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_silent(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.silent, false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_using_nonstandard_configs(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_using_nonstandard_configs(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.using_nonstandard_configs(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_should_return(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_should_return(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.return_code.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_return_code(object: *mut c_void) -> isize {
+pub unsafe extern "C" fn rs_cliargsparser_return_code(object: *mut c_void) -> isize {
     with_cliargsparser(object, |o| o.return_code.unwrap_or(0) as isize, 0)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_display_msg(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_display_msg(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_str(object, |o| &o.display_msg)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_should_print_usage(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_should_print_usage(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.should_print_usage, false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_refresh_on_start(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_refresh_on_start(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.refresh_on_start, false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_set_url_file(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_set_url_file(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.url_file.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_url_file(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_url_file(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_opt_str(object, |o| &o.url_file)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_set_lock_file(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_set_lock_file(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.lock_file.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_lock_file(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_lock_file(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_opt_str(object, |o| &o.lock_file)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_set_cache_file(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_set_cache_file(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.cache_file.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_cache_file(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_cache_file(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_opt_str(object, |o| &o.cache_file)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_set_config_file(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_set_config_file(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.config_file.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_config_file(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_config_file(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_opt_str(object, |o| &o.config_file)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_execute_cmds(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_execute_cmds(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| !o.cmds_to_execute.is_empty(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_cmds_to_execute_count(object: *mut c_void) -> usize {
+pub unsafe extern "C" fn rs_cliargsparser_cmds_to_execute_count(object: *mut c_void) -> usize {
     with_cliargsparser(object, |o| o.cmds_to_execute.len(), 0)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_cmd_to_execute_n(object: *mut c_void, n: usize) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_cmd_to_execute_n(
+    object: *mut c_void,
+    n: usize,
+) -> *mut c_char {
     if object.is_null() {
         return ptr::null_mut();
     }
     abort_on_panic(|| {
-        let object = unsafe { Box::from_raw(object as *mut CliArgsParser) };
+        let object = Box::from_raw(object as *mut CliArgsParser);
         let result = if n < object.cmds_to_execute.len() {
             CString::new(object.cmds_to_execute[n].clone())
                 .unwrap()
@@ -240,21 +243,21 @@ pub extern "C" fn rs_cliargsparser_cmd_to_execute_n(object: *mut c_void, n: usiz
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_set_log_file(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_set_log_file(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.log_file.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_log_file(object: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_cliargsparser_log_file(object: *mut c_void) -> *mut c_char {
     with_cliargsparser_opt_str(object, |o| &o.log_file)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_set_log_level(object: *mut c_void) -> bool {
+pub unsafe extern "C" fn rs_cliargsparser_set_log_level(object: *mut c_void) -> bool {
     with_cliargsparser(object, |o| o.log_level.is_some(), false)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cliargsparser_log_level(object: *mut c_void) -> u8 {
+pub unsafe extern "C" fn rs_cliargsparser_log_level(object: *mut c_void) -> u8 {
     with_cliargsparser(object, |o| o.log_level.unwrap_or(Level::None) as u8, 0)
 }

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -30,7 +30,7 @@ pub extern "C" fn destroy_rs_cliargsparser(object: *mut c_void) {
             return;
         }
         unsafe {
-            Box::from_raw(object);
+            Box::from_raw(object as *mut CliArgsParser);
         }
     })
 }

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -37,7 +37,7 @@ pub extern "C" fn destroy_rs_cliargsparser(object: *mut c_void) {
 
 fn with_cliargsparser<F, T>(object: *mut c_void, action: F, default: T) -> T
 where
-    F: RefUnwindSafe + Fn(&Box<CliArgsParser>) -> T,
+    F: RefUnwindSafe + Fn(&CliArgsParser) -> T,
     T: UnwindSafe,
 {
     abort_on_panic(|| {
@@ -55,7 +55,7 @@ where
 
 fn with_cliargsparser_str<F>(object: *mut c_void, action: F) -> *mut c_char
 where
-    F: RefUnwindSafe + Fn(&Box<CliArgsParser>) -> &str,
+    F: RefUnwindSafe + Fn(&CliArgsParser) -> &str,
 {
     with_cliargsparser(
         object,
@@ -66,7 +66,7 @@ where
 
 fn with_cliargsparser_opt_str<F>(object: *mut c_void, action: F) -> *mut c_char
 where
-    F: RefUnwindSafe + Fn(&Box<CliArgsParser>) -> &Option<String>,
+    F: RefUnwindSafe + Fn(&CliArgsParser) -> &Option<String>,
 {
     with_cliargsparser(
         object,

--- a/rust/libnewsboat-ffi/src/fmtstrformatter.rs
+++ b/rust/libnewsboat-ffi/src/fmtstrformatter.rs
@@ -1,35 +1,36 @@
 use abort_on_panic;
-use libc::c_char;
+use libc::{c_char, c_void};
 use libnewsboat::fmtstrformatter::FmtStrFormatter;
 use std::ffi::{CStr, CString};
+use std::mem;
 
 #[no_mangle]
-pub extern "C" fn rs_fmtstrformatter_new() -> *mut FmtStrFormatter {
-    abort_on_panic(|| Box::into_raw(Box::new(FmtStrFormatter::new())))
+pub extern "C" fn rs_fmtstrformatter_new() -> *mut c_void {
+    abort_on_panic(|| Box::into_raw(Box::new(FmtStrFormatter::new())) as *mut c_void)
 }
 
 #[no_mangle]
-pub extern "C" fn rs_fmtstrformatter_free(fmt: *mut FmtStrFormatter) {
+pub extern "C" fn rs_fmtstrformatter_free(fmt: *mut c_void) {
     abort_on_panic(|| {
         if fmt.is_null() {
             return;
         }
         unsafe {
-            Box::from_raw(fmt);
+            Box::from_raw(fmt as *mut FmtStrFormatter);
         }
     })
 }
 
 #[no_mangle]
 pub extern "C" fn rs_fmtstrformatter_register_fmt(
-    fmt: *mut FmtStrFormatter,
+    fmt: *mut c_void,
     key: c_char,
     value: *const c_char,
 ) {
     abort_on_panic(|| {
-        let fmt = unsafe {
+        let mut fmt = unsafe {
             assert!(!fmt.is_null());
-            &mut *fmt
+            Box::from_raw(fmt as *mut FmtStrFormatter)
         };
         let value = unsafe {
             assert!(!value.is_null());
@@ -41,19 +42,22 @@ pub extern "C" fn rs_fmtstrformatter_register_fmt(
         // From there, it's safe to cast to Rust's char.
         let key = key as u8 as char;
         fmt.register_fmt(key as char, value);
+
+        // Do not deallocate the object - C still has a pointer to it
+        mem::forget(fmt);
     })
 }
 
 #[no_mangle]
 pub extern "C" fn rs_fmtstrformatter_do_format(
-    fmt: *mut FmtStrFormatter,
+    fmt: *mut c_void,
     format: *const c_char,
     width: u32,
 ) -> *mut c_char {
     abort_on_panic(|| {
         let fmt = unsafe {
             assert!(!fmt.is_null());
-            &mut *fmt
+            Box::from_raw(fmt as *mut FmtStrFormatter)
         };
         let format = unsafe {
             assert!(!format.is_null());
@@ -62,6 +66,11 @@ pub extern "C" fn rs_fmtstrformatter_do_format(
         .to_str()
         .expect("format contained invalid UTF-8");
         let result = fmt.do_format(format, width);
-        CString::new(result).unwrap().into_raw()
+        let result = CString::new(result).unwrap().into_raw();
+
+        // Do not deallocate the object - C still has a pointer to it
+        mem::forget(fmt);
+
+        result
     })
 }

--- a/rust/libnewsboat-ffi/src/fmtstrformatter.rs
+++ b/rust/libnewsboat-ffi/src/fmtstrformatter.rs
@@ -10,29 +10,27 @@ pub extern "C" fn rs_fmtstrformatter_new() -> *mut c_void {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_fmtstrformatter_free(fmt: *mut c_void) {
+pub unsafe extern "C" fn rs_fmtstrformatter_free(fmt: *mut c_void) {
     abort_on_panic(|| {
         if fmt.is_null() {
             return;
         }
-        unsafe {
-            Box::from_raw(fmt as *mut FmtStrFormatter);
-        }
+        Box::from_raw(fmt as *mut FmtStrFormatter);
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_fmtstrformatter_register_fmt(
+pub unsafe extern "C" fn rs_fmtstrformatter_register_fmt(
     fmt: *mut c_void,
     key: c_char,
     value: *const c_char,
 ) {
     abort_on_panic(|| {
-        let mut fmt = unsafe {
+        let mut fmt = {
             assert!(!fmt.is_null());
             Box::from_raw(fmt as *mut FmtStrFormatter)
         };
-        let value = unsafe {
+        let value = {
             assert!(!value.is_null());
             CStr::from_ptr(value)
         }
@@ -49,17 +47,17 @@ pub extern "C" fn rs_fmtstrformatter_register_fmt(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_fmtstrformatter_do_format(
+pub unsafe extern "C" fn rs_fmtstrformatter_do_format(
     fmt: *mut c_void,
     format: *const c_char,
     width: u32,
 ) -> *mut c_char {
     abort_on_panic(|| {
-        let fmt = unsafe {
+        let fmt = {
             assert!(!fmt.is_null());
             Box::from_raw(fmt as *mut FmtStrFormatter)
         };
-        let format = unsafe {
+        let format = {
             assert!(!format.is_null());
             CStr::from_ptr(format)
         }

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -24,13 +24,11 @@ fn abort_on_panic<F: FnOnce() -> R + UnwindSafe, R>(function: F) -> R {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_cstring_free(string: *mut c_char) {
+pub unsafe extern "C" fn rs_cstring_free(string: *mut c_char) {
     abort_on_panic(|| {
-        unsafe {
-            if string.is_null() {
-                return;
-            }
-            CString::from_raw(string);
-        };
+        if string.is_null() {
+            return;
+        }
+        CString::from_raw(string);
     })
 }

--- a/rust/libnewsboat-ffi/src/logger.rs
+++ b/rust/libnewsboat-ffi/src/logger.rs
@@ -4,24 +4,24 @@ use libnewsboat::logger;
 use std::ffi::CStr;
 
 #[no_mangle]
-pub extern "C" fn rs_log(level: logger::Level, message: *const c_char) {
+pub unsafe extern "C" fn rs_log(level: logger::Level, message: *const c_char) {
     abort_on_panic(|| {
-        let message = unsafe { CStr::from_ptr(message) };
+        let message = CStr::from_ptr(message);
         logger::get_instance().log_raw(level, message.to_bytes());
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_set_loglevel(level: logger::Level) {
+pub unsafe extern "C" fn rs_set_loglevel(level: logger::Level) {
     abort_on_panic(|| {
         logger::get_instance().set_loglevel(level);
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_set_logfile(logfile: *const c_char) {
+pub unsafe extern "C" fn rs_set_logfile(logfile: *const c_char) {
     abort_on_panic(|| {
-        let logfile = unsafe { CStr::from_ptr(logfile) };
+        let logfile = CStr::from_ptr(logfile);
         let logfile = logfile
             .to_str()
             .expect("logfile path contained invalid UTF-8");
@@ -30,9 +30,9 @@ pub extern "C" fn rs_set_logfile(logfile: *const c_char) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_set_user_error_logfile(user_error_logfile: *const c_char) {
+pub unsafe extern "C" fn rs_set_user_error_logfile(user_error_logfile: *const c_char) {
     abort_on_panic(|| {
-        let user_error_logfile = unsafe { CStr::from_ptr(user_error_logfile) };
+        let user_error_logfile = CStr::from_ptr(user_error_logfile);
         let user_error_logfile = user_error_logfile
             .to_str()
             .expect("user_error_logfile path contained invalid UTF-8");

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -7,19 +7,19 @@ use std::path;
 use std::ptr;
 
 #[no_mangle]
-pub extern "C" fn rs_replace_all(
+pub unsafe extern "C" fn rs_replace_all(
     input: *const c_char,
     from: *const c_char,
     to: *const c_char,
 ) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy().into_owned();
 
-        let rs_from = unsafe { CStr::from_ptr(from) };
+        let rs_from = CStr::from_ptr(from);
         let rs_from = rs_from.to_str().expect("rs_from contained invalid UTF-8");
 
-        let rs_to = unsafe { CStr::from_ptr(to) };
+        let rs_to = CStr::from_ptr(to);
         let rs_to = rs_to.to_str().expect("rs_to contained invalid UTF-8");
 
         let result = utils::replace_all(rs_input, rs_from, rs_to);
@@ -35,9 +35,9 @@ pub extern "C" fn rs_replace_all(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_consolidate_whitespace(input: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_consolidate_whitespace(input: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy().into_owned();
 
         let result = utils::consolidate_whitespace(rs_input);
@@ -51,9 +51,9 @@ pub extern "C" fn rs_consolidate_whitespace(input: *const c_char) -> *mut c_char
 }
 
 #[no_mangle]
-pub extern "C" fn rs_resolve_tilde(path: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_resolve_tilde(path: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_path = unsafe { CStr::from_ptr(path) };
+        let rs_path = CStr::from_ptr(path);
         let rs_path = rs_path.to_string_lossy().into_owned();
 
         let result = utils::resolve_tilde(rs_path);
@@ -64,16 +64,16 @@ pub extern "C" fn rs_resolve_tilde(path: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_resolve_relative(
+pub unsafe extern "C" fn rs_resolve_relative(
     reference: *const c_char,
     path: *const c_char,
 ) -> *mut c_char {
     use std::path::Path;
     abort_on_panic(|| {
-        let rs_reference = unsafe { CStr::from_ptr(reference) };
+        let rs_reference = CStr::from_ptr(reference);
         let rs_reference = rs_reference.to_string_lossy().into_owned();
 
-        let rs_path = unsafe { CStr::from_ptr(path) };
+        let rs_path = CStr::from_ptr(path);
         let rs_path = rs_path.to_string_lossy().into_owned();
 
         let result = utils::resolve_relative(Path::new(&rs_reference), Path::new(&rs_path));
@@ -91,9 +91,9 @@ pub extern "C" fn rs_resolve_relative(
 }
 
 #[no_mangle]
-pub extern "C" fn rs_to_u(in_str: *const c_char, default_value: u32) -> u32 {
+pub unsafe extern "C" fn rs_to_u(in_str: *const c_char, default_value: u32) -> u32 {
     abort_on_panic(|| {
-        let rs_str = unsafe { CStr::from_ptr(in_str) };
+        let rs_str = CStr::from_ptr(in_str);
         let rs_str = rs_str.to_string_lossy().into_owned();
 
         utils::to_u(rs_str, default_value)
@@ -101,11 +101,14 @@ pub extern "C" fn rs_to_u(in_str: *const c_char, default_value: u32) -> u32 {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_absolute_url(base_url: *const c_char, link: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_absolute_url(
+    base_url: *const c_char,
+    link: *const c_char,
+) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_base_url = unsafe { CStr::from_ptr(base_url) };
+        let rs_base_url = CStr::from_ptr(base_url);
         let rs_base_url = rs_base_url.to_string_lossy();
-        let rs_link = unsafe { CStr::from_ptr(link) };
+        let rs_link = CStr::from_ptr(link);
         let rs_link = rs_link.to_string_lossy();
 
         let ret = utils::absolute_url(&rs_base_url, &rs_link);
@@ -114,63 +117,63 @@ pub extern "C" fn rs_absolute_url(base_url: *const c_char, link: *const c_char) 
 }
 
 #[no_mangle]
-pub extern "C" fn rs_is_special_url(in_str: *const c_char) -> bool {
+pub unsafe extern "C" fn rs_is_special_url(in_str: *const c_char) -> bool {
     abort_on_panic(|| {
-        let rs_str = unsafe { CStr::from_ptr(in_str) };
+        let rs_str = CStr::from_ptr(in_str);
         let rs_str = rs_str.to_string_lossy();
         utils::is_special_url(&rs_str)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_is_http_url(in_str: *const c_char) -> bool {
+pub unsafe extern "C" fn rs_is_http_url(in_str: *const c_char) -> bool {
     abort_on_panic(|| {
-        let rs_str = unsafe { CStr::from_ptr(in_str) };
+        let rs_str = CStr::from_ptr(in_str);
         let rs_str = rs_str.to_string_lossy();
         utils::is_http_url(&rs_str)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_is_query_url(in_str: *const c_char) -> bool {
+pub unsafe extern "C" fn rs_is_query_url(in_str: *const c_char) -> bool {
     abort_on_panic(|| {
-        let rs_str = unsafe { CStr::from_ptr(in_str) };
+        let rs_str = CStr::from_ptr(in_str);
         let rs_str = rs_str.to_string_lossy();
         utils::is_query_url(&rs_str)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_is_filter_url(in_str: *const c_char) -> bool {
+pub unsafe extern "C" fn rs_is_filter_url(in_str: *const c_char) -> bool {
     abort_on_panic(|| {
-        let rs_str = unsafe { CStr::from_ptr(in_str) };
+        let rs_str = CStr::from_ptr(in_str);
         let rs_str = rs_str.to_string_lossy();
         utils::is_filter_url(&rs_str)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_is_exec_url(in_str: *const c_char) -> bool {
+pub unsafe extern "C" fn rs_is_exec_url(in_str: *const c_char) -> bool {
     abort_on_panic(|| {
-        let rs_str = unsafe { CStr::from_ptr(in_str) };
+        let rs_str = CStr::from_ptr(in_str);
         let rs_str = rs_str.to_string_lossy();
         utils::is_exec_url(&rs_str)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_censor_url(url: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_censor_url(url: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_url = unsafe { CStr::from_ptr(url) };
+        let rs_url = CStr::from_ptr(url);
         let rs_url = rs_url.to_string_lossy();
         CString::new(utils::censor_url(&rs_url)).unwrap().into_raw()
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_trim_end(input: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_trim_end(input: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy().into_owned();
 
         let result = utils::trim_end(rs_input);
@@ -181,9 +184,9 @@ pub extern "C" fn rs_trim_end(input: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_trim(input: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_trim(input: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy().into_owned();
 
         let result = utils::trim(rs_input);
@@ -194,9 +197,9 @@ pub extern "C" fn rs_trim(input: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_quote(input: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_quote(input: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy().into_owned();
 
         let output = utils::quote(rs_input);
@@ -210,9 +213,9 @@ pub extern "C" fn rs_quote(input: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_quote_if_necessary(input: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_quote_if_necessary(input: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy().into_owned();
 
         let output = utils::quote_if_necessary(rs_input);
@@ -231,9 +234,9 @@ pub extern "C" fn rs_get_random_value(rs_max: u32) -> u32 {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_get_auth_method(input: *const c_char) -> c_ulong {
+pub unsafe extern "C" fn rs_get_auth_method(input: *const c_char) -> c_ulong {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy().into_owned();
 
         utils::get_auth_method(&rs_input)
@@ -241,9 +244,9 @@ pub extern "C" fn rs_get_auth_method(input: *const c_char) -> c_ulong {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_unescape_url(input: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_unescape_url(input: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy().into_owned();
 
         let result = utils::unescape_url(rs_input);
@@ -261,9 +264,9 @@ pub extern "C" fn rs_unescape_url(input: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_make_title(input: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_make_title(input: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy().into_owned();
 
         let result = utils::make_title(rs_input);
@@ -310,9 +313,9 @@ pub extern "C" fn rs_get_default_browser() -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_is_valid_color(input: *const c_char) -> bool {
+pub unsafe extern "C" fn rs_is_valid_color(input: *const c_char) -> bool {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy();
         utils::is_valid_color(&rs_input)
     })
@@ -330,36 +333,36 @@ pub unsafe extern "C" fn rs_get_basename(input: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_is_valid_attribute(attribute: *const c_char) -> bool {
+pub unsafe extern "C" fn rs_is_valid_attribute(attribute: *const c_char) -> bool {
     abort_on_panic(|| {
-        let rs_attribute = unsafe { CStr::from_ptr(attribute) };
+        let rs_attribute = CStr::from_ptr(attribute);
         let rs_attribute = rs_attribute.to_string_lossy();
         utils::is_valid_attribute(&rs_attribute)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_strwidth(input: *const c_char) -> usize {
+pub unsafe extern "C" fn rs_strwidth(input: *const c_char) -> usize {
     abort_on_panic(|| {
-        let rs_str = unsafe { CStr::from_ptr(input) };
+        let rs_str = CStr::from_ptr(input);
         let rs_str = rs_str.to_string_lossy().into_owned();
         utils::strwidth(&rs_str)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_strwidth_stfl(input: *const c_char) -> usize {
+pub unsafe extern "C" fn rs_strwidth_stfl(input: *const c_char) -> usize {
     abort_on_panic(|| {
-        let rs_str = unsafe { CStr::from_ptr(input) };
+        let rs_str = CStr::from_ptr(input);
         let rs_str = rs_str.to_string_lossy().into_owned();
         utils::strwidth_stfl(&rs_str)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_remove_soft_hyphens(text: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_remove_soft_hyphens(text: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_text = unsafe { CStr::from_ptr(text) };
+        let rs_text = CStr::from_ptr(text);
         let mut rs_text = rs_text.to_string_lossy().into_owned();
         utils::remove_soft_hyphens(&mut rs_text);
         // Panic can't happen here because:
@@ -371,18 +374,18 @@ pub extern "C" fn rs_remove_soft_hyphens(text: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_is_valid_podcast_type(mimetype: *const c_char) -> bool {
+pub unsafe extern "C" fn rs_is_valid_podcast_type(mimetype: *const c_char) -> bool {
     abort_on_panic(|| {
-        let rs_mimetype = unsafe { CStr::from_ptr(mimetype) };
+        let rs_mimetype = CStr::from_ptr(mimetype);
         let rs_mimetype = rs_mimetype.to_string_lossy();
         utils::is_valid_podcast_type(&rs_mimetype)
     })
 }
 
 #[no_mangle]
-pub extern "C" fn rs_get_command_output(input: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_get_command_output(input: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
-        let rs_input = unsafe { CStr::from_ptr(input) };
+        let rs_input = CStr::from_ptr(input);
         let rs_input = rs_input.to_string_lossy();
         let output = utils::get_command_output(&rs_input);
         // String::from_utf8_lossy() will replace invalid unicode (including null bytes) with U+FFFD,
@@ -393,12 +396,12 @@ pub extern "C" fn rs_get_command_output(input: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_run_command(command: *const c_char, param: *const c_char) {
+pub unsafe extern "C" fn rs_run_command(command: *const c_char, param: *const c_char) {
     abort_on_panic(|| {
-        let command = unsafe { CStr::from_ptr(command) };
+        let command = CStr::from_ptr(command);
         let command = command.to_str().expect("command contained invalid UTF-8");
 
-        let param = unsafe { CStr::from_ptr(param) };
+        let param = CStr::from_ptr(param);
         let param = param.to_str().expect("param contained invalid UTF-8");
 
         utils::run_command(command, param);
@@ -406,9 +409,12 @@ pub extern "C" fn rs_run_command(command: *const c_char, param: *const c_char) {
 }
 
 #[no_mangle]
-pub extern "C" fn rs_run_program(argv: *mut *mut c_char, input: *const c_char) -> *mut c_char {
+pub unsafe extern "C" fn rs_run_program(
+    argv: *mut *mut c_char,
+    input: *const c_char,
+) -> *mut c_char {
     abort_on_panic(|| {
-        let argv = unsafe {
+        let argv = {
             let mut result: Vec<&str> = Vec::new();
             let mut cur_ptr = argv;
 
@@ -428,7 +434,7 @@ pub extern "C" fn rs_run_program(argv: *mut *mut c_char, input: *const c_char) -
             result
         };
 
-        let input = unsafe { CStr::from_ptr(input) };
+        let input = CStr::from_ptr(input);
         let input = input.to_str().expect("input contained invalid UTF-8");
 
         let output = utils::run_program(&argv, input);


### PR DESCRIPTION
Reviewers in #413 uncovered a number of problems that I kept copy-pasting from module to module:

1. most FFI functions can cause undefined behaviour even if called from a safe code—it's sufficient to pass some rubbish in place of a pointer to cause a SIGSEGV, for example. The functions are now marked `unsafe`, which doesn't affect the code in any way, but reminds us that we should be careful;

2. when deallocating an object allocated by Rust, the code created `Box<c_void>` instead of `Box<TheTypeWeWant>`. We're lucky our Rust structs don't hold resources other than memory, and don't cause many problems if deallocated incorrectly;

3. all modules create a wrapper function that turns `*mut c_void` into a `Box<T>`, and pass a `&mut Box<T>` into a function that does the actual work of converting arguments, calling `T`'s method, and converting the result into FFI types. However, a call to `fn f(input: &mut Box<T>)` can re-assign `input`, which will drop the old `Box` and thus invalidate the pointer that's held by C. To avoid that, we now pass `&mut T` everywhere.

Reviews are welcome (@kpcyrd, perhaps?) Otherwise I'll merge this in three days.