### PR TITLE
Move (most of) Travis to Ubuntu Bionic, and add Clang 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
   apt:
     packages: &clang_deps
     - *global_deps
-    - g++-4.9 # required for some niceties in C++ standard library
+    - g++ # required for some niceties in C++ standard library
 
 install_coveralls_commands: &install_coveralls
   - pip install --user cpp-coveralls
@@ -81,11 +81,11 @@ matrix:
         *osx_deps
     - compiler: gcc-8
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-8
             - *global_deps
@@ -97,12 +97,11 @@ matrix:
         - ( cd test && ./test --order rand ); ret=$?; (cargo test) && sh -c "exit $ret"
     - compiler: clang-8
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-8
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - clang-8
             - llvm-8
@@ -118,7 +117,7 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-4.9
             - *global_deps
@@ -133,7 +132,7 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-4.9
             - *global_deps
@@ -144,11 +143,11 @@ matrix:
         *install_coveralls
     - compiler: gcc-5
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-5
             - *global_deps
@@ -159,11 +158,11 @@ matrix:
         *install_coveralls
     - compiler: gcc-6
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-6
             - *global_deps
@@ -174,11 +173,11 @@ matrix:
         *install_coveralls
     - compiler: gcc-7
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-7
             - *global_deps
@@ -189,11 +188,11 @@ matrix:
         *install_coveralls
     - compiler: gcc-8
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-8
             - *global_deps
@@ -204,11 +203,11 @@ matrix:
         *install_coveralls
     - compiler: gcc-9
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - g++-9
             - *global_deps
@@ -219,11 +218,11 @@ matrix:
         *install_coveralls
     - compiler: clang
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - *clang_deps
       env:
@@ -237,7 +236,7 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
             - llvm-toolchain-xenial-4.0
           packages:
             - clang-4.0
@@ -250,12 +249,11 @@ matrix:
         *install_coveralls
     - compiler: clang-5.0
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-5.0
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - clang-5.0
             - llvm-5.0
@@ -267,12 +265,11 @@ matrix:
         *install_coveralls
     - compiler: clang-6.0
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-6.0
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - clang-6.0
             - llvm-6.0
@@ -284,12 +281,11 @@ matrix:
         *install_coveralls
     - compiler: clang-7
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-7
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - clang-7
             - llvm-7
@@ -301,12 +297,11 @@ matrix:
         *install_coveralls
     - compiler: clang-8
       os: linux
-      dist: xenial
+      dist: bionic
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-xenial-8
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - clang-8
             - llvm-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -311,6 +311,24 @@ matrix:
         - GCOV="llvm-cov-8 gcov"
       before_install:
         *install_coveralls
+    - compiler: clang-9
+      os: linux
+      dist: bionic
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"
+              key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
+          packages:
+            - clang-9
+            - llvm-9
+            - *clang_deps
+      env:
+        - COMPILER=clang++-9
+        - GCOV="llvm-cov-9 gcov"
+      before_install:
+        *install_coveralls
     - addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ matrix:
         *osx_deps
     - compiler: gcc-8
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
@@ -97,12 +97,12 @@ matrix:
         - ( cd test && ./test --order rand ); ret=$?; (cargo test) && sh -c "exit $ret"
     - compiler: clang-8
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-8
+            - llvm-toolchain-xenial-8
           packages:
             - clang-8
             - llvm-8
@@ -113,7 +113,7 @@ matrix:
       script: *release_build_script
     - compiler: gcc-4.9
       os: linux
-      dist: trusty
+      dist: xenial
       rust: 1.26.0
       addons:
         apt:
@@ -129,7 +129,7 @@ matrix:
         *install_coveralls
     - compiler: gcc-4.9
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
@@ -144,7 +144,7 @@ matrix:
         *install_coveralls
     - compiler: gcc-5
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
@@ -159,7 +159,7 @@ matrix:
         *install_coveralls
     - compiler: gcc-6
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
@@ -174,7 +174,7 @@ matrix:
         *install_coveralls
     - compiler: gcc-7
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
@@ -189,7 +189,7 @@ matrix:
         *install_coveralls
     - compiler: gcc-8
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
@@ -204,7 +204,7 @@ matrix:
         *install_coveralls
     - compiler: gcc-9
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
@@ -219,7 +219,7 @@ matrix:
         *install_coveralls
     - compiler: clang
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
@@ -233,12 +233,12 @@ matrix:
         *install_coveralls
     - compiler: clang-4.0
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
+            - llvm-toolchain-xenial-4.0
           packages:
             - clang-4.0
             - llvm-4.0
@@ -250,12 +250,12 @@ matrix:
         *install_coveralls
     - compiler: clang-5.0
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
+            - llvm-toolchain-xenial-5.0
           packages:
             - clang-5.0
             - llvm-5.0
@@ -267,12 +267,12 @@ matrix:
         *install_coveralls
     - compiler: clang-6.0
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-6.0
+            - llvm-toolchain-xenial-6.0
           packages:
             - clang-6.0
             - llvm-6.0
@@ -284,12 +284,12 @@ matrix:
         *install_coveralls
     - compiler: clang-7
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-7
+            - llvm-toolchain-xenial-7
           packages:
             - clang-7
             - llvm-7
@@ -301,12 +301,12 @@ matrix:
         *install_coveralls
     - compiler: clang-8
       os: linux
-      dist: trusty
+      dist: xenial
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-8
+            - llvm-toolchain-xenial-8
           packages:
             - clang-8
             - llvm-8


### PR DESCRIPTION
As mentioned in #495, Travis CI made Ubuntu Xenial a default some time ago. While updating our config, it occurred to me that we can upgrade straight to the most recent LTS release, Ubuntu Bionic, so I did that. The only job that's left on Xenial is GCC 4.9 builds, because Bionic doesn't ship this version of GCC.

I also added Clang 9. Figured I'd make it part of this PR, because it's not too big of a change.

This fixes #495 and #648. Will merge in three days unless someone—anyone—will stop me for a review.