### PR TITLE
pb-purge: Only delete files marked as "finished" or "deleted"

### DIFF
--- a/include/pbcontroller.h
+++ b/include/pbcontroller.h
@@ -42,7 +42,7 @@ public:
 	std::string get_formatstr();
 
 	unsigned int downloads_in_progress();
-	void reload_queue(bool remove_unplayed = false);
+	void reload_queue(bool also_remove_finished = false);
 
 	unsigned int get_maxdownloads();
 	void start_downloads();

--- a/include/pbcontroller.h
+++ b/include/pbcontroller.h
@@ -42,7 +42,7 @@ public:
 	std::string get_formatstr();
 
 	unsigned int downloads_in_progress();
-	void reload_queue(bool also_remove_finished = false);
+	void purge_queue();
 
 	unsigned int get_maxdownloads();
 	void start_downloads();

--- a/include/queueloader.h
+++ b/include/queueloader.h
@@ -14,7 +14,7 @@ public:
 	QueueLoader(const std::string& file, newsboat::ConfigContainer& cfg,
 		std::function<void()> cb_require_view_update);
 	void reload(std::vector<Download>& downloads,
-		bool remove_unplayed = false);
+		bool also_remove_finished = false);
 
 private:
 	std::string get_filename(const std::string& str);

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -660,6 +660,11 @@ test/opmlurlreader.o: test/opmlurlreader.cpp include/opmlurlreader.h \
  include/configactionhandler.h include/urlreader.h 3rd-party/catch.hpp \
  test/test-helpers.h include/utils.h include/logger.h config.h \
  include/strprintf.h
+test/queueloader.o: test/queueloader.cpp include/queueloader.h \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/download.h 3rd-party/catch.hpp \
+ include/configcontainer.h include/download.h test/test-helpers.h \
+ include/utils.h include/logger.h config.h include/strprintf.h
 test/regexmanager.o: test/regexmanager.cpp include/regexmanager.h \
  include/configparser.h include/configactionhandler.h include/matcher.h \
  filter/FilterParser.h 3rd-party/catch.hpp \

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -402,10 +402,10 @@ unsigned int PbController::get_maxdownloads()
 	return max_dls;
 }
 
-void PbController::reload_queue(bool remove_unplayed)
+void PbController::reload_queue(bool also_remove_finished)
 {
 	if (ql) {
-		ql->reload(downloads_, remove_unplayed);
+		ql->reload(downloads_, also_remove_finished);
 	}
 }
 

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -402,10 +402,10 @@ unsigned int PbController::get_maxdownloads()
 	return max_dls;
 }
 
