### PR TITLE
Do not unbind command line keybindings for "all" context

### DIFF
--- a/include/keymap.h
+++ b/include/keymap.h
@@ -181,6 +181,7 @@ public:
 
 private:
 	bool is_valid_context(const std::string& context);
+	std::map<std::string, Operation> get_internal_operations() const;
 	std::string getopname(Operation op);
 	std::map<std::string, std::map<std::string, Operation>> keymap_;
 	std::map<std::string, std::vector<MacroCmd>> macros_;

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -476,13 +476,13 @@ void KeyMap::unset_key(const std::string& key, const std::string& context)
 void KeyMap::unset_all_keys(const std::string& context)
 {
 	LOG(Level::DEBUG, "KeyMap::unset_all_keys(%s) called", context);
+	auto internal_ops_only = get_internal_operations();
 	if (context == "all") {
-		keymap_.clear();
-	} else {
-		auto& key_operation_map = keymap_[context];
-		for (auto& map : key_operation_map) {
-			map.second = OP_NIL;
+		for (unsigned int i = 0; contexts[i] != nullptr; i++) {
+			keymap_[contexts[i]] = internal_ops_only;
 		}
+	} else {
+		keymap_[context] = std::move(internal_ops_only);
 	}
 }
 
@@ -705,6 +705,17 @@ bool KeyMap::is_valid_context(const std::string& context)
 			return true;
 	}
 	return false;
+}
+
+std::map<std::string, Operation> KeyMap::get_internal_operations() const
+{
+	std::map<std::string, Operation> internal_ops;
+	for (int i = 0; opdescs[i].op != OP_NIL; ++i) {
+		if (opdescs[i].flags & KM_INTERNAL) {
+			internal_ops[opdescs[i].default_key] = opdescs[i].op;
+		}
+	}
+	return internal_ops;
 }
 
 unsigned short KeyMap::get_flag_from_context(const std::string& context)

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -61,12 +61,40 @@ TEST_CASE(
 		}
 	}
 
-	SECTION("\"all\" context clears the keymap from all key bindings") {
+	SECTION("\"all\" context clears the keymap from all defined keybindings") {
 		KeyMap k(KM_NEWSBOAT);
 		k.unset_all_keys("all");
 
-		for (int i = OP_NB_MIN; i < OP_NB_MAX; ++i) {
+		for (int i = OP_NB_MIN; i < OP_SK_MAX; ++i) {
 			REQUIRE(k.getkey(static_cast<Operation>(i), "all") == "<none>");
+		}
+	}
+
+	SECTION("\"all\" context doesn't clear the keymap from internal keybindings") {
+		KeyMap default_keymap(KM_NEWSBOAT);
+		KeyMap unset_keymap(KM_NEWSBOAT);
+		unset_keymap.unset_all_keys("all");
+
+		for (int i = OP_INT_MIN; i < OP_INT_MAX; ++i) {
+			REQUIRE(default_keymap.getkey(static_cast<Operation>(i), "all")
+				== unset_keymap.getkey(static_cast<Operation>(i), "all"));
+		}
+	}
+
+	SECTION("Contexts don't have their internal keybindings cleared") {
+		const auto contexts = { "feedlist", "filebrowser", "help", "articlelist",
+			"article", "tagselection", "filterselection", "urlview", "podbeuter",
+			"dialogs", "dirbrowser" };
+		KeyMap default_keymap(KM_NEWSBOAT);
+
+		for (const auto& context : contexts) {
+			KeyMap unset_keymap(KM_NEWSBOAT);
+			unset_keymap.unset_all_keys(context);
+
+			for (int i = OP_INT_MIN; i < OP_INT_MAX; ++i) {
+				REQUIRE(default_keymap.getkey(static_cast<Operation>(i), "all")
+					== unset_keymap.getkey(static_cast<Operation>(i), "all"));
+			}
 		}
 	}
 


### PR DESCRIPTION
This should fix #454. I don't really have a better idea how to do it, if someone has, please share. Also, it's kind of surprising that `OP_INT_END_CMDLINE` doesn't actually handle this.