### PR TITLE
Run tests with {Address,Leak}Sanitizer on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -215,3 +215,30 @@ linux_task:
     build_script: *build_script
     test_script: *test_script
     before_cache_script: *before_cache_script
+
+address_sanitizer_task:
+    name: AddressSanitizer
+
+    container:
+      dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
+      docker_arguments:
+          # We need llvm-symbolizer from llvm-9-tools to demangle symbols in
+          # sanitizer's reports
+          cxx_package: "clang-9 llvm-9"
+          cc: clang-9
+          cxx: clang++-9
+
+    env:
+      CXXFLAGS: "-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-optimize-sibling-calls -g"
+      ASAN_OPTIONS: "check_initialization_order=1:detect_stack_use_after_return=1"
+
+    cargo_cache:
+        folder: $HOME/.cargo/registry
+        fingerprint_script: cat Cargo.lock
+
+    # Sanitizers only apply to C++, so we only build and run C++ tests. Also,
+    # we don't pass --keep-going to the build: failures can be debugged with
+    # logs of other jobs.
+    build_script: make -j3 test/test
+    test_script: cd test && ./test --order rand
+    before_cache_script: *before_cache_script


### PR DESCRIPTION
This is something I meant to do ever since filing #540, #620, #621, #622, #623, and #624. 

[AddressSanitizer is a static analysis tool](https://releases.llvm.org/9.0.0/tools/clang/docs/AddressSanitizer.html) built right into the compiler. It adds checks for different memory-related errors: use-after-free, double-free, etc. Tests are a perfect place to apply these checks, since tests are reproducible by design, so any problems spotted by the sanitizer will be easier to fix. On Linux, AddressSanitizer automatically includes [LeakSanitizer](https://releases.llvm.org/9.0.0/tools/clang/docs/LeakSanitizer.html) as well.

Clang and GCC include the same sanitizers, but my understanding is that their upstream is with Clang, so that's what I use to run the checks.

AddressSanitizer [is not expected to produce false-positives](https://releases.llvm.org/9.0.0/tools/clang/docs/AddressSanitizer.html#issue-suppression), but it might create some problems as we expand our test coverage: if a newly written test uncovers a memory-related bug, the build for that test would fail, and we won't merge that pull request until the bug is fixed. However, this is a very good problem to have, so I'm not worried about it at all.

There are a few more sanitizers, which we don't run for various reasons:
- [ThreadSanitizer](https://releases.llvm.org/9.0.0/tools/clang/docs/ThreadSanitizer.html) doesn't make sense for us because our C++ tests are single-threaded. It did find a number of problems in the build of Newsboat itself, though (#671, #672, #673, #674)
- [MemorySanitizer](https://releases.llvm.org/9.0.0/tools/clang/docs/MemorySanitizer.html) requires instrumenting *all* the libraries we link to, including libstdc++. Ubuntu doesn't ship those, and building all of them would be quite a task, so this sanitizer is out of the picture for now
- [UndefinedBehaviorSanitizer](https://releases.llvm.org/9.0.0/tools/clang/docs/UndefinedBehaviorSanitizer.html) would be useful, but it finds a ton of errors in our filter parser. The parser is already being rewritten in Rust (#631), so I hope to add this sanitizer to CI in the near future
- [DataFlowSanitizer](https://releases.llvm.org/9.0.0/tools/clang/docs/DataFlowSanitizer.html) requires instrumenting the code manually, which I'm not up to

Will merge in 24 hours unless someone stops me for a review.