### PR TITLE
Drop dev-oriented files from release tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,8 @@
 /.clang-format export-ignore
 /.editorconfig export-ignore
 /.gitignore export-ignore
+/.gitattributes export-ignore
 /.travis.yml export-ignore
+/.cirrus.yml export-ignore
 /submit-to-coveralls.sh export-ignore
+/docker/ export-ignore


### PR DESCRIPTION
End users don't need our CI's config, nor our .gitattributes file, nor the Docker images we use for development and testing. Also saves us a few kilobytes (after compression).

Will merge in three days unless someone—anyone—stops me for a review.