### PR TITLE
Travis CI: cache Cargo's registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: rust
 
 rust: stable
 
+cache:
+  directories:
+    - $HOME/.cargo/registry
+
+before_cache:
+  - rm -rf $HOME/.cargo/registry/index
+
 addons:
   apt:
     packages: &global_deps


### PR DESCRIPTION
The rationale is the same as with the similar change to Cirrus CI (cf. 48ecfb911019e37dca0d1da0c7e9a8e993a7681c): slightly faster builds and additional resilience to outages.

Will merge in about 24 hours, unless someone stops me for a review.