-void PbController::reload_queue(bool also_remove_finished)
+void PbController::purge_queue()
 {
 	if (ql) {
-		ql->reload(downloads_, also_remove_finished);
+		ql->reload(downloads_, true);
 	}
 }
 

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -227,7 +227,7 @@ void PbView::run(bool auto_download)
 					_("Error: unable to perform operation: "
 						"download(s) in progress."));
 			} else {
-				ctrl->reload_queue(true);
+				ctrl->purge_queue();
 			}
 			ctrl->set_view_update_necessary(true);
 			break;

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -28,7 +28,8 @@ QueueLoader::QueueLoader(const std::string& file, ConfigContainer& cfg_,
 {
 }
 
-void QueueLoader::reload(std::vector<Download>& downloads, bool remove_unplayed)
+void QueueLoader::reload(std::vector<Download>& downloads,
+	bool also_remove_finished)
 {
 	std::vector<Download> dltemp;
 	std::vector<Download> deletion_list;
@@ -56,7 +57,7 @@ void QueueLoader::reload(std::vector<Download>& downloads, bool remove_unplayed)
 			keep_entry = true;
 			break;
 		case DlStatus::FINISHED:
-			if (!remove_unplayed) {
+			if (!also_remove_finished) {
 				LOG(Level::DEBUG,
 					"QueueLoader::reload: storing %s to "
 					"new "

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -49,12 +49,12 @@ void QueueLoader::reload(std::vector<Download>& downloads, bool remove_unplayed)
 		case DlStatus::FAILED:
 		case DlStatus::ALREADY_DOWNLOADED:
 		case DlStatus::READY:
+		case DlStatus::PLAYED:
 			LOG(Level::DEBUG,
 				"QueueLoader::reload: storing %s to new vector",
 				dl.url());
 			keep_entry = true;
 			break;
-		case DlStatus::PLAYED:
 		case DlStatus::FINISHED:
 			if (!remove_unplayed) {
 				LOG(Level::DEBUG,

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -9,7 +9,7 @@
 
 using namespace podboat;
 
-bool contains_download_with_status(std::vector<Download>& downloads,
+bool contains_download_with_status(const std::vector<Download>& downloads,
 	DlStatus status)
 {
 	for (const Download& d : downloads) {
@@ -29,7 +29,7 @@ TEST_CASE("reload removes downloads iff they are marked as finished or deleted",
 
 	QueueLoader queue_loader(queueFile.get_path(), cfg, empty_callback);
 
-	std::vector<DlStatus> possible_statuses = {
+	const std::vector<DlStatus> possible_statuses = {
 		DlStatus::QUEUED,
 		DlStatus::CANCELLED,
 		DlStatus::DELETED,

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -1,5 +1,7 @@
 #include "queueloader.h"
 
+#include <fstream>
+
 #include "3rd-party/catch.hpp"
 #include "configcontainer.h"
 #include "download.h"
@@ -7,72 +9,73 @@
 
 using namespace podboat;
 
-TEST_CASE("reload(also_remove_finished == true) removes files iff they are marked as finished or deleted",
+bool contains_download_with_status(std::vector<Download>& downloads,
+	DlStatus status)
+{
+	for (const Download& d : downloads) {
+		if (d.status() == status) {
+			return true;
+		}
+	}
+	return false;
+}
+
+TEST_CASE("reload removes downloads iff they are marked as finished or deleted",
 	"[QueueLoader]")
 {
-	auto emptyCallback = []() {};
+	auto empty_callback = []() {};
 	newsboat::ConfigContainer cfg;
 	TestHelpers::TempFile queueFile;
 
-	std::vector<Download> downloads;
-	downloads.emplace_back(emptyCallback);
+	QueueLoader queue_loader(queueFile.get_path(), cfg, empty_callback);
 
-	QueueLoader queue_loader(queueFile.get_path(), cfg, emptyCallback);
+	std::vector<DlStatus> possible_statuses = {
+		DlStatus::QUEUED,
+		DlStatus::CANCELLED,
+		DlStatus::DELETED,
+		DlStatus::FINISHED,
+		DlStatus::FAILED,
+		DlStatus::ALREADY_DOWNLOADED,
+		DlStatus::READY,
+		DlStatus::PLAYED
+		// Not including DlStatus::Downloading because that aborts the reload
+	};
 
-	REQUIRE(downloads.size() == 1);
+	GIVEN("A vector with a download in every possible state") {
+		std::vector<Download> downloads;
+		for (DlStatus status : possible_statuses) {
+			downloads.emplace_back(empty_callback);
+			downloads.back().set_status(status);
+		}
 
-	SECTION("reload removes download marked as DELETED") {
-		downloads.back().set_status(DlStatus::DELETED);
-		queue_loader.reload(downloads, true);
-		REQUIRE(downloads.size() == 0);
-	}
+		WHEN("reload() is called with also_remove_finished == false") {
+			queue_loader.reload(downloads, false);
 
-	SECTION("reload removes download marked as FINISHED") {
-		downloads.back().set_status(DlStatus::FINISHED);
-		queue_loader.reload(downloads, true);
-		REQUIRE(downloads.size() == 0);
-	}
+			THEN("only files marked as deleted are removed") {
+				for (DlStatus status : possible_statuses) {
+					INFO("status: " << static_cast<int>(status));
+					if (status == DlStatus::DELETED) {
+						REQUIRE_FALSE(contains_download_with_status(downloads, status));
+					} else {
+						REQUIRE(contains_download_with_status(downloads, status));
+					}
+				}
+			}
+		}
 
+		WHEN("reload() is called with also_remove_finished == true") {
+			queue_loader.reload(downloads, true);
 
-	SECTION("reload does not remove download marked as QUEUED") {
-		downloads.back().set_status(DlStatus::QUEUED);
-		queue_loader.reload(downloads, true);
-		REQUIRE(downloads.size() == 1);
-	}
-
-	SECTION("reload does not remove download marked as DOWNLOADING") {
-		downloads.back().set_status(DlStatus::DOWNLOADING);
-		queue_loader.reload(downloads, true);
-		REQUIRE(downloads.size() == 1);
-	}
-
-	SECTION("reload does not remove download marked as CANCELLED") {
-		downloads.back().set_status(DlStatus::CANCELLED);
-		queue_loader.reload(downloads, true);
-		REQUIRE(downloads.size() == 1);
-	}
-
-	SECTION("reload does not remove download marked as FAILED") {
-		downloads.back().set_status(DlStatus::FAILED);
-		queue_loader.reload(downloads, true);
-		REQUIRE(downloads.size() == 1);
-	}
-
-	SECTION("reload does not remove download marked as ALREADY_DOWNLOADED") {
-		downloads.back().set_status(DlStatus::ALREADY_DOWNLOADED);
-		queue_loader.reload(downloads, true);
-		REQUIRE(downloads.size() == 1);
-	}
-
-	SECTION("reload does not remove download marked as READY") {
-		downloads.back().set_status(DlStatus::READY);
-		queue_loader.reload(downloads, true);
-		REQUIRE(downloads.size() == 1);
-	}
-
-	SECTION("reload does not remove download marked as PLAYED") {
-		downloads.back().set_status(DlStatus::PLAYED);
-		queue_loader.reload(downloads, true);
-		REQUIRE(downloads.size() == 1);
+			THEN("only files marked as finished or deleted are removed") {
+				for (DlStatus status : possible_statuses) {
+					INFO("status: " << static_cast<int>(status));
+					if (status == DlStatus::FINISHED || status == DlStatus::DELETED) {
+						REQUIRE_FALSE(contains_download_with_status(downloads, status));
+					} else {
+						REQUIRE(contains_download_with_status(downloads, status));
+					}
+				}
+			}
+		}
 	}
 }

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -1,0 +1,78 @@
+#include "queueloader.h"
+
+#include "3rd-party/catch.hpp"
+#include "configcontainer.h"
+#include "download.h"
+#include "test-helpers.h"
+
+using namespace podboat;
+
+TEST_CASE("reload(also_remove_finished == true) removes files iff they are marked as finished or deleted",
+	"[QueueLoader]")
+{
+	auto emptyCallback = []() {};
+	newsboat::ConfigContainer cfg;
+	TestHelpers::TempFile queueFile;
+
+	std::vector<Download> downloads;
+	downloads.emplace_back(emptyCallback);
+
+	QueueLoader queue_loader(queueFile.get_path(), cfg, emptyCallback);
+
+	REQUIRE(downloads.size() == 1);
+
+	SECTION("reload removes download marked as DELETED") {
+		downloads.back().set_status(DlStatus::DELETED);
+		queue_loader.reload(downloads, true);
+		REQUIRE(downloads.size() == 0);
+	}
+
+	SECTION("reload removes download marked as FINISHED") {
+		downloads.back().set_status(DlStatus::FINISHED);
+		queue_loader.reload(downloads, true);
+		REQUIRE(downloads.size() == 0);
+	}
+
+
+	SECTION("reload does not remove download marked as QUEUED") {
+		downloads.back().set_status(DlStatus::QUEUED);
+		queue_loader.reload(downloads, true);
+		REQUIRE(downloads.size() == 1);
+	}
+
+	SECTION("reload does not remove download marked as DOWNLOADING") {
+		downloads.back().set_status(DlStatus::DOWNLOADING);
+		queue_loader.reload(downloads, true);
+		REQUIRE(downloads.size() == 1);
+	}
+
+	SECTION("reload does not remove download marked as CANCELLED") {
+		downloads.back().set_status(DlStatus::CANCELLED);
+		queue_loader.reload(downloads, true);
+		REQUIRE(downloads.size() == 1);
+	}
+
+	SECTION("reload does not remove download marked as FAILED") {
+		downloads.back().set_status(DlStatus::FAILED);
+		queue_loader.reload(downloads, true);
+		REQUIRE(downloads.size() == 1);
+	}
+
+	SECTION("reload does not remove download marked as ALREADY_DOWNLOADED") {
+		downloads.back().set_status(DlStatus::ALREADY_DOWNLOADED);
+		queue_loader.reload(downloads, true);
+		REQUIRE(downloads.size() == 1);
+	}
+
+	SECTION("reload does not remove download marked as READY") {
+		downloads.back().set_status(DlStatus::READY);
+		queue_loader.reload(downloads, true);
+		REQUIRE(downloads.size() == 1);
+	}
+
+	SECTION("reload does not remove download marked as PLAYED") {
+		downloads.back().set_status(DlStatus::PLAYED);
+		queue_loader.reload(downloads, true);
+		REQUIRE(downloads.size() == 1);
+	}
+}


### PR DESCRIPTION
According to the documentation [1] and keymap [2], `pb-purge` only removes downloads marked as `finished` or `deleted`.
I think that makes sense but the actual implementation also removed downloads marked as `played`.

This PR fixes the inconsistency between implementation and documentation and adds a test for `QueueLoader::reload()`.
I'm still planning to write more tests for `QueueLoader` but that will be submitted in a separate Pull Request.

[1] https://github.com/newsboat/newsboat/blob/22bb5253773ec2b58213a4952db57426e852ba6c/doc/newsboat.asciidoc#user-content-pb-purge
[2] https://github.com/newsboat/newsboat/blob/22bb5253773ec2b58213a4952db57426e852ba6c/src/keymap.cpp#L203-L205