### PR TITLE
Do not remove feed titles if update brought no new items

### DIFF
--- a/include/rssparser.h
+++ b/include/rssparser.h
@@ -80,7 +80,6 @@ private:
 	Cache* ch;
 	ConfigContainer* cfgcont;
 	bool skip_parsing;
-	bool is_valid;
 	RssIgnores* ign;
 	rsspp::Feed f;
 	RemoteApi* api;

--- a/include/rssparser.h
+++ b/include/rssparser.h
@@ -79,7 +79,6 @@ private:
 	std::string my_uri;
 	Cache* ch;
 	ConfigContainer* cfgcont;
-	bool skip_parsing;
 	RssIgnores* ign;
 	rsspp::Feed f;
 	RemoteApi* api;

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -77,7 +77,7 @@ void Reloader::reload(unsigned int pos,
 					utils::censor_url(oldfeed->rssurl())));
 		}
 
-		bool ignore_dl =
+		const bool ignore_dl =
 			(cfg->get_configvalue("ignore-mode") == "download");
 
 		RssParser parser(oldfeed->rssurl(),
@@ -90,11 +90,13 @@ void Reloader::reload(unsigned int pos,
 		try {
 			oldfeed->set_status(DlStatus::DURING_DOWNLOAD);
 			std::shared_ptr<RssFeed> newfeed = parser.parse();
-			ctrl->replace_feed(
-				oldfeed, newfeed, pos, unattended);
-			if (newfeed->total_item_count() == 0) {
-				LOG(Level::DEBUG,
-					"Reloader::reload: feed is empty");
+			if (newfeed != nullptr) {
+				ctrl->replace_feed(
+					oldfeed, newfeed, pos, unattended);
+				if (newfeed->total_item_count() == 0) {
+					LOG(Level::DEBUG,
+						"Reloader::reload: feed is empty");
+				}
 			}
 			oldfeed->set_status(DlStatus::SUCCESS);
 			ctrl->get_view()->set_status("");
@@ -114,7 +116,7 @@ void Reloader::reload(unsigned int pos,
 					utils::censor_url(oldfeed->rssurl()),
 					e.what());
 		}
-		if (errmsg != "") {
+		if (!errmsg.empty()) {
 			oldfeed->set_status(DlStatus::DL_ERROR);
 			ctrl->get_view()->set_status(errmsg);
 			LOG(Level::USERERROR, "%s", errmsg);

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -317,7 +317,7 @@ void RssParser::fill_feed_fields(std::shared_ptr<RssFeed> feed)
 
 	feed->set_link(utils::absolute_url(my_uri, f.link));
 
-	if (f.pubDate != "") {
+	if (!f.pubDate.empty()) {
 		feed->set_pubDate(parse_date(f.pubDate));
 	} else {
 		feed->set_pubDate(::time(nullptr));
@@ -343,7 +343,7 @@ void RssParser::fill_feed_items(std::shared_ptr<RssFeed> feed)
 
 		set_item_title(feed, x, item);
 
-		if (item.link != "") {
+		if (!item.link.empty()) {
 			x->set_link(
 				utils::absolute_url(feed->link(), item.link));
 		}
@@ -411,7 +411,7 @@ void RssParser::fill_feed_items(std::shared_ptr<RssFeed> feed)
 
 		set_item_content(x, item);
 
-		if (item.pubDate != "") {
+		if (!item.pubDate.empty()) {
 			x->set_pubDate(parse_date(item.pubDate));
 		} else {
 			x->set_pubDate(::time(nullptr));
@@ -466,8 +466,8 @@ void RssParser::set_item_author(std::shared_ptr<RssItem> x,
 	 * some feeds only have a feed-wide managingEditor, which we use as an
 	 * item's author if there is no item-specific one available.
 	 */
-	if (item.author == "") {
-		if (f.managingeditor != "") {
+	if (item.author.empty()) {
+		if (!f.managingeditor.empty()) {
 			x->set_author(f.managingeditor);
 		} else {
 			x->set_author(f.dc_creator);
@@ -484,21 +484,21 @@ void RssParser::set_item_content(std::shared_ptr<RssItem> x,
 
 	handle_itunes_summary(x, item);
 
-	if (x->description() == "") {
+	if (x->description().empty()) {
 		x->set_description(item.description);
 	} else {
 		if (cfgcont->get_configvalue_as_bool(
 				"always-display-description") &&
-			item.description != "")
+			!item.description.empty())
 			x->set_description(
 				x->description() + "<hr>" + item.description);
 	}
 
 	/* if it's still empty and we shall download the full page, then we do
 	 * so. */
-	if (x->description() == "" &&
+	if (x->description().empty() &&
 		cfgcont->get_configvalue_as_bool("download-full-page") &&
-		x->link() != "") {
+		!x->link().empty()) {
 		x->set_description(utils::retrieve_url(x->link(), cfgcont));
 	}
 
@@ -516,13 +516,13 @@ std::string RssParser::get_guid(const rsspp::Item& item) const
 	 * is suboptimal, of course, because it makes it impossible to recognize
 	 * duplicates when the title or the link changes.
 	 */
-	if (item.guid != "") {
+	if (!item.guid.empty()) {
 		return item.guid;
-	} else if (item.link != "" && item.pubDate != "") {
+	} else if (!item.link.empty() && !item.pubDate.empty()) {
 		return item.link + item.pubDate;
-	} else if (item.link != "") {
+	} else if (!item.link.empty()) {
 		return item.link;
-	} else if (item.title != "") {
+	} else if (!item.title.empty()) {
 		return item.title;
 	} else {
 		return "";        // too bad.
@@ -569,13 +569,13 @@ void RssParser::add_item_to_feed(std::shared_ptr<RssFeed> feed,
 void RssParser::handle_content_encoded(std::shared_ptr<RssItem> x,
 	const rsspp::Item& item) const
 {
-	if (x->description() != "") {
+	if (!x->description().empty()) {
 		return;
 	}
 
 	/* here we handle content:encoded tags that are an extension but very
 	 * widespread */
-	if (item.content_encoded != "") {
+	if (!item.content_encoded.empty()) {
 		x->set_description(item.content_encoded);
 	} else {
 		LOG(Level::DEBUG,
@@ -586,12 +586,12 @@ void RssParser::handle_content_encoded(std::shared_ptr<RssItem> x,
 void RssParser::handle_itunes_summary(std::shared_ptr<RssItem> x,
 	const rsspp::Item& item)
 {
-	if (x->description() != "") {
+	if (!x->description().empty()) {
 		return;
 	}
 
 	std::string summary = item.itunes_summary;
-	if (summary != "") {
+	if (!summary.empty()) {
 		std::string desc = "<ituneshack>";
 		desc.append(summary);
 		desc.append("</ituneshack>");

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -47,28 +47,29 @@ RssParser::~RssParser() {}
 
 std::shared_ptr<RssFeed> RssParser::parse()
 {
-	std::shared_ptr<RssFeed> feed(new RssFeed(ch));
-
-	feed->set_rssurl(my_uri);
-
 	retrieve_uri(my_uri);
 
-	if (f.rss_version != rsspp::Feed::Version::UNKNOWN) {
-		/*
-		 * After parsing is done, we fill our feed object with title,
-		 * description, etc.  It's important to note that all data that
-		 * comes from rsspp must be converted to UTF-8 before, because
-		 * all data is internally stored as UTF-8, and converted
-		 * on-the-fly in case some other encoding is required. This is
-		 * because UTF-8 can hold all available Unicode characters,
-		 * unlike other non-Unicode encodings.
-		 */
-
-		fill_feed_fields(feed);
-		fill_feed_items(feed);
-
-		ch->remove_old_deleted_items(feed.get());
+	if (f.rss_version == rsspp::Feed::Version::UNKNOWN) {
+		return nullptr;
 	}
+
+	std::shared_ptr<RssFeed> feed(new RssFeed(ch));
+	feed->set_rssurl(my_uri);
+
+	/*
+	 * After parsing is done, we fill our feed object with title,
+	 * description, etc.  It's important to note that all data that
+	 * comes from rsspp must be converted to UTF-8 before, because
+	 * all data is internally stored as UTF-8, and converted
+	 * on-the-fly in case some other encoding is required. This is
+	 * because UTF-8 can hold all available Unicode characters,
+	 * unlike other non-Unicode encodings.
+	 */
+
+	fill_feed_fields(feed);
+	fill_feed_items(feed);
+
+	ch->remove_old_deleted_items(feed.get());
 
 	feed->set_empty(false);
 

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -34,7 +34,6 @@ RssParser::RssParser(const std::string& uri,
 	: my_uri(uri)
 	, ch(c)
 	, cfgcont(cfg)
-	, skip_parsing(false)
 	, ign(ii)
 	, api(a)
 	, easyhandle(0)
@@ -54,7 +53,7 @@ std::shared_ptr<RssFeed> RssParser::parse()
 
 	retrieve_uri(my_uri);
 
-	if (!skip_parsing && f.rss_version != rsspp::Feed::Version::UNKNOWN) {
+	if (f.rss_version != rsspp::Feed::Version::UNKNOWN) {
 		/*
 		 * After parsing is done, we fill our feed object with title,
 		 * description, etc.  It's important to note that all data that
@@ -171,7 +170,7 @@ void RssParser::retrieve_uri(const std::string& uri)
 		utils::extract_filter(uri, filter, url);
 		download_filterplugin(filter, url);
 	} else if (utils::is_query_url(my_uri)) {
-		skip_parsing = true;
+		f.rss_version = rsspp::Feed::Version::UNKNOWN;
 	} else if (my_uri.substr(0, 7) == "file://") {
 		parse_file(my_uri.substr(7, my_uri.length() - 7));
 	} else {

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -35,7 +35,6 @@ RssParser::RssParser(const std::string& uri,
 	, ch(c)
 	, cfgcont(cfg)
 	, skip_parsing(false)
-	, is_valid(false)
 	, ign(ii)
 	, api(a)
 	, easyhandle(0)
@@ -55,7 +54,7 @@ std::shared_ptr<RssFeed> RssParser::parse()
 
 	retrieve_uri(my_uri);
 
-	if (!skip_parsing && is_valid) {
+	if (!skip_parsing && f.rss_version != rsspp::Feed::Version::UNKNOWN) {
 		/*
 		 * After parsing is done, we fill our feed object with title,
 		 * description, etc.  It's important to note that all data that
@@ -187,7 +186,6 @@ void RssParser::download_http(const std::string& uri)
 	std::string proxy;
 	std::string proxy_auth;
 	std::string proxy_type;
-	is_valid = false;
 
 	if (cfgcont->get_configvalue_as_bool("use-proxy") == true) {
 		proxy = cfgcont->get_configvalue("proxy");
@@ -195,109 +193,90 @@ void RssParser::download_http(const std::string& uri)
 		proxy_type = cfgcont->get_configvalue("proxy-type");
 	}
 
-	for (unsigned int i = 0; i < retrycount && !is_valid; i++) {
-		try {
-			std::string useragent = utils::get_useragent(cfgcont);
+	for (unsigned int i = 0; i < retrycount
+		&& f.rss_version == rsspp::Feed::Version::UNKNOWN; i++) {
+		std::string useragent = utils::get_useragent(cfgcont);
+		LOG(Level::DEBUG,
+			"RssParser::download_http: user-agent = %s",
+			useragent);
+		rsspp::Parser p(cfgcont->get_configvalue_as_int(
+				"download-timeout"),
+			useragent.c_str(),
+			proxy.c_str(),
+			proxy_auth.c_str(),
+			utils::get_proxy_type(proxy_type),
+			cfgcont->get_configvalue_as_bool(
+				"ssl-verifypeer"));
+		time_t lm = 0;
+		std::string etag;
+		if (!ign || !ign->matches_lastmodified(uri)) {
+			ch->fetch_lastmodified(uri, lm, etag);
+		}
+		f = p.parse_url(uri,
+				lm,
+				etag,
+				api,
+				cfgcont->get_configvalue("cookie-cache"),
+				easyhandle ? easyhandle->ptr() : 0);
+		LOG(Level::DEBUG,
+			"RssParser::download_http: lm = %" PRId64 " etag = %s",
+			// On GCC, `time_t` is `long int`, which is at least 32 bits
+			// long according to the spec. On x86_64, it's actually 64
+			// bits. Thus, casting to int64_t is either a no-op, or an
+			// up-cast which are always safe.
+			static_cast<int64_t>(p.get_last_modified()),
+			p.get_etag());
+		if (p.get_last_modified() != 0 ||
+			p.get_etag().length() > 0) {
 			LOG(Level::DEBUG,
-				"RssParser::download_http: user-agent = %s",
-				useragent);
-			rsspp::Parser p(cfgcont->get_configvalue_as_int(
-					"download-timeout"),
-				useragent.c_str(),
-				proxy.c_str(),
-				proxy_auth.c_str(),
-				utils::get_proxy_type(proxy_type),
-				cfgcont->get_configvalue_as_bool(
-					"ssl-verifypeer"));
-			time_t lm = 0;
-			std::string etag;
-			if (!ign || !ign->matches_lastmodified(uri)) {
-				ch->fetch_lastmodified(uri, lm, etag);
-			}
-			f = p.parse_url(uri,
-					lm,
-					etag,
-					api,
-					cfgcont->get_configvalue("cookie-cache"),
-					easyhandle ? easyhandle->ptr() : 0);
+				"RssParser::download_http: "
+				"lastmodified "
+				"old: %" PRId64 " new: %" PRId64,
+				// On GCC, `time_t` is `long int`, which is at least 32
+				// bits long according to the spec. On x86_64, it's
+				// actually 64 bits. Thus, casting to int64_t is either
+				// a no-op, or an up-cast which are always safe.
+				static_cast<int64_t>(lm),
+				static_cast<int64_t>(p.get_last_modified()));
 			LOG(Level::DEBUG,
-				"RssParser::download_http: lm = %" PRId64 " etag = %s",
-				// On GCC, `time_t` is `long int`, which is at least 32 bits
-				// long according to the spec. On x86_64, it's actually 64
-				// bits. Thus, casting to int64_t is either a no-op, or an
-				// up-cast which are always safe.
-				static_cast<int64_t>(p.get_last_modified()),
+				"RssParser::download_http: etag old: "
+				"%s "
+				"new %s",
+				etag,
 				p.get_etag());
-			if (p.get_last_modified() != 0 ||
-				p.get_etag().length() > 0) {
-				LOG(Level::DEBUG,
-					"RssParser::download_http: "
-					"lastmodified "
-					"old: %" PRId64 " new: %" PRId64,
-					// On GCC, `time_t` is `long int`, which is at least 32
-					// bits long according to the spec. On x86_64, it's
-					// actually 64 bits. Thus, casting to int64_t is either
-					// a no-op, or an up-cast which are always safe.
-					static_cast<int64_t>(lm),
-					static_cast<int64_t>(p.get_last_modified()));
-				LOG(Level::DEBUG,
-					"RssParser::download_http: etag old: "
-					"%s "
-					"new %s",
-					etag,
-					p.get_etag());
-				ch->update_lastmodified(uri,
-					(p.get_last_modified() != lm)
-					? p.get_last_modified()
-					: 0,
-					(etag != p.get_etag()) ? p.get_etag()
-					: "");
-			}
-			is_valid = true;
-		} catch (rsspp::Exception& e) {
-			is_valid = false;
-			throw;
+			ch->update_lastmodified(uri,
+				(p.get_last_modified() != lm)
+				? p.get_last_modified()
+				: 0,
+				(etag != p.get_etag()) ? p.get_etag()
+				: "");
 		}
 	}
 	LOG(Level::DEBUG,
-		"RssParser::parse: http URL %s, is_valid = %s",
+		"RssParser::parse: http URL %s, valid: %s",
 		uri,
-		is_valid ? "true" : "false");
+		(f.rss_version != rsspp::Feed::Version::UNKNOWN) ? "true" : "false");
 }
 
 void RssParser::get_execplugin(const std::string& plugin)
 {
 	std::string buf = utils::get_command_output(plugin);
-	is_valid = false;
-	try {
-		rsspp::Parser p;
-		f = p.parse_buffer(buf);
-		is_valid = true;
-	} catch (rsspp::Exception& e) {
-		is_valid = false;
-		throw;
-	}
+	rsspp::Parser p;
+	f = p.parse_buffer(buf);
 	LOG(Level::DEBUG,
-		"RssParser::parse: execplugin %s, is_valid = %s",
+		"RssParser::parse: execplugin %s, valid = %s",
 		plugin,
-		is_valid ? "true" : "false");
+		(f.rss_version != rsspp::Feed::Version::UNKNOWN) ? "true" : "false");
 }
 
 void RssParser::parse_file(const std::string& file)
 {
-	is_valid = false;
-	try {
-		rsspp::Parser p;
-		f = p.parse_file(file);
-		is_valid = true;
-	} catch (rsspp::Exception& e) {
-		is_valid = false;
-		throw;
-	}
+	rsspp::Parser p;
+	f = p.parse_file(file);
 	LOG(Level::DEBUG,
-		"RssParser::parse: parsed file %s, is_valid = %s",
+		"RssParser::parse: parsed file %s, valid = %s",
 		file,
-		is_valid ? "true" : "false");
+		(f.rss_version != rsspp::Feed::Version::UNKNOWN) ? "true" : "false");
 }
 
 void RssParser::download_filterplugin(const std::string& filter,
@@ -315,19 +294,12 @@ void RssParser::download_filterplugin(const std::string& filter,
 		"RssParser::parse: output of `%s' is: %s",
 		filter,
 		result);
-	is_valid = false;
-	try {
-		rsspp::Parser p;
-		f = p.parse_buffer(result);
-		is_valid = true;
-	} catch (rsspp::Exception& e) {
-		is_valid = false;
-		throw;
-	}
+	rsspp::Parser p;
+	f = p.parse_buffer(result);
 	LOG(Level::DEBUG,
-		"RssParser::parse: filterplugin %s, is_valid = %s",
+		"RssParser::parse: filterplugin %s, valid = %s",
 		filter,
-		is_valid ? "true" : "false");
+		(f.rss_version != rsspp::Feed::Version::UNKNOWN) ? "true" : "false");
 }
 
 void RssParser::fill_feed_fields(std::shared_ptr<RssFeed> feed)
@@ -640,7 +612,6 @@ void RssParser::fetch_ttrss(const std::string& feed_id)
 	if (tapi) {
 		f = tapi->fetch_feed(
 				feed_id, easyhandle ? easyhandle->ptr() : nullptr);
-		is_valid = true;
 	}
 	LOG(Level::DEBUG,
 		"RssParser::fetch_ttrss: f.items.size = %" PRIu64,
@@ -652,7 +623,6 @@ void RssParser::fetch_newsblur(const std::string& feed_id)
 	NewsBlurApi* napi = dynamic_cast<NewsBlurApi*>(api);
 	if (napi) {
 		f = napi->fetch_feed(feed_id);
-		is_valid = true;
 	}
 	LOG(Level::INFO,
 		"RssParser::fetch_newsblur: f.items.size = %" PRIu64,
@@ -664,7 +634,6 @@ void RssParser::fetch_ocnews(const std::string& feed_id)
 	OcNewsApi* napi = dynamic_cast<OcNewsApi*>(api);
 	if (napi) {
 		f = napi->fetch_feed(feed_id);
-		is_valid = true;
 	}
 	LOG(Level::INFO,
 		"RssParser::fetch_ocnews: f.items.size = %" PRIu64,


### PR DESCRIPTION
Fixes #748.

The fix relies on the fact that `rsspp::Feed` stays default-initialized unless something is fetched. Remote APIs (TT-RSS, NewsBlur etc.) store feed titles as part of subscription list, so they always update `rsspp::Feed`, even if the feed doesn't have any items.

If you were affected by #748 and lost some titles, you can forcibly re-fetch them:
1. in the command line, run `sqlite3 ~/.newsboat/cache.db 'UPDATE rss_feed SET lastmodified = 0, etag = ""'` (cache.db might be in ~/.local/share/newsboat/cache.db, or somewhere else if you overrode the location). All your existing items will be kept; this command only makes Newsboat *pretend* like it never fetched feeds, so HTTP servers send the whole feeds again—complete with the titles;
2. start Newsboat and reload all your feeds with `R` (or whatever key you bound [`reload-all`](https://newsboat.org/releases/2.18/docs/newsboat.html#reload-all) to).

This might bring some old items too, if servers decide to provide them. That's okay.