### PR TITLE
Allow configuring color/attributes for EOT tildes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 ### Changed
 - `podlist-format` which now uses `%K` instead of `%k` by default (shows human
   readable speed instead of always using KB/s)
+- The EOT markers ("~" characters below blocks of text) no longer inherit their
+  style (colors + attributes) from the "article" style. Instead, they can be
+  configured separately allowing to hide them without hiding the article text
+  (example config line: `color styleend default default invis`)
 
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - The EOT markers ("~" characters below blocks of text) no longer inherit their
   style (colors + attributes) from the "article" style. Instead, they can be
   configured separately allowing to hide them without hiding the article text
-  (example config line: `color styleend default default invis`)
+  (example config line: `color eot-tildes default default invis`)
 
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - The EOT markers ("~" characters below blocks of text) no longer inherit their
   style (colors + attributes) from the "article" style. Instead, they can be
   configured separately allowing to hide them without hiding the article text
-  (example config line: `color eot-tildes default default invis`)
+  (example config line: `color end-of-text-marker default default invis`)
 
 ### Deprecated
 ### Removed

--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -190,7 +190,7 @@ Currently, the following elements are supported:
 - `info`: the info bars on top and bottom
 - `background`: the application background
 - `article`: the article text
-- `styleend`: the EOT markers ("~" characters below blocks of text)
+- `eot-tildes`: the EOT markers ("~" characters below blocks of text)
 
 The default color configuration of newsboat looks like this:
 

--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -190,6 +190,7 @@ Currently, the following elements are supported:
 - `info`: the info bars on top and bottom
 - `background`: the application background
 - `article`: the article text
+- `styleend`: the EOT markers ("~" characters below blocks of text)
 
 The default color configuration of newsboat looks like this:
 

--- a/doc/newsboat.txt
+++ b/doc/newsboat.txt
@@ -190,7 +190,7 @@ Currently, the following elements are supported:
 - `info`: the info bars on top and bottom
 - `background`: the application background
 - `article`: the article text
-- `eot-tildes`: the EOT markers ("~" characters below blocks of text)
+- `end-of-text-marker`: filler lines (~) below blocks of text
 
 The default color configuration of newsboat looks like this:
 

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -72,7 +72,7 @@ void ColorManager::handle_action(const std::string& action,
 		if (element == "listnormal" || element == "listfocus" ||
 			element == "listnormal_unread" ||
 			element == "listfocus_unread" || element == "info" ||
-			element == "background" || element == "article" || element == "styleend") {
+			element == "background" || element == "article" || element == "eot-tildes") {
 			fg_colors[element] = fgcolor;
 			bg_colors[element] = bgcolor;
 			attributes[element] = attribs;

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -72,7 +72,8 @@ void ColorManager::handle_action(const std::string& action,
 		if (element == "listnormal" || element == "listfocus" ||
 			element == "listnormal_unread" ||
 			element == "listfocus_unread" || element == "info" ||
-			element == "background" || element == "article" || element == "eot-tildes") {
+			element == "background" || element == "article" ||
+			element == "end-of-text-marker") {
 			fg_colors[element] = fgcolor;
 			bg_colors[element] = bgcolor;
 			attributes[element] = attribs;

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -72,7 +72,7 @@ void ColorManager::handle_action(const std::string& action,
 		if (element == "listnormal" || element == "listfocus" ||
 			element == "listnormal_unread" ||
 			element == "listfocus_unread" || element == "info" ||
-			element == "background" || element == "article") {
+			element == "background" || element == "article" || element == "styleend") {
 			fg_colors[element] = fgcolor;
 			bg_colors[element] = bgcolor;
 			attributes[element] = attribs;

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -140,21 +140,6 @@ void ColorManager::set_pb_colors(podboat::PbView* v)
 
 		v->dllist_form.set(fgcit->first, colorattr);
 		v->help_form.set(fgcit->first, colorattr);
-
-		if (fgcit->first == "article") {
-			std::string styleend_str;
-
-			if (bgcit->second != "default") {
-				styleend_str.append("bg=");
-				styleend_str.append(bgcit->second);
-			}
-			if (styleend_str.length() > 0) {
-				styleend_str.append(",");
-			}
-			styleend_str.append("attr=bold");
-
-			v->help_form.set("styleend", styleend_str.c_str());
-		}
 	}
 }
 

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -556,7 +556,7 @@ void ItemViewFormAction::set_regexmanager(RegexManager* r)
 		"@style_u_normal[color_underline]:attr=underline ");
 	std::string textview = strprintf::fmt(
 			"{textview[article] style_normal[article]: "
-			"style_end[eot-tildes]:fg=blue,attr=bold %s .expand:vh "
+			"style_end[end-of-text-marker]:fg=blue,attr=bold %s .expand:vh "
 			"offset[articleoffset]:0 richtext:1}",
 			attrstr);
 	f->modify("article", "replace", textview);

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -556,7 +556,7 @@ void ItemViewFormAction::set_regexmanager(RegexManager* r)
 		"@style_u_normal[color_underline]:attr=underline ");
 	std::string textview = strprintf::fmt(
 			"{textview[article] style_normal[article]: "
-			"style_end[styleend]:fg=blue,attr=bold %s .expand:vh "
+			"style_end[eot-tildes]:fg=blue,attr=bold %s .expand:vh "
 			"offset[articleoffset]:0 richtext:1}",
 			attrstr);
 	f->modify("article", "replace", textview);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1165,23 +1165,6 @@ void View::apply_colors(std::shared_ptr<FormAction> fa)
 			colorattr);
 
 		fa->get_form()->set(fgcit->first, colorattr);
-
-		if (fgcit->first == "article") {
-			if (fa->id() == "article" || fa->id() == "help") {
-				std::string styleend_str;
-				if (bgcit->second != "default") {
-					styleend_str.append("bg=");
-					styleend_str.append(bgcit->second);
-				}
-				if (styleend_str.length() > 0) {
-					styleend_str.append(",");
-				}
-				styleend_str.append("attr=bold");
-
-				fa->get_form()->set(
-					"styleend", styleend_str.c_str());
-			}
-		}
 	}
 }
 

