### PR TITLE
Include Rust in test coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -274,7 +274,8 @@ matrix:
             - *clang_deps
       env:
         - COMPILER=clang++-9
-    - compiler: clang-8
+    - name: "Test Coverage"
+      compiler: clang-8
       os: linux
       dist: bionic
       rust: nightly
@@ -295,7 +296,8 @@ matrix:
           # Can't have these in the `env` section above, because these settings break `cargo install`
         - export CARGO_INCREMENTAL=0
         - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
-    - addons:
+    - name: "i18nspector"
+      addons:
         apt:
           packages:
             - i18nspector

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ addons:
     - *global_deps
     - g++ # required for some niceties in C++ standard library
 
-install_coveralls_commands: &install_coveralls
-  - pip install --user cpp-coveralls
-
 newsboat_brew_commands: &osx_deps
   - brew update
   - brew install gcc || brew link --overwrite gcc
@@ -36,12 +33,6 @@ newsboat_brew_commands: &osx_deps
   - brew outdated "json-c" || brew upgrade "json-c"
   - brew install "asciidoc"
   - brew install "docbook-xsl"
-  - brew unlink python@2
-  - brew outdated "python" || brew upgrade "python"
-  - brew install "pyenv" || brew upgrade "pyenv"
-  - eval "$(pyenv init -)"
-  - pip3 install cpp-coveralls
-  - pyenv rehash
 
 env:
   - CXXFLAGS='-fstack-clash-protection -D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2'
@@ -54,7 +45,6 @@ matrix:
       rust: 1.26.0
       env:
         - COMPILER=g++
-        - GCOV=/usr/bin/gcov
         # a2x will run xmllint on generated files, so we have to pass the path
         # to AsciiDoc's catalog files
         - XML_CATALOG_FILES=/usr/local/etc/xml/catalog
@@ -64,7 +54,6 @@ matrix:
       os: osx
       env:
         - COMPILER=g++
-        - GCOV=/usr/bin/gcov
         # a2x will run xmllint on generated files, so we have to pass the path
         # to AsciiDoc's catalog files
         - XML_CATALOG_FILES=/usr/local/etc/xml/catalog
@@ -74,7 +63,6 @@ matrix:
       os: osx
       env:
         - COMPILER=clang++
-        - GCOV=/usr/bin/gcov
         # a2x will run xmllint on generated files, so we have to pass the path
         # to AsciiDoc's catalog files
         - XML_CATALOG_FILES=/usr/local/etc/xml/catalog
@@ -92,7 +80,6 @@ matrix:
             - *global_deps
       env:
         - COMPILER=g++-8
-        - GCOV=/usr/bin/gcov-8
       script: &release_build_script
         - CXXFLAGS="$CXXFLAGS -Wnull-dereference -Wdouble-promotion -O3" make -j2 --keep-going all test
         - ( cd test && ./test --order rand ); ret=$?; (cargo test) && sh -c "exit $ret"
@@ -109,7 +96,6 @@ matrix:
             - *clang_deps
       env:
         - COMPILER=clang++-8
-        - GCOV="llvm-cov-8 gcov"
       script: *release_build_script
     - compiler: gcc-4.9
       os: linux
@@ -124,9 +110,6 @@ matrix:
             - *global_deps
       env:
         - COMPILER=g++-4.9
-        - GCOV=/usr/bin/gcov-4.9
-      before_install:
-        *install_coveralls
     - compiler: gcc-4.9
       os: linux
       dist: xenial
@@ -139,9 +122,6 @@ matrix:
             - *global_deps
       env:
         - COMPILER=g++-4.9
-        - GCOV=/usr/bin/gcov-4.9
-      before_install:
-        *install_coveralls
     - compiler: gcc-5
       os: linux
       dist: bionic
@@ -154,9 +134,6 @@ matrix:
             - *global_deps
       env:
         - COMPILER=g++-5
