### PR TITLE
Port utils::gentabs to Rust

### DIFF
--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -80,6 +80,8 @@ char* rs_program_version();
 
 unsigned int rs_newsboat_version_major();
 
+unsigned int rs_gentabs(const char* path);
+
 int rs_mkdir_parents(const char* path, const std::uint32_t mode);
 
 class RustString {

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -347,6 +347,15 @@ pub unsafe extern "C" fn rs_get_basename(input: *const c_char) -> *mut c_char {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn rs_gentabs(input: *const c_char) -> usize {
+    abort_on_panic(|| {
+        let rs_str = CStr::from_ptr(input);
+        let rs_str = rs_str.to_string_lossy().into_owned();
+        utils::gentabs(&rs_str)
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rs_mkdir_parents(path: *const c_char, mode: u32) -> isize {
     abort_on_panic(|| {
         let rs_input = CStr::from_ptr(path);

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -16,6 +16,7 @@ use self::url::percent_encoding::*;
 use self::url::Url;
 use libc::c_ulong;
 use logger::{self, Level};
+use std::cmp::max;
 use std::fs::DirBuilder;
 use std::io::{self, Write};
 use std::os::unix::fs::DirBuilderExt;
@@ -483,6 +484,45 @@ pub fn getcwd() -> Result<PathBuf, io::Error> {
 
 pub fn strnaturalcmp(a: &str, b: &str) -> std::cmp::Ordering {
     natord::compare(a, b)
+}
+
+/// Calculate the number of padding tabs when formatting columns
+///
+/// The number of tabs will be adjusted by the width of the given string.  Usually, a column will
+/// consist of 4 tabs, 8 characters each.  Each column will consist of at least one tab.
+///
+/// ```
+/// use libnewsboat::utils::gentabs;
+///
+/// fn genstring(len: usize) -> String {
+///     return std::iter::repeat("a").take(len).collect::<String>();
+/// }
+///
+/// assert_eq!(gentabs(""), 4);
+/// assert_eq!(gentabs("a"), 4);
+/// assert_eq!(gentabs("aa"), 4);
+/// assert_eq!(gentabs("aaa"), 4);
+/// assert_eq!(gentabs("aaaa"), 4);
+/// assert_eq!(gentabs("aaaaa"), 4);
+/// assert_eq!(gentabs("aaaaaa"), 4);
+/// assert_eq!(gentabs("aaaaaaa"), 4);
+/// assert_eq!(gentabs("aaaaaaaa"), 3);
+/// assert_eq!(gentabs(&genstring(8)), 3);
+/// assert_eq!(gentabs(&genstring(9)), 3);
+/// assert_eq!(gentabs(&genstring(15)), 3);
+/// assert_eq!(gentabs(&genstring(16)), 2);
+/// assert_eq!(gentabs(&genstring(20)), 2);
+/// assert_eq!(gentabs(&genstring(24)), 1);
+/// assert_eq!(gentabs(&genstring(32)), 1);
+/// assert_eq!(gentabs(&genstring(100)), 1);
+/// ```
+pub fn gentabs(string: &str) -> usize {
+    let tabcount = strwidth(string) / 8;
+    if tabcount >= 4 {
+        1
+    } else {
+        4 - tabcount
+    }
 }
 
 /// Recursively create directories if missing and set permissions accordingly.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -931,11 +931,7 @@ std::wstring utils::clean_nonprintable_characters(std::wstring text)
 
 unsigned int utils::gentabs(const std::string& str)
 {
-	int tabcount = 4 - (utils::strwidth(str) / 8);
-	if (tabcount <= 0) {
-		tabcount = 1;
-	}
-	return tabcount;
+	return rs_gentabs(str.c_str());
 }
 
 /* Like mkdir(), but creates ancestors (parent directories) if they don't

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1084,6 +1084,14 @@ TEST_CASE("unescape_url() takes a percent-encoded string and returns the string 
 
 }
 
+TEST_CASE("gentabs() calculates padding tabs based on stringwidth", "[utils]")
+{
+	REQUIRE(utils::gentabs("") == 4);
+	REQUIRE(utils::gentabs("aaaaaaa") == 4);
+	REQUIRE(utils::gentabs("aaaaaaaa") == 3);
+	REQUIRE(utils::gentabs("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") == 1);
+}
+
 TEST_CASE("mkdir_parents() creates all paths components and returns 0 if "
 		"the path now exists",
 		"[utils]")


### PR DESCRIPTION
This commit ports utils::gentabs to rust, as outlined in #334. The original tests pass.
As this is my first attemt at production rust, any comments and criticism is welcome :)

I'm not really convinced about all that casting in the rust implementation, even though it should not really be any practical problem (both `isize` and `usize` should be able to store all effective tab-values that should occur. Even theory-wisse as stringwidth is bounded by the addressable memory, this implementation should work, but it still seems strange to have all that casting going on).