### PR TITLE
Do not install rust-doc on CI

### DIFF
--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -41,7 +41,11 @@ WORKDIR /home/builder/src
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
-    && $HOME/rustup.sh -y --default-host i686-unknown-linux-gnu --default-toolchain stable \
+    && $HOME/rustup.sh -y \
+        --default-host i686-unknown-linux-gnu \
+        --default-toolchain stable \
+        # Install only rustc, rust-std, and cargo
+        --profile minimal \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder


### PR DESCRIPTION
We don't need docs on CI, so let's not install them. The `--profile` option is [a recent addition](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html).

Will merge in three days unless someone—anyone—stops me for a review.