### PR TITLE
Do not cast arbitrary integer into enum class

### DIFF
--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -130,8 +130,6 @@ TEST_CASE("getkey()", "[KeyMap]")
 	{
 		REQUIRE(k.getkey(OP_OPEN, "all") == "ENTER");
 		REQUIRE(k.getkey(OP_TOGGLEITEMREAD, "all") == "N");
-		REQUIRE(k.getkey(static_cast<Operation>(30000), "all") ==
-			"<none>");
 	}
 
 	SECTION("Returns context-specific bindings only in that context")


### PR DESCRIPTION
It's undefined behaviour to cast an integer into an enum that doesn't have a corresponding constant. Constants in `Operation` end at 3010, so 30000 cannot be casted.

Issue spotted by Clang's UndefinedBehaviourSanitizer. (There are 88 more issues, all in `filter/`, and all about misaligned accesses. I'd rather work on #631 rather than editing that auto-generated code.)

Will merge in three days unless someone—anyone—stops me for a review.