### PR TITLE
Make Cargo aware of how many jobs Make can run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ all: doc $(NEWSBOAT) $(PODBOAT) mo-files
 NB_DEPS=xlicense.h $(LIB_OUTPUT) $(FILTERLIB_OUTPUT) $(NEWSBOAT_OBJS) $(RSSPPLIB_OUTPUT) $(NEWSBOATLIB_OUTPUT)
 
 $(NEWSBOATLIB_OUTPUT): $(RUST_SRCS)
-	$(CARGO) build --package libnewsboat-ffi $(CARGO_FLAGS)
+	+$(CARGO) build --package libnewsboat-ffi $(CARGO_FLAGS)
 
 $(NEWSBOAT): $(NB_DEPS)
 	$(CXX) $(CXXFLAGS) -o $(NEWSBOAT) $(NEWSBOAT_OBJS) $(NEWSBOAT_LIBS) $(LDFLAGS)
@@ -338,7 +338,7 @@ uninstall-mo:
 test: test/test rust-test
 
 rust-test:
-	$(CARGO) test --no-run
+	+$(CARGO) test --no-run
 
 TEST_SRCS:=$(wildcard test/*.cpp)
 TEST_OBJS:=$(patsubst %.cpp,%.o,$(TEST_SRCS))


### PR DESCRIPTION
All the credit goes to Anatoly Sablin (@ma1uta): he's the one who told me about Make jobserver and its support in Cargo. I'm merely applying that knowledge to my particular problem.

Fixes #768.

I'll merge this in 24 hours unless someone stops me for a review.