-        - GCOV=/usr/bin/gcov-5
-      before_install:
-        *install_coveralls
     - compiler: gcc-6
       os: linux
       dist: bionic
@@ -169,9 +146,6 @@ matrix:
             - *global_deps
       env:
         - COMPILER=g++-6
-        - GCOV=/usr/bin/gcov-6
-      before_install:
-        *install_coveralls
     - compiler: gcc-7
       os: linux
       dist: bionic
@@ -184,9 +158,6 @@ matrix:
             - *global_deps
       env:
         - COMPILER=g++-7
-        - GCOV=/usr/bin/gcov-7
-      before_install:
-        *install_coveralls
     - compiler: gcc-8
       os: linux
       dist: bionic
@@ -199,9 +170,6 @@ matrix:
             - *global_deps
       env:
         - COMPILER=g++-8
-        - GCOV=/usr/bin/gcov-8
-      before_install:
-        *install_coveralls
     - compiler: gcc-9
       os: linux
       dist: bionic
@@ -214,9 +182,6 @@ matrix:
             - *global_deps
       env:
         - COMPILER=g++-9
-        - GCOV=/usr/bin/gcov-9
-      before_install:
-        *install_coveralls
     - compiler: clang
       os: linux
       dist: bionic
@@ -228,9 +193,6 @@ matrix:
             - *clang_deps
       env:
         - COMPILER=clang++
-        - GCOV="llvm-cov gcov"
-      before_install:
-        *install_coveralls
     - compiler: clang-4.0
       os: linux
       dist: xenial
@@ -245,9 +207,6 @@ matrix:
             - *clang_deps
       env:
         - COMPILER=clang++-4.0
-        - GCOV="llvm-cov-4.0 gcov"
-      before_install:
-        *install_coveralls
     - compiler: clang-5.0
       os: linux
       dist: bionic
@@ -261,9 +220,6 @@ matrix:
             - *clang_deps
       env:
         - COMPILER=clang++-5.0
-        - GCOV="llvm-cov-5.0 gcov"
-      before_install:
-        *install_coveralls
     - compiler: clang-6.0
       os: linux
       dist: bionic
@@ -277,9 +233,6 @@ matrix:
             - *clang_deps
       env:
         - COMPILER=clang++-6.0
-        - GCOV="llvm-cov-6.0 gcov"
-      before_install:
-        *install_coveralls
     - compiler: clang-7
       os: linux
       dist: bionic
@@ -293,9 +246,6 @@ matrix:
             - *clang_deps
       env:
         - COMPILER=clang++-7
-        - GCOV="llvm-cov-7 gcov"
-      before_install:
-        *install_coveralls
     - compiler: clang-8
       os: linux
       dist: bionic
@@ -309,9 +259,6 @@ matrix:
             - *clang_deps
       env:
         - COMPILER=clang++-8
-        - GCOV="llvm-cov-8 gcov"
-      before_install:
-        *install_coveralls
     - compiler: clang-9
       os: linux
       dist: bionic
@@ -327,9 +274,27 @@ matrix:
             - *clang_deps
       env:
         - COMPILER=clang++-9
-        - GCOV="llvm-cov-9 gcov"
+    - compiler: clang-8
+      os: linux
+      dist: bionic
+      rust: nightly
+      addons:
+        apt:
+          sources:
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
+          packages:
+            - clang-8
+            - llvm-8
+            - *clang_deps
+      env:
+        - COMPILER=clang++-8
+        - REPORT_COVERAGE=yes
       before_install:
-        *install_coveralls
+        - cargo install grcov
+
+          # Can't have these in the `env` section above, because these settings break `cargo install`
+        - export CARGO_INCREMENTAL=0
+        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
     - addons:
         apt:
           packages:
@@ -356,4 +321,4 @@ script:
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
-  - if [ -z "$CHECKS" ]; then   ./submit-to-coveralls.sh   ; fi
+  - if [ -n "${REPORT_COVERAGE}" ]; then   ./submit-to-coveralls.sh   ; fi

