### PR TITLE
PB Queueloader: Remove PbController dependency

### DIFF
--- a/include/download.h
+++ b/include/download.h
@@ -1,6 +1,7 @@
 #ifndef PODBOAT_DOWNLOAD_H_
 #define PODBOAT_DOWNLOAD_H_
 
+#include <functional>
 #include <string>
 
 namespace podboat {
@@ -21,7 +22,7 @@ class PbController;
 
 class Download {
 public:
-	explicit Download(PbController* c = 0);
+	explicit Download(std::function<void()> cb_require_view_update);
 	~Download();
 	double percents_finished() const;
 	const std::string status_text() const;
@@ -57,7 +58,7 @@ private:
 	double totalsize;
 	double curkbps;
 	unsigned long offs;
-	PbController* ctrl;
+	std::function<void()> cb_require_view_update;
 };
 
 } // namespace podboat

--- a/include/pbcontroller.h
+++ b/include/pbcontroller.h
@@ -39,7 +39,6 @@ public:
 		return downloads_;
 	}
 
-	std::string get_dlpath();
 	std::string get_formatstr();
 
 	unsigned int downloads_in_progress();

--- a/include/queueloader.h
+++ b/include/queueloader.h
@@ -1,23 +1,26 @@
 #ifndef PODBOAT_QUEUELOADER_H_
 #define PODBOAT_QUEUELOADER_H_
 
+#include <functional>
 #include <vector>
 
+#include "configcontainer.h"
 #include "download.h"
-#include "pbcontroller.h"
 
 namespace podboat {
 
 class QueueLoader {
 public:
-	QueueLoader(const std::string& file, PbController* c = 0);
+	QueueLoader(const std::string& file, newsboat::ConfigContainer& cfg,
+		std::function<void()> cb_require_view_update);
 	void reload(std::vector<Download>& downloads,
 		bool remove_unplayed = false);
 
 private:
 	std::string get_filename(const std::string& str);
 	std::string queuefile;
-	PbController* ctrl;
+	newsboat::ConfigContainer& cfg;
+	std::function<void()> cb_require_view_update;
 };
 
 } // namespace podboat

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -12,13 +12,13 @@ namespace podboat {
  * It manages the filename, the URL, the current state, the progress, etc.
  */
 
-Download::Download(PbController* c)
+Download::Download(std::function<void()> cb_require_view_update_)
 	: download_status(DlStatus::QUEUED)
 	, cursize(0.0)
 	, totalsize(0.0)
 	, curkbps(0.0)
 	, offs(0)
-	, ctrl(c)
+	, cb_require_view_update(cb_require_view_update_)
 {
 }
 
@@ -92,7 +92,7 @@ void Download::set_url(const std::string& u)
 void Download::set_progress(double downloaded, double total)
 {
 	if (downloaded > cursize) {
-		ctrl->set_view_update_necessary(true);
+		cb_require_view_update();
 	}
 	cursize = downloaded;
 	totalsize = total;
@@ -101,7 +101,7 @@ void Download::set_progress(double downloaded, double total)
 void Download::set_status(DlStatus dls)
 {
 	if (download_status != dls) {
-		ctrl->set_view_update_necessary(true);
+		cb_require_view_update();
 	}
 	download_status = dls;
 }

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -301,7 +301,8 @@ int PbController::run(int argc, char* argv[])
 
 	std::cout << _("done.") << std::endl;
 
-	ql = new QueueLoader(queue_file, this);
+	ql = new QueueLoader(queue_file, *cfg,
+		std::bind(&PbController::set_view_update_necessary, this, true));
 	ql->reload(downloads_);
 
 	v->set_keymap(&keys);
@@ -379,11 +380,6 @@ void PbController::print_usage(const char* argv0)
 		}
 		std::cout << a.desc << std::endl;
 	}
-}
-
-std::string PbController::get_dlpath()
-{
-	return cfg->get_configvalue("download-path");
 }
 
 std::string PbController::get_formatstr()

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -20,9 +20,11 @@ using namespace newsboat;
 
 namespace podboat {
 
-QueueLoader::QueueLoader(const std::string& file, PbController* c)
+QueueLoader::QueueLoader(const std::string& file, ConfigContainer& cfg_,
+	std::function<void()> cb_require_view_update_)
 	: queuefile(file)
-	, ctrl(c)
+	, cfg(cfg_)
+	, cb_require_view_update(cb_require_view_update_)
 {
 }
 
@@ -136,7 +138,7 @@ void QueueLoader::reload(std::vector<Download>& downloads, bool remove_unplayed)
 						"nowhere -> storing to new "
 						"vector",
 						line);
-					Download d(ctrl);
+					Download d(cb_require_view_update);
 					std::string fn;
 					if (fields.size() == 1) {
 						fn = get_filename(fields[0]);
@@ -216,7 +218,7 @@ void QueueLoader::reload(std::vector<Download>& downloads, bool remove_unplayed)
 		f.close();
 	}
 
-	if (ctrl->get_cfgcont()->get_configvalue_as_bool("delete-played-files")) {
+	if (cfg.get_configvalue_as_bool("delete-played-files")) {
 		for (const auto& dl : deletion_list) {
 			const std::string filename = dl.filename();
 			LOG(Level::INFO,
@@ -237,7 +239,7 @@ void QueueLoader::reload(std::vector<Download>& downloads, bool remove_unplayed)
 
 std::string QueueLoader::get_filename(const std::string& str)
 {
-	std::string fn = ctrl->get_dlpath();
+	std::string fn = cfg.get_configvalue("download-path");
 
 	if (fn[fn.length() - 1] != NEWSBEUTER_PATH_SEP[0]) {
 		fn.append(NEWSBEUTER_PATH_SEP);


### PR DESCRIPTION
This will simplify writing tests for QueueLoader because it:
- allows testing with different queue file location;
- removes the need for setting up PbController with serveral environment variables.