### PR TITLE
Fix test failure on macOS Catalina

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ freebsd_task:
 
 macos_task:
     osx_instance:
-        image: mojave-base
+        image: catalina-base
 
     install_script:
         - brew update

--- a/rss/rssparser.cpp
+++ b/rss/rssparser.cpp
@@ -82,11 +82,6 @@ std::string RssParser::get_prop(xmlNode* node,
 
 std::string RssParser::w3cdtf_to_rfc822(const std::string& w3cdtf)
 {
-	return __w3cdtf_to_rfc822(w3cdtf);
-}
-
-std::string RssParser::__w3cdtf_to_rfc822(const std::string& w3cdtf)
-{
 	if (w3cdtf.empty()) {
 		return "";
 	}

--- a/rss/rssparser.cpp
+++ b/rss/rssparser.cpp
@@ -136,7 +136,13 @@ std::string RssParser::__w3cdtf_to_rfc822(const std::string& w3cdtf)
 	// then the offset will be zeroed out, since that was manually added
 	// https://github.com/akrennmair/newsbeuter/issues/369
 	stm.tm_isdst = -1;
-	time_t gmttime = mktime(&stm) + offs;
+
+	const time_t local_time = mktime(&stm);
+	if (local_time == -1) {
+		return "";
+	}
+
+	const time_t gmttime = local_time + offs;
 	return newsboat::utils::mt_strf_localtime("%a, %d %b %Y %H:%M:%S +0000",
 			gmttime);
 }

--- a/rss/rssparser.h
+++ b/rss/rssparser.h
@@ -15,7 +15,7 @@ struct RssParser {
 	{
 	}
 	virtual ~RssParser() {}
-	static std::string __w3cdtf_to_rfc822(const std::string& w3cdtf);
+	static std::string w3cdtf_to_rfc822(const std::string& w3cdtf);
 
 protected:
 	std::string get_content(xmlNode* node);
@@ -24,7 +24,6 @@ protected:
 	std::string get_prop(xmlNode* node,
 		const std::string& prop,
 		const std::string& ns = "");
-	std::string w3cdtf_to_rfc822(const std::string& w3cdtf);
 	bool node_is(xmlNode* node, const char* name, const char* ns_uri = nullptr);
 	xmlDocPtr doc;
 	std::string globalbase;

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -86,7 +86,7 @@ time_t RssParser::parse_date(const std::string& datestr)
 			"out "
 			"W3CDTF parser...");
 		t = curl_getdate(
-				rsspp::RssParser::__w3cdtf_to_rfc822(datestr).c_str(),
+				rsspp::RssParser::w3cdtf_to_rfc822(datestr).c_str(),
 				nullptr);
 	}
 	if (t == -1) {

--- a/test/rsspp_rssparser.cpp
+++ b/test/rsspp_rssparser.cpp
@@ -21,6 +21,21 @@ TEST_CASE("W3CDTF parser extracts date and time from any valid string",
 			"Tue, 30 Dec 2008 00:00:00 +0000");
 	}
 