--- a/submit-to-coveralls.sh
+++ b/submit-to-coveralls.sh
@@ -17,6 +17,13 @@ else
     branch="${TRAVIS_BRANCH}"
 fi
 
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]
+then
+    service_pull_request=""
+else
+    service_pull_request="--service-pull-request ${TRAVIS_PULL_REQUEST}"
+fi
+
 ${HOME}/.cargo/bin/grcov \
     . \
     --service-name "travis-ci" \
@@ -25,6 +32,7 @@ ${HOME}/.cargo/bin/grcov \
     --token "${COVERALLS_REPO_TOKEN}" \
     --commit-sha "${TRAVIS_COMMIT}" \
     --vcs-branch "${branch}" \
+    ${service_pull_request} \
     --ignore-not-existing \
     --ignore='/*' \
     --ignore='3rd-party/*' \

--- a/submit-to-coveralls.sh
+++ b/submit-to-coveralls.sh
@@ -1,12 +1,41 @@
 #!/bin/sh
 
-if [ "$TRAVIS_OS_NAME" = "osx" ]
+# For pull requests, TRAVIS_BRANCH is the *target* branch, usually "master".
+# This leads to mis-assigned coverage reports: they aren't assigned to PR's
+# source branch. To combat this, we detect if the build is triggered by a PR,
+# and explicitly use PR's source branch if so. That branch might not actually
+# exist in our main repo, but that's fine -- Coveralls doesn't check.
+#
+# Similar distinction exists between TRAVIS_COMMIT and TRAVIS_PULL_REQUEST_SHA,
+# but we don't paper over it there because we *do* want the report to attach to
+# the commit that was actually built: this way, we (theoretically) can notice
+# if the merge commit affected our coverage somehow.
+if [ "${TRAVIS_EVENT_TYPE}" = "pull_request" ]
 then
-    eval "$(pyenv init -)"
+    branch="${TRAVIS_PULL_REQUEST_BRANCH}"
+else
+    branch="${TRAVIS_BRANCH}"
 fi
 
-coveralls \
-    --exclude 'test' \
-    --exclude 'usr' \
-    --exclude '3rd-party' \
-    --gcov "$GCOV" --gcov-options '\-lp'
+${HOME}/.cargo/bin/grcov \
+    . \
+    --service-name "travis-ci" \
+    --service-number "${TRAVIS_BUILD_ID}" \
+    --service-job-number "${TRAVIS_JOB_ID}" \
+    --token "${COVERALLS_REPO_TOKEN}" \
+    --commit-sha "${TRAVIS_COMMIT}" \
+    --vcs-branch "${branch}" \
+    --ignore-not-existing \
+    --ignore='/*' \
+    --ignore='3rd-party/*' \
+    --ignore='doc/*' \
+    --ignore='test/*' \
+    --ignore='newsboat.cpp' \
+    --ignore='podboat.cpp' \
+    -t coveralls \
+    -o coveralls.json
+
+curl \
+    --form "json_file=@coveralls.json" \
+    --include \
+    https://coveralls.io/api/v1/jobs


### PR DESCRIPTION
This replaces cpp-coveralls tool (using gcov under the hood) with grcov and curl. There are both up- and down-sides with this.

Upsides
=======

- grcov creates a single report for C++ and Rust.

Downsides
=========

- grcov only supports LLVM's coverage data -- GCC builds no longer participate in coverage reports.

- rustc support for coverage is not yet stable -- only Nightly Rust generates coverage.

  Also, Nightly Rust is a less stable of the branches, so we might have occasional problems with coverage. Eventually I'll look into pinning the Nightly version to avoid this, but I'm exhausted with this particular problem for now.

- Coveralls reports don't have consecutive numbers anymore -- we now use Travis build IDs, which are long integers.

- Coveralls reports no longer contain commit's message and author. I think this can be fixed in grcov itself.

Fixes #346.

Will merge in three days unless someone stops me for a review.