### PR TITLE
Improve docs regarding cookies

### DIFF
--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -13,7 +13,7 @@ cache-file||<path>||"~/.newsboat/cache.db"||This configuration option sets the c
 cleanup-on-quit||[yes/no]||yes||If set to `yes`, then the cache gets locked and superfluous feeds and items are removed, such as feeds that can't be found in the urls configuration file anymore.||cleanup-on-quit no
 color||<element> <fgcolor> <bgcolor> [<attribute> ...]||n/a||Set the foreground color, background color and optional attributes for a certain element.||color background white black
 confirm-exit||[yes/no]||no||If set to `yes`, then newsboat will ask for confirmation whether the user really wants to quit newsboat.||confirm-exit yes
-cookie-cache||<path>||""||Set a cookie cache. If set, then cookies will be cached (i.e. read from and written to) in this file.||cookie-cache "~/.newsboat/cookies.txt"
+cookie-cache||<path>||""||Set a cookie cache. If set, cookies will be cached in (i.e. read from and written to) this file, using http://www.cookiecentral.com/faq/#3.5[Netscape format].||cookie-cache "~/.newsboat/cookies.txt"
 datetime-format||<date/time format>||%b %d||This format specifies the date/time format in the article list. For a detailed documentation on the allowed formats, consult the manpage of strftime(3).||datetime-format "%D, %R"
 define-filter||<name> <filterexpr>||n/a||With this command, you can predefine filters, which you can later select from a list, and which are then applied after selection. This is especially useful for filters that you need often and you don't want to enter them every time you need them.||define-filter "all feeds with 'fun' tag" "tags # \"fun\""
 delete-read-articles-on-quit||[yes/no]||no||If set to `yes`, then all read articles will be deleted when you quit newsboat.||delete-read-articles-on-quit yes

--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -377,10 +377,8 @@ filter feeds by tags; see <<_tagging>> and <<_filter_language>> for details.
 NewsBlur
 ~~~~~~~~
 
-https://newsblur.com/[NewsBlur] is a successor to Google Reader. Configuration
-basically works the same as with <<_the_old_reader,The Old Reader>>.
-
-First, set your <<urls-source,`urls-source`>>:
+https://newsblur.com/[NewsBlur] is a successor to Google Reader. To use it, set
+your <<urls-source,`urls-source`>>:
 
 	urls-source "newsblur"
 
@@ -395,6 +393,10 @@ instead of `"`.
 See also <<newsblur-passwordfile,`newsblur-passwordfile`>>,
 <<newsblur-passwordeval,`newsblur-passwordeval`>>, and
 <<_passwords_for_external_apis>>.
+
+Finally, set a path to the file where Newsboat can store the HTTP cookies:
+
+    cookie-cache "~/.newsboat/cookies.txt"
 
 When you start Newsboat, it will download the feeds that you configured
 in NewsBlur. Please take a closer look at the

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -288,10 +288,7 @@ mod tests {
         // illegal single %
         assert_eq!(fmt.do_format("%", 0), "");
         assert_eq!(fmt.do_format("%%", 0), "%");
-        assert_eq!(
-            fmt.do_format("%a%b%c", 0),
-            "АБВбукваещё одна переменная"
-        );
+        assert_eq!(fmt.do_format("%a%b%c", 0), "АБВбукваещё одна переменная");
         assert_eq!(
             fmt.do_format("%%%a%%%b%%%c%%", 0),
             "%АБВ%буква%ещё одна переменная%"
@@ -425,10 +422,7 @@ mod tests {
         // The total length of the string is specified in the argument to do_format
 
         // Default (zero) is \"as long as needed to fit all the values\"
-        assert_eq!(
-            fmt.do_format("%x%> %y", 0),
-            "example string пример строки"
-        );
+        assert_eq!(fmt.do_format("%x%> %y", 0), "example string пример строки");
 
         assert_eq!(
             fmt.do_format("%x%> %y", 30),
@@ -447,10 +441,7 @@ mod tests {
         fmt.register_fmt('x', "example string".to_string());
         fmt.register_fmt('y', "пример строки".to_string());
 
-        assert_eq!(
-            fmt.do_format("%x%>m%y", 0),
-            "example stringmпример строки"
-        );
+        assert_eq!(fmt.do_format("%x%>m%y", 0), "example stringmпример строки");
         assert_eq!(
             fmt.do_format("%x%>k%y", 30),
             "example stringkkkпример строки"
@@ -483,14 +474,8 @@ mod tests {
 
         assert_eq!(fmt.do_format("%?t?non-empty&empty?", 0), "non-empty");
         assert_eq!(fmt.do_format("%?m?non-empty&empty?", 0), "empty");
-        assert_eq!(
-            fmt.do_format("%?t?непустое&пустое?", 0),
-            "непустое"
-        );
-        assert_eq!(
-            fmt.do_format("%?m?непустое&пустое?", 0),
-            "пустое"
-        );
+        assert_eq!(fmt.do_format("%?t?непустое&пустое?", 0), "непустое");
+        assert_eq!(fmt.do_format("%?m?непустое&пустое?", 0), "пустое");
     }
 
     #[test]
@@ -500,10 +485,7 @@ mod tests {
         fmt.register_fmt('t', "this is a non-empty string".to_string());
         fmt.register_fmt('m', String::new());
 
-        assert_eq!(
-            fmt.do_format("%?t?непустое?", 0),
-            "непустое"
-        );
+        assert_eq!(fmt.do_format("%?t?непустое?", 0), "непустое");
         assert_eq!(fmt.do_format("%?m?непустое?", 0), "");
     }
 


### PR DESCRIPTION
f-a on IRC pointed out that we don't say what the format of `cookie-cache` file is; I added a note.

I also updated the instructions for NewsBlur, which requires `cookie-cache` to be set.

@der-lyse, if you have a moment, can you please take a look at this? Is the wording clear? Reviews from anyone else are welcome, of course.

Will merge in three days per my usual routine.