### PR TITLE
Resolve tilde in command-line options that take paths

### DIFF
--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -54,9 +54,12 @@ pub unsafe extern "C" fn rs_consolidate_whitespace(input: *const c_char) -> *mut
 pub unsafe extern "C" fn rs_resolve_tilde(path: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
         let rs_path = CStr::from_ptr(path);
+        // We simply assume that all the paths are in UTF-8 -- hence to_string_lossy().
         let rs_path = rs_path.to_string_lossy().into_owned();
 
-        let result = utils::resolve_tilde(rs_path);
+        let result = utils::resolve_tilde(path::PathBuf::from(rs_path));
+        // We simply assume that all the paths are in UTF-8 -- hence to_string_lossy().
+        let result = result.to_string_lossy().into_owned();
 
         let result = CString::new(result).unwrap();
         result.into_raw()

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -4,6 +4,7 @@ use libc::{EXIT_FAILURE, EXIT_SUCCESS};
 use std::path::PathBuf;
 
 use logger::Level;
+use utils;
 
 #[derive(Default)]
 pub struct CliArgsParser {
@@ -207,21 +208,23 @@ impl CliArgsParser {
                 args.should_print_usage = true;
                 args.return_code = Some(EXIT_FAILURE);
             } else {
-                args.importfile = Some(PathBuf::from(importfile));
+                args.importfile = Some(utils::resolve_tilde(PathBuf::from(importfile)));
             }
         }
 
         if let Some(url_file) = matches.value_of(URL_FILE) {
-            args.url_file = Some(PathBuf::from(url_file));
+            args.url_file = Some(utils::resolve_tilde(PathBuf::from(url_file)));
         }
 
         if let Some(cache_file) = matches.value_of(CACHE_FILE) {
-            args.cache_file = Some(PathBuf::from(cache_file));
-            args.lock_file = Some(PathBuf::from(cache_file.to_string() + LOCK_SUFFIX));
+            args.cache_file = Some(utils::resolve_tilde(PathBuf::from(cache_file)));
+            args.lock_file = Some(utils::resolve_tilde(PathBuf::from(
+                cache_file.to_string() + LOCK_SUFFIX,
+            )));
         }
 
         if let Some(config_file) = matches.value_of(CONFIG_FILE) {
-            args.config_file = Some(PathBuf::from(config_file));
+            args.config_file = Some(utils::resolve_tilde(PathBuf::from(config_file)));
         }
 
         // Casting u64 to usize. Highly unlikely that the user will hit the limit, even if we were
@@ -243,7 +246,7 @@ impl CliArgsParser {
                 args.should_print_usage = true;
                 args.return_code = Some(EXIT_FAILURE);
             } else {
-                args.readinfo_import_file = Some(PathBuf::from(importfile));
+                args.readinfo_import_file = Some(utils::resolve_tilde(PathBuf::from(importfile)));
             }
         }
 
