### PR TITLE
Fix some Clippy warnings

### DIFF
--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -268,13 +268,13 @@ pub unsafe extern "C" fn rs_unescape_url(input: *const c_char) -> *mut c_char {
         let rs_input = rs_input.to_string_lossy().into_owned();
 
         let result = utils::unescape_url(rs_input);
-        // Panic here can't happen because:
-        // 1. It would have already occured within unescape_url
-        // 2. panic can only happen if `result` contains null bytes;
-        // 3. `result` contains what `input` contained, and input is a
-        // null-terminated string from C.
-        if result.is_some() {
-            let result = CString::new(result.unwrap()).unwrap();
+        if let Some(result) = result {
+            // Panic here can't happen because:
+            // 1. It would have already occured within unescape_url
+            // 2. panic can only happen if `result` contains null bytes;
+            // 3. `result` contains what `input` contained, and input is a
+            // null-terminated string from C.
+            let result = CString::new(result).unwrap();
             return result.into_raw();
         }
         ptr::null_mut()

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -277,7 +277,7 @@ pub unsafe extern "C" fn rs_unescape_url(input: *const c_char) -> *mut c_char {
             let result = CString::new(result.unwrap()).unwrap();
             return result.into_raw();
         }
-        return ptr::null_mut();
+        ptr::null_mut()
     })
 }
 

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -514,7 +514,7 @@ pub extern "C" fn rs_program_version() -> *mut c_char {
 
 #[no_mangle]
 pub extern "C" fn rs_newsboat_version_major() -> u32 {
-    abort_on_panic(|| utils::newsboat_major_version())
+    abort_on_panic(utils::newsboat_major_version)
 }
 
 #[no_mangle]

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -169,7 +169,7 @@ impl CliArgsParser {
 
         let mut args = CliArgsParser::default();
 
-        if let Some(program_name) = opts.get(0).map(|s| s.clone()) {
+        if let Some(program_name) = opts.get(0).cloned() {
             args.program_name = program_name;
         }
 

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -169,7 +169,7 @@ impl CliArgsParser {
 
         let mut args = CliArgsParser::default();
 
-        if let Some(program_name) = opts.get(0).and_then(|s| Some(s.clone())) {
+        if let Some(program_name) = opts.get(0).map(|s| s.clone()) {
             args.program_name = program_name;
         }
 

--- a/rust/libnewsboat/src/configpaths.rs
+++ b/rust/libnewsboat/src/configpaths.rs
@@ -23,7 +23,7 @@ const QUEUE_FILENAME: &str = "queue";
 const SEARCH_HISTORY_FILENAME: &str = "history.search";
 const CMDLINE_HISTORY_FILENAME: &str = "history.cmdline";
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ConfigPaths {
     env_home: PathBuf,
     error_message: String,

--- a/rust/libnewsboat/src/configpaths.rs
+++ b/rust/libnewsboat/src/configpaths.rs
@@ -346,7 +346,7 @@ impl ConfigPaths {
             let current_extension = path
                 .extension()
                 .map(|p| p.to_string_lossy().into_owned())
-                .unwrap_or_else(|| String::new());
+                .unwrap_or_else(String::new);
             path.set_extension(current_extension + LOCK_SUFFIX);
             path
         };

--- a/rust/libnewsboat/src/configpaths.rs
+++ b/rust/libnewsboat/src/configpaths.rs
@@ -345,7 +345,7 @@ impl ConfigPaths {
         self.lock_file = {
             let current_extension = path
                 .extension()
-                .and_then(|p| Some(p.to_string_lossy().into_owned()))
+                .map(|p| p.to_string_lossy().into_owned())
                 .unwrap_or_else(|| String::new());
             path.set_extension(current_extension + LOCK_SUFFIX);
             path

--- a/rust/libnewsboat/src/configpaths.rs
+++ b/rust/libnewsboat/src/configpaths.rs
@@ -114,7 +114,7 @@ impl ConfigPaths {
                     path
                 );
             }
-            return exists;
+            exists
         }
 
         if exists(&newsboat_config_dir) {
@@ -163,7 +163,7 @@ impl ConfigPaths {
             CMDLINE_HISTORY_FILENAME,
         );
 
-        return true;
+        true
     }
 
     fn migrate_data_from_newsbeuter_simple(&self) -> bool {
@@ -217,7 +217,7 @@ impl ConfigPaths {
         let _ = migrate_file(&newsbeuter_dir, &newsboat_dir, SEARCH_HISTORY_FILENAME);
         let _ = migrate_file(&newsbeuter_dir, &newsboat_dir, CMDLINE_HISTORY_FILENAME);
 
-        return true;
+        true
     }
 
     fn migrate_data_from_newsbeuter(&mut self) -> bool {
@@ -234,7 +234,7 @@ impl ConfigPaths {
     }
 
     pub fn create_dirs(&self) -> bool {
-        return try_mkdir(&self.config_dir) && try_mkdir(&self.data_dir);
+        try_mkdir(&self.config_dir) && try_mkdir(&self.data_dir)
     }
 
     fn find_dirs(&mut self) {

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -53,6 +53,7 @@ use utils;
 /// Doe` etc. would be "values". The term "format specifiers" will be reserved to things like `%a`,
 /// and "format strings" would mean a collection of format specifiers, with optional text in
 /// between.
+#[derive(Default)]
 pub struct FmtStrFormatter {
     /// Stores keys and their values.
     fmts: BTreeMap<char, String>,

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -101,10 +101,10 @@ impl FmtStrFormatter {
     fn format_format(&self, c: char, padding: &Padding, _width: u32, result: &mut LimitedString) {
         let empty_string = String::new();
         let value = self.fmts.get(&c).unwrap_or_else(|| &empty_string);
-        match padding {
-            &Padding::None => result.push_str(value),
+        match *padding {
+            Padding::None => result.push_str(value),
 
-            &Padding::Left(total_width) => {
+            Padding::Left(total_width) => {
                 let padding_width = total_width - min(total_width, utils::graphemes_count(value));
                 let stripping_width = total_width - padding_width;
                 let padding = String::from(" ").repeat(padding_width);
@@ -112,7 +112,7 @@ impl FmtStrFormatter {
                 result.push_str(&utils::take_graphemes(value, stripping_width));
             }
 
-            &Padding::Right(total_width) => {
+            Padding::Right(total_width) => {
                 let padding_width = total_width - min(total_width, utils::graphemes_count(value));
                 let stripping_width = total_width - padding_width;
                 let padding = String::from(" ").repeat(padding_width);
@@ -135,7 +135,7 @@ impl FmtStrFormatter {
                 result.push_str(&self.formatting_helper(then, width))
             }
             _ => {
-                if let &Some(ref els) = els {
+                if let Some(ref els) = *els {
                     result.push_str(&self.formatting_helper(&els, width))
                 }
             }
@@ -150,19 +150,19 @@ impl FmtStrFormatter {
         });
 
         for (i, specifier) in format_ast.iter().enumerate() {
-            match specifier {
-                &Specifier::Spacing(c) => {
+            match *specifier {
+                Specifier::Spacing(c) => {
                     let rest = &format_ast[i + 1..];
                     self.format_spacing(c, rest, width, &mut result);
                     // format_spacing will also format the rest of the string, so quit the loop
                     break;
                 }
 
-                &Specifier::Format(c, ref padding) => {
+                Specifier::Format(c, ref padding) => {
                     self.format_format(c, &padding, width, &mut result);
                 }
 
-                &Specifier::Text(s) => {
+                Specifier::Text(s) => {
                     if width == 0 {
                         result.push_str(s);
                     } else {
@@ -176,7 +176,7 @@ impl FmtStrFormatter {
                     }
                 }
 
-                &Specifier::Conditional(cond, ref then, ref els) => {
+                Specifier::Conditional(cond, ref then, ref els) => {
                     self.format_conditional(cond, &then, &els, width, &mut result)
                 }
             }

--- a/rust/libnewsboat/src/fmtstrformatter/parser.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/parser.rs
@@ -135,7 +135,7 @@ fn parser(input: CompleteStr) -> IResult<CompleteStr, Vec<Specifier>> {
 
 fn sanitize(mut input: Vec<Specifier>) -> Vec<Specifier> {
     input.retain(|s| {
-        if let &Specifier::Format(c, ref _b) = s {
+        if let Specifier::Format(c, ref _b) = *s {
             c.is_ascii()
         } else {
             true

--- a/rust/libnewsboat/src/history.rs
+++ b/rust/libnewsboat/src/history.rs
@@ -55,7 +55,7 @@ impl History {
         Ok(())
     }
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P, limit: usize) -> io::Result<()> {
-        if limit == 0 || self.lines.len() == 0 {
+        if limit == 0 || self.lines.is_empty() {
             return Ok(());
         }
 

--- a/rust/libnewsboat/src/history.rs
+++ b/rust/libnewsboat/src/history.rs
@@ -40,7 +40,7 @@ impl History {
             len if self.idx < len => {
                 let line = self.lines[self.idx].clone();
                 self.idx += 1;
-                return line;
+                line
             }
             _ => self.lines[self.idx - 1].clone(),
         }

--- a/rust/libnewsboat/src/history.rs
+++ b/rust/libnewsboat/src/history.rs
@@ -2,6 +2,7 @@ use std::fs::OpenOptions;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 
+#[derive(Default)]
 pub struct History {
     idx: usize,
     lines: Vec<String>,

--- a/rust/libnewsboat/src/human_panic.rs
+++ b/rust/libnewsboat/src/human_panic.rs
@@ -75,14 +75,10 @@ use std::panic::{self, PanicInfo};
 ///
 /// See module description for details.
 pub fn setup() {
-    match ::std::env::var("RUST_BACKTRACE") {
-        Err(_) => {
-            panic::set_hook(Box::new(move |panic_info: &PanicInfo| {
-                print_panic_msg(panic_info)
-                    .expect("An error occurred while preparing a crash report");
-            }));
-        }
-        Ok(_) => {}
+    if ::std::env::var("RUST_BACKTRACE").is_err() {
+        panic::set_hook(Box::new(move |panic_info: &PanicInfo| {
+            print_panic_msg(panic_info).expect("An error occurred while preparing a crash report");
+        }));
     }
 }
 

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -279,6 +279,12 @@ impl Logger {
     }
 }
 
+impl Default for Logger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 static GLOBAL_LOGGER: OnceCell<Logger> = OnceCell::INIT;
 
 /// Returns a global logger instance.

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -244,7 +244,7 @@ impl Logger {
                 let _ = logfile.write_all(timestamp.as_bytes());
                 let _ = logfile.write_all(level.as_bytes());
                 let _ = logfile.write_all(data);
-                let _ = logfile.write_all("\n".as_bytes());
+                let _ = logfile.write_all(b"\n");
             }
         }
 
@@ -253,7 +253,7 @@ impl Logger {
                 // Ignoring the error since checking every log() call will be too bothersome.
                 let _ = user_error_logfile.write_all(timestamp.as_bytes());
                 let _ = user_error_logfile.write_all(data);
-                let _ = user_error_logfile.write_all("\n".as_bytes());
+                let _ = user_error_logfile.write_all(b"\n");
             }
         }
     }

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -198,7 +198,7 @@ pub fn censor_url(url: &str) -> String {
 /// assert_eq!(&quote_for_stfl("test"), "test");
 /// ```
 pub fn quote_for_stfl(string: &str) -> String {
-    return string.replace("<", "<>");
+    string.replace("<", "<>")
 }
 
 /// Get basename from a URL if available else return an empty string

--- a/rust/strprintf/src/format_specifiers_32bit.rs
+++ b/rust/strprintf/src/format_specifiers_32bit.rs
@@ -6,19 +6,19 @@
 /// `printf` format specifiers for 32-bit platforms.
 
 /// `printf`'s format conversion specifier to output an `i32` (equivalent to `PRIi32`).
-pub const PRId32: &'static str = "d";
+pub const PRId32: &str = "d";
 
 /// `printf`'s format conversion specifier to output an `i32` (equivalent to `PRId32`).
-pub const PRIi32: &'static str = "i";
+pub const PRIi32: &str = "i";
 
 /// `printf`'s format conversion specifier to output an `u32`.
-pub const PRIu32: &'static str = "u";
+pub const PRIu32: &str = "u";
 
 /// `printf`'s format conversion specifier to output an `i64` (equivalent to `PRIi64`).
-pub const PRId64: &'static str = "lld";
+pub const PRId64: &str = "lld";
 
 /// `printf`'s format conversion specifier to output an `i64` (equivalent to `PRId64`).
-pub const PRIi64: &'static str = "lli";
+pub const PRIi64: &str = "lli";
 
 /// `printf`'s format conversion specifier to output an `u64`.
-pub const PRIu64: &'static str = "llu";
+pub const PRIu64: &str = "llu";

--- a/rust/strprintf/src/format_specifiers_64bit.rs
+++ b/rust/strprintf/src/format_specifiers_64bit.rs
@@ -6,19 +6,19 @@
 /// `printf` format specifiers for 64-bit platforms.
 
 /// `printf`'s format conversion specifier to output an `i32` (equivalent to `PRIi32`).
-pub const PRId32: &'static str = "d";
+pub const PRId32: &str = "d";
 
 /// `printf`'s format conversion specifier to output an `i32` (equivalent to `PRId32`).
-pub const PRIi32: &'static str = "i";
+pub const PRIi32: &str = "i";
 
 /// `printf`'s format conversion specifier to output an `u32`.
-pub const PRIu32: &'static str = "u";
+pub const PRIu32: &str = "u";
 
 /// `printf`'s format conversion specifier to output an `i64` (equivalent to `PRIi64`).
-pub const PRId64: &'static str = "ld";
+pub const PRId64: &str = "ld";
 
 /// `printf`'s format conversion specifier to output an `i64` (equivalent to `PRId64`).
-pub const PRIi64: &'static str = "li";
+pub const PRIi64: &str = "li";
 
 /// `printf`'s format conversion specifier to output an `u64`.
-pub const PRIu64: &'static str = "lu";
+pub const PRIu64: &str = "lu";

--- a/rust/strprintf/src/specifiers_iterator.rs
+++ b/rust/strprintf/src/specifiers_iterator.rs
@@ -29,7 +29,7 @@ fn find_percent_signs(input: &str) -> Option<(usize, usize)> {
     input.find('%').and_then(|first| {
         input[first + 1..]
             .find('%')
-            .and_then(|second| Some((first, first + 1 + second)))
+            .map(|second| (first, first + 1 + second))
     })
 }
 
@@ -40,9 +40,8 @@ impl<'a> Iterator for SpecifiersIterator<'a> {
         let mut pair;
         let mut current_offset = 0usize;
         loop {
-            pair = find_percent_signs(&self.current_string[current_offset..]).and_then(
-                |(first, second)| Some((first + current_offset, second + current_offset)),
-            );
+            pair = find_percent_signs(&self.current_string[current_offset..])
+                .map(|(first, second)| (first + current_offset, second + current_offset));
             match pair {
                 Some((first, second)) if second - first == 1 => {
                     // Found an escaped percent sign; continue the search after it


### PR DESCRIPTION
I deliberately didn't add Rust's linter, Clippy, to our CI pipeline, because I don't want to enforce idiomatic Rust yet. For now, I'm happy with whatever we get by simply rewriting C++ to Rust.

However, this doesn't mean I'm not interested in idiomatic Rust. So yesterday I looked through Clippy warnings, and fixed most of them. The remaining ones are either questionable (e,g. rewriting `if` ladders with a more idiomatic but harder-to-understand `match`), or inapplicable (Clippy wants us to document all `unsafe` functions, but we don't expose that interface to anyone, so I don't see a reason to waste time documenting them).

I'll merge these changes in three days unless someone—anyone—stops me for a code review.