### PR TITLE
Add basic <audio>, <video> and <source> support for HtmlRenderer

### DIFF
--- a/include/htmlrenderer.h
+++ b/include/htmlrenderer.h
@@ -10,7 +10,7 @@
 
 namespace newsboat {
 
-enum class LinkType { HREF, IMG, EMBED };
+enum class LinkType { HREF, IMG, EMBED, VIDEO, AUDIO };
 enum class HtmlTag {
 	A = 1,
 	EMBED,
@@ -43,7 +43,10 @@ enum class HtmlTag {
 	TABLE,
 	TH,
 	TR,
-	TD
+	TD,
+	VIDEO,
+	AUDIO,
+	SOURCE
 };
 
 typedef std::pair<std::string, LinkType> LinkPair;
@@ -130,6 +133,9 @@ private:
 	void add_hr(std::vector<std::pair<LineType, std::string>>& lines);
 	std::string get_char_numbering(unsigned int count);
 	std::string get_roman_numbering(unsigned int count);
+	void add_media_link(std::string& line, std::vector<LinkPair>& links,
+		const std::string& url, const std::string& media_url,
+		unsigned int media_count, LinkType type);
 	bool raw_;
 };
 

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -491,6 +491,13 @@ void HtmlRenderer::render(std::istream& input,
 			}
 
 			case HtmlTag::VIDEO: {
+				if (inside_video || inside_audio) {
+					inside_video = false;
+					inside_audio = false;
+					LOG(Level::WARN,
+						"HtmlRenderer::render media element left unclosed");
+				}
+
 				std::string videourl;
 				try {
 					videourl = xpp.get_attribute_value("src");
@@ -505,6 +512,13 @@ void HtmlRenderer::render(std::istream& input,
 			break;
 
 			case HtmlTag::AUDIO: {
+				if (inside_video || inside_audio) {
+					inside_video = false;
+					inside_audio = false;
+					LOG(Level::WARN,
+						"HtmlRenderer::render media element left unclosed");
+				}
+
 				std::string audiourl;
 				try {
 					audiourl = xpp.get_attribute_value("src");

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -1371,24 +1371,25 @@ TEST_CASE("Unclosed <video> and <audio> tags are closed upon encounter with a "
 	REQUIRE(links[4].second == LinkType::AUDIO);
 }
 
-TEST_CASE("Empty <source> tags do not increase the link count",
+TEST_CASE("Empty <source> tags do not increase the link count. Media elements"
+	"without valid sources do not increase the element count",
 	"[HtmlRenderer]")
 {
 	HtmlRenderer r;
 
 	const std::string input =
+		"<video></video>"
 		"<video>"
 		"	<source src='http://example.com/video.avi'>"
 		"	<source>"
 		"	<source src='http://example.com/video.mkv'>"
 		"</video>"
-		"<video></video>"
+		"<audio></audio>"
 		"<audio>"
 		"	<source src='http://example.com/audio.mp3'>"
 		"	<source>"
 		"	<source src='http://example.com/audio.oga'>"
-		"</audio>"
-		"<audio></audio>";
+		"</audio>";
 
 	std::vector<std::pair<LineType, std::string>> lines;
 	std::vector<LinkPair> links;

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -1204,3 +1204,109 @@ TEST_CASE("When rendeing text, HtmlRenderer strips leading whitespace",
 		p(LineType::wrappable, "Text preceded by whitespace."));
 	REQUIRE(links.size() == 0);
 }
+
+TEST_CASE("<video> results in a placeholder and a link for each valid source",
+	"[HtmlRenderer]")
+{
+	HtmlRenderer r;
+
+	const std::string input =
+		"<video src='http://example.com/video.avi'></video>"
+		"<video>"
+		"	<source src='http://example.com/video2.avi'>"
+		"	<source src='http://example.com/video2.mkv'>"
+		"</video>";
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	REQUIRE_NOTHROW(r.render(input, lines, links, url));
+	REQUIRE(lines.size() == 6);
+	REQUIRE(lines[0] == p(LineType::wrappable, "[video 1 (link #1)]"
+			"[video 2 (link #2)]"
+			"[video 2 (link #3)]"));
+	REQUIRE(lines[1] == p(LineType::wrappable, ""));
+	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
+	REQUIRE(lines[3] ==
+		p(LineType::softwrappable,
+			"[1]: http://example.com/video.avi (video)"));
+	REQUIRE(lines[4] ==
+		p(LineType::softwrappable,
+			"[2]: http://example.com/video2.avi (video)"));
+	REQUIRE(lines[5] ==
+		p(LineType::softwrappable,
+			"[3]: http://example.com/video2.mkv (video)"));
+	REQUIRE(links.size() == 3);
+	REQUIRE(links[0].first == "http://example.com/video.avi");
+	REQUIRE(links[0].second == LinkType::VIDEO);
+	REQUIRE(links[1].first == "http://example.com/video2.avi");
+	REQUIRE(links[1].second == LinkType::VIDEO);
+	REQUIRE(links[2].first == "http://example.com/video2.mkv");
+	REQUIRE(links[2].second == LinkType::VIDEO);
+}
+
+TEST_CASE("<video>s without valid sources are ignored", "[HtmlRenderer]")
+{
+	HtmlRenderer r;
+
+	const std::string input = "<video></video>"
+		"<video><source><source></video>";
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	REQUIRE_NOTHROW(r.render(input, lines, links, url));
+	REQUIRE(lines.size() == 0);
+	REQUIRE(links.size() == 0);
+}
+
+TEST_CASE("<audio> results in a placeholder and a link for each valid source",
+	"[HtmlRenderer]")
+{
+	HtmlRenderer r;
+
+	const std::string input =
+		"<audio src='http://example.com/audio.oga'></audio>"
+		"<audio>"
+		"	<source src='http://example.com/audio2.mp3'>"
+		"	<source src='http://example.com/audio2.m4a'>"
+		"</audio>";
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	REQUIRE_NOTHROW(r.render(input, lines, links, url));
+	REQUIRE(lines.size() == 6);
+	REQUIRE(lines[0] == p(LineType::wrappable, "[audio 1 (link #1)]"
+			"[audio 2 (link #2)]"
+			"[audio 2 (link #3)]"));
+	REQUIRE(lines[1] == p(LineType::wrappable, ""));
+	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
+	REQUIRE(lines[3] ==
+		p(LineType::softwrappable,
+			"[1]: http://example.com/audio.oga (audio)"));
+	REQUIRE(lines[4] ==
+		p(LineType::softwrappable,
+			"[2]: http://example.com/audio2.mp3 (audio)"));
+	REQUIRE(lines[5] ==
+		p(LineType::softwrappable,
+			"[3]: http://example.com/audio2.m4a (audio)"));
+	REQUIRE(links.size() == 3);
+	REQUIRE(links[0].first == "http://example.com/audio.oga");
+	REQUIRE(links[0].second == LinkType::AUDIO);
+	REQUIRE(links[1].first == "http://example.com/audio2.mp3");
+	REQUIRE(links[1].second == LinkType::AUDIO);
+	REQUIRE(links[2].first == "http://example.com/audio2.m4a");
+	REQUIRE(links[2].second == LinkType::AUDIO);
+}
+
+TEST_CASE("<audio>s without valid sources are ignored", "[HtmlRenderer]")
+{
+	HtmlRenderer r;
+
+	const std::string input = "<audio></audio>"
+		"<audio><source><source></audio>";
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	REQUIRE_NOTHROW(r.render(input, lines, links, url));
+	REQUIRE(lines.size() == 0);
+	REQUIRE(links.size() == 0);
+}


### PR DESCRIPTION
This patch adds basic support for the <audio> and <video> tags emiting a new link for each available <source> (the MediaElement src is included in the available sources).

A feed that can be used to test parts of this patch is the [Factorio Blog](https://www.factorio.com/blog/rss).