### PR TITLE
Cirrus CI: request 3GB of memory for FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,11 +3,11 @@ freebsd_task:
         - name: FreeBSD 11.2
           freebsd_instance:
             image: freebsd-11-2-release-amd64
-            memory: 2GB
+            memory: 3GB
         - name: FreeBSD 12.0
           freebsd_instance:
             image: freebsd-12-0-release-amd64
-            memory: 2GB
+            memory: 3GB
 
     cargo_cache:
         folder: $HOME/.cargo/registry


### PR DESCRIPTION
FreeBSD VMs on Cirrus CI occasionally stop, saying they've been "signaled to exit":
- https://cirrus-ci.com/task/4911591850246144
- https://cirrus-ci.com/task/5253449772171264
- https://cirrus-ci.com/task/6008502887907328

Someone else had this problem, and it turned out to be an OOM killer: https://github.com/dart-lang/sdk/commit/fcf88fe6faa0b7a63a690a716f914b5400657c2a

Given our Docker containers need 3GB of RAM, perhaps the same applies to FreeBSD; so this commit increases the RAM size in hopes of fixing the intermittern VM crashes.

I'm going to merge this right away, to start testing as quickly as possible. If you have any feedback, please comment here even after the PR was merged.