### PR TITLE
Unbork depslist check on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -248,7 +248,7 @@ depslist_task:
 
     container:
       cpu: 1
-      memory: 256MB
+      memory: 512MB
       dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
       docker_arguments:
           cxx_package: g++-9
@@ -258,5 +258,6 @@ depslist_task:
     script:
         - make depslist
           # --exit-code forces git-diff to exit with code 1 if there were
-          # changes; that'll fail the task, which is exactly what we need
-        - git diff --exit-code || echo 'WARNING: the above diff is produced by GCC. Copy it if you only have Clang installed; otherwise just run `make depslist` and commit the result'
+          # changes. If it does, we print a warning, and propagate the error.
+          # Otherwise this whole script exits with 0
+        - git diff --exit-code || (echo 'WARNING: the above diff is produced by GCC. Copy it if you only have Clang installed; otherwise just run `make depslist` and commit the result'; false)

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -14,7 +14,7 @@ ARG cxx_package
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
-        libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext \
+        libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
         asciidoctor wget \
     && apt-get autoremove \
     && apt-get clean


### PR DESCRIPTION
#786 introduced a check on Cirrus CI that runs `make depslist` and checks that no changes were introduced; if they were, it means the depslist is not up to date. Unfortunately, that check never actually worked. @rnestler [spotted that](https://github.com/newsboat/newsboat/pull/786#discussion_r383173465), and this PR fixes it. Yes, I did verify that it fails as it should: https://cirrus-ci.com/task/4775935220121600?command=main#L161 :)

I'll merge in 24 hours if no-one stops me for a review.