### PR TITLE
add clang-format executable in alpine docker image

### DIFF
--- a/docker/alpine-3.10.2-clang-8.0.0-r0.dockerfile
+++ b/docker/alpine-3.10.2-clang-8.0.0-r0.dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.10.2
+
+WORKDIR /workspace
+
+ENV CLANG_VERSION=8.0.0-r0
+RUN apk add --no-cache clang==$CLANG_VERSION
+
+ENTRYPOINT ["clang-format"]
+CMD ["--help"]


### PR DESCRIPTION
Created a small alpine docker image for clang-format. Fixed the alpine and clang versions. Image size comes to about 194mb. 

`docker run -v $(pwd):/workspace alpineclang -verbose --style=file -i *.cpp doc/*.cpp include/*.h rss/*.h rss/*.cpp src/*.cpp test/*.h test/*.cpp`

We could also take inspiration from  https://hub.docker.com/r/unibeautify/clang-format/dockerfile. Builds clang and only keeps statically linked clang-format in the final image. Image size comes to 34mb but build time is much longer. 

Last but not least, we could simply pull the built image from `unibeautify/clang-format`. Only issue is that they don't tag the image so we might not stay fixed to clang `8.0.0`.
