### PR TITLE
combine clang and rust 1.38.0 into single dockerfile

### DIFF
--- a/docker/alpine-3.10-clang-8.0.0-r0-rust-1.38.0.dockerfile
+++ b/docker/alpine-3.10-clang-8.0.0-r0-rust-1.38.0.dockerfile
@@ -1,9 +1,5 @@
-FROM alpine:3.10.2
-
+FROM rust:1.38.0-alpine3.10
 WORKDIR /workspace
-
 ENV CLANG_VERSION=8.0.0-r0
 RUN apk add --no-cache clang==$CLANG_VERSION
-
-ENTRYPOINT ["clang-format"]
-CMD ["--help"]
+RUN rustup component add rustfmt


### PR DESCRIPTION
See https://github.com/newsboat/newsboat/issues/654
The rust alpine image on its own is ~ 745MB. That's crazy! 

Running `clang-format` now requires including the executable (since I removed the entrypoint)
```shell
docker run -it --user $(id -u):$(id -g) -v $(pwd):/workspace some_image_tag clang-format -verbose --style=file -i test/*
```
and running `rustfmt`:
```shell
docker run -it --user $(id -u):$(id -g) -v $(pwd):/workspace alpoineclangrust cargo fmt
```

Let me know what you think