### PR TITLE
Fix "no title on empty feed" issue

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -592,7 +592,7 @@ void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
 {
 	std::lock_guard<std::mutex> feedslock(feeds_mutex);
 
-	LOG(Level::DEBUG, "Controller::replace_feed: feed is nonempty, saving");
+	LOG(Level::DEBUG, "Controller::replace_feed: saving");
 	rsscache->externalize_rssfeed(
 		newfeed, ign.matches_resetunread(newfeed->rssurl()));
 	LOG(Level::DEBUG,

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -82,10 +82,9 @@ void Reloader::reload(unsigned int pos,
 		try {
 			oldfeed->set_status(DlStatus::DURING_DOWNLOAD);
 			std::shared_ptr<RssFeed> newfeed = parser.parse();
-			if (newfeed->total_item_count() > 0) {
-				ctrl->replace_feed(
-					oldfeed, newfeed, pos, unattended);
-			} else {
+			ctrl->replace_feed(
+				oldfeed, newfeed, pos, unattended);
+			if (newfeed->total_item_count() == 0) {
 				LOG(Level::DEBUG,
 					"Reloader::reload: feed is empty");
 			}

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -82,8 +82,10 @@ void Reloader::reload(unsigned int pos,
 		try {
 			oldfeed->set_status(DlStatus::DURING_DOWNLOAD);
 			std::shared_ptr<RssFeed> newfeed = parser.parse();
-			ctrl->replace_feed(
-				oldfeed, newfeed, pos, unattended);
+			if (!newfeed->is_query_feed()) {
+				ctrl->replace_feed(
+					oldfeed, newfeed, pos, unattended);
+			}
 			if (newfeed->total_item_count() == 0) {
 				LOG(Level::DEBUG,
 					"Reloader::reload: feed is empty");


### PR DESCRIPTION
Fixes #732.

The issue was caused by not updating (replacing) the feed if the number of articles was 0.

Query feeds are explicitly not updated because that would result in unread/total counts to reset to 0 in the feed overview (on `OP_RELOAD`->`Reloader::reload()`).
A different solution to that might be to make the reload function call `View::prepare_query_feed()` [1] for single feeds (make it similar to `Reloader::reload_all` [2]).

[1] https://github.com/newsboat/newsboat/blob/1574cf6c2f615339c4be3030b81a99173daa3e7e/src/view.cpp#L999-L1012

[2] https://github.com/newsboat/newsboat/blob/1574cf6c2f615339c4be3030b81a99173daa3e7e/src/reloader.cpp#L176-L181