--- a/stfl/help.stfl
+++ b/stfl/help.stfl
@@ -15,7 +15,7 @@ vbox
     richtext:1
     style_hl_normal[highlight]:
     style_normal[article]:
-    style_end[styleend]:fg=blue,attr=bold
+    style_end[eot-tildes]:fg=blue,attr=bold
     .expand:vh
     offset[helpoffset]:0
   vbox[hints]

--- a/stfl/help.stfl
+++ b/stfl/help.stfl
@@ -15,7 +15,7 @@ vbox
     richtext:1
     style_hl_normal[highlight]:
     style_normal[article]:
-    style_end[eot-tildes]:fg=blue,attr=bold
+    style_end[end-of-text-marker]:fg=blue,attr=bold
     .expand:vh
     offset[helpoffset]:0
   vbox[hints]

--- a/stfl/itemview.stfl
+++ b/stfl/itemview.stfl
@@ -13,7 +13,7 @@ vbox
     .display[showtitle]:1
   textview[article]
     style_normal[article]:
-    style_end[eot-tildes]:fg=blue,attr=bold
+    style_end[end-of-text-marker]:fg=blue,attr=bold
     .expand:vh
     offset[articleoffset]:0
     richtext:1

--- a/stfl/itemview.stfl
+++ b/stfl/itemview.stfl
@@ -13,7 +13,7 @@ vbox
     .display[showtitle]:1
   textview[article]
     style_normal[article]:
-    style_end[styleend]:fg=blue,attr=bold
+    style_end[eot-tildes]:fg=blue,attr=bold
     .expand:vh
     offset[articleoffset]:0
     richtext:1


### PR DESCRIPTION
Fixes #507. 

Let me know if you think of a better name to replace `styleend` (taken from stfl files: [item](https://github.com/newsboat/newsboat/blob/f0a4b9dbe0b0b0a58086938d6cb7469c9e6e703e/stfl/itemview.stfl#L16) and [help](https://github.com/newsboat/newsboat/blob/f0a4b9dbe0b0b0a58086938d6cb7469c9e6e703e/stfl/help.stfl#L18)).
I will see if I can think of a better name after sleeping.