### PR TITLE
Fix filter being unapplied when a command is ran

### DIFF
--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -27,13 +27,6 @@ public:
 	KeyMapHintEntry* get_keymap_hint() override;
 	std::shared_ptr<RssFeed> get_feed();
 
-	void set_redraw(bool b) override
-	{
-		FormAction::set_redraw(b);
-		apply_filter =
-			!(cfg->get_configvalue_as_bool("show-read-feeds"));
-	}
-
 	std::string id() const override
 	{
 		return "feedlist";

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -29,8 +29,6 @@ public:
 	void set_redraw(bool b) override
 	{
 		FormAction::set_redraw(b);
-		apply_filter = !(v->get_cfg()->get_configvalue_as_bool(
-			"show-read-articles"));
 		invalidate_everything();
 	}
 


### PR DESCRIPTION
I traced this back to https://github.com/newsboat/newsboat/commit/595ba442ad11585f396f99c446b69f2edca81fca but couldn't figure out why resetting `apply_filter` here was useful.

Fixes #607