### PR TITLE
FreeBSD on Cirrus CI: set HOME envvar

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,12 +13,15 @@ freebsd_task:
         folder: $HOME/.cargo/registry
         fingerprint_script: cat Cargo.lock
 
+    env:
+        HOME: /home/testuser
+
     install_script: pkg install -y rust gmake rubygem-asciidoctor pkgconf stfl curl json-c ncurses openssl111 sqlite3 gettext-tools libxml2
     setup_script:
         - pw groupadd testgroup
         - pw useradd testuser -g testgroup -w none -m
-        - cp -R . /home/testuser
-        - chown -R testuser:testgroup /home/testuser/
+        - cp -R . $HOME
+        - chown -R testuser:testgroup $HOME
     # CI builds take a while to provision, install dependencies and compile our
     # stuff. To maximize the benefits, we ask Make to process as many rules as
     # possible before failing. This enables developers to fix more errors before


### PR DESCRIPTION
[Turns out](https://github.com/cirruslabs/cirrus-ci-docs/issues/463#issuecomment-589306089) we need that for the cache to work.

I don't expect any controversy on this, and I already saw it working, so I'm going to merge this right away.