### PR TITLE
Const-qualify argv in utils::run_program

### DIFF
--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -76,7 +76,7 @@ char* rs_get_basename(const char* str);
 
 void rs_run_command(const char* command, const char* param);
 
-char* rs_run_program(char* argv[], const char* input);
+char* rs_run_program(const char* argv[], const char* input);
 
 char* rs_program_version();
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -46,7 +46,7 @@ std::string retrieve_url(const std::string& url,
 	CURL* easyhandle = nullptr);
 void run_command(const std::string& cmd,
 	const std::string& param); // used for notifications only
-std::string run_program(char* argv[], const std::string& input);
+std::string run_program(const char* argv[], const std::string& input);
 
 std::string resolve_tilde(const std::string&);
 std::string resolve_relative(const std::string&, const std::string&);

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -463,7 +463,7 @@ pub unsafe extern "C" fn rs_run_command(command: *const c_char, param: *const c_
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_run_program(
-    argv: *mut *mut c_char,
+    argv: *const *mut c_char,
     input: *const c_char,
 ) -> *mut c_char {
     abort_on_panic(|| {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -544,10 +544,10 @@ std::string FormAction::bookmark(const std::string& url,
 			v->pop_current_formaction();
 			return "";
 		} else {
-			char* my_argv[4];
-			my_argv[0] = const_cast<char*>("/bin/sh");
-			my_argv[1] = const_cast<char*>("-c");
-			my_argv[2] = const_cast<char*>(cmdline.c_str());
+			const char* my_argv[4];
+			my_argv[0] = "/bin/sh";
+			my_argv[1] = "-c";
+			my_argv[2] = cmdline.c_str();
 			my_argv[3] = nullptr;
 			return utils::run_program(my_argv, "");
 		}

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -93,10 +93,10 @@ void render_html(
 		HtmlRenderer rnd(raw);
 		rnd.render(source, lines, thelinks, url);
 	} else {
-		char* argv[4];
-		argv[0] = const_cast<char*>("/bin/sh");
-		argv[1] = const_cast<char*>("-c");
-		argv[2] = const_cast<char*>(renderer.c_str());
+		const char* argv[4];
+		argv[0] = "/bin/sh";
+		argv[1] = "-c";
+		argv[2] = renderer.c_str();
 		argv[3] = nullptr;
 		LOG(Level::DEBUG,
 			"item_renderer::render_html: source = %s",

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -284,9 +284,9 @@ void RssParser::download_filterplugin(const std::string& filter,
 {
 	std::string buf = utils::retrieve_url(uri, cfgcont);
 
-	char* argv[4] = {const_cast<char*>("/bin/sh"),
-			const_cast<char*>("-c"),
-			const_cast<char*>(filter.c_str()),
+	const char* argv[4] = {"/bin/sh",
+			"-c",
+			filter.c_str(),
 			nullptr
 		};
 	std::string result = utils::run_program(argv, buf);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -502,7 +502,7 @@ void utils::run_command(const std::string& cmd, const std::string& input)
 	rs_run_command(cmd.c_str(), input.c_str());
 }
 
-std::string utils::run_program(char* argv[], const std::string& input)
+std::string utils::run_program(const char* argv[], const std::string& input)
 {
 	return RustString(rs_run_program(argv, input.c_str()));
 }

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -377,20 +377,16 @@ TEST_CASE("extract_filter()", "[utils]")
 
 TEST_CASE("run_program()", "[utils]")
 {
-	char* argv[4];
-	char cat[] = "cat";
-	argv[0] = cat;
+	const char* argv[4];
+	argv[0] = "cat";
 	argv[1] = nullptr;
 	REQUIRE(utils::run_program(
 			argv, "this is a multine-line\ntest string") ==
 		"this is a multine-line\ntest string");
 
-	char echo[] = "echo";
-	char dashn[] = "-n";
-	char helloworld[] = "hello world";
-	argv[0] = echo;
-	argv[1] = dashn;
-	argv[2] = helloworld;
+	argv[0] = "echo";
+	argv[1] = "-n";
+	argv[2] = "hello world";
 	argv[3] = nullptr;
 	REQUIRE(utils::run_program(argv, "") == "hello world");
 }


### PR DESCRIPTION
The previous implementation used execvp(3), which requires `char* const
argv[]` (constant pointer to modifiable strings). The new implementation
uses std::process::Command, and requires `&[&str]` (constant slice of of
constant strings). Since I'm so bent on const correctness, I decided to
update the signature in C++.

I'll merge this in three days unless someone stops me for a review.