### PR TITLE
Convert UTF-8 to locale's charset at the boundary

### DIFF
--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -33,7 +33,7 @@ public:
 		utils::trim(title_);
 	}
 
-	std::string description_raw() const
+	std::string description() const
 	{
 		return description_;
 	}

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -37,7 +37,6 @@ public:
 	{
 		return description_;
 	}
-	std::string description() const;
 	void set_description(const std::string& d)
 	{
 		description_ = d;

--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -36,7 +36,6 @@ public:
 	}
 	void set_author(const std::string& a);
 
-	std::string description() const;
 	std::string description_raw() const
 	{
 		return description_;

--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -17,7 +17,7 @@ public:
 	explicit RssItem(Cache* c);
 	~RssItem() override;
 
-	std::string title_raw() const
+	std::string title() const
 	{
 		return title_;
 	}
@@ -30,13 +30,13 @@ public:
 	}
 	void set_link(const std::string& l);
 
-	std::string author_raw() const
+	std::string author() const
 	{
 		return author_;
 	}
 	void set_author(const std::string& a);
 
-	std::string description_raw() const
+	std::string description() const
 	{
 		return description_;
 	}

--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -30,7 +30,6 @@ public:
 	}
 	void set_link(const std::string& l);
 
-	std::string author() const;
 	std::string author_raw() const
 	{
 		return author_;

--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -17,7 +17,6 @@ public:
 	explicit RssItem(Cache* c);
 	~RssItem() override;
 
-	std::string title() const;
 	std::string title_raw() const
 	{
 		return title_;

--- a/include/utils.h
+++ b/include/utils.h
@@ -35,6 +35,10 @@ std::string convert_text(const std::string& text,
 	const std::string& tocode,
 	const std::string& fromcode);
 
+/// Converts input string from UTF-8 to the locale's encoding (as detected by
+/// nl_langinfo(CODESET)).
+std::string utf8_to_locale(const std::string& text);
+
 std::string get_command_output(const std::string& cmd);
 void extract_filter(const std::string& line,
 	std::string& filter,

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -812,13 +812,13 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 					"'%q';",
 					item->guid());
 			run_sql(query, single_string_callback, &content);
-			if (content != item->description_raw()) {
+			if (content != item->description()) {
 				LOG(Level::DEBUG,
 					"Cache::update_rssitem_unlocked: '%s' "
 					"is "
 					"different from '%s'",
 					content,
-					item->description_raw());
+					item->description());
 				query = prepare_query(
 						"UPDATE rss_item SET unread = 1 WHERE "
 						"guid = '%q';",
@@ -836,11 +836,11 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 					"enclosure_type = '%q', base = '%q', unread = "
 					"'%d' "
 					"WHERE guid = '%q'",
-					item->title_raw(),
-					item->author_raw(),
+					item->title(),
+					item->author(),
 					item->link(),
 					feedurl,
-					item->description_raw(),
+					item->description(),
 					item->enclosure_url(),
 					item->enclosure_type(),
 					item->get_base(),
@@ -854,11 +854,11 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 					"content = '%q', enclosure_url = '%q', "
 					"enclosure_type = '%q', base = '%q' "
 					"WHERE guid = '%q'",
-					item->title_raw(),
-					item->author_raw(),
+					item->title(),
+					item->author(),
 					item->link(),
 					feedurl,
-					item->description_raw(),
+					item->description(),
 					item->enclosure_url(),
 					item->enclosure_type(),
 					item->get_base(),
@@ -876,12 +876,12 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 				" "
 				"'%q')",
 				item->guid(),
-				item->title_raw(),
-				item->author_raw(),
+				item->title(),
+				item->author(),
 				item->link(),
 				feedurl,
 				item->pubDate_timestamp(),
-				item->description_raw(),
+				item->description(),
 				(item->unread() ? 1 : 0),
 				item->enclosure_url(),
 				item->enclosure_type(),

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -1031,7 +1031,7 @@ std::string FeedListFormAction::format_line(const std::string& feedlist_format,
 	fmt.register_fmt('T', feed->get_firsttag());
 	fmt.register_fmt('l', utils::censor_url(feed->link()));
 	fmt.register_fmt('L', utils::censor_url(feed->rssurl()));
-	fmt.register_fmt('d', utils::utf8_to_locale(feed->description_raw()));
+	fmt.register_fmt('d', utils::utf8_to_locale(feed->description()));
 
 	auto formattedLine = fmt.do_format(feedlist_format, width);
 	if (unread_count > 0) {

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -1031,7 +1031,7 @@ std::string FeedListFormAction::format_line(const std::string& feedlist_format,
 	fmt.register_fmt('T', feed->get_firsttag());
 	fmt.register_fmt('l', utils::censor_url(feed->link()));
 	fmt.register_fmt('L', utils::censor_url(feed->rssurl()));
-	fmt.register_fmt('d', feed->description());
+	fmt.register_fmt('d', utils::utf8_to_locale(feed->description_raw()));
 
 	auto formattedLine = fmt.do_format(feedlist_format, width);
 	if (unread_count > 0) {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -421,7 +421,7 @@ void FormAction::start_bookmark_qna(const std::string& default_title,
 		new_title = utils::make_title(default_url);
 		prompts.push_back(QnaPair(_("Title: "), new_title));
 	} else {
-		prompts.push_back(QnaPair(_("Title: "), default_title));
+		prompts.push_back(QnaPair(_("Title: "), utils::utf8_to_locale(default_title)));
 	}
 	prompts.push_back(QnaPair(_("Description: "), default_desc));
 	prompts.push_back(QnaPair(_("Feed title: "), default_feed_title));
@@ -433,7 +433,7 @@ void FormAction::start_bookmark_qna(const std::string& default_title,
 					default_url); // try to make the title from url
 		} else {
 			// assignment just to make the call to bookmark() below easier
-			new_title = default_title;
+			new_title = utils::utf8_to_locale(default_title);
 		}
 
 		// if url or title is missing, abort autopilot and ask user

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -327,9 +327,8 @@ void ItemListFormAction::process_operation(Operation op,
 					qna_responses.push_back(
 						visible_items[itempos]
 						.first->link());
-					qna_responses.push_back(
-						visible_items[itempos]
-						.first->title());
+					qna_responses.push_back(utils::utf8_to_locale(
+							visible_items[itempos].first->title_raw()));
 					qna_responses.push_back(args->size() > 0
 						? (*args)[0]
 						: "");
@@ -337,10 +336,8 @@ void ItemListFormAction::process_operation(Operation op,
 					this->finished_qna(OP_INT_BM_END);
 				} else {
 					this->start_bookmark_qna(
-						visible_items[itempos]
-						.first->title(),
-						visible_items[itempos]
-						.first->link(),
+						visible_items[itempos].first->title_raw(),
+						visible_items[itempos].first->link(),
 						"",
 						feed->title());
 				}
@@ -388,10 +385,10 @@ void ItemListFormAction::process_operation(Operation op,
 					filename = (*args)[0];
 				}
 			} else {
-				filename = v->run_filebrowser(
-						v->get_filename_suggestion(
-							visible_items[itempos]
-							.first->title()));
+				const auto title = utils::utf8_to_locale(
+						visible_items[itempos].first->title_raw());
+				const auto suggestion = v->get_filename_suggestion(title);
+				filename = v->run_filebrowser(suggestion);
 			}
 			save_article(filename, visible_items[itempos].first);
 		} else {
@@ -1036,7 +1033,8 @@ std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 		fmt.register_fmt('T', feedtitle);
 	}
 
-	auto itemtitle = utils::quote_for_stfl(item.first->title());
+	auto itemtitle = utils::quote_for_stfl(utils::utf8_to_locale(
+				item.first->title_raw()));
 	utils::remove_soft_hyphens(itemtitle);
 	fmt.register_fmt('t', itemtitle);
 
@@ -1456,7 +1454,7 @@ void ItemListFormAction::handle_op_saveall()
 
 	if (visible_items.size() == 1) {
 		const std::string filename = v->get_filename_suggestion(
-				visible_items[0].first->title());
+				utils::utf8_to_locale(visible_items[0].first->title_raw()));
 		const std::string fpath = directory + filename;
 
 		struct stat sbuf;
@@ -1494,7 +1492,7 @@ void ItemListFormAction::handle_op_saveall()
 		std::vector<std::string> filenames;
 		for (const auto& item : visible_items) {
 			filenames.emplace_back(
-				v->get_filename_suggestion(item.first->title()));
+				utils::utf8_to_locale(v->get_filename_suggestion(item.first->title_raw())));
 		}
 
 		const auto unique_filenames = std::set<std::string>(

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -294,7 +294,7 @@ void ItemListFormAction::process_operation(Operation op,
 						: visible_items[itempos]
 						.first->feedurl();
 					rnd.render(
-						utils::utf8_to_locale(visible_items[itempos].first->description_raw()),
+						utils::utf8_to_locale(visible_items[itempos].first->description()),
 						lines,
 						links,
 						baseurl);
@@ -327,7 +327,7 @@ void ItemListFormAction::process_operation(Operation op,
 						visible_items[itempos]
 						.first->link());
 					qna_responses.push_back(utils::utf8_to_locale(
-							visible_items[itempos].first->title_raw()));
+							visible_items[itempos].first->title()));
 					qna_responses.push_back(args->size() > 0
 						? (*args)[0]
 						: "");
@@ -335,7 +335,7 @@ void ItemListFormAction::process_operation(Operation op,
 					this->finished_qna(OP_INT_BM_END);
 				} else {
 					this->start_bookmark_qna(
-						visible_items[itempos].first->title_raw(),
+						visible_items[itempos].first->title(),
 						visible_items[itempos].first->link(),
 						"",
 						feed->title());
@@ -384,8 +384,7 @@ void ItemListFormAction::process_operation(Operation op,
 					filename = (*args)[0];
 				}
 			} else {
-				const auto title = utils::utf8_to_locale(
-						visible_items[itempos].first->title_raw());
+				const auto title = utils::utf8_to_locale(visible_items[itempos].first->title());
 				const auto suggestion = v->get_filename_suggestion(title);
 				filename = v->run_filebrowser(suggestion);
 			}
@@ -1033,12 +1032,12 @@ std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	}
 
 	auto itemtitle = utils::quote_for_stfl(utils::utf8_to_locale(
-				item.first->title_raw()));
+				item.first->title()));
 	utils::remove_soft_hyphens(itemtitle);
 	fmt.register_fmt('t', itemtitle);
 
 	auto itemauthor = utils::quote_for_stfl(utils::utf8_to_locale(
-				item.first->author_raw()));
+				item.first->author()));
 	utils::remove_soft_hyphens(itemauthor);
 	fmt.register_fmt('a', itemauthor);
 