+	SECTION("date and hours") {
+		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("2008-12-30T13") ==
+			"Tue, 30 Dec 2008 13:00:00 +0000");
+	}
+
+	SECTION("date, hours, and minutes") {
+		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("2008-12-30T13:21") ==
+			"Tue, 30 Dec 2008 13:21:00 +0000");
+	}
+
+	SECTION("date and time, without timezone") {
+		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("2008-12-30T13:21:59") ==
+			"Tue, 30 Dec 2008 13:21:59 +0000");
+	}
+
 	SECTION("date and time with Z timezone") {
 		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822(
 				"2008-12-30T13:03:15Z") ==

--- a/test/rsspp_rssparser.cpp
+++ b/test/rsspp_rssparser.cpp
@@ -7,43 +7,43 @@ TEST_CASE("W3CDTF parser extracts date and time from any valid string",
 	"[rsspp::RssParser]")
 {
 	SECTION("year only") {
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("2008") ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822("2008") ==
 			"Tue, 01 Jan 2008 00:00:00 +0000");
 	}
 
 	SECTION("year-month only") {
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("2008-12") ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822("2008-12") ==
 			"Mon, 01 Dec 2008 00:00:00 +0000");
 	}
 
 	SECTION("year-month-day only") {
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("2008-12-30") ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822("2008-12-30") ==
 			"Tue, 30 Dec 2008 00:00:00 +0000");
 	}
 
 	SECTION("date and hours") {
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("2008-12-30T13") ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822("2008-12-30T13") ==
 			"Tue, 30 Dec 2008 13:00:00 +0000");
 	}
 
 	SECTION("date, hours, and minutes") {
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("2008-12-30T13:21") ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822("2008-12-30T13:21") ==
 			"Tue, 30 Dec 2008 13:21:00 +0000");
 	}
 
 	SECTION("date and time, without timezone") {
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("2008-12-30T13:21:59") ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822("2008-12-30T13:21:59") ==
 			"Tue, 30 Dec 2008 13:21:59 +0000");
 	}
 
 	SECTION("date and time with Z timezone") {
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822(
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822(
 				"2008-12-30T13:03:15Z") ==
 			"Tue, 30 Dec 2008 13:03:15 +0000");
 	}
 
 	SECTION("date and time with -08:00 timezone") {
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822(
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822(
 				"2008-12-30T10:03:15-08:00") ==
 			"Tue, 30 Dec 2008 18:03:15 +0000");
 	}
@@ -52,9 +52,9 @@ TEST_CASE("W3CDTF parser extracts date and time from any valid string",
 TEST_CASE("W3CDTF parser returns empty string on invalid input",
 	"[rsspp::RssParser]")
 {
-	REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("foobar") == "");
-	REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("-3") == "");
-	REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822("") == "");
+	REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822("foobar") == "");
+	REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822("-3") == "");
+	REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822("") == "");
 }
 
 TEST_CASE(
@@ -75,13 +75,13 @@ TEST_CASE(
 	// sections will be observing DST while other won't
 	SECTION("Timezone Pacific") {
 		tzEnv.set("US/Pacific");
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822(input) ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822(input) ==
 			expected);
 	}
 
 	SECTION("Timezone Australia") {
 		tzEnv.set("Australia/Sydney");
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822(input) ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822(input) ==
 			expected);
 	}
 
@@ -90,13 +90,13 @@ TEST_CASE(
 	// tests will cover October
 	SECTION("Timezone Arizona") {
 		tzEnv.set("US/Arizona");
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822(input) ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822(input) ==
 			expected);
 	}
 
 	SECTION("Timezone UTC") {
 		tzEnv.set("UTC");
-		REQUIRE(rsspp::RssParser::__w3cdtf_to_rfc822(input) ==
+		REQUIRE(rsspp::RssParser::w3cdtf_to_rfc822(input) ==
 			expected);
 	}
 }


### PR DESCRIPTION
A few days ago, Cirrus CI started auto-upgrading VMs to latest macOS release, 10.15 Catalina. This led to [one of the tests failing](https://cirrus-ci.com/task/5236688679075840):

```
-------------------------------------------------------------------------------
W3CDTF parser returns empty string on invalid input
-------------------------------------------------------------------------------
test/rsspp_rssparser.cpp:38
...............................................................................
test/rsspp_rssparser.cpp:41: FAILED:
  REQUIRE( rsspp::RssParser::__w3cdtf_to_rfc822("-3") == "" )
with expansion:
  "Wed, 31 Dec 1969 15:59:59 +0000" == ""
```

With Catalina, `strptime` started accepting negative numbers for `%Y` ("year") format, producing an invalid `struct tm`. This was then fed into `mktime`, which failed and returned `-1`—but since we didn't check the return value, that invalid struct made its way into `strftime`, which dutifully created a string describing an invalid date.

The fix is simple: check the return code of `mktime`.

I also took this opportunity to add a few more tests, and to clean up the code a bit.

I don't expect this to be controversial, and I also want to un-block the two currently outstanding PRs. This is why I'm going to merge this PR as soon as builds turn green. If you have any comments, please leave them even after I've merged this: I can always make more PRs to fix problems you spot ;)