### PR TITLE
Remove Coverity badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Newsboat [![Travis CI Build Status](https://travis-ci.org/newsboat/newsboat.svg?branch=master)](https://travis-ci.org/newsboat/newsboat) [![Cirrus CI Build Status](https://api.cirrus-ci.com/github/newsboat/newsboat.svg)](https://cirrus-ci.com/github/newsboat/newsboat) [![Coverage Status](https://coveralls.io/repos/github/newsboat/newsboat/badge.svg?branch=master)](https://coveralls.io/github/newsboat/newsboat?branch=master) [![Coverity Scan Build Status](https://scan.coverity.com/projects/15567/badge.svg)](https://scan.coverity.com/projects/newsboat-newsboat)
+Newsboat [![Travis CI Build Status](https://travis-ci.org/newsboat/newsboat.svg?branch=master)](https://travis-ci.org/newsboat/newsboat) [![Cirrus CI Build Status](https://api.cirrus-ci.com/github/newsboat/newsboat.svg)](https://cirrus-ci.com/github/newsboat/newsboat) [![Coverage Status](https://coveralls.io/repos/github/newsboat/newsboat/badge.svg?branch=master)](https://coveralls.io/github/newsboat/newsboat?branch=master)
 ========
 
 <a href="https://newsboat.org">


### PR DESCRIPTION
Submitting builds there was always troublesome, so I never did it
regularly. The analyzer is falling behind the times, and now requires
booting Linux with a special parameter.

It did found a number of bugs in our code, but the pain of maintaining
it is not worth it for me.