@@ -252,12 +255,12 @@ impl CliArgsParser {
                 args.should_print_usage = true;
                 args.return_code = Some(EXIT_FAILURE);
             } else {
-                args.readinfo_export_file = Some(PathBuf::from(exportfile));
+                args.readinfo_export_file = Some(utils::resolve_tilde(PathBuf::from(exportfile)));
             }
         }
 
         if let Some(log_file) = matches.value_of(LOG_FILE) {
-            args.log_file = Some(PathBuf::from(log_file));
+            args.log_file = Some(utils::resolve_tilde(PathBuf::from(log_file)));
         }
 
         if let Some(log_level_str) = matches.value_of(LOG_LEVEL) {

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -86,28 +86,15 @@ pub fn absolute_url(base_url: &str, link: &str) -> String {
         .to_owned()
 }
 
-pub fn resolve_tilde(path: String) -> String {
-    let mut file_path: String = path;
-    let home_path = dirs::home_dir();
-
-    if let Some(home_path) = home_path {
-        let home_path_string = home_path.to_string_lossy().into_owned();
-
-        if file_path == "~" {
-            file_path = home_path_string;
-        } else {
-            let tmp_file_path = file_path.clone();
-
-            if tmp_file_path.len() > 1 {
-                let (tilde, remaining) = tmp_file_path.split_at(2);
-
-                if tilde == "~/" {
-                    file_path = home_path_string + "/" + remaining;
-                }
-            }
-        }
+/// Replaces tilde (`~`) at the beginning of the path with the path to user's home directory.
+pub fn resolve_tilde(path: PathBuf) -> PathBuf {
+    if let (Some(home), Ok(suffix)) = (dirs::home_dir(), path.strip_prefix("~")) {
+        return home.join(suffix);
     }
-    file_path
+
+    // Either the `path` doesn't start with tilde, or we couldn't figure out the path to the
+    // home directory -- either way, it's no big deal. Let's return the original string.
+    path
 }
 
 pub fn resolve_relative(reference: &Path, path: &Path) -> PathBuf {

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_cache_file.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_cache_file.rs
@@ -1,0 +1,41 @@
+extern crate libnewsboat;
+extern crate tempfile;
+
+use self::libnewsboat::cliargsparser::CliArgsParser;
+use self::tempfile::TempDir;
+use std::{env, path::PathBuf};
+
+#[test]
+fn t_cliargsparser_dash_c_resolves_tilde_to_homedir() {
+    let tmp = TempDir::new().unwrap();
+
+    env::set_var("HOME", tmp.path());
+
+    let filename = "mycache.db";
+    let arg = format!("~/{}", filename);
+
+    let check = |opts| {
+        let args = CliArgsParser::new(opts);
+        assert_eq!(
+            args.cache_file,
+            Some(PathBuf::from(tmp.path().join(filename)))
+        );
+        assert_eq!(
+            args.lock_file,
+            Some(PathBuf::from(
+                tmp.path().join(filename.to_owned() + ".lock")
+            ))
+        );
+    };
+
+    check(vec![
+        "newsboat".to_string(),
+        "-c".to_string(),
+        arg.to_string(),
+    ]);
+
+    check(vec![
+        "newsboat".to_string(),
+        "--cache-file=".to_string() + &arg,
+    ]);
+}

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_config_file.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_config_file.rs
@@ -1,0 +1,35 @@
+extern crate libnewsboat;
+extern crate tempfile;
+
+use self::libnewsboat::cliargsparser::CliArgsParser;
+use self::tempfile::TempDir;
+use std::{env, path::PathBuf};
+
+#[test]
+fn t_cliargsparser_dash_capital_c_resolves_tilde_to_homedir() {
+    let tmp = TempDir::new().unwrap();
+
+    env::set_var("HOME", tmp.path());
+
+    let filename = "newsboat-config";
+    let arg = format!("~/{}", filename);
+
+    let check = |opts| {
+        let args = CliArgsParser::new(opts);
+        assert_eq!(
+            args.config_file,
+            Some(PathBuf::from(tmp.path().join(filename)))
+        );
+    };
+
+    check(vec![
+        "newsboat".to_string(),
+        "-C".to_string(),
+        arg.to_string(),
+    ]);
+
+    check(vec![
+        "newsboat".to_string(),
+        "--config-file=".to_string() + &arg,
+    ]);
+}

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_exportfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_exportfile.rs
@@ -1,0 +1,35 @@
+extern crate libnewsboat;
+extern crate tempfile;
+
+use self::libnewsboat::cliargsparser::CliArgsParser;
+use self::tempfile::TempDir;
+use std::{env, path::PathBuf};
+
+#[test]
+fn t_cliargsparser_dash_capital_e_resolves_tilde_to_homedir() {
+    let tmp = TempDir::new().unwrap();
+
+    env::set_var("HOME", tmp.path());
+
+    let filename = "read.txt";
+    let arg = format!("~/{}", filename);
+
+    let check = |opts| {
+        let args = CliArgsParser::new(opts);
+        assert_eq!(
+            args.readinfo_export_file,
+            Some(PathBuf::from(tmp.path().join(filename)))
+        );
+    };
+
+    check(vec![
+        "newsboat".to_string(),
+        "-E".to_string(),
+        arg.to_string(),
+    ]);
+
+    check(vec![
+        "newsboat".to_string(),
+        "--export-to-file=".to_string() + &arg,
+    ]);
+}

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_importfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_importfile.rs
@@ -1,0 +1,35 @@
+extern crate libnewsboat;
+extern crate tempfile;
+
+use self::libnewsboat::cliargsparser::CliArgsParser;
+use self::tempfile::TempDir;
+use std::{env, path::PathBuf};
+
+#[test]
+fn t_cliargsparser_dash_capital_i_resolves_tilde_to_homedir() {
+    let tmp = TempDir::new().unwrap();
+
+    env::set_var("HOME", tmp.path());
+
+    let filename = "read.txt";
+    let arg = format!("~/{}", filename);
+
+    let check = |opts| {
+        let args = CliArgsParser::new(opts);
+        assert_eq!(
+            args.readinfo_import_file,
+            Some(PathBuf::from(tmp.path().join(filename)))
+        );
+    };
+
+    check(vec![
+        "newsboat".to_string(),
+        "-I".to_string(),
+        arg.to_string(),
+    ]);
+
+    check(vec![
+        "newsboat".to_string(),
+        "--import-from-file=".to_string() + &arg,
+    ]);
+}

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_logfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_logfile.rs
@@ -1,0 +1,35 @@
+extern crate libnewsboat;
+extern crate tempfile;
+
+use self::libnewsboat::cliargsparser::CliArgsParser;
+use self::tempfile::TempDir;
+use std::{env, path::PathBuf};
+
+#[test]
+fn t_cliargsparser_dash_d_resolves_tilde_to_homedir() {
+    let tmp = TempDir::new().unwrap();
+
+    env::set_var("HOME", tmp.path());
+
+    let filename = "newsboat.log";
+    let arg = format!("~/{}", filename);
+
+    let check = |opts| {
+        let args = CliArgsParser::new(opts);
+        assert_eq!(
+            args.log_file,
+            Some(PathBuf::from(tmp.path().join(filename)))
+        );
+    };
+
+    check(vec![
+        "newsboat".to_string(),
+        "-d".to_string(),
+        arg.to_string(),
+    ]);
+
+    check(vec![
+        "newsboat".to_string(),
+        "--log-file=".to_string() + &arg,
+    ]);
+}

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_opmlfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_opmlfile.rs
@@ -1,0 +1,35 @@
+extern crate libnewsboat;
+extern crate tempfile;
+
+use self::libnewsboat::cliargsparser::CliArgsParser;
+use self::tempfile::TempDir;
+use std::{env, path::PathBuf};
+
+#[test]
+fn t_cliargsparser_dash_i_resolves_tilde_to_homedir() {
+    let tmp = TempDir::new().unwrap();
+
+    env::set_var("HOME", tmp.path());
+
+    let filename = "feedlist.opml";
+    let arg = format!("~/{}", filename);
+
+    let check = |opts| {
+        let args = CliArgsParser::new(opts);
+        assert_eq!(
+            args.importfile,
+            Some(PathBuf::from(tmp.path().join(filename)))
+        );
+    };
+
+    check(vec![
+        "newsboat".to_string(),
+        "-i".to_string(),
+        arg.to_string(),
+    ]);
+
+    check(vec![
+        "newsboat".to_string(),
+        "--import-from-opml=".to_string() + &arg,
+    ]);
+}

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_urlfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_urlfile.rs
@@ -1,0 +1,35 @@
+extern crate libnewsboat;
+extern crate tempfile;
+
+use self::libnewsboat::cliargsparser::CliArgsParser;
+use self::tempfile::TempDir;
+use std::{env, path::PathBuf};
+
+#[test]
+fn t_cliargsparser_dash_u_resolves_tilde_to_homedir() {
+    let tmp = TempDir::new().unwrap();
+
+    env::set_var("HOME", tmp.path());
+
+    let filename = "urlfile";
+    let arg = format!("~/{}", filename);
+
+    let check = |opts| {
+        let args = CliArgsParser::new(opts);
+        assert_eq!(
+            args.url_file,
+            Some(PathBuf::from(tmp.path().join(filename)))
+        );
+    };
+
+    check(vec![
+        "newsboat".to_string(),
+        "-u".to_string(),
+        arg.to_string(),
+    ]);
+
+    check(vec![
+        "newsboat".to_string(),
+        "--url-file=".to_string() + &arg,
+    ]);
+}

--- a/rust/libnewsboat/tests/resolve_tilde.rs
+++ b/rust/libnewsboat/tests/resolve_tilde.rs
@@ -2,17 +2,30 @@ extern crate libnewsboat;
 
 use libnewsboat::utils;
 use std::env;
+use std::path::{Path, PathBuf};
 
 #[test]
 fn t_resolve_tilde() {
     env::set_var("HOME", "test");
-    assert_eq!(utils::resolve_tilde(String::from("~")), "test");
-    assert_eq!(utils::resolve_tilde(String::from("~/")), "test/");
-    assert_eq!(utils::resolve_tilde(String::from("~/dir")), "test/dir");
-    assert_eq!(utils::resolve_tilde(String::from("/home/~")), "/home/~");
+    assert_eq!(&utils::resolve_tilde(PathBuf::from("~")), Path::new("test"));
     assert_eq!(
-        utils::resolve_tilde(String::from("~/foo/bar")),
-        "test/foo/bar"
+        &utils::resolve_tilde(PathBuf::from("~/")),
+        Path::new("test/")
     );
-    assert_eq!(utils::resolve_tilde(String::from("/foo/bar")), "/foo/bar");
+    assert_eq!(
+        &utils::resolve_tilde(PathBuf::from("~/dir")),
+        Path::new("test/dir")
+    );
+    assert_eq!(
+        &utils::resolve_tilde(PathBuf::from("/home/~")),
+        Path::new("/home/~")
+    );
+    assert_eq!(
+        &utils::resolve_tilde(PathBuf::from("~/foo/bar")),
+        Path::new("test/foo/bar")
+    );
+    assert_eq!(
+        &utils::resolve_tilde(PathBuf::from("/foo/bar")),
+        Path::new("/foo/bar")
+    );
 }

--- a/rust/libnewsboat/tests/resolve_tilde.rs
+++ b/rust/libnewsboat/tests/resolve_tilde.rs
@@ -8,6 +8,8 @@ fn t_resolve_tilde() {
     env::set_var("HOME", "test");
     assert_eq!(utils::resolve_tilde(String::from("~")), "test");
     assert_eq!(utils::resolve_tilde(String::from("~/")), "test/");
+    assert_eq!(utils::resolve_tilde(String::from("~/dir")), "test/dir");
+    assert_eq!(utils::resolve_tilde(String::from("/home/~")), "/home/~");
     assert_eq!(
         utils::resolve_tilde(String::from("~/foo/bar")),
         "test/foo/bar"

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -60,6 +60,33 @@ TEST_CASE(
 	}
 }
 
+TEST_CASE("Resolves tilde to homedir in -i/--import-from-opml",
+	"[CliArgsParser]")
+{
+	TestHelpers::TempDir tmp;
+
+	TestHelpers::EnvVar home("HOME");
+	home.set(tmp.get_path());
+
+	const std::string filename("feedlist.opml");
+	const std::string arg = std::string("~/") + filename;
+
+	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
+		CliArgsParser args(opts.argc(), opts.argv());
+
+		REQUIRE(args.do_import());
+		REQUIRE(args.importfile() == tmp.get_path() + filename);
+	};
+
+	SECTION("-i") {
+		check({"newsboat", "-i", arg});
+	}
+
+	SECTION("--import-from-opml") {
+		check({"newsboat", "--import-from-opml", arg});
+	}
+}
+
 TEST_CASE(
 	"Asks to print usage and exit with failure if both "
 	"-i/--import-from-opml and -e/--export-to-opml are provided",
@@ -175,6 +202,32 @@ TEST_CASE(
 	}
 }
 
+TEST_CASE("Resolves tilde to homedir in -u/--url-file", "[CliArgsParser]")
+{
+	TestHelpers::TempDir tmp;
+
+	TestHelpers::EnvVar home("HOME");
+	home.set(tmp.get_path());
+
+	const std::string filename("urlfile");
+	const std::string arg = std::string("~/") + filename;
+
+	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
+		CliArgsParser args(opts.argc(), opts.argv());
+
+		REQUIRE(args.set_url_file());
+		REQUIRE(args.url_file() == tmp.get_path() + filename);
+	};
+
+	SECTION("-u") {
+		check({"newsboat", "-u", arg});
+	}
+
+	SECTION("--url-file") {
+		check({"newsboat", "--url-file", arg});
+	}
+}
+
 TEST_CASE(
 	"Sets `cache_file`, `lock_file`, `set_cache_file`, `set_lock_file`, "
 	"and "
@@ -202,6 +255,34 @@ TEST_CASE(
 	}
 }
 
+TEST_CASE("Resolves tilde to homedir in -c/--cache-file", "[CliArgsParser]")
+{
+	TestHelpers::TempDir tmp;
+
+	TestHelpers::EnvVar home("HOME");
+	home.set(tmp.get_path());
+
+	const std::string filename("mycache.db");
+	const std::string arg = std::string("~/") + filename;
+
+	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
+		CliArgsParser args(opts.argc(), opts.argv());
+
+		REQUIRE(args.set_cache_file());
+		REQUIRE(args.cache_file() == tmp.get_path() + filename);
+		REQUIRE(args.set_lock_file());
+		REQUIRE(args.lock_file() == tmp.get_path() + filename + ".lock");
+	};
+
+	SECTION("-c") {
+		check({"newsboat", "-c", arg});
+	}
+
+	SECTION("--cache-file") {
+		check({"newsboat", "--cache-file", arg});
+	}
+}
+
 TEST_CASE(
 	"Sets `config_file`, `set_config_file`, and "
 	"`using_nonstandard_configs` if -C/--config-file is provided",
@@ -223,6 +304,33 @@ TEST_CASE(
 
 	SECTION("--config-file") {
 		check({"newsboat", "--config-file=" + filename});
+	}
+}
+
+TEST_CASE("Resolves tilde to homedir in -C/--config-file", "[CliArgsParser]")
+{
+	TestHelpers::TempDir tmp;
+
+	TestHelpers::EnvVar home("HOME");
+	home.set(tmp.get_path());
+
+	const std::string filename("newsboat-config");
+	const std::string arg = std::string("~/") + filename;
+
+	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
+		CliArgsParser args(opts.argc(), opts.argv());
+
+		REQUIRE(args.set_config_file());
+		REQUIRE(args.config_file() == tmp.get_path() + filename);
+		REQUIRE(args.using_nonstandard_configs());
+	};
+
+	SECTION("-C") {
+		check({"newsboat", "-C", arg});
+	}
+
+	SECTION("--config-file") {
+		check({"newsboat", "--config-file", arg});
 	}
 }
 
@@ -388,6 +496,33 @@ TEST_CASE(
 	}
 }
 
+TEST_CASE("Resolves tilde to homedir in -I/--import-from-file",
+	"[CliArgsParser]")
+{
+	TestHelpers::TempDir tmp;
+
+	TestHelpers::EnvVar home("HOME");
+	home.set(tmp.get_path());
+
+	const std::string filename("read.txt");
+	const std::string arg = std::string("~/") + filename;
+
+	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
+		CliArgsParser args(opts.argc(), opts.argv());
+
+		REQUIRE(args.do_read_import());
+		REQUIRE(args.readinfo_import_file() == tmp.get_path() + filename);
+	};
+
+	SECTION("-I") {
+		check({"newsboat", "-I", arg});
+	}
+
+	SECTION("--import-from-file") {
+		check({"newsboat", "--import-from-file", arg});
+	}
+}
+
 TEST_CASE(
 	"Sets `do_read_export` and `readinfofile` if -E/--export-to-file "
 	"is provided",
@@ -408,6 +543,32 @@ TEST_CASE(
 
 	SECTION("--export-from-file") {
 		check({"newsboat", "--export-to-file=" + filename});
+	}
+}
+
+TEST_CASE("Resolves tilde to homedir in -E/--export-to-file", "[CliArgsParser]")
+{
+	TestHelpers::TempDir tmp;
+
+	TestHelpers::EnvVar home("HOME");
+	home.set(tmp.get_path());
+
+	const std::string filename("read.txt");
+	const std::string arg = std::string("~/") + filename;
+
+	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
+		CliArgsParser args(opts.argc(), opts.argv());
+
+		REQUIRE(args.do_read_export());
+		REQUIRE(args.readinfo_export_file() == tmp.get_path() + filename);
+	};
+
+	SECTION("-E") {
+		check({"newsboat", "-E", arg});
+	}
+
+	SECTION("--export-to-file") {
+		check({"newsboat", "--export-to-file", arg});
 	}
 }
 
