### PR TITLE
Ignore # characters inside double quotes and backticks

### DIFF
--- a/doc/chapter-firststeps.txt
+++ b/doc/chapter-firststeps.txt
@@ -92,12 +92,12 @@ also contain comments, which start with the `#` character and go as far as the
 end of line. If you need to enter a configuration argument that contains
 spaces, use quotes (`"`) around the whole argument. It's even possible to
 integrate the output of external commands into the configuration. The text
-between two backticks (+\`+) is evaluated as shell command, and its output is
-put on its place instead. This works like backtick evaluation in
+between two backticks (+&#96;+) is evaluated as shell command, and its output
+is put on its place instead. This works like backtick evaluation in
 Bourne-compatible shells and allows users to use external information from the
-system within the configuration. Backticks can be escaped with a backslash
-(+\`+); in that case, they'll be replaced with a literal backtick in the
-configuration.
+system within the configuration. Backticks and `#` characters can be escaped
+with a backslash (e.g. `\`` and `\#`); in that case, they'll be replaced with
+literal +&#96;+ or `#` in the configuration.
 
 Searching for articles is possible in newsboat, too. Just press the "/" key,
 enter your search phrase, and the title and content of all articles are

--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -82,6 +82,8 @@ unsigned int rs_newsboat_version_major();
 
 int rs_mkdir_parents(const char* path, const std::uint32_t mode);
 
+char* rs_strip_comments(const char* line);
+
 class RustString {
 private:
 	char* str;

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -500,7 +500,7 @@ pub unsafe extern "C" fn rs_strip_comments(line: *const c_char) -> *mut c_char {
 
         // `result` contains a subset of `line`, which is a C string. Thus, we conclude that
         // `result` doesn't contain null bytes. Therefore, `CString::new` always returns `Some`.
-        let result = CString::new(result.into_owned()).unwrap();
+        let result = CString::new(result).unwrap();
         result.into_raw()
     })
 }

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -489,3 +489,18 @@ pub extern "C" fn rs_program_version() -> *mut c_char {
 pub extern "C" fn rs_newsboat_version_major() -> u32 {
     abort_on_panic(|| utils::newsboat_major_version())
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn rs_strip_comments(line: *const c_char) -> *mut c_char {
+    abort_on_panic(|| {
+        let line = CStr::from_ptr(line);
+        let line = line.to_str().expect("line contained invalid UTF-8");
+
+        let result = utils::strip_comments(line);
+
+        // `result` contains a subset of `line`, which is a C string. Thus, we conclude that
+        // `result` doesn't contain null bytes. Therefore, `CString::new` always returns `Some`.
+        let result = CString::new(result.into_owned()).unwrap();
+        result.into_raw()
+    })
+}

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -865,6 +865,7 @@ mod tests {
             get_command_output("a-program-that-is-guaranteed-to-not-exists"),
             "".to_string()
         );
+        assert_eq!(get_command_output("echo c\" d e"), "".to_string());
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -559,8 +559,8 @@ pub fn strip_comments(line: &str) -> &str {
             prev_was_backslash = true;
             continue;
         } else if chr == '"' {
-            // If the quote is escaped, do nothing
-            if !prev_was_backslash {
+            // If the quote is escaped or we're inside backticks, do nothing
+            if !prev_was_backslash && !inside_backticks {
                 inside_quotes = !inside_quotes;
             }
         } else if chr == '`' {

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -569,7 +569,7 @@ pub fn strip_comments(line: &str) -> &str {
                 inside_backticks = !inside_backticks;
             }
         } else if chr == '#' {
-            if !inside_quotes && !inside_backticks {
+            if !prev_was_backslash && !inside_quotes && !inside_backticks {
                 first_pound_chr_idx = idx;
                 break;
             }
@@ -1125,6 +1125,11 @@ mod tests {
         // Escaped backtick inside backticks is not treated as closing
         let expected = r#"some `other \` tricky # test` hehe"#;
         let input = expected.to_owned() + "#here goescomment";
+        assert_eq!(strip_comments(&input), expected);
+
+        // Ignores escaped # characters (\\#)
+        let expected = r#"one two \# three four"#;
+        let input = expected.to_owned() + "# and a comment";
         assert_eq!(strip_comments(&input), expected);
     }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -78,14 +78,7 @@ void append_escapes(std::string& str, char c)
 
 std::string utils::strip_comments(const std::string& line)
 {
-	/*
-	 * This functions returns only the non-comment part of the line,
-	 * which can then be safely evaluated and tokenized.
-	 *
-	 * If no comments are present on the line, the whole line is returned.
-	 */
-	auto hash_pos = line.find_first_of("#");
-	return line.substr(0, hash_pos);
+	return RustString(rs_strip_comments(line.c_str()));
 }
 
 std::vector<std::string> utils::tokenize_quoted(const std::string& str,

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -59,6 +59,16 @@ TEST_CASE("evaluate_backticks replaces command in backticks with its output",
 		REQUIRE_NOTHROW(cfgparser.parse("data/config-space-backticks"));
 		REQUIRE_FALSE(keys.get_operation("s", "all") == OP_NIL);
 	}
+
+	SECTION("Unbalanced backtick does *not* start a command")
+	{
+		const auto input1 = std::string("one `echo two three");
+		REQUIRE(ConfigParser::evaluate_backticks(input1) == input1);
+
+		const auto input2 = std::string("this `echo is a` test `here");
+		const auto expected2 = std::string("this is a test `here");
+		REQUIRE(ConfigParser::evaluate_backticks(input2) == expected2);
+	}
 }
 
 TEST_CASE("\"unbind-key -a\" removes all key bindings", "[ConfigParser]")

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -275,6 +275,14 @@ TEST_CASE(
 	}
 }
 
+TEST_CASE("strip_comments ignores escaped # characters (\\#)")
+{
+	const auto expected =
+		std::string(R"#(one two \# three four)#");
+	const auto input = expected + "# and a comment";
+	REQUIRE(utils::strip_comments(input) == expected);
+}
+
 TEST_CASE("strip_comments ignores # characters inside double quotes",
 		"[utils][issue652]")
 {

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -307,6 +307,7 @@ TEST_CASE("get_command_output()", "[utils]")
 		"a-program-that-is-guaranteed-to-not-exists"));
 	REQUIRE(utils::get_command_output(
 			"a-program-that-is-guaranteed-to-not-exists") == "");
+	REQUIRE(utils::get_command_output("echo c\" d e") == "");
 }
 
 TEST_CASE("extract_filter()", "[utils]")

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -329,7 +329,7 @@ TEST_CASE("strip_comments is not confused by nested double quotes and backticks"
 		"[utils]")
 {
 	{
-		const auto expected = std::string(R"#("`" ... ` )#");
+		const auto expected = std::string(R"#("`" ... ` `"` ")#");
 		const auto input = expected + "#comment";
 		REQUIRE(utils::strip_comments(input) == expected);
 	}
@@ -338,6 +338,13 @@ TEST_CASE("strip_comments is not confused by nested double quotes and backticks"
 		const auto expected = std::string(R"#(aaa ` bbb "ccc ddd" e` dd)#");
 		const auto input = expected + "# a comment string";
 		REQUIRE(utils::strip_comments(input) == expected);
+	}
+
+	{
+        const auto expected =
+			std::string(R"#(option "this `weird " command` for value")#");
+        const auto input = expected + "#and a comment";
+        REQUIRE(utils::strip_comments(input) == expected);
 	}
 }
 


### PR DESCRIPTION
When reviewing #584, I didn't consider that a pound character can appear inside titles or regexes, not just in front of a comment. This introduced a regression, which was reported in #652 when 2.17 was released.

This PR makes `utils::strip_comments` aware of double quotes and backticks, so it now ignores pound signs inside.

I'd be really happy if someone reviewed this within 20 hours, so I can make a release on Sunday. Otherwise I'll wait my ordinary three days, and release this on Thursday.