@@ -1453,8 +1452,8 @@ void ItemListFormAction::handle_op_saveall()
 	}
 
 	if (visible_items.size() == 1) {
-		const std::string filename = v->get_filename_suggestion(
-				utils::utf8_to_locale(visible_items[0].first->title_raw()));
+		const std::string filename = v->get_filename_suggestion( utils::utf8_to_locale(
+					visible_items[0].first->title()));
 		const std::string fpath = directory + filename;
 
 		struct stat sbuf;
@@ -1491,8 +1490,8 @@ void ItemListFormAction::handle_op_saveall()
 	} else {
 		std::vector<std::string> filenames;
 		for (const auto& item : visible_items) {
-			filenames.emplace_back(
-				utils::utf8_to_locale(v->get_filename_suggestion(item.first->title_raw())));
+			filenames.emplace_back( utils::utf8_to_locale(v->get_filename_suggestion(
+						item.first->title())));
 		}
 
 		const auto unique_filenames = std::set<std::string>(

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -294,8 +294,7 @@ void ItemListFormAction::process_operation(Operation op,
 						: visible_items[itempos]
 						.first->feedurl();
 					rnd.render(
-						visible_items[itempos]
-						.first->description(),
+						utils::utf8_to_locale(visible_items[itempos].first->description_raw()),
 						lines,
 						links,
 						baseurl);

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1038,7 +1038,8 @@ std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	utils::remove_soft_hyphens(itemtitle);
 	fmt.register_fmt('t', itemtitle);
 
-	auto itemauthor = utils::quote_for_stfl(item.first->author());
+	auto itemauthor = utils::quote_for_stfl(utils::utf8_to_locale(
+				item.first->author_raw()));
 	utils::remove_soft_hyphens(itemauthor);
 	fmt.register_fmt('a', itemauthor);
 

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -127,7 +127,8 @@ std::string item_renderer::to_plain_text(
 
 	prepare_header(item, lines, links);
 	const auto base = get_item_base_link(item);
-	render_html(cfg, item->description(), lines, links, base, true);
+	render_html(cfg, utils::utf8_to_locale(item->description_raw()), lines, links,
+		base, true);
 
 	TextFormatter txtfmt;
 	txtfmt.add_lines(lines);
@@ -153,7 +154,7 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 
 	prepare_header(item, lines, links);
 	const std::string baseurl = get_item_base_link(item);
-	const auto body = item->description();
+	const auto body = utils::utf8_to_locale(item->description_raw());
 	render_html(cfg, body, lines, links, baseurl, false);
 
 	TextFormatter txtfmt;
@@ -195,7 +196,8 @@ std::pair<std::string, size_t> item_renderer::source_to_stfl_list(
 	std::vector<LinkPair> links;
 
 	prepare_header(item, lines, links);
-	render_source(lines, utils::quote_for_stfl(item->description()));
+	render_source(lines, utils::quote_for_stfl(utils::utf8_to_locale(
+				item->description_raw())));
 
 	TextFormatter txtfmt;
 	txtfmt.add_lines(lines);

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -48,8 +48,8 @@ void prepare_header(
 
 	const std::string feedtitle = item_renderer::get_feedtitle(item);
 	add_line(feedtitle, _("Feed: "));
-	add_line(utils::utf8_to_locale(item->title_raw()), _("Title: "));
-	add_line(utils::utf8_to_locale(item->author_raw()), _("Author: "));
+	add_line(utils::utf8_to_locale(item->title()), _("Title: "));
+	add_line(utils::utf8_to_locale(item->author()), _("Author: "));
 	add_line(item->pubDate(), _("Date: "));
 	add_line(item->link(), _("Link: "), LineType::softwrappable);
 	add_line(item->flags(), _("Flags: "));
@@ -127,7 +127,7 @@ std::string item_renderer::to_plain_text(
 
 	prepare_header(item, lines, links);
 	const auto base = get_item_base_link(item);
-	render_html(cfg, utils::utf8_to_locale(item->description_raw()), lines, links,
+	render_html(cfg, utils::utf8_to_locale(item->description()), lines, links,
 		base, true);
 
 	TextFormatter txtfmt;
@@ -154,7 +154,7 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 
 	prepare_header(item, lines, links);
 	const std::string baseurl = get_item_base_link(item);
-	const auto body = utils::utf8_to_locale(item->description_raw());
+	const auto body = utils::utf8_to_locale(item->description());
 	render_html(cfg, body, lines, links, baseurl, false);
 
 	TextFormatter txtfmt;
@@ -197,7 +197,7 @@ std::pair<std::string, size_t> item_renderer::source_to_stfl_list(
 
 	prepare_header(item, lines, links);
 	render_source(lines, utils::quote_for_stfl(utils::utf8_to_locale(
-				item->description_raw())));
+				item->description())));
 
 	TextFormatter txtfmt;
 	txtfmt.add_lines(lines);

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -48,7 +48,7 @@ void prepare_header(
 
 	const std::string feedtitle = item_renderer::get_feedtitle(item);
 	add_line(feedtitle, _("Feed: "));
-	add_line(item->title(), _("Title: "));
+	add_line(utils::utf8_to_locale(item->title_raw()), _("Title: "));
 	add_line(item->author(), _("Author: "));
 	add_line(item->pubDate(), _("Date: "));
 	add_line(item->link(), _("Link: "), LineType::softwrappable);

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -49,7 +49,7 @@ void prepare_header(
 	const std::string feedtitle = item_renderer::get_feedtitle(item);
 	add_line(feedtitle, _("Feed: "));
 	add_line(utils::utf8_to_locale(item->title_raw()), _("Title: "));
-	add_line(item->author(), _("Author: "));
+	add_line(utils::utf8_to_locale(item->author_raw()), _("Author: "));
 	add_line(item->pubDate(), _("Date: "));
 	add_line(item->link(), _("Link: "), LineType::softwrappable);
 	add_line(item->flags(), _("Flags: "));

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -72,7 +72,7 @@ void ItemViewFormAction::update_head(const std::shared_ptr<RssItem>& item)
 	if (item->unread()) {
 		unread_item_count--;
 	}
-	set_head(item->title(),
+	set_head(utils::utf8_to_locale(item->title_raw()),
 		feedtitle,
 		unread_item_count,
 		feed->total_item_count());
@@ -195,7 +195,7 @@ void ItemViewFormAction::process_operation(Operation op,
 			}
 		} else {
 			filename = v->run_filebrowser(
-					v->get_filename_suggestion(item->title()));
+					utils::utf8_to_locale(v->get_filename_suggestion(item->title_raw())));
 		}
 		if (filename == "") {
 			v->show_error(_("Aborted saving."));
@@ -223,13 +223,13 @@ void ItemViewFormAction::process_operation(Operation op,
 		if (automatic) {
 			qna_responses.clear();
 			qna_responses.push_back(item->link());
-			qna_responses.push_back(item->title());
+			qna_responses.push_back(utils::utf8_to_locale(item->title_raw()));
 			qna_responses.push_back(
 				args->size() > 0 ? (*args)[0] : "");
 			qna_responses.push_back(feed->title());
 		} else {
 			this->start_bookmark_qna(
-				item->title(), item->link(), "", feed->title());
+				utils::utf8_to_locale(item->title_raw()), item->link(), "", feed->title());
 		}
 		break;
 	case OP_SEARCH: {
@@ -593,9 +593,9 @@ void ItemViewFormAction::update_percent()
 
 std::string ItemViewFormAction::title()
 {
-	auto title = item->title();
+	auto title = item->title_raw();
 	utils::remove_soft_hyphens(title);
-	return strprintf::fmt(_("Article - %s"), title);
+	return strprintf::fmt(_("Article - %s"), utils::utf8_to_locale(title));
 }
 
 void ItemViewFormAction::set_highlightphrase(const std::string& text)

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -72,7 +72,7 @@ void ItemViewFormAction::update_head(const std::shared_ptr<RssItem>& item)
 	if (item->unread()) {
 		unread_item_count--;
 	}
-	set_head(utils::utf8_to_locale(item->title_raw()),
+	set_head(utils::utf8_to_locale(item->title()),
 		feedtitle,
 		unread_item_count,
 		feed->total_item_count());
@@ -194,8 +194,8 @@ void ItemViewFormAction::process_operation(Operation op,
 				filename = (*args)[0];
 			}
 		} else {
-			filename = v->run_filebrowser(
-					utils::utf8_to_locale(v->get_filename_suggestion(item->title_raw())));
+			filename = v->run_filebrowser( utils::utf8_to_locale(v->get_filename_suggestion(
+							item->title())));
 		}
 		if (filename == "") {
 			v->show_error(_("Aborted saving."));
@@ -223,13 +223,13 @@ void ItemViewFormAction::process_operation(Operation op,
 		if (automatic) {
 			qna_responses.clear();
 			qna_responses.push_back(item->link());
-			qna_responses.push_back(utils::utf8_to_locale(item->title_raw()));
+			qna_responses.push_back(utils::utf8_to_locale(item->title()));
 			qna_responses.push_back(
 				args->size() > 0 ? (*args)[0] : "");
 			qna_responses.push_back(feed->title());
 		} else {
-			this->start_bookmark_qna(
-				utils::utf8_to_locale(item->title_raw()), item->link(), "", feed->title());
+			this->start_bookmark_qna(utils::utf8_to_locale(item->title()), item->link(), "",
+				feed->title());
 		}
 		break;
 	case OP_SEARCH: {
@@ -593,7 +593,7 @@ void ItemViewFormAction::update_percent()
 
 std::string ItemViewFormAction::title()
 {
-	auto title = item->title_raw();
+	auto title = item->title();
 	utils::remove_soft_hyphens(title);
 	return strprintf::fmt(_("Article - %s"), utils::utf8_to_locale(title));
 }

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -64,7 +64,7 @@ std::string QueueManager::generate_enqueue_filename(std::shared_ptr<RssItem>
 	std::shared_ptr<RssFeed> feed)
 {
 	const std::string& url = item->enclosure_url();
-	const std::string& title = utils::utf8_to_locale(item->title_raw());
+	const std::string& title = utils::utf8_to_locale(item->title());
 	const time_t pubDate = item->pubDate_timestamp();
 
 	std::string dlformat = cfg->get_configvalue("download-path");

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -64,7 +64,7 @@ std::string QueueManager::generate_enqueue_filename(std::shared_ptr<RssItem>
 	std::shared_ptr<RssFeed> feed)
 {
 	const std::string& url = item->enclosure_url();
-	const std::string& title = item->title();
+	const std::string& title = utils::utf8_to_locale(item->title_raw());
 	const time_t pubDate = item->pubDate_timestamp();
 
 	std::string dlformat = cfg->get_configvalue("download-path");

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -97,12 +97,12 @@ std::string RssFeed::title() const
 	}
 	return found_title
 		? alt_title
-		: utils::convert_text(title_, nl_langinfo(CODESET), "utf-8");
+		: utils::utf8_to_locale(title_);
 }
 
 std::string RssFeed::description() const
 {
-	return utils::convert_text(description_, nl_langinfo(CODESET), "utf-8");
+	return utils::utf8_to_locale(description_);
 }
 
 bool RssFeed::hidden() const

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -100,11 +100,6 @@ std::string RssFeed::title() const
 		: utils::utf8_to_locale(title_);
 }
 
-std::string RssFeed::description() const
-{
-	return utils::utf8_to_locale(description_);
-}
-
 bool RssFeed::hidden() const
 {
 	return std::any_of(tags_.begin(),
@@ -154,7 +149,7 @@ std::string RssFeed::get_attribute(const std::string& attribname)
 	if (attribname == "feedtitle") {
 		return title();
 	} else if (attribname == "description") {
-		return description();
+		return utils::utf8_to_locale(description_raw());
 	} else if (attribname == "feedlink") {
 		return title();
 	} else if (attribname == "feeddate") {

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -149,7 +149,7 @@ std::string RssFeed::get_attribute(const std::string& attribname)
 	if (attribname == "feedtitle") {
 		return title();
 	} else if (attribname == "description") {
-		return utils::utf8_to_locale(description_raw());
+		return utils::utf8_to_locale(description());
 	} else if (attribname == "feedlink") {
 		return title();
 	} else if (attribname == "feeddate") {
@@ -262,8 +262,8 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 			items_.end(),
 			[&](const std::shared_ptr<RssItem>& a,
 		const std::shared_ptr<RssItem>& b) {
-			const auto cmp = utils::strnaturalcmp(utils::utf8_to_locale(a->title_raw()),
-					utils::utf8_to_locale(b->title_raw()));
+			const auto cmp = utils::strnaturalcmp(utils::utf8_to_locale(a->title()),
+					utils::utf8_to_locale(b->title()));
 			return sort_strategy.sd == SortDirection::DESC ? (cmp > 0) : (cmp < 0);
 		});
 		break;
@@ -285,8 +285,8 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 			items_.end(),
 			[&](const std::shared_ptr<RssItem>& a,
 		const std::shared_ptr<RssItem>& b) {
-			const auto author_a = utils::utf8_to_locale(a->author_raw());
-			const auto author_b = utils::utf8_to_locale(b->author_raw());
+			const auto author_a = utils::utf8_to_locale(a->author());
+			const auto author_b = utils::utf8_to_locale(b->author());
 			const auto cmp = strcmp(author_a.c_str(), author_b.c_str());
 			return sort_strategy.sd == SortDirection::DESC ? (cmp > 0) : (cmp < 0);
 		});

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -290,12 +290,10 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 			items_.end(),
 			[&](const std::shared_ptr<RssItem>& a,
 		const std::shared_ptr<RssItem>& b) {
-			return sort_strategy.sd ==
-				SortDirection::DESC
-				? (strcmp(a->author().c_str(),
-						b->author().c_str()) > 0)
-				: (strcmp(a->author().c_str(),
-						b->author().c_str()) < 0);
+			const auto author_a = utils::utf8_to_locale(a->author_raw());
+			const auto author_b = utils::utf8_to_locale(b->author_raw());
+			const auto cmp = strcmp(author_a.c_str(), author_b.c_str());
+			return sort_strategy.sd == SortDirection::DESC ? (cmp > 0) : (cmp < 0);
 		});
 		break;
 	case ArtSortMethod::LINK:

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -267,12 +267,9 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 			items_.end(),
 			[&](const std::shared_ptr<RssItem>& a,
 		const std::shared_ptr<RssItem>& b) {
-			return sort_strategy.sd ==
-				SortDirection::DESC
-				? (utils::strnaturalcmp(a->title().c_str(),
-						b->title().c_str()) > 0)
-				: (utils::strnaturalcmp(a->title().c_str(),
-						b->title().c_str()) < 0);
+			const auto cmp = utils::strnaturalcmp(utils::utf8_to_locale(a->title_raw()),
+					utils::utf8_to_locale(b->title_raw()));
+			return sort_strategy.sd == SortDirection::DESC ? (cmp > 0) : (cmp < 0);
 		});
 		break;
 	case ArtSortMethod::FLAGS:

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -134,11 +134,6 @@ void RssItem::set_enclosure_type(const std::string& type)
 	enclosure_type_ = type;
 }
 
-std::string RssItem::description() const
-{
-	return utils::utf8_to_locale(description_);
-}
-
 bool RssItem::has_attribute(const std::string& attribname)
 {
 	if (attribname == "title" || attribname == "link" ||
@@ -168,7 +163,7 @@ std::string RssItem::get_attribute(const std::string& attribname)
 	} else if (attribname == "author") {
 		return utils::utf8_to_locale(author_raw());
 	} else if (attribname == "content") {
-		return description();
+		return utils::utf8_to_locale(description_raw());
 	} else if (attribname == "date") {
 		return pubDate();
 	} else if (attribname == "guid") {

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -157,13 +157,13 @@ bool RssItem::has_attribute(const std::string& attribname)
 std::string RssItem::get_attribute(const std::string& attribname)
 {
 	if (attribname == "title") {
-		return utils::utf8_to_locale(title_raw());
+		return utils::utf8_to_locale(title());
 	} else if (attribname == "link") {
 		return link();
 	} else if (attribname == "author") {
-		return utils::utf8_to_locale(author_raw());
+		return utils::utf8_to_locale(author());
 	} else if (attribname == "content") {
-		return utils::utf8_to_locale(description_raw());
+		return utils::utf8_to_locale(description());
 	} else if (attribname == "date") {
 		return pubDate();
 	} else if (attribname == "guid") {

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -137,20 +137,20 @@ void RssItem::set_enclosure_type(const std::string& type)
 std::string RssItem::title() const
 {
 	std::string retval;
-	if (title_.length() > 0)
-		retval = utils::convert_text(
-				title_, nl_langinfo(CODESET), "utf-8");
+	if (!title_.empty()) {
+		retval = utils::utf8_to_locale( title_);
+	}
 	return retval;
 }
 
 std::string RssItem::author() const
 {
-	return utils::convert_text(author_, nl_langinfo(CODESET), "utf-8");
+	return utils::utf8_to_locale(author_);
 }
 
 std::string RssItem::description() const
 {
-	return utils::convert_text(description_, nl_langinfo(CODESET), "utf-8");
+	return utils::utf8_to_locale(description_);
 }
 
 bool RssItem::has_attribute(const std::string& attribname)

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -134,15 +134,6 @@ void RssItem::set_enclosure_type(const std::string& type)
 	enclosure_type_ = type;
 }
 
-std::string RssItem::title() const
-{
-	std::string retval;
-	if (!title_.empty()) {
-		retval = utils::utf8_to_locale( title_);
-	}
-	return retval;
-}
-
 std::string RssItem::author() const
 {
 	return utils::utf8_to_locale(author_);
@@ -176,7 +167,7 @@ bool RssItem::has_attribute(const std::string& attribname)
 std::string RssItem::get_attribute(const std::string& attribname)
 {
 	if (attribname == "title") {
-		return title();
+		return utils::utf8_to_locale(title_raw());
 	} else if (attribname == "link") {
 		return link();
 	} else if (attribname == "author") {

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -134,11 +134,6 @@ void RssItem::set_enclosure_type(const std::string& type)
 	enclosure_type_ = type;
 }
 
-std::string RssItem::author() const
-{
-	return utils::utf8_to_locale(author_);
-}
-
 std::string RssItem::description() const
 {
 	return utils::utf8_to_locale(description_);
@@ -171,7 +166,7 @@ std::string RssItem::get_attribute(const std::string& attribname)
 	} else if (attribname == "link") {
 		return link();
 	} else if (attribname == "author") {
-		return author();
+		return utils::utf8_to_locale(author_raw());
 	} else if (attribname == "content") {
 		return description();
 	} else if (attribname == "date") {

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -428,7 +428,7 @@ void RssParser::fill_feed_items(std::shared_ptr<RssFeed> feed)
 			"RssParser::parse: item title = `%s' link = `%s' "
 			"pubDate "
 			"= `%s' (%" PRId64 ") description = `%s'",
-			x->title(),
+			x->title_raw(),
 			x->link(),
 			x->pubDate(),
 			// On GCC, `time_t` is `long int`, which is at least 32 bits long
@@ -554,7 +554,7 @@ void RssParser::add_item_to_feed(std::shared_ptr<RssFeed> feed,
 			"RssParser::parse: added article title = `%s' link = "
 			"`%s' "
 			"ign = %p",
-			item->title(),
+			item->title_raw(),
 			item->link(),
 			ign);
 	} else {
@@ -562,7 +562,7 @@ void RssParser::add_item_to_feed(std::shared_ptr<RssFeed> feed,
 			"RssParser::parse: ignored article title = `%s' link "
 			"= "
 			"`%s'",
-			item->title(),
+			item->title_raw(),
 			item->link());
 	}
 }

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -436,7 +436,7 @@ void RssParser::fill_feed_items(std::shared_ptr<RssFeed> feed)
 			// casting to int64_t is either a no-op, or an up-cast which are
 			// always safe.
 			static_cast<int64_t>(x->pubDate_timestamp()),
-			x->description());
+			x->description_raw());
 
 		add_item_to_feed(feed, x);
 	}
@@ -485,19 +485,19 @@ void RssParser::set_item_content(std::shared_ptr<RssItem> x,
 
 	handle_itunes_summary(x, item);
 
-	if (x->description().empty()) {
+	if (x->description_raw().empty()) {
 		x->set_description(item.description);
 	} else {
 		if (cfgcont->get_configvalue_as_bool(
 				"always-display-description") &&
 			!item.description.empty())
 			x->set_description(
-				x->description() + "<hr>" + item.description);
+				x->description_raw() + "<hr>" + item.description);
 	}
 
 	/* if it's still empty and we shall download the full page, then we do
 	 * so. */
-	if (x->description().empty() &&
+	if (x->description_raw().empty() &&
 		cfgcont->get_configvalue_as_bool("download-full-page") &&
 		!x->link().empty()) {
 		x->set_description(utils::retrieve_url(x->link(), cfgcont));
@@ -505,7 +505,7 @@ void RssParser::set_item_content(std::shared_ptr<RssItem> x,
 
 	LOG(Level::DEBUG,
 		"RssParser::set_item_content: content = %s",
-		x->description());
+		x->description_raw());
 }
 
 std::string RssParser::get_guid(const rsspp::Item& item) const
@@ -570,7 +570,7 @@ void RssParser::add_item_to_feed(std::shared_ptr<RssFeed> feed,
 void RssParser::handle_content_encoded(std::shared_ptr<RssItem> x,
 	const rsspp::Item& item) const
 {
-	if (!x->description().empty()) {
+	if (!x->description_raw().empty()) {
 		return;
 	}
 
@@ -587,7 +587,7 @@ void RssParser::handle_content_encoded(std::shared_ptr<RssItem> x,
 void RssParser::handle_itunes_summary(std::shared_ptr<RssItem> x,
 	const rsspp::Item& item)
 {
-	if (!x->description().empty()) {
+	if (!x->description_raw().empty()) {
 		return;
 	}
 

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -428,7 +428,7 @@ void RssParser::fill_feed_items(std::shared_ptr<RssFeed> feed)
 			"RssParser::parse: item title = `%s' link = `%s' "
 			"pubDate "
 			"= `%s' (%" PRId64 ") description = `%s'",
-			x->title_raw(),
+			x->title(),
 			x->link(),
 			x->pubDate(),
 			// On GCC, `time_t` is `long int`, which is at least 32 bits long
@@ -436,7 +436,7 @@ void RssParser::fill_feed_items(std::shared_ptr<RssFeed> feed)
 			// casting to int64_t is either a no-op, or an up-cast which are
 			// always safe.
 			static_cast<int64_t>(x->pubDate_timestamp()),
-			x->description_raw());
+			x->description());
 
 		add_item_to_feed(feed, x);
 	}
@@ -485,19 +485,19 @@ void RssParser::set_item_content(std::shared_ptr<RssItem> x,
 
 	handle_itunes_summary(x, item);
 
-	if (x->description_raw().empty()) {
+	if (x->description().empty()) {
 		x->set_description(item.description);
 	} else {
 		if (cfgcont->get_configvalue_as_bool(
 				"always-display-description") &&
 			!item.description.empty())
 			x->set_description(
-				x->description_raw() + "<hr>" + item.description);
+				x->description() + "<hr>" + item.description);
 	}
 
 	/* if it's still empty and we shall download the full page, then we do
 	 * so. */
-	if (x->description_raw().empty() &&
+	if (x->description().empty() &&
 		cfgcont->get_configvalue_as_bool("download-full-page") &&
 		!x->link().empty()) {
 		x->set_description(utils::retrieve_url(x->link(), cfgcont));
@@ -505,7 +505,7 @@ void RssParser::set_item_content(std::shared_ptr<RssItem> x,
 
 	LOG(Level::DEBUG,
 		"RssParser::set_item_content: content = %s",
-		x->description_raw());
+		x->description());
 }
 
 std::string RssParser::get_guid(const rsspp::Item& item) const
@@ -554,7 +554,7 @@ void RssParser::add_item_to_feed(std::shared_ptr<RssFeed> feed,
 			"RssParser::parse: added article title = `%s' link = "
 			"`%s' "
 			"ign = %p",
-			item->title_raw(),
+			item->title(),
 			item->link(),
 			ign);
 	} else {
@@ -562,7 +562,7 @@ void RssParser::add_item_to_feed(std::shared_ptr<RssFeed> feed,
 			"RssParser::parse: ignored article title = `%s' link "
 			"= "
 			"`%s'",
-			item->title_raw(),
+			item->title(),
 			item->link());
 	}
 }
@@ -570,7 +570,7 @@ void RssParser::add_item_to_feed(std::shared_ptr<RssFeed> feed,
 void RssParser::handle_content_encoded(std::shared_ptr<RssItem> x,
 	const rsspp::Item& item) const
 {
-	if (!x->description_raw().empty()) {
+	if (!x->description().empty()) {
 		return;
 	}
 
@@ -587,7 +587,7 @@ void RssParser::handle_content_encoded(std::shared_ptr<RssItem> x,
 void RssParser::handle_itunes_summary(std::shared_ptr<RssItem> x,
 	const rsspp::Item& item)
 {
-	if (!x->description_raw().empty()) {
+	if (!x->description().empty()) {
 		return;
 	}
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -417,7 +417,7 @@ std::string utils::convert_text(const std::string& text,
 	return result;
 }
 
-std::string utf8_to_locale(const std::string& text)
+std::string utils::utf8_to_locale(const std::string& text)
 {
 	if (text.empty()) {
 		return {};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -417,6 +417,15 @@ std::string utils::convert_text(const std::string& text,
 	return result;
 }
 
+std::string utf8_to_locale(const std::string& text)
+{
+	if (text.empty()) {
+		return {};
+	}
+
+	return utils::convert_text(text, nl_langinfo(CODESET), "utf-8");
+}
+
 std::string utils::get_command_output(const std::string& cmd)
 {
 	return RustString(rs_get_command_output(cmd.c_str()));

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -320,7 +320,7 @@ TEST_CASE("fetch_descriptions fills out feed item's descriptions", "[Cache]")
 	REQUIRE_NOTHROW(rsscache.fetch_descriptions(feed.get()));
 
 	for (auto& item : feed->items()) {
-		REQUIRE(item->description_raw() != "your test failed!");
+		REQUIRE(item->description() != "your test failed!");
 	}
 }
 
@@ -616,7 +616,7 @@ TEST_CASE(
 	feed2) {
 		REQUIRE(feed1->title_raw() == feed2->title_raw());
 		REQUIRE(feed1->title() == feed2->title());
-		REQUIRE(feed1->description_raw() == feed2->description_raw());
+		REQUIRE(feed1->description() == feed2->description());
 		REQUIRE(feed1->link() == feed2->link());
 		REQUIRE(feed1->rssurl() == feed2->rssurl());
 		REQUIRE(feed1->unread_item_count() ==
@@ -632,13 +632,10 @@ TEST_CASE(
 		for (; fst_it != fst_end && snd_it != snd_end;
 			++fst_it, ++snd_it) {
 			REQUIRE((*fst_it)->guid() == (*snd_it)->guid());
-			REQUIRE((*fst_it)->title_raw() ==
-				(*snd_it)->title_raw());
+			REQUIRE((*fst_it)->title() == (*snd_it)->title());
 			REQUIRE((*fst_it)->link() == (*snd_it)->link());
-			REQUIRE((*fst_it)->author_raw() ==
-				(*snd_it)->author_raw());
-			REQUIRE((*fst_it)->description_raw() ==
-				(*snd_it)->description_raw());
+			REQUIRE((*fst_it)->author() == (*snd_it)->author());
+			REQUIRE((*fst_it)->description() == (*snd_it)->description());
 			REQUIRE((*fst_it)->size() == (*snd_it)->size());
 			REQUIRE((*fst_it)->length() == (*snd_it)->length());
 			REQUIRE((*fst_it)->pubDate() == (*snd_it)->pubDate());

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -633,7 +633,6 @@ TEST_CASE(
 		for (; fst_it != fst_end && snd_it != snd_end;
 			++fst_it, ++snd_it) {
 			REQUIRE((*fst_it)->guid() == (*snd_it)->guid());
-			REQUIRE((*fst_it)->title() == (*snd_it)->title());
 			REQUIRE((*fst_it)->title_raw() ==
 				(*snd_it)->title_raw());
 			REQUIRE((*fst_it)->link() == (*snd_it)->link());

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -320,7 +320,7 @@ TEST_CASE("fetch_descriptions fills out feed item's descriptions", "[Cache]")
 	REQUIRE_NOTHROW(rsscache.fetch_descriptions(feed.get()));
 
 	for (auto& item : feed->items()) {
-		REQUIRE(item->description() != "your test failed!");
+		REQUIRE(item->description_raw() != "your test failed!");
 	}
 }
 
@@ -638,8 +638,6 @@ TEST_CASE(
 			REQUIRE((*fst_it)->link() == (*snd_it)->link());
 			REQUIRE((*fst_it)->author_raw() ==
 				(*snd_it)->author_raw());
-			REQUIRE((*fst_it)->description() ==
-				(*snd_it)->description());
 			REQUIRE((*fst_it)->description_raw() ==
 				(*snd_it)->description_raw());
 			REQUIRE((*fst_it)->size() == (*snd_it)->size());

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -617,7 +617,6 @@ TEST_CASE(
 		REQUIRE(feed1->title_raw() == feed2->title_raw());
 		REQUIRE(feed1->title() == feed2->title());
 		REQUIRE(feed1->description_raw() == feed2->description_raw());
-		REQUIRE(feed1->description() == feed2->description());
 		REQUIRE(feed1->link() == feed2->link());
 		REQUIRE(feed1->rssurl() == feed2->rssurl());
 		REQUIRE(feed1->unread_item_count() ==

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -636,7 +636,6 @@ TEST_CASE(
 			REQUIRE((*fst_it)->title_raw() ==
 				(*snd_it)->title_raw());
 			REQUIRE((*fst_it)->link() == (*snd_it)->link());
-			REQUIRE((*fst_it)->author() == (*snd_it)->author());
 			REQUIRE((*fst_it)->author_raw() ==
 				(*snd_it)->author_raw());
 			REQUIRE((*fst_it)->description() ==

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -108,20 +108,20 @@ TEST_CASE("RssFeed::sort() correctly sorts articles", "[rss]")
 		ss.sd = SortDirection::ASC;
 		f.sort(ss);
 		articles = f.items();
-		REQUIRE(articles[0]->author() == "Anonymous");
-		REQUIRE(articles[1]->author() == "Platon");
-		REQUIRE(articles[2]->author() == "Sartre");
-		REQUIRE(articles[3]->author() == "Socrates");
-		REQUIRE(articles[4]->author() == "Spinoza");
+		REQUIRE(articles[0]->author_raw() == "Anonymous");
+		REQUIRE(articles[1]->author_raw() == "Platon");
+		REQUIRE(articles[2]->author_raw() == "Sartre");
+		REQUIRE(articles[3]->author_raw() == "Socrates");
+		REQUIRE(articles[4]->author_raw() == "Spinoza");
 
 		ss.sd = SortDirection::DESC;
 		f.sort(ss);
 		articles = f.items();
-		REQUIRE(articles[0]->author() == "Spinoza");
-		REQUIRE(articles[1]->author() == "Socrates");
-		REQUIRE(articles[2]->author() == "Sartre");
-		REQUIRE(articles[3]->author() == "Platon");
-		REQUIRE(articles[4]->author() == "Anonymous");
+		REQUIRE(articles[0]->author_raw() == "Spinoza");
+		REQUIRE(articles[1]->author_raw() == "Socrates");
+		REQUIRE(articles[2]->author_raw() == "Sartre");
+		REQUIRE(articles[3]->author_raw() == "Platon");
+		REQUIRE(articles[4]->author_raw() == "Anonymous");
 	}
 
 	SECTION("link") {

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -366,12 +366,12 @@ TEST_CASE("If item's <title> is empty, try to deduce it from the URL",
 		nullptr);
 	auto feed = p.parse();
 
-	REQUIRE(feed->items()[0]->title() ==
+	REQUIRE(feed->items()[0]->title_raw() ==
 		"A gentle introduction to testing");
-	REQUIRE(feed->items()[1]->title() == "A missing rel attribute");
-	REQUIRE(feed->items()[2]->title() == "Alternate link isnt first");
-	REQUIRE(feed->items()[3]->title() == "A test for htm extension");
-	REQUIRE(feed->items()[4]->title() == "Alternate link isn't first");
+	REQUIRE(feed->items()[1]->title_raw() == "A missing rel attribute");
+	REQUIRE(feed->items()[2]->title_raw() == "Alternate link isnt first");
+	REQUIRE(feed->items()[3]->title_raw() == "A test for htm extension");
+	REQUIRE(feed->items()[4]->title_raw() == "Alternate link isn't first");
 }
 
 TEST_CASE(

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -50,20 +50,20 @@ TEST_CASE("RssFeed::sort() correctly sorts articles", "[rss]")
 		ss.sd = SortDirection::ASC;
 		f.sort(ss);
 		articles = f.items();
-		REQUIRE(articles[0]->title_raw() == "Article 1: A boring article");
-		REQUIRE(articles[1]->title_raw() == "Article 2: Article you must read");
-		REQUIRE(articles[2]->title_raw() == "Article 10: Another great article");
-		REQUIRE(articles[3]->title_raw() == "Read me");
-		REQUIRE(articles[4]->title_raw() == "Wow tests are great");
+		REQUIRE(articles[0]->title() == "Article 1: A boring article");
+		REQUIRE(articles[1]->title() == "Article 2: Article you must read");
+		REQUIRE(articles[2]->title() == "Article 10: Another great article");
+		REQUIRE(articles[3]->title() == "Read me");
+		REQUIRE(articles[4]->title() == "Wow tests are great");
 
 		ss.sd = SortDirection::DESC;
 		f.sort(ss);
 		articles = f.items();
-		REQUIRE(articles[0]->title_raw() == "Wow tests are great");
-		REQUIRE(articles[1]->title_raw() == "Read me");
-		REQUIRE(articles[2]->title_raw() == "Article 10: Another great article");
-		REQUIRE(articles[3]->title_raw() == "Article 2: Article you must read");
-		REQUIRE(articles[4]->title_raw() == "Article 1: A boring article");
+		REQUIRE(articles[0]->title() == "Wow tests are great");
+		REQUIRE(articles[1]->title() == "Read me");
+		REQUIRE(articles[2]->title() == "Article 10: Another great article");
+		REQUIRE(articles[3]->title() == "Article 2: Article you must read");
+		REQUIRE(articles[4]->title() == "Article 1: A boring article");
 	}
 
 	SECTION("flags") {
@@ -108,20 +108,20 @@ TEST_CASE("RssFeed::sort() correctly sorts articles", "[rss]")
 		ss.sd = SortDirection::ASC;
 		f.sort(ss);
 		articles = f.items();
-		REQUIRE(articles[0]->author_raw() == "Anonymous");
-		REQUIRE(articles[1]->author_raw() == "Platon");
-		REQUIRE(articles[2]->author_raw() == "Sartre");
-		REQUIRE(articles[3]->author_raw() == "Socrates");
-		REQUIRE(articles[4]->author_raw() == "Spinoza");
+		REQUIRE(articles[0]->author() == "Anonymous");
+		REQUIRE(articles[1]->author() == "Platon");
+		REQUIRE(articles[2]->author() == "Sartre");
+		REQUIRE(articles[3]->author() == "Socrates");
+		REQUIRE(articles[4]->author() == "Spinoza");
 
 		ss.sd = SortDirection::DESC;
 		f.sort(ss);
 		articles = f.items();
-		REQUIRE(articles[0]->author_raw() == "Spinoza");
-		REQUIRE(articles[1]->author_raw() == "Socrates");
-		REQUIRE(articles[2]->author_raw() == "Sartre");
-		REQUIRE(articles[3]->author_raw() == "Platon");
-		REQUIRE(articles[4]->author_raw() == "Anonymous");
+		REQUIRE(articles[0]->author() == "Spinoza");
+		REQUIRE(articles[1]->author() == "Socrates");
+		REQUIRE(articles[2]->author() == "Sartre");
+		REQUIRE(articles[3]->author() == "Platon");
+		REQUIRE(articles[4]->author() == "Anonymous");
 	}
 
 	SECTION("link") {
@@ -366,12 +366,12 @@ TEST_CASE("If item's <title> is empty, try to deduce it from the URL",
 		nullptr);
 	auto feed = p.parse();
 
-	REQUIRE(feed->items()[0]->title_raw() ==
+	REQUIRE(feed->items()[0]->title() ==
 		"A gentle introduction to testing");
-	REQUIRE(feed->items()[1]->title_raw() == "A missing rel attribute");
-	REQUIRE(feed->items()[2]->title_raw() == "Alternate link isnt first");
-	REQUIRE(feed->items()[3]->title_raw() == "A test for htm extension");
-	REQUIRE(feed->items()[4]->title_raw() == "Alternate link isn't first");
+	REQUIRE(feed->items()[1]->title() == "A missing rel attribute");
+	REQUIRE(feed->items()[2]->title() == "Alternate link isnt first");
+	REQUIRE(feed->items()[3]->title() == "A test for htm extension");
+	REQUIRE(feed->items()[4]->title() == "Alternate link isn't first");
 }
 
 TEST_CASE(


### PR DESCRIPTION
In Newsboat, all strings are in UTF-8, but user might've set a different charset for their locale, so we have to convert. Somehow this job was pushed into getters in `RssItem` and `RssFeed`. It doesn't belong there. This PR simplifies interfaces of these classes by removing those methods, and moving the conversions closer to the edge.

Most of the time, I simply replaced calls of `X()` with `utils::utf8_to_locale(X_raw())`, because I assume existing code works correctly. Some places, though, it was obvious that the code wanted the UTF-8 version; there, I simply called `X_raw()`.

The final commit drops the `_raw` suffix, removing confusion and simplifying the names.

I'll merge this in three days unless someone stops me for a review.