### PR TITLE
Update download status for query feed

### DIFF
--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -185,7 +185,10 @@ void Reloader::reload_all(bool unattended)
 	// refresh query feeds (update and sort)
 	LOG(Level::DEBUG, "Reloader::reload_all: refresh query feeds");
 	for (const auto& feed : ctrl->get_feedcontainer()->feeds) {
-		ctrl->get_view()->prepare_query_feed(feed);
+		if (feed->is_query_feed()) {
+			ctrl->get_view()->prepare_query_feed(feed);
+			feed->set_status(DlStatus::SUCCESS);
+		}
 	}
 	ctrl->get_view()->force_redraw();
 


### PR DESCRIPTION
Fixes small regression introduced by commit [1] which caused
`oldfeed->set_status(DlStatus::SUCCESS);` to no longer get called.
This results in a `_` being shown for query feeds (`DlStatus::TO_BE_DOWNLOADED`), even after relaoding finished.

Effect can be seen by adding the following line (with `%S` [2]) to the config file:
`feedlist-format "%S %4i %n %11u %t"`
and a queryfeed to the urls file, e.g.:
`"query:Unread Articles:unread = \"yes\""`

[1] https://github.com/newsboat/newsboat/pull/746/commits/46547a749b1a05bfcc1a5e1d93bc93c01e7319d3
[2] https://newsboat.org/releases/2.18/docs/newsboat.html#feedlist-format-S