### PR TITLE
Resolve conflict between Python 2 and 3 on macOS Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
 
 newsboat_brew_commands: &osx_deps
   - brew update
+  - brew unlink python@2 # to prevent conflict with Python 3, see https://travis-ci.org/newsboat/newsboat/jobs/649475862#L1510
   - brew install gcc || brew link --overwrite gcc
   - brew outdated "pkg-config" || brew upgrade "pkg-config"
   - brew install "gettext" && brew link --force "gettext"


### PR DESCRIPTION
This fixes build failures uncovered by a recent PR: https://travis-ci.org/newsboat/newsboat/builds/649481789