### PR TITLE
port `utils::mkdir_parents` to rust

### DIFF
--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -78,6 +78,8 @@ char* rs_program_version();
 
 unsigned int rs_newsboat_version_major();
 
+int rs_mkdir_parents(const char* path, const unsigned int mode);
+
 class RustString {
 private:
 	char* str;

--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -78,7 +78,7 @@ char* rs_program_version();
 
 unsigned int rs_newsboat_version_major();
 
-int rs_mkdir_parents(const char* path, const unsigned int mode);
+int rs_mkdir_parents(const char* path, const std::uint32_t mode);
 
 class RustString {
 private:

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -333,6 +333,15 @@ pub unsafe extern "C" fn rs_get_basename(input: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn rs_mkdir_parents(path: *const c_char, mode: u32) -> isize {
+    abort_on_panic(|| {
+        let rs_input = CStr::from_ptr(path);
+        let rs_input = rs_input.to_string_lossy();
+        utils::mkdir_parents(&rs_input, mode)
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rs_is_valid_attribute(attribute: *const c_char) -> bool {
     abort_on_panic(|| {
         let rs_attribute = CStr::from_ptr(attribute);

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -336,8 +336,11 @@ pub unsafe extern "C" fn rs_get_basename(input: *const c_char) -> *mut c_char {
 pub unsafe extern "C" fn rs_mkdir_parents(path: *const c_char, mode: u32) -> isize {
     abort_on_panic(|| {
         let rs_input = CStr::from_ptr(path);
-        let rs_input = rs_input.to_string_lossy();
-        utils::mkdir_parents(&rs_input, mode)
+        let rs_input = rs_input.to_string_lossy().into_owned();
+        match utils::mkdir_parents(&rs_input, mode) {
+            Ok(()) => 0,
+            Err(_) => -1,
+        }
     })
 }
 

--- a/rust/libnewsboat/src/configpaths.rs
+++ b/rust/libnewsboat/src/configpaths.rs
@@ -7,7 +7,9 @@ use std::fs::{self, DirBuilder};
 use std::io;
 use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
+use utils;
 use xdg;
+
 
 pub const NEWSBOAT_SUBDIR_XDG: &str = "newsboat";
 pub const NEWSBOAT_CONFIG_SUBDIR: &str = ".newsboat";
@@ -372,11 +374,7 @@ impl ConfigPaths {
 }
 
 fn try_mkdir<R: AsRef<Path>>(path: R) -> bool {
-    DirBuilder::new()
-        .recursive(true)
-        .mode(0o700)
-        .create(path.as_ref())
-        .is_ok()
+    utils::mkdir_parents(&path.as_ref(), 0o700).is_ok()
 }
 
 fn mkdir<R: AsRef<Path>>(path: R, mode: u32) -> io::Result<()> {

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -14,7 +14,9 @@ use self::url::percent_encoding::*;
 use self::url::Url;
 use libc::c_ulong;
 use logger::{self, Level};
+use std::fs;
 use std::io::{self, Write};
+use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -475,6 +477,19 @@ pub fn make_title(rs_str: String) -> String {
 pub fn getcwd() -> Result<PathBuf, io::Error> {
     use std::env;
     env::current_dir()
+}
+
+/// Recursively create directories if missing and set permissions accordingly.
+pub fn mkdir_parents(p: &str, mode: u32) -> isize {
+    let path = Path::new(p);
+    let result = fs::DirBuilder::new()
+        .mode(mode)
+        .recursive(true) // directories created with same security and permissions
+        .create(path);
+    match result {
+        Ok(()) => 0,
+        Err(_) => -1,
+    }
 }
 
 /// Counts graphemes in a given string.
@@ -973,4 +988,27 @@ mod tests {
         }
     }
 
+    #[test]
+    fn t_mkdir_parents() {
+        use self::tempfile::TempDir;
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode: u32 = 0o700;
+        let tmp_dir = TempDir::new().unwrap();
+        let path = tmp_dir.path().join("parent/dir");
+        assert_eq!(path.exists(), false);
+
+        let result = mkdir_parents(&path, mode);
+        assert_eq!(result, 0);
+        assert_eq!(path.exists(), true);
+
+        let file_type_mask = 0o7777;
+        let metadata = fs::metadata(&path).unwrap();
+        assert_eq!(file_type_mask & metadata.permissions().mode(), mode);
+
+        // rerun on existing directories
+        let result = mkdir_parents(&path, mode);
+        assert_eq!(result, 0);
+    }
 }

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -100,12 +100,10 @@ bool PbController::setup_dirs_xdg(const char* env_home)
 
 	// create data directory if it doesn't exist
 	int ret = utils::mkdir_parents(xdg_data_dir, 0700);
-	if (ret && errno != EEXIST) {
+	if (ret == -1) {
 		LOG(Level::CRITICAL,
-			"Couldn't create `%s': (%i) %s",
-			xdg_data_dir,
-			errno,
-			strerror(errno));
+			"Couldn't create `%s'",
+			xdg_data_dir);
 		::exit(EXIT_FAILURE);
 	}
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -21,7 +21,6 @@
 #include <sstream>
 #include <stfl.h>
 #include <sys/param.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <unistd.h>
@@ -944,44 +943,7 @@ unsigned int utils::gentabs(const std::string& str)
  * exist. */
 int utils::mkdir_parents(const std::string& p, mode_t mode)
 {
-	int result = -1;
-
-	/* Have to copy the path because we're going to modify it */
-	std::vector<char> pathname(p.cbegin(), p.cend());
-	pathname.push_back('\0');
-	/* This pointer will run through the whole string looking for '/'.
-	 * We move it by one if path starts with slash because if we don't, the
-	 * first call to access() will fail (because of empty path) */
-	char* curr = pathname.data() + (pathname[0] == '/' ? 1 : 0);
-
-	while (*curr) {
-		if (*curr == '/') {
-			*curr = '\0';
-			result = mkdir(pathname.data(), mode);
-			if (result != 0) {
-				if (errno == EEXIST) {
-					result = 0;
-				} else {
-					break;
-				}
-			}
-			*curr = '/';
-		}
-		curr++;
-	}
-
-	if (result == 0) {
-		result = mkdir(p.c_str(), mode);
-
-		// It's not an error if the directory already exists. This happens when
-		// `p` ended with a slash, in which case the loop above creates all the
-		// path components.
-		if (result == -1 && errno == EEXIST) {
-			result = 0;
-		}
-	}
-
-	return result;
+	return rs_mkdir_parents(p.c_str(), (int) mode);
 }
 
 std::string utils::make_title(const std::string& const_url)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -943,7 +943,7 @@ unsigned int utils::gentabs(const std::string& str)
  * exist. */
 int utils::mkdir_parents(const std::string& p, mode_t mode)
 {
-	return rs_mkdir_parents(p.c_str(), (int) mode);
+	return rs_mkdir_parents(p.c_str(), static_cast<std::uint32_t>(mode));
 }
 
 std::string utils::make_title(const std::string& const_url)


### PR DESCRIPTION
See #334. I'm casting mode_t to a signed int before sending it over. Not sure if there was a more appropriate way of going about it. 