### PR TITLE
Fix left/right padding documentation for format specifiers

### DIFF
--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -946,10 +946,10 @@ the format of entries in the feed list or in the article list.
 Format strings are similar to those that are found in the `printf` function in
 the C programming language. A format sequence begins with the '%' character,
 followed by optional alignment indication: positive numbers indicate that the
-text that is inserted for the sequence shall be padded right to a total width
-that is specified by the number, while negative number specify left padding.
-Followed by the padding indication comes the actual sequence identifier, which
-is usually a single letter.
+text that is inserted for the sequence shall be padded on the left to a total
+width that is specified by the number, while negative number specify padding on
+the right.  Followed by the padding indication comes the actual sequence
+identifier, which is usually a single letter.
 
 In addition, newsboat provides other, more powerful sequences, such as
 `%>[char]`, which indicates that the text right to the sequence will be aligned


### PR DESCRIPTION
Relevant source locations:
- Positive values result in padding on the left: [fmtstrformatter/parser.rs](https://github.com/newsboat/newsboat/blob/master/rust/libnewsboat/src/fmtstrformatter/parser.rs#L67-L71)
- Padding being applied: [fmtstrformatter/mod.rs](https://github.com/newsboat/newsboat/blob/master/rust/libnewsboat/src/fmtstrformatter/mod.rs#L107-L121)

Related to https://github.com/newsboat/newsboat/pull/744#discussion_r376712119