@@ -454,6 +615,32 @@ TEST_CASE("Sets `set_log_file` and `log_file` if -d/--log-file is provided",
 
 	SECTION("--log-file") {
 		check({"newsboat", "--log-file=" + filename});
+	}
+}
+
+TEST_CASE("Resolves tilde to homedir in -d/--log-file", "[CliArgsParser]")
+{
+	TestHelpers::TempDir tmp;
+
+	TestHelpers::EnvVar home("HOME");
+	home.set(tmp.get_path());
+
+	const std::string filename("newsboat.log");
+	const std::string arg = std::string("~/") + filename;
+
+	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
+		CliArgsParser args(opts.argc(), opts.argv());
+
+		REQUIRE(args.set_log_file());
+		REQUIRE(args.log_file() == tmp.get_path() + filename);
+	};
+
+	SECTION("-d") {
+		check({"newsboat", "-d", arg});
+	}
+
+	SECTION("--log-file") {
+		check({"newsboat", "--log-file", arg});
 	}
 }
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -462,6 +462,11 @@ TEST_CASE("resolve_tilde() replaces ~ with the path to the $HOME directory",
 	REQUIRE(utils::resolve_tilde("~/") == "test/");
 	REQUIRE(utils::resolve_tilde("~/dir") == "test/dir");
 	REQUIRE(utils::resolve_tilde("/home/~") == "/home/~");
+	REQUIRE(
+		utils::resolve_tilde("~/foo/bar") ==
+		"test/foo/bar"
+	);
+	REQUIRE(utils::resolve_tilde("/foo/bar") == "/foo/bar");
 }
 
 TEST_CASE("resolve_relative() returns an absolute file path relative to another",

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -458,7 +458,7 @@ TEST_CASE("resolve_tilde() replaces ~ with the path to the $HOME directory",
 {
 	TestHelpers::EnvVar envVar("HOME");
 	envVar.set("test");
-	REQUIRE(utils::resolve_tilde("~") == "test");
+	REQUIRE(utils::resolve_tilde("~") == "test/");
 	REQUIRE(utils::resolve_tilde("~/") == "test/");
 	REQUIRE(utils::resolve_tilde("~/dir") == "test/dir");
 	REQUIRE(utils::resolve_tilde("/home/~") == "/home/~");


### PR DESCRIPTION
This fixes #524.

Will merge in three days unless someone—anyone—stops me for a review.