### PR TITLE
Fix memory leaks in RegexManager

### DIFF
--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -32,6 +32,10 @@ private:
 	std::vector<std::string> cheat_store_for_dump_config;
 	std::vector<std::pair<std::shared_ptr<Matcher>, int>> matchers;
 
+	void handle_highlight_action(const std::vector<std::string>& params);
+	void handle_highlight_article_action(
+			const std::vector<std::string>& params);
+
 public:
 	std::vector<std::string>& get_attrs(const std::string& loc)
 	{

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -43,15 +43,17 @@ void RegexManager::handle_action(const std::string& action,
 	const std::vector<std::string>& params)
 {
 	if (action == "highlight") {
-		if (params.size() < 3)
+		if (params.size() < 3) {
 			throw ConfigHandlerException(
 				ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
 
 		std::string location = params[0];
 		if (location != "all" && location != "article" &&
-			location != "articlelist" && location != "feedlist")
+			location != "articlelist" && location != "feedlist") {
 			throw ConfigHandlerException(strprintf::fmt(
 				_("`%s' is an invalid dialog type"), location));
+		}
 
 		regex_t* rx = new regex_t;
 		int err;
@@ -77,30 +79,34 @@ void RegexManager::handle_action(const std::string& action,
 		}
 		if (params.size() > 3) {
 			if (params[3] != "default") {
-				if (colorstr.length() > 0)
+				if (colorstr.length() > 0) {
 					colorstr.append(",");
+				}
 				colorstr.append("bg=");
-				if (!utils::is_valid_color(params[3]))
+				if (!utils::is_valid_color(params[3])) {
 					throw ConfigHandlerException(
 						strprintf::fmt(
 							_("`%s' is not a valid "
 							  "color"),
 							params[3]));
+				}
 				colorstr.append(params[3]);
 			}
 			for (unsigned int i = 4; i < params.size(); ++i) {
 				if (params[i] != "default") {
-					if (colorstr.length() > 0)
+					if (colorstr.length() > 0) {
 						colorstr.append(",");
+					}
 					colorstr.append("attr=");
 					if (!utils::is_valid_attribute(
-						    params[i]))
+						    params[i])) {
 						throw ConfigHandlerException(
 							strprintf::fmt(
 								_("`%s' is not "
 								  "a valid "
 								  "attribute"),
 								params[i]));
+					}
 					colorstr.append(params[i]);
 				}
 			}
@@ -141,9 +147,10 @@ void RegexManager::handle_action(const std::string& action,
 		}
 		cheat_store_for_dump_config.push_back(line);
 	} else if (action == "highlight-article") {
-		if (params.size() < 3)
+		if (params.size() < 3) {
 			throw ConfigHandlerException(
 				ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
 
 		std::string expr = params[0];
 		std::string fgcolor = params[1];
@@ -152,34 +159,39 @@ void RegexManager::handle_action(const std::string& action,
 		std::string colorstr;
 		if (fgcolor != "default") {
 			colorstr.append("fg=");
-			if (!utils::is_valid_color(fgcolor))
+			if (!utils::is_valid_color(fgcolor)) {
 				throw ConfigHandlerException(strprintf::fmt(
 					_("`%s' is not a valid color"),
 					fgcolor));
+			}
 			colorstr.append(fgcolor);
 		}
 		if (bgcolor != "default") {
-			if (colorstr.length() > 0)
+			if (colorstr.length() > 0) {
 				colorstr.append(",");
+			}
 			colorstr.append("bg=");
-			if (!utils::is_valid_color(bgcolor))
+			if (!utils::is_valid_color(bgcolor)) {
 				throw ConfigHandlerException(strprintf::fmt(
 					_("`%s' is not a valid color"),
 					bgcolor));
+			}
 			colorstr.append(bgcolor);
 		}
 
 		for (unsigned int i = 3; i < params.size(); i++) {
 			if (params[i] != "default") {
-				if (colorstr.length() > 0)
+				if (colorstr.length() > 0) {
 					colorstr.append(",");
+				}
 				colorstr.append("attr=");
-				if (!utils::is_valid_attribute(params[i]))
+				if (!utils::is_valid_attribute(params[i])) {
 					throw ConfigHandlerException(
 						strprintf::fmt(
 							_("`%s' is not a valid "
 							  "attribute"),
 							params[i]));
+				}
 				colorstr.append(params[i]);
 			}
 		}
@@ -200,9 +212,10 @@ void RegexManager::handle_action(const std::string& action,
 		matchers.push_back(
 			std::pair<std::shared_ptr<Matcher>, int>(m, pos));
 
-	} else
+	} else {
 		throw ConfigHandlerException(
 			ActionHandlerStatus::INVALID_COMMAND);
+	}
 }
 
 int RegexManager::article_matches(Matchable* item)

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -94,7 +94,7 @@ void RegexManager::handle_action(const std::string& action,
 			}
 			for (unsigned int i = 4; i < params.size(); ++i) {
 				if (params[i] != "default") {
-					if (colorstr.length() > 0) {
+					if (!colorstr.empty()) {
 						colorstr.append(",");
 					}
 					colorstr.append("attr=");
@@ -167,7 +167,7 @@ void RegexManager::handle_action(const std::string& action,
 			colorstr.append(fgcolor);
 		}
 		if (bgcolor != "default") {
-			if (colorstr.length() > 0) {
+			if (!colorstr.empty()) {
 				colorstr.append(",");
 			}
 			colorstr.append("bg=");
@@ -181,7 +181,7 @@ void RegexManager::handle_action(const std::string& action,
 
 		for (unsigned int i = 3; i < params.size(); i++) {
 			if (params[i] != "default") {
-				if (colorstr.length() > 0) {
+				if (!colorstr.empty()) {
 					colorstr.append(",");
 				}
 				colorstr.append("attr=");
@@ -249,7 +249,7 @@ std::string RegexManager::extract_outer_marker(std::string str, const int index)
 	std::stack<std::string> tagstack;
 	int offset = 0;
 
-	if (str.length() == 0) {
+	if (str.empty()) {
 		return "";
 	}
 

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -26,7 +26,10 @@ RegexManager::~RegexManager()
 	for (const auto& location : locations) {
 		if (location.second.first.size() > 0) {
 			for (const auto& regex : location.second.first) {
-				delete regex;
+				if (regex != nullptr) {
+					regfree(regex);
+					delete regex;
+				}
 			}
 		}
 	}
@@ -70,6 +73,7 @@ void RegexManager::remove_last_regex(const std::string& location)
 	}
 
 	auto it = regexes.end() - 1;
+	regfree(*it);
 	delete *it;
 	regexes.erase(it);
 }
@@ -123,11 +127,11 @@ std::string RegexManager::extract_outer_marker(std::string str, const int index)
 void RegexManager::quote_and_highlight(std::string& str,
 	const std::string& location)
 {
-	std::vector<regex_t*>& regexes = locations[location].first;
+	auto& regexes = locations[location].first;
 
 	unsigned int i = 0;
 	for (const auto& regex : regexes) {
-		if (!regex) {
+		if (regex == nullptr) {
 			continue;
 		}
 		regmatch_t pmatch;
@@ -237,6 +241,7 @@ void RegexManager::handle_highlight_action(const std::vector<std::string>& param
 		locations[location].first.push_back(rx);
 		locations[location].second.push_back(colorstr);
 	} else {
+		regfree(rx);
 		delete rx;
 		for (auto& location : locations) {
 			LOG(Level::DEBUG,

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -217,9 +217,12 @@ int RegexManager::article_matches(Matchable* item)
 
 void RegexManager::remove_last_regex(const std::string& location)
 {
-	std::vector<regex_t*>& regexes = locations[location].first;
+	auto& regexes = locations[location].first;
+	if (regexes.empty()) {
+		return;
+	}
 
-	auto it = regexes.begin() + regexes.size() - 1;
+	auto it = regexes.end() - 1;
 	delete *it;
 	regexes.erase(it);
 }

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -191,10 +191,13 @@ void RegexManager::handle_highlight_action(const std::vector<std::string>& param
 	std::string colorstr;
 	if (params[2] != "default") {
 		colorstr.append("fg=");
-		if (!utils::is_valid_color(params[2]))
+		if (!utils::is_valid_color(params[2])) {
+			regfree(rx);
+			delete rx;
 			throw ConfigHandlerException(strprintf::fmt(
 				_("`%s' is not a valid color"),
 				params[2]));
+		}
 		colorstr.append(params[2]);
 	}
 	if (params.size() > 3) {
@@ -204,6 +207,8 @@ void RegexManager::handle_highlight_action(const std::vector<std::string>& param
 			}
 			colorstr.append("bg=");
 			if (!utils::is_valid_color(params[3])) {
+				regfree(rx);
+				delete rx;
 				throw ConfigHandlerException(
 					strprintf::fmt(
 						_("`%s' is not a valid "
@@ -220,6 +225,8 @@ void RegexManager::handle_highlight_action(const std::vector<std::string>& param
 				colorstr.append("attr=");
 				if (!utils::is_valid_attribute(
 						params[i])) {
+					regfree(rx);
+					delete rx;
 					throw ConfigHandlerException(
 						strprintf::fmt(
 							_("`%s' is not "

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -43,175 +43,9 @@ void RegexManager::handle_action(const std::string& action,
 	const std::vector<std::string>& params)
 {
 	if (action == "highlight") {
-		if (params.size() < 3) {
-			throw ConfigHandlerException(
-				ActionHandlerStatus::TOO_FEW_PARAMS);
-		}
-
-		std::string location = params[0];
-		if (location != "all" && location != "article" &&
-			location != "articlelist" && location != "feedlist") {
-			throw ConfigHandlerException(strprintf::fmt(
-				_("`%s' is an invalid dialog type"), location));
-		}
-
-		regex_t* rx = new regex_t;
-		int err;
-		if ((err = regcomp(rx,
-			     params[1].c_str(),
-			     REG_EXTENDED | REG_ICASE)) != 0) {
-			char buf[1024];
-			regerror(err, rx, buf, sizeof(buf));
-			delete rx;
-			throw ConfigHandlerException(strprintf::fmt(
-				_("`%s' is not a valid regular expression: %s"),
-				params[1],
-				buf));
-		}
-		std::string colorstr;
-		if (params[2] != "default") {
-			colorstr.append("fg=");
-			if (!utils::is_valid_color(params[2]))
-				throw ConfigHandlerException(strprintf::fmt(
-					_("`%s' is not a valid color"),
-					params[2]));
-			colorstr.append(params[2]);
-		}
-		if (params.size() > 3) {
-			if (params[3] != "default") {
-				if (colorstr.length() > 0) {
-					colorstr.append(",");
-				}
-				colorstr.append("bg=");
-				if (!utils::is_valid_color(params[3])) {
-					throw ConfigHandlerException(
-						strprintf::fmt(
-							_("`%s' is not a valid "
-							  "color"),
-							params[3]));
-				}
-				colorstr.append(params[3]);
-			}
-			for (unsigned int i = 4; i < params.size(); ++i) {
-				if (params[i] != "default") {
-					if (!colorstr.empty()) {
-						colorstr.append(",");
-					}
-					colorstr.append("attr=");
-					if (!utils::is_valid_attribute(
-						    params[i])) {
-						throw ConfigHandlerException(
-							strprintf::fmt(
-								_("`%s' is not "
-								  "a valid "
-								  "attribute"),
-								params[i]));
-					}
-					colorstr.append(params[i]);
-				}
-			}
-		}
-		if (location != "all") {
-			LOG(Level::DEBUG,
-				"RegexManager::handle_action: adding rx = %s "
-				"colorstr = %s to location %s",
-				params[1],
-				colorstr,
-				location);
-			locations[location].first.push_back(rx);
-			locations[location].second.push_back(colorstr);
-		} else {
-			delete rx;
-			for (auto& location : locations) {
-				LOG(Level::DEBUG,
-					"RegexManager::handle_action: adding "
-					"rx = "
-					"%s colorstr = %s to location %s",
-					params[1],
-					colorstr,
-					location.first);
-				rx = new regex_t;
-				// we need to create a new one for each
-				// push_back, otherwise we'd have double frees.
-				regcomp(rx,
-					params[1].c_str(),
-					REG_EXTENDED | REG_ICASE);
-				location.second.first.push_back(rx);
-				location.second.second.push_back(colorstr);
-			}
-		}
-		std::string line = "highlight";
-		for (const auto& param : params) {
-			line.append(" ");
-			line.append(utils::quote(param));
-		}
-		cheat_store_for_dump_config.push_back(line);
+		handle_highlight_action(params);
 	} else if (action == "highlight-article") {
-		if (params.size() < 3) {
-			throw ConfigHandlerException(
-				ActionHandlerStatus::TOO_FEW_PARAMS);
-		}
-
-		std::string expr = params[0];
-		std::string fgcolor = params[1];
-		std::string bgcolor = params[2];
-
-		std::string colorstr;
-		if (fgcolor != "default") {
-			colorstr.append("fg=");
-			if (!utils::is_valid_color(fgcolor)) {
-				throw ConfigHandlerException(strprintf::fmt(
-					_("`%s' is not a valid color"),
-					fgcolor));
-			}
-			colorstr.append(fgcolor);
-		}
-		if (bgcolor != "default") {
-			if (!colorstr.empty()) {
-				colorstr.append(",");
-			}
-			colorstr.append("bg=");
-			if (!utils::is_valid_color(bgcolor)) {
-				throw ConfigHandlerException(strprintf::fmt(
-					_("`%s' is not a valid color"),
-					bgcolor));
-			}
-			colorstr.append(bgcolor);
-		}
-
-		for (unsigned int i = 3; i < params.size(); i++) {
-			if (params[i] != "default") {
-				if (!colorstr.empty()) {
-					colorstr.append(",");
-				}
-				colorstr.append("attr=");
-				if (!utils::is_valid_attribute(params[i])) {
-					throw ConfigHandlerException(
-						strprintf::fmt(
-							_("`%s' is not a valid "
-							  "attribute"),
-							params[i]));
-				}
-				colorstr.append(params[i]);
-			}
-		}
-
-		std::shared_ptr<Matcher> m(new Matcher());
-		if (!m->parse(params[0])) {
-			throw ConfigHandlerException(strprintf::fmt(
-				_("couldn't parse filter expression `%s': %s"),
-				params[0],
-				m->get_parse_error()));
-		}
-
-		int pos = locations["articlelist"].first.size();
-
-		locations["articlelist"].first.push_back(nullptr);
-		locations["articlelist"].second.push_back(colorstr);
-
-		matchers.push_back(
-			std::pair<std::shared_ptr<Matcher>, int>(m, pos));
-
+		handle_highlight_article_action(params);
 	} else {
 		throw ConfigHandlerException(
 			ActionHandlerStatus::INVALID_COMMAND);
@@ -321,6 +155,181 @@ void RegexManager::quote_and_highlight(std::string& str,
 		}
 		i++;
 	}
+}
+
+void RegexManager::handle_highlight_action(const std::vector<std::string>& params)
+{
+	if (params.size() < 3) {
+		throw ConfigHandlerException(
+			ActionHandlerStatus::TOO_FEW_PARAMS);
+	}
+
+	std::string location = params[0];
+	if (location != "all" && location != "article" &&
+		location != "articlelist" && location != "feedlist") {
+		throw ConfigHandlerException(strprintf::fmt(
+			_("`%s' is an invalid dialog type"), location));
+	}
+
+	regex_t* rx = new regex_t;
+	int err;
+	if ((err = regcomp(rx,
+			 params[1].c_str(),
+			 REG_EXTENDED | REG_ICASE)) != 0) {
+		char buf[1024];
+		regerror(err, rx, buf, sizeof(buf));
+		delete rx;
+		throw ConfigHandlerException(strprintf::fmt(
+			_("`%s' is not a valid regular expression: %s"),
+			params[1],
+			buf));
+	}
+	std::string colorstr;
+	if (params[2] != "default") {
+		colorstr.append("fg=");
+		if (!utils::is_valid_color(params[2]))
+			throw ConfigHandlerException(strprintf::fmt(
+				_("`%s' is not a valid color"),
+				params[2]));
+		colorstr.append(params[2]);
+	}
+	if (params.size() > 3) {
+		if (params[3] != "default") {
+			if (colorstr.length() > 0) {
+				colorstr.append(",");
+			}
+			colorstr.append("bg=");
+			if (!utils::is_valid_color(params[3])) {
+				throw ConfigHandlerException(
+					strprintf::fmt(
+						_("`%s' is not a valid "
+						  "color"),
+						params[3]));
+			}
+			colorstr.append(params[3]);
+		}
+		for (unsigned int i = 4; i < params.size(); ++i) {
+			if (params[i] != "default") {
+				if (!colorstr.empty()) {
+					colorstr.append(",");
+				}
+				colorstr.append("attr=");
+				if (!utils::is_valid_attribute(
+						params[i])) {
+					throw ConfigHandlerException(
+						strprintf::fmt(
+							_("`%s' is not "
+							  "a valid "
+							  "attribute"),
+							params[i]));
+				}
+				colorstr.append(params[i]);
+			}
+		}
+	}
+	if (location != "all") {
+		LOG(Level::DEBUG,
+			"RegexManager::handle_action: adding rx = %s "
+			"colorstr = %s to location %s",
+			params[1],
+			colorstr,
+			location);
+		locations[location].first.push_back(rx);
+		locations[location].second.push_back(colorstr);
+	} else {
+		delete rx;
+		for (auto& location : locations) {
+			LOG(Level::DEBUG,
+				"RegexManager::handle_action: adding "
+				"rx = "
+				"%s colorstr = %s to location %s",
+				params[1],
+				colorstr,
+				location.first);
+			rx = new regex_t;
+			// we need to create a new one for each
+			// push_back, otherwise we'd have double frees.
+			regcomp(rx,
+				params[1].c_str(),
+				REG_EXTENDED | REG_ICASE);
+			location.second.first.push_back(rx);
+			location.second.second.push_back(colorstr);
+		}
+	}
+	std::string line = "highlight";
+	for (const auto& param : params) {
+		line.append(" ");
+		line.append(utils::quote(param));
+	}
+	cheat_store_for_dump_config.push_back(line);
+}
+
+void RegexManager::handle_highlight_article_action(const std::vector<std::string>& params)
+{
+	if (params.size() < 3) {
+		throw ConfigHandlerException(
+			ActionHandlerStatus::TOO_FEW_PARAMS);
+	}
+
+	std::string expr = params[0];
+	std::string fgcolor = params[1];
+	std::string bgcolor = params[2];
+
+	std::string colorstr;
+	if (fgcolor != "default") {
+		colorstr.append("fg=");
+		if (!utils::is_valid_color(fgcolor)) {
+			throw ConfigHandlerException(strprintf::fmt(
+				_("`%s' is not a valid color"),
+				fgcolor));
+		}
+		colorstr.append(fgcolor);
+	}
+	if (bgcolor != "default") {
+		if (!colorstr.empty()) {
+			colorstr.append(",");
+		}
+		colorstr.append("bg=");
+		if (!utils::is_valid_color(bgcolor)) {
+			throw ConfigHandlerException(strprintf::fmt(
+				_("`%s' is not a valid color"),
+				bgcolor));
+		}
+		colorstr.append(bgcolor);
+	}
+
+	for (unsigned int i = 3; i < params.size(); i++) {
+		if (params[i] != "default") {
+			if (!colorstr.empty()) {
+				colorstr.append(",");
+			}
+			colorstr.append("attr=");
+			if (!utils::is_valid_attribute(params[i])) {
+				throw ConfigHandlerException(
+					strprintf::fmt(
+						_("`%s' is not a valid "
+						  "attribute"),
+						params[i]));
+			}
+			colorstr.append(params[i]);
+		}
+	}
+
+	std::shared_ptr<Matcher> m(new Matcher());
+	if (!m->parse(params[0])) {
+		throw ConfigHandlerException(strprintf::fmt(
+			_("couldn't parse filter expression `%s': %s"),
+			params[0],
+			m->get_parse_error()));
+	}
+
+	int pos = locations["articlelist"].first.size();
+
+	locations["articlelist"].first.push_back(nullptr);
+	locations["articlelist"].second.push_back(colorstr);
+
+	matchers.push_back(
+		std::pair<std::shared_ptr<Matcher>, int>(m, pos));
 }
 
 } // namespace newsboat

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -7,30 +7,32 @@
 
 using namespace newsboat;
 
-struct testMatchable : public Matchable {
+struct MatcherMockMatchable : public Matchable {
 	virtual bool has_attribute(const std::string& attribname)
 	{
 		if (attribname == "abcd" || attribname == "AAAA" ||
-			attribname == "tags")
+			attribname == "tags") {
 			return true;
+		}
 		return false;
 	}
 
 	virtual std::string get_attribute(const std::string& attribname)
 	{
-		if (attribname == "abcd")
+		if (attribname == "abcd") {
 			return "xyz";
-		if (attribname == "AAAA")
+		} else if (attribname == "AAAA") {
 			return "12345";
-		if (attribname == "tags")
+		} else if (attribname == "tags") {
 			return "foo bar baz quux";
+		}
 		return "";
 	}
 };
 
 TEST_CASE("Operator `=` checks if field has given value", "[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("abcd = \"xyz\"");
@@ -42,7 +44,7 @@ TEST_CASE("Operator `=` checks if field has given value", "[Matcher]")
 
 TEST_CASE("Operator `!=` checks if field doesn't have given value", "[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("abcd != \"uiop\"");
@@ -54,7 +56,7 @@ TEST_CASE("Operator `!=` checks if field doesn't have given value", "[Matcher]")
 
 TEST_CASE("Operator `=~` checks if field matches given regex", "[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("AAAA =~ \".\"");
@@ -78,7 +80,7 @@ TEST_CASE("Operator `=~` checks if field matches given regex", "[Matcher]")
 
 TEST_CASE("Matcher throws if expression contains undefined fields", "[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("BBBB =~ \"foo\"");
@@ -100,7 +102,7 @@ TEST_CASE("Matcher throws if expression contains undefined fields", "[Matcher]")
 TEST_CASE("Matcher throws if regex passed to `=~` or `!~` is invalid",
 	"[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("AAAA =~ \"[[\"");
@@ -113,7 +115,7 @@ TEST_CASE("Matcher throws if regex passed to `=~` or `!~` is invalid",
 TEST_CASE("Operator `!~` checks if field doesn't match given regex",
 	"[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("AAAA !~ \".\"");
@@ -135,7 +137,7 @@ TEST_CASE("Operator `!~` checks if field doesn't match given regex",
 TEST_CASE("Operator `#` checks if \"tags\" field contains given value",
 	"[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("tags # \"foo\"");
@@ -166,7 +168,7 @@ TEST_CASE("Operator `#` checks if \"tags\" field contains given value",
 TEST_CASE("Operator `!#` checks if \"tags\" field doesn't contain given value",
 	"[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("tags !# \"nein\"");
@@ -181,7 +183,7 @@ TEST_CASE(
 	"value",
 	"[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("AAAA > 12344");
@@ -203,7 +205,7 @@ TEST_CASE(
 TEST_CASE("Operator `between` checks if field's value is in given range",
 	"[Matcher]")
 {
-	testMatchable mock;
+	MatcherMockMatchable mock;
 	Matcher m;
 
 	m.parse("AAAA between 0:12345");

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -1,9 +1,24 @@
 #include "regexmanager.h"
 
 #include "3rd-party/catch.hpp"
+
 #include "confighandlerexception.h"
+#include "matchable.h"
 
 using namespace newsboat;
+
+TEST_CASE("RegexManager throws on invalid command", "[RegexManager]")
+{
+	RegexManager rxman;
+	std::vector<std::string> params;
+
+	SECTION("on invalid command")
+	{
+		REQUIRE_THROWS_AS(
+			rxman.handle_action("an-invalid-command", params),
+			ConfigHandlerException);
+	}
+}
 
 TEST_CASE("RegexManager throws on invalid `highlight' definition",
 	"[RegexManager]")
@@ -28,13 +43,6 @@ TEST_CASE("RegexManager throws on invalid `highlight' definition",
 	{
 		params = {"feedlist", "*", "blue", "red"};
 		REQUIRE_THROWS_AS(rxman.handle_action("highlight", params),
-			ConfigHandlerException);
-	}
-
-	SECTION("on invalid command")
-	{
-		REQUIRE_THROWS_AS(
-			rxman.handle_action("an-invalid-command", params),
 			ConfigHandlerException);
 	}
 }
@@ -63,15 +71,37 @@ TEST_CASE("RegexManager highlights according to definition", "[RegexManager]")
 	RegexManager rxman;
 	std::string input;
 
+	SECTION("In articlelist") {
+		rxman.handle_action("highlight", {"articlelist", "foo", "blue", "red"});
+		input = "xfoox";
+		rxman.quote_and_highlight(input, "articlelist");
+		REQUIRE(input == "x<0>foo</>x");
+	}
+
+	SECTION("In feedlist") {
+		rxman.handle_action("highlight", {"feedlist", "foo", "blue", "red"});
+		input = "yfooy";
+		rxman.quote_and_highlight(input, "feedlist");
+		REQUIRE(input == "y<0>foo</>y");
+	}
+}
+
+// This test might seem totally out of the blue, but we do need it: as of this
+// writing, `highlight-article` add a nullptr for a regex to "articlelist"
+// context, which would've crashed the program if it were to be dereferenced.
+// This test checks that those nullptrs are skipped.
+TEST_CASE("RegexManager::quote_and_highlight works fine even if there were "
+		"`highlight-article` commands",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+
 	rxman.handle_action("highlight", {"articlelist", "foo", "blue", "red"});
-	input = "xfoox";
+	rxman.handle_action("highlight-article", {"title==\"\"", "blue", "red"});
+
+	std::string input = "xfoox";
 	rxman.quote_and_highlight(input, "articlelist");
 	REQUIRE(input == "x<0>foo</>x");
-
-	rxman.handle_action("highlight", {"feedlist", "foo", "blue", "red"});
-	input = "yfooy";
-	rxman.quote_and_highlight(input, "feedlist");
-	REQUIRE(input == "y<0>foo</>y");
 }
 
 TEST_CASE("RegexManager preserves text when there's nothing to highlight",
@@ -107,7 +137,8 @@ TEST_CASE("`highlight all` adds rules for all locations", "[RegexManager]")
 	}
 }
 
-TEST_CASE("RegexManager does not hang on regexes that can match empty strings", "[RegexManager]")
+TEST_CASE("RegexManager does not hang on regexes that can match empty strings",
+		"[RegexManager]")
 {
 	RegexManager rxman;
 	std::string input = "The quick brown fox jumps over the lazy dog";
@@ -117,7 +148,8 @@ TEST_CASE("RegexManager does not hang on regexes that can match empty strings", 
 	REQUIRE(input == "The quick bro<0>w</>n fox jumps over the lazy dog");
 }
 
-TEST_CASE("RegexManager does not hang on regexes that match empty strings", "[RegexManager]")
+TEST_CASE("RegexManager does not hang on regexes that match empty strings",
+		"[RegexManager]")
 {
 	RegexManager rxman;
 	std::string input = "The quick brown fox jumps over the lazy dog";
@@ -145,7 +177,8 @@ TEST_CASE("RegexManager does not hang on regexes that match empty strings", "[Re
 	}
 }
 
-TEST_CASE("quote_and_highlight wraps highlighted text in numbered tags", "[RegexManager]")
+TEST_CASE("quote_and_highlight wraps highlighted text in numbered tags",
+		"[RegexManager]")
 {
 	RegexManager rxman;
 	std::string input =  "The quick brown fox jumps over the lazy dog";
@@ -178,7 +211,18 @@ TEST_CASE("quote_and_highlight wraps highlighted text in numbered tags", "[Regex
 	}
 }
 
-TEST_CASE("Extract_outer_marker pulls tags", "[RegexManager]")
+TEST_CASE("RegexManager::extract_outer_marker returns empty string if input "
+		"string is empty",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+	REQUIRE(rxman.extract_outer_marker("", 0) == "");
+	REQUIRE(rxman.extract_outer_marker("", 10) == "");
+}
+
+TEST_CASE("RegexManager::extract_outer_marker finds the innermost tag "
+		"relative to given position in the text",
+		"[RegexManager]")
 {
 	RegexManager rxman;
 	std::string out;
@@ -215,4 +259,337 @@ TEST_CASE("Extract_outer_marker pulls tags", "[RegexManager]")
 		REQUIRE(out == "<1>");
 	}
 
+}
+
+TEST_CASE("RegexManager::extract_outer_marker returns empty string if input "
+		"string contains closing tag without a pairing opening one, before "
+		"the position we're looking at",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+	REQUIRE(rxman.extract_outer_marker("hello</>world", 10) == "");
+}
+
+TEST_CASE("RegexManager::dump_config turns each `highlight` rule into a string, "
+		"and appends them onto a vector",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+	std::vector<std::string> result;
+
+	SECTION("Empty object returns empty vector") {
+		REQUIRE_NOTHROW(rxman.dump_config(result));
+		REQUIRE(result.empty());
+	}
+
+	SECTION("One rule") {
+		rxman.handle_action("highlight", {"article", "this test is", "green"});
+		REQUIRE_NOTHROW(rxman.dump_config(result));
+		REQUIRE(result.size() == 1);
+		REQUIRE(result[0] == R"#(highlight "article" "this test is" "green")#");
+	}
+
+	SECTION("Two rules, one of them a `highlight-article`") {
+		rxman.handle_action("highlight", {"all", "keywords", "red", "blue"});
+		rxman.handle_action(
+				"highlight-article",
+				{"title==\"\"", "green", "black"});
+		REQUIRE_NOTHROW(rxman.dump_config(result));
+		REQUIRE(result.size() == 1);
+		REQUIRE(result[0] == R"#(highlight "all" "keywords" "red" "blue")#");
+	}
+}
+
+TEST_CASE("RegexManager::dump_config appends to given vector", "[RegexManager]")
+{
+	RegexManager rxman;
+	std::vector<std::string> result;
+
+	result.emplace_back("sentinel");
+
+	rxman.handle_action("highlight", {"all", "this", "black"});
+
+	REQUIRE_NOTHROW(rxman.dump_config(result));
+	REQUIRE(result.size() == 2);
+	REQUIRE(result[0] == "sentinel");
+	REQUIRE(result[1] == R"#(highlight "all" "this" "black")#");
+}
+
+TEST_CASE("RegexManager::handle_action throws ConfigHandlerException "
+		"on invalid foreground color",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action("highlight", {"all", "keyword", "whatever"}),
+			ConfigHandlerException);
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action("highlight", {"feedlist", "keyword", ""}),
+			ConfigHandlerException);
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight-article",
+				{"author == \"\"", "whatever", "white"}),
+			ConfigHandlerException);
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight-article",
+				{"title =~ \"k\"", "", "white"}),
+			ConfigHandlerException);
+}
+
+TEST_CASE("RegexManager::handle_action throws ConfigHandlerException "
+		"on invalid background color",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight",
+				{"all", "keyword", "red", "whatever"}),
+			ConfigHandlerException);
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight",
+				{"feedlist", "keyword", "green", ""}),
+			ConfigHandlerException);
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight-article",
+				{"title == \"keyword\"", "red", "whatever"}),
+			ConfigHandlerException);
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight-article",
+				{"content == \"\"", "green", ""}),
+			ConfigHandlerException);
+}
+
+TEST_CASE("RegexManager::handle_action throws ConfigHandlerException "
+		"on invalid attribute",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight",
+				{"all", "keyword", "red", "green", "sparkles"}),
+			ConfigHandlerException);
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight",
+				{"feedlist", "keyword", "green", "red", ""}),
+			ConfigHandlerException);
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight-article",
+				{"title==\"\"", "red", "green", "sparkles"}),
+			ConfigHandlerException);
+
+	REQUIRE_THROWS_AS(
+			rxman.handle_action(
+				"highlight-article",
+				{"title==\"\"", "green", "red", ""}),
+			ConfigHandlerException);
+}
+
+TEST_CASE("RegexManager throws on invalid `highlight-article' definition",
+	"[RegexManager]")
+{
+	RegexManager rxman;
+	std::vector<std::string> params;
+
+	SECTION("on `highlight-article' without parameters")
+	{
+		REQUIRE_THROWS_AS(rxman.handle_action("highlight-article", params),
+			ConfigHandlerException);
+	}
+
+	SECTION("on invalid filter expression")
+	{
+		params = {"a = b", "red", "green"};
+		REQUIRE_THROWS_AS(rxman.handle_action("highlight-article", params),
+			ConfigHandlerException);
+	}
+
+	SECTION("on missing colors")
+	{
+		params = {"title==\"\""};
+		REQUIRE_THROWS_AS(rxman.handle_action("highlight-article", params),
+			ConfigHandlerException);
+	}
+
+	SECTION("on missing background color")
+	{
+		params = {"title==\"\"", "white"};
+		REQUIRE_THROWS_AS(rxman.handle_action("highlight-article", params),
+			ConfigHandlerException);
+	}
+}
+
+TEST_CASE("RegexManager doesn't throw on valid `highlight-article' definition",
+	"[RegexManager]")
+{
+	RegexManager rxman;
+	std::vector<std::string> params;
+
+	params = {"title == \"\"", "blue", "red"};
+	REQUIRE_NOTHROW(rxman.handle_action("highlight-article", params));
+
+	params = {"content =~ \"keyword\"", "blue", "red"};
+	REQUIRE_NOTHROW(rxman.handle_action("highlight-article", params));
+
+	params = {"unread == \"yes\"", "blue", "red", "bold", "underline"};
+	REQUIRE_NOTHROW(rxman.handle_action("highlight-article", params));
+
+	params = {"age > 3", "blue", "red", "bold", "underline"};
+	REQUIRE_NOTHROW(rxman.handle_action("highlight-article", params));
+}
+
+struct RegexManagerMockMatchable : public Matchable {
+public:
+	bool has_attribute(const std::string& attribname) override
+	{
+		return attribname == "attr";
+	}
+
+	std::string get_attribute(const std::string& attribname) override
+	{
+		if (attribname == "attr") {
+			return "val";
+		}
+		return "";
+	}
+};
+
+TEST_CASE("RegexManager::article_matches returns position of the Matcher "
+		"that matches a given Matchable",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+	RegexManagerMockMatchable mock;
+
+	const auto cmd = std::string("highlight-article");
+
+	SECTION("Just one rule") {
+		rxman.handle_action(cmd, {"attr != \"hello\"", "red", "green"});
+
+		REQUIRE(rxman.article_matches(&mock) == 0);
+	}
+
+	SECTION("Couple rules") {
+		rxman.handle_action(cmd, {"attr != \"val\"", "green", "white"});
+		rxman.handle_action(cmd, {"attr # \"entry\"", "green", "white"});
+		rxman.handle_action(cmd, {"attr == \"val\"", "green", "white"});
+		rxman.handle_action(cmd, {"attr =~ \"hello\"", "green", "white"});
+
+		REQUIRE(rxman.article_matches(&mock) == 2);
+	}
+}
+
+TEST_CASE("RegexManager::article_matches returns -1 if there are no Matcher "
+		"to match a given Matchable",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+	RegexManagerMockMatchable mock;
+
+	const auto cmd = std::string("highlight-article");
+
+	SECTION("No rules") {
+		REQUIRE(rxman.article_matches(&mock) == -1);
+	}
+
+	SECTION("Just one rule") {
+		rxman.handle_action(cmd, {"attr == \"hello\"", "red", "green"});
+
+		REQUIRE(rxman.article_matches(&mock) == -1);
+	}
+
+	SECTION("Couple rules") {
+		rxman.handle_action(cmd, {"attr != \"val\"", "green", "white"});
+		rxman.handle_action(cmd, {"attr # \"entry\"", "green", "white"});
+		rxman.handle_action(cmd, {"attr =~ \"hello\"", "green", "white"});
+
+		REQUIRE(rxman.article_matches(&mock) == -1);
+	}
+}
+
+TEST_CASE("RegexManager::remove_last_regex removes last added `highlight` rule",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+
+	rxman.handle_action("highlight", {"articlelist", "foo", "blue", "red"});
+	rxman.handle_action("highlight", {"articlelist", "bar", "blue", "red"});
+
+	const auto INPUT = std::string("xfoobarx");
+
+	auto input = INPUT;
+	rxman.quote_and_highlight(input, "articlelist");
+	REQUIRE(input == "x<0>foo</><1>bar</>x");
+
+	input = INPUT;
+	rxman.quote_and_highlight(input, "feedlist");
+	REQUIRE(input == INPUT);
+
+	REQUIRE_NOTHROW(rxman.remove_last_regex("articlelist"));
+
+	input = INPUT;
+	rxman.quote_and_highlight(input, "articlelist");
+	REQUIRE(input == "x<0>foo</>barx");
+
+	input = INPUT;
+	rxman.quote_and_highlight(input, "feedlist");
+	REQUIRE(input == INPUT);
+}
+
+TEST_CASE("RegexManager::remove_last_regex does not crash if there are "
+		"no regexes to remove",
+		"[RegexManager]")
+{
+	RegexManager rxman;
+
+	SECTION("No rules existed") {
+		rxman.remove_last_regex("articlelist");
+
+		SECTION("Repeated calls don't crash either") {
+			rxman.remove_last_regex("articlelist");
+			rxman.remove_last_regex("articlelist");
+			rxman.remove_last_regex("articlelist");
+
+			rxman.remove_last_regex("feedlist");
+		}
+	}
+
+	SECTION("A few rules were added and then deleted") {
+		rxman.handle_action("highlight", {"articlelist", "test test", "red"});
+		rxman.handle_action("highlight", {"articlelist", "another test", "red"});
+		rxman.handle_action("highlight", {"articlelist", "more", "green", "blue"});
+
+		rxman.remove_last_regex("articlelist");
+		rxman.remove_last_regex("articlelist");
+		rxman.remove_last_regex("articlelist");
+		// At this point, all the rules are removed
+		rxman.remove_last_regex("articlelist");
+
+		SECTION("Repeated calls don't crash either") {
+			rxman.remove_last_regex("articlelist");
+			rxman.remove_last_regex("articlelist");
+			rxman.remove_last_regex("articlelist");
+
+			rxman.remove_last_regex("feedlist");
+		}
+	}
 }


### PR DESCRIPTION
Regular expressions compiled with `regcomp` weren't freed with `regfree` before their memory was `delete`d, leaking a tiny bit of memory (hundreds of bytes at a time). The impact is pretty much nil; most of these regular expressions are part of `highlight` rules, and live for the entire run-time of the program anyway.

Coveralls says that `RegexManager` is fully covered by tests now, but it's actually not, since there are no tests for `get_attrs` and `get_regexes`. I want to concentrate on other memleak issues for now, so I filed #638.

Will merge in three days unless someone stops me for a review.