### PR TITLE
De-emphasize that Newsboat is a fork of Newsbeuter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 Newsboat [![Travis CI Build Status](https://travis-ci.org/newsboat/newsboat.svg?branch=master)](https://travis-ci.org/newsboat/newsboat) [![Cirrus CI Build Status](https://api.cirrus-ci.com/github/newsboat/newsboat.svg)](https://cirrus-ci.com/github/newsboat/newsboat) [![Coverage Status](https://coveralls.io/repos/github/newsboat/newsboat/badge.svg?branch=master)](https://coveralls.io/github/newsboat/newsboat?branch=master) [![Coverity Scan Build Status](https://scan.coverity.com/projects/15567/badge.svg)](https://scan.coverity.com/projects/newsboat-newsboat)
 ========
 
-Newsboat is a fork of Newsbeuter, an RSS/Atom feed reader for the text console.
-The only difference is that Newsboat is actively maintained while Newsbeuter
-isn't.
+Newsboat is an RSS/Atom feed reader for the text console. It's an actively
+maintained fork of Newsbeuter.
 
 Downloading
 -----------

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,9 +2,8 @@ name: newsboat
 version: git
 summary: An RSS/Atom feed reader for text terminals
 description: |
-  Newsboat is a fork of Newsbeuter, an RSS/Atom feed reader for the text 
-  console. The only difference is that Newsboat is actively maintained 
-  while Newsbeuter isn't.
+  Newsboat is an RSS/Atom feed reader for the text console. It's an actively
+  maintained fork of Newsbeuter.
 grade: stable
 confinement: strict
 


### PR DESCRIPTION
I'm certifying Newsboat with BadgeApp (a topic for a future PR), and imm_ on IRC commented that our webpage should focus more on Newsboat itself. I think that's fair; after two years of work, and with recent move to Rust, Newsboat isn't simply "an actively maintained fork" anymore.

I already applied these changes to our website and on Snap store. Doing a pull request here to leave a trace of that change, with an explanation.

Will merge in three days unless someone—anyone—stops me for a discussion.