### PR TITLE
Add a few new warning flags and fix resulting warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ matrix:
         - COMPILER=g++-8
         - GCOV=/usr/bin/gcov-8
       script: &release_build_script
-        - CXXFLAGS="$CXXFLAGS -Wnull-dereference -O3" make -j2 --keep-going all test
+        - CXXFLAGS="$CXXFLAGS -Wnull-dereference -Wdouble-promotion -O3" make -j2 --keep-going all test
         - ( cd test && ./test --order rand ); ret=$?; (cargo test) && sh -c "exit $ret"
     - compiler: clang-8
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ matrix:
         - COMPILER=g++-8
         - GCOV=/usr/bin/gcov-8
       script: &release_build_script
-        - CXXFLAGS="$CXXFLAGS -O3" make -j2 --keep-going all test
+        - CXXFLAGS="$CXXFLAGS -Wnull-dereference -O3" make -j2 --keep-going all test
         - ( cd test && ./test --order rand ); ret=$?; (cargo test) && sh -c "exit $ret"
     - compiler: clang-8
       os: linux

--- a/include/download.h
+++ b/include/download.h
@@ -53,8 +53,8 @@ private:
 	std::string fn;
 	std::string url_;
 	DlStatus download_status;
-	float cursize;
-	float totalsize;
+	double cursize;
+	double totalsize;
 	double curkbps;
 	unsigned long offs;
 	PbController* ctrl;

--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -65,13 +65,15 @@ std::string fmt(const std::string& format, const std::nullptr_t argument,
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format, const double argument, Args... args)
+std::string fmt(const std::string& format, const float argument, Args... args)
 {
-	return fmt_impl(format, argument, args...);
+	// Variadic functions (like snprintf) do not accept `float`, so let's
+	// convert that.
+	return fmt_impl(format, static_cast<double>(argument), args...);
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format, const float argument, Args... args)
+std::string fmt(const std::string& format, const double argument, Args... args)
 {
 	return fmt_impl(format, argument, args...);
 }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -532,7 +532,9 @@ void View::push_itemlist(unsigned int pos)
 		std::shared_ptr<ItemListFormAction> itemlist =
 			std::dynamic_pointer_cast<ItemListFormAction,
 			FormAction>(get_current_formaction());
-		itemlist->set_pos(pos);
+		if (itemlist) {
+			itemlist->set_pos(pos);
+		}
 	}
 }
 


### PR DESCRIPTION
I was reading [a blog post about interesting compiler flags](https://kristerw.blogspot.com/2017/09/useful-gcc-warning-options-not-enabled.html) and tried them on Newsboat. A few stuck, so I'm adding them ~to Makefile~ to "release build" job on Travis (because optimization makes warnings more precise).

`-Wshadow`, `-Wuseless-cast`, and `-Wold-style-cast` trigger a lot of warnings in filter parser. I'll try them again once #631 is fixed.

The rest didn't produce any warnings, so I decided not to enable them at all.

Will merge in three days unless someone stops me for a review.