### PR TITLE
Don't mark as read when browser fails

### DIFF
--- a/include/listformaction.h
+++ b/include/listformaction.h
@@ -13,7 +13,7 @@ protected:
 	void process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
-	void open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
+	int open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
 		bool markread);
 };
 

--- a/include/view.h
+++ b/include/view.h
@@ -78,7 +78,7 @@ public:
 	std::string select_filter(
 		const std::vector<FilterNameExprPair>& filters);
 
-	void open_in_browser(const std::string& url);
+	int open_in_browser(const std::string& url);
 	void open_in_pager(const std::string& filename);
 
 	std::string get_filename_suggestion(const std::string& s);

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -185,7 +185,11 @@ void ItemListFormAction::process_operation(Operation op,
 				"ItemListFormAction: opening all unread items "
 				"in "
 				"browser");
-			open_unread_items_in_browser(feed, false);
+			int err;
+			if ((err = open_unread_items_in_browser(feed, false))) {
+				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+				break;
+			}
 		}
 	} break;
 	case OP_OPENALLUNREADINBROWSER_AND_MARK: {
@@ -194,7 +198,11 @@ void ItemListFormAction::process_operation(Operation op,
 				"ItemListFormAction: opening all unread items "
 				"in "
 				"browser and marking read");
-			open_unread_items_in_browser(feed, true);
+			int err;
+			if ((err = open_unread_items_in_browser(feed, true))) {
+				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+				break;
+			}
 			invalidate_everything();
 		}
 	} break;

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -131,7 +131,9 @@ void ItemListFormAction::process_operation(Operation op,
 			itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
-				if (v->open_in_browser(visible_items[itempos].first->link())) {
+				int err;
+				if ((err = v->open_in_browser(visible_items[itempos].first->link()))) {
+					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
 					break;
 				}
 				visible_items[itempos].first->set_unread(false);

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -165,8 +165,11 @@ void ItemListFormAction::process_operation(Operation op,
 			itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
-				v->open_in_browser(
-					visible_items[itempos].first->link());
+				int err;
+				if ((err = v->open_in_browser(visible_items[itempos].first->link()))) {
+					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+					break;
+				}
 				invalidate(itempos);
 			}
 		} else {

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -132,7 +132,8 @@ void ItemListFormAction::process_operation(Operation op,
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
 				int err;
-				if ((err = v->open_in_browser(visible_items[itempos].first->link()))) {
+				auto link = visible_items[itempos].first->link();
+				if ((err = v->open_in_browser(link))) {
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
 					break;
 				}
@@ -166,7 +167,8 @@ void ItemListFormAction::process_operation(Operation op,
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
 				int err;
-				if ((err = v->open_in_browser(visible_items[itempos].first->link()))) {
+				auto link = visible_items[itempos].first->link();
+				if ((err = v->open_in_browser(link))) {
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
 					break;
 				}

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -131,12 +131,13 @@ void ItemListFormAction::process_operation(Operation op,
 			itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
+				if (v->open_in_browser(visible_items[itempos].first->link())) {
+					break;
+				}
 				visible_items[itempos].first->set_unread(false);
 				v->get_ctrl()->mark_article_read(
 					visible_items[itempos].first->guid(),
 					true);
-				v->open_in_browser(
-					visible_items[itempos].first->link());
 				if (!cfg->get_configvalue_as_bool(
 					    "openbrowser-and-mark-jumps-to-"
 					    "next-unread")) {

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -131,9 +131,8 @@ void ItemListFormAction::process_operation(Operation op,
 			itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
-				int err;
 				auto link = visible_items[itempos].first->link();
-				if ((err = v->open_in_browser(link))) {
+				if (int err = v->open_in_browser(link)) {
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
 					break;
 				}
@@ -166,9 +165,8 @@ void ItemListFormAction::process_operation(Operation op,
 			itemposname);
 		if (itemposname.length() > 0 && visible_items.size() != 0) {
 			if (itempos < visible_items.size()) {
-				int err;
 				auto link = visible_items[itempos].first->link();
-				if ((err = v->open_in_browser(link))) {
+				if (int err = v->open_in_browser(link)) {
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
 					break;
 				}
@@ -185,8 +183,7 @@ void ItemListFormAction::process_operation(Operation op,
 				"ItemListFormAction: opening all unread items "
 				"in "
 				"browser");
-			int err;
-			if ((err = open_unread_items_in_browser(feed, false))) {
+			if (int err = open_unread_items_in_browser(feed, false)) {
 				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
 				break;
 			}
@@ -198,8 +195,7 @@ void ItemListFormAction::process_operation(Operation op,
 				"ItemListFormAction: opening all unread items "
 				"in "
 				"browser and marking read");
-			int err;
-			if ((err = open_unread_items_in_browser(feed, true))) {
+			if (int err = open_unread_items_in_browser(feed, true)) {
 				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
 				break;
 			}

--- a/src/listformaction.cpp
+++ b/src/listformaction.cpp
@@ -49,7 +49,7 @@ void ListFormAction::process_operation(Operation op,
 	}
 }
 
-void ListFormAction::open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
+int ListFormAction::open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
 	bool markread)
 {
 	int tabcount = 0;
@@ -57,7 +57,10 @@ void ListFormAction::open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
 		if (tabcount <
 			cfg->get_configvalue_as_int("max-browser-tabs")) {
 			if (item->unread()) {
-				v->open_in_browser(item->link());
+				int err;
+				if ((err = v->open_in_browser(item->link()))) {
+					return err;
+				}
 				tabcount += 1;
 				item->set_unread(!markread);
 			}
@@ -65,6 +68,7 @@ void ListFormAction::open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
 			break;
 		}
 	}
+	return 0;
 }
 
 } // namespace newsboat

--- a/src/listformaction.cpp
+++ b/src/listformaction.cpp
@@ -57,8 +57,7 @@ int ListFormAction::open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
 		if (tabcount <
 			cfg->get_configvalue_as_int("max-browser-tabs")) {
 			if (item->unread()) {
-				int err;
-				if ((err = v->open_in_browser(item->link()))) {
+				if (int err = v->open_in_browser(item->link())) {
 					return err;
 				}
 				tabcount += 1;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -391,7 +391,7 @@ void View::open_in_pager(const std::string& filename)
 	pop_current_formaction();
 }
 
-void View::open_in_browser(const std::string& url)
+int View::open_in_browser(const std::string& url)
 {
 	formaction_stack.push_back(std::shared_ptr<FormAction>());
 	current_formaction = formaction_stack_size() - 1;
@@ -415,8 +415,9 @@ void View::open_in_browser(const std::string& url)
 		cmdline.append("'");
 	}
 	Stfl::reset();
-	utils::run_interactively(cmdline, "View::open_in_browser");
+	int ret = utils::run_interactively(cmdline, "View::open_in_browser");
 	pop_current_formaction();
+	return ret;
 }
 
 void View::update_visible_feeds(std::vector<std::shared_ptr<RssFeed>> feeds)

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -133,6 +133,37 @@ TEST_CASE(
 	REQUIRE(feed->unread_item_count() == 0);
 }
 
+TEST_CASE(
+	"OP_OPENBROWSER_AND_MARK does not mark read when browser fails",
+	"[ItemListFormAction]")
+{
+	Controller c;
+	newsboat::View v(&c);
+
+	std::string test_url = "http://test_url";
+
+	ConfigContainer cfg;
+	cfg.set_configvalue("browser", "false %u");
+
+	Cache rsscache(":memory:", &cfg);
+	FilterContainer filters;
+
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
+	item->set_link(test_url);
+	item->set_unread(true);
+	feed->add_item(item);
+
+	v.set_config_container(&cfg);
+	c.set_view(&v);
+
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	itemlist.set_feed(feed);
+	itemlist.process_op(OP_OPENBROWSER_AND_MARK);
+
+	REQUIRE(feed->unread_item_count() == 1);
+}
+
 TEST_CASE("OP_OPENINBROWSER passes the url to the browser",
 	"[ItemListFormAction]")
 {

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -20,7 +20,7 @@ TEST_CASE("OP_OPEN displays article using an external pager",
 	newsboat::View v(&c);
 	TestHelpers::TempFile pagerfile;
 
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 	std::string test_title = "Article Title";
 	std::string test_author = "Article Author";
 	std::string test_description = "Article Description";
@@ -104,7 +104,7 @@ TEST_CASE(
 	newsboat::View v(&c);
 	TestHelpers::TempFile browserfile;
 
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 	std::string line;
 
 	ConfigContainer cfg;
@@ -140,7 +140,7 @@ TEST_CASE(
 	Controller c;
 	newsboat::View v(&c);
 
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 
 	ConfigContainer cfg;
 	cfg.set_configvalue("browser", "false %u");
@@ -170,7 +170,7 @@ TEST_CASE("OP_OPENINBROWSER passes the url to the browser",
 	Controller c;
 	newsboat::View v(&c);
 	TestHelpers::TempFile browserfile;
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 	std::string line;
 
 	ConfigContainer cfg;
@@ -203,7 +203,7 @@ TEST_CASE("OP_OPENALLUNREADINBROWSER passes the url list to the browser",
 	newsboat::View v(&c);
 	TestHelpers::TempFile browserfile;
 	std::unordered_set<std::string> url_set;
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 	std::string line;
 	int itemCount = 6;
 
@@ -287,7 +287,7 @@ TEST_CASE(
 	newsboat::View v(&c);
 	TestHelpers::TempFile browserfile;
 	std::unordered_set<std::string> url_set;
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 	std::string line;
 	int itemCount = 6;
 
@@ -373,7 +373,7 @@ TEST_CASE("OP_SHOWURLS shows the article's properties", "[ItemListFormAction]")
 	FilterContainer filters;
 	TestHelpers::TempFile urlFile;
 
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 	std::string test_title = "Article Title";
 	std::string test_author = "Article Author";
 	std::string test_description = "Article Description";
@@ -439,7 +439,7 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 	std::string line;
 	std::vector<std::string> bookmark_args;
 
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 	std::string test_title = "Article Title";
 	std::string feed_title = "Feed Title";
 	std::string separator = " ";
@@ -582,7 +582,7 @@ TEST_CASE("OP_SAVE writes an article's attributes to the specified file",
 	std::vector<std::string> op_args;
 	op_args.push_back(saveFile.get_path());
 
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 	std::string test_title = "Article Title";
 	std::string test_author = "Article Author";
 	std::string test_description = "Article Description";
@@ -787,7 +787,7 @@ TEST_CASE("OP_PIPE_TO pipes an article's content to an external command",
 	std::vector<std::string> op_args;
 	op_args.push_back("tee > " + articleFile.get_path());
 
-	std::string test_url = "http://test_url";
+	const std::string test_url = "http://test_url";
 	std::string test_title = "Article Title";
 	std::string test_author = "Article Author";
 	std::string test_description = "Article Description";


### PR DESCRIPTION
closes #570

One question: is it alright to break early in this switch, specifically before a `invalidate(itempos)`? Not exactly sure what this is doing..