### PR TITLE
Fix several highlighting issues

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1144,9 +1144,11 @@ When specifying `all`, the matching will be done in all three views. The
 `<regex>` must be
 a https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/basedefs/V1_chap09.html[POSIX
 extended regular expression], which will be matched case-insensitive against
-the text. `<fgcolor>` and `<bgcolor>` specify the foreground color resp. the
-background color of the matches. You can also specify 0 or more attributes. You
-can find a list of valid colors and attributes in the <<_configuring_colors>>.
+the text. If multiple highlight matches overlap, the style of the later
+specified highlight rule will be applied. `<fgcolor>` and `<bgcolor>` specify
+the foreground color resp. the background color of the matches. You can also
+specify 0 or more attributes. You can find a list of valid colors and
+attributes in the <<_configuring_colors>>.
 
 Examples for possible highlighting configurations are:
 

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -25,6 +25,8 @@ public:
 	int article_matches(Matchable* item);
 	std::map<int, std::string> extract_style_tags(std::string& str);
 	void insert_style_tags(std::string& str, std::map<int, std::string> tags);
+	void merge_style_tag(std::map<int, std::string>& tags, std::string tag,
+		int start, int end);
 
 private:
 	typedef std::pair<std::vector<regex_t*>, std::vector<std::string>>

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -24,8 +24,9 @@ public:
 	void remove_last_regex(const std::string& location);
 	int article_matches(Matchable* item);
 	std::map<size_t, std::string> extract_style_tags(std::string& str);
-	void insert_style_tags(std::string& str, std::map<size_t, std::string> tags);
-	void merge_style_tag(std::map<size_t, std::string>& tags, std::string tag,
+	void insert_style_tags(std::string& str, std::map<size_t, std::string>& tags);
+	void merge_style_tag(std::map<size_t, std::string>& tags,
+		const std::string& tag,
 		size_t start, size_t end);
 
 private:

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -23,10 +23,10 @@ public:
 	void quote_and_highlight(std::string& str, const std::string& location);
 	void remove_last_regex(const std::string& location);
 	int article_matches(Matchable* item);
-	std::map<int, std::string> extract_style_tags(std::string& str);
-	void insert_style_tags(std::string& str, std::map<int, std::string> tags);
-	void merge_style_tag(std::map<int, std::string>& tags, std::string tag,
-		int start, int end);
+	std::map<size_t, std::string> extract_style_tags(std::string& str);
+	void insert_style_tags(std::string& str, std::map<size_t, std::string> tags);
+	void merge_style_tag(std::map<size_t, std::string>& tags, std::string tag,
+		size_t start, size_t end);
 
 private:
 	typedef std::pair<std::vector<regex_t*>, std::vector<std::string>>

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -23,7 +23,7 @@ public:
 	void quote_and_highlight(std::string& str, const std::string& location);
 	void remove_last_regex(const std::string& location);
 	int article_matches(Matchable* item);
-	std::vector<std::string> extract_style_tags(std::string& str);
+	std::map<int, std::string> extract_style_tags(std::string& str);
 
 private:
 	typedef std::pair<std::vector<regex_t*>, std::vector<std::string>>

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -24,6 +24,7 @@ public:
 	void remove_last_regex(const std::string& location);
 	int article_matches(Matchable* item);
 	std::map<int, std::string> extract_style_tags(std::string& str);
+	void insert_style_tags(std::string& str, std::map<int, std::string> tags);
 
 private:
 	typedef std::pair<std::vector<regex_t*>, std::vector<std::string>>

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -23,7 +23,7 @@ public:
 	void quote_and_highlight(std::string& str, const std::string& location);
 	void remove_last_regex(const std::string& location);
 	int article_matches(Matchable* item);
-	std::string extract_outer_marker(std::string str, const int index);
+	std::vector<std::string> extract_style_tags(std::string& str);
 
 private:
 	typedef std::pair<std::vector<regex_t*>, std::vector<std::string>>

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -118,7 +118,18 @@ std::map<int, std::string> RegexManager::extract_style_tags(std::string& str)
 void RegexManager::insert_style_tags(std::string& str,
 	std::map<int, std::string> tags)
 {
-	// TODO(densch): Expand "<" into "<>" (reverse of what happened in extract_style_tags()
+	// Expand "<" into "<>" (reverse of what happened in extract_style_tags()
+	size_t pos = 0;
+	while (pos < str.size()) {
+		auto bracket = str.find_first_of("<", pos);
+		if (bracket == std::string::npos) {
+			break;
+		}
+		pos = bracket + 1;
+		// Add to strings in the `tags` map so we don't have to shift all the positions in that map
+		tags[pos] = ">" + tags[pos];
+	}
+
 	for (auto it = tags.rbegin(); it != tags.rend(); ++it) {
 		str.insert(it->first, it->second);
 	}

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -65,6 +65,19 @@ int RegexManager::article_matches(Matchable* item)
 	return -1;
 }
 
+void RegexManager::remove_last_regex(const std::string& location)
+{
+	auto& regexes = locations[location].first;
+	if (regexes.empty()) {
+		return;
+	}
+
+	auto it = regexes.end() - 1;
+	regfree(*it);
+	delete *it;
+	regexes.erase(it);
+}
+
 std::map<int, std::string> RegexManager::extract_style_tags(std::string& str)
 {
 	std::map<int, std::string> tags;
@@ -135,19 +148,6 @@ void RegexManager::merge_style_tag(std::map<int, std::string>& tags,
 			++it;
 		}
 	}
-}
-
-void RegexManager::remove_last_regex(const std::string& location)
-{
-	auto& regexes = locations[location].first;
-	if (regexes.empty()) {
-		return;
-	}
-
-	auto it = regexes.end() - 1;
-	regfree(*it);
-	delete *it;
-	regexes.erase(it);
 }
 
 void RegexManager::quote_and_highlight(std::string& str,

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -116,7 +116,7 @@ std::map<size_t, std::string> RegexManager::extract_style_tags(std::string& str)
 }
 
 void RegexManager::insert_style_tags(std::string& str,
-	std::map<size_t, std::string> tags)
+	std::map<size_t, std::string>& tags)
 {
 	// Expand "<" into "<>" (reverse of what happened in extract_style_tags()
 	size_t pos = 0;
@@ -141,7 +141,7 @@ void RegexManager::insert_style_tags(std::string& str,
 }
 
 void RegexManager::merge_style_tag(std::map<size_t, std::string>& tags,
-	std::string tag, size_t start, size_t end)
+	const std::string& tag, size_t start, size_t end)
 {
 	if (end <= start) {
 		return;
@@ -187,8 +187,8 @@ void RegexManager::quote_and_highlight(std::string& str,
 		while (regexec(regex, str.c_str() + offset, 1, &pmatch, 0) == 0) {
 			if (pmatch.rm_so != pmatch.rm_eo) {
 				const std::string marker = strprintf::fmt("<%u>", i);
-				int match_start = offset + pmatch.rm_so;
-				int match_end = offset + pmatch.rm_eo;
+				const int match_start = offset + pmatch.rm_so;
+				const int match_end = offset + pmatch.rm_eo;
 				merge_style_tag(tag_locations, marker, match_start, match_end);
 				offset = match_end;
 			} else {

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -78,9 +78,9 @@ void RegexManager::remove_last_regex(const std::string& location)
 	regexes.erase(it);
 }
 
-std::map<int, std::string> RegexManager::extract_style_tags(std::string& str)
+std::map<size_t, std::string> RegexManager::extract_style_tags(std::string& str)
 {
-	std::map<int, std::string> tags;
+	std::map<size_t, std::string> tags;
 
 	size_t pos = 0;
 	while (pos < str.size()) {
@@ -116,7 +116,7 @@ std::map<int, std::string> RegexManager::extract_style_tags(std::string& str)
 }
 
 void RegexManager::insert_style_tags(std::string& str,
-	std::map<int, std::string> tags)
+	std::map<size_t, std::string> tags)
 {
 	// Expand "<" into "<>" (reverse of what happened in extract_style_tags()
 	size_t pos = 0;
@@ -127,22 +127,27 @@ void RegexManager::insert_style_tags(std::string& str,
 		}
 		pos = bracket + 1;
 		// Add to strings in the `tags` map so we don't have to shift all the positions in that map
+		// (would be necessary if inserting directly into `str`
 		tags[pos] = ">" + tags[pos];
 	}
 
 	for (auto it = tags.rbegin(); it != tags.rend(); ++it) {
+		if (it->first > str.length()) {
+			// Ignore tags outside of string
+			continue;
+		}
 		str.insert(it->first, it->second);
 	}
 }
 
-void RegexManager::merge_style_tag(std::map<int, std::string>& tags,
-	std::string tag, int start, int end)
+void RegexManager::merge_style_tag(std::map<size_t, std::string>& tags,
+	std::string tag, size_t start, size_t end)
 {
 	// Find the latest tag occurring before `end`.
 	// It is important that looping executes in ascending order of location.
 	std::string latest_tag = "</>";
 	for (auto location_tag : tags) {
-		int location = location_tag.first;
+		size_t location = location_tag.first;
 		if (location > end) {
 			break;
 		}

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -143,6 +143,10 @@ void RegexManager::insert_style_tags(std::string& str,
 void RegexManager::merge_style_tag(std::map<size_t, std::string>& tags,
 	std::string tag, size_t start, size_t end)
 {
+	if (end <= start) {
+		return;
+	}
+
 	// Find the latest tag occurring before `end`.
 	// It is important that looping executes in ascending order of location.
 	std::string latest_tag = "</>";

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -136,8 +136,7 @@ void RegexManager::quote_and_highlight(std::string& str,
 		}
 		regmatch_t pmatch;
 		unsigned int offset = 0;
-		int err = regexec(regex, str.c_str(), 1, &pmatch, 0);
-		while (err == 0) {
+		while (regexec(regex, str.c_str() + offset, 1, &pmatch, 0) == 0) {
 			std::string outer_marker = "";
 			if (pmatch.rm_so != pmatch.rm_eo) {
 				outer_marker = extract_outer_marker(str, offset + pmatch.rm_so);
@@ -153,8 +152,6 @@ void RegexManager::quote_and_highlight(std::string& str,
 			if (offset >= str.length()) {
 				break;
 			}
-			err = regexec(
-					regex, str.c_str() + offset, 1, &pmatch, 0);
 		}
 		i++;
 	}

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -150,7 +150,7 @@ void RegexManager::merge_style_tag(std::map<size_t, std::string>& tags,
 	// Find the latest tag occurring before `end`.
 	// It is important that looping executes in ascending order of location.
 	std::string latest_tag = "</>";
-	for (auto location_tag : tags) {
+	for (const auto& location_tag : tags) {
 		size_t location = location_tag.first;
 		if (location > end) {
 			break;

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -727,7 +727,8 @@ TEST_CASE("quote_and_highlight() keeps stfl-encoded angle brackets and allows ma
 	}
 
 	SECTION("angle brackets can be matched directly") {
-		const std::string output = "<unread>title with <0><>literal><unread> angle brackets</>";
+		const std::string output =
+			"<unread>title with <0><>literal><unread> angle brackets</>";
 		rxman.handle_action("highlight", {"article", "<literal>", "red"});
 		rxman.quote_and_highlight(input, "article");
 		REQUIRE(input == output);
@@ -835,22 +836,23 @@ TEST_CASE("insert_style_tags() stfl-encodes angle brackets existing in input str
 	"[RegexManager]")
 {
 	RegexManager rxman;
-	std::string input = ">>This <is> a sentence< with brackets<<";
-	
+	std::string input = ">>This <is> a sentence with brackets<<";
+
 	SECTION("brackets are stfl-encoded") {
-		const std::string output = ">>This <>is> a sentence< with brackets<><>";
+		const std::string output = ">>This <>is> a sentence with brackets<><>";
 		rxman.insert_style_tags(input, {});
 		REQUIRE(input == output);
 	}
-	
+
 	SECTION("brackets are stfl-encoded and tags are inserted") {
 		std::map<int, std::string> tags = {
 			{0, "<0>"},
 			{1, "<1>"},
 			{6, "<hello>"},
-			{39, "</>"},
+			{38, "</>"},
 		};
-		const std::string output = "<0>><1>>This<hello> <>is> a sentence< with brackets<><></>";
+		const std::string output =
+			"<0>><1>>This<hello> <>is> a sentence with brackets<><></>";
 		rxman.insert_style_tags(input, tags);
 		REQUIRE(input == output);
 	}

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -469,7 +469,7 @@ TEST_CASE("RegexManager::remove_last_regex removes last added `highlight` rule",
 
 	auto input = INPUT;
 	rxman.quote_and_highlight(input, "articlelist");
-	REQUIRE(input == "x<0>foo</><1>bar</>x");
+	REQUIRE(input == "x<0>foo<1>bar</>x");
 
 	input = INPUT;
 	rxman.quote_and_highlight(input, "feedlist");

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -205,61 +205,6 @@ TEST_CASE("quote_and_highlight wraps highlighted text in numbered tags",
 	}
 }
 
-TEST_CASE("RegexManager::extract_outer_marker returns empty string if input "
-	"string is empty",
-	"[RegexManager]")
-{
-	RegexManager rxman;
-	REQUIRE(rxman.extract_outer_marker("", 0) == "");
-	REQUIRE(rxman.extract_outer_marker("", 10) == "");
-}
-
-TEST_CASE("RegexManager::extract_outer_marker finds the innermost tag "
-	"relative to given position in the text",
-	"[RegexManager]")
-{
-	RegexManager rxman;
-	std::string out;
-
-	SECTION("Find outer tag basic") {
-		std::string input = "<1>TestString</>";
-		out = rxman.extract_outer_marker(input, 7);
-
-		REQUIRE(out == "<1>");
-	}
-
-	SECTION("Find nested tag") {
-		std::string input = "<1>Nested<2>Test</>String</>";
-		out = rxman.extract_outer_marker(input, 14);
-
-		REQUIRE(out == "<2>");
-	}
-
-	SECTION("Find outer tag with second set") {
-		std::string input = "<1>Nested<2>Test</>String</>";
-		out = rxman.extract_outer_marker(input, 21);
-
-		REQUIRE(out == "<1>");
-	}
-
-	SECTION("Find unclosed nested tag") {
-		std::string input = "<1>Nested<2>Test</>String";
-		out = rxman.extract_outer_marker(input, 21);
-
-		REQUIRE(out == "<1>");
-	}
-
-}
-
-TEST_CASE("RegexManager::extract_outer_marker returns empty string if input "
-	"string contains closing tag without a pairing opening one, before "
-	"the position we're looking at",
-	"[RegexManager]")
-{
-	RegexManager rxman;
-	REQUIRE(rxman.extract_outer_marker("hello</>world", 10) == "");
-}
-
 TEST_CASE("RegexManager::dump_config turns each `highlight` rule into a string, "
 	"and appends them onto a vector",
 	"[RegexManager]")

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -631,3 +631,31 @@ TEST_CASE("RegexManager uses POSIX extended regex syntax",
 
 	// If you add more checks to this test, consider adding the same to Matcher tests
 }
+
+TEST_CASE("quote_and_highlight() does not break existing tags like <unread>",
+	"[RegexManager]")
+{
+	RegexManager rxman;
+	std::string input =  "<unread>This entry is unread now</>";
+
+	WHEN("matching `read`") {
+		const std::string output = "<unread>This entry is un<0>read</> now</>";
+		rxman.handle_action("highlight", {"article", "read", "red"});
+		rxman.quote_and_highlight(input, "article");
+		REQUIRE(input == output);
+	}
+
+	WHEN("matching `unread`") {
+		const std::string output = "<unread>This entry is <0>unread</> now</>";
+		rxman.handle_action("highlight", {"article", "unread", "red"});
+		rxman.quote_and_highlight(input, "article");
+		REQUIRE(input == output);
+	}
+
+	WHEN("matching the full line") {
+		const std::string output = "<unread><0>This entry is unread now</></>";
+		rxman.handle_action("highlight", {"article", "^.*$", "red"});
+		rxman.quote_and_highlight(input, "article");
+		REQUIRE(input == output);
+	}
+}

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -108,13 +108,15 @@ TEST_CASE("RegexManager preserves text when there's nothing to highlight",
 	rxman.quote_and_highlight(input, "feedlist");
 	REQUIRE(input == "xbarx");
 
-	input = "<";
-	rxman.quote_and_highlight(input, "feedlist");
-	REQUIRE(input == "<");
-
 	input = "a<b>";
 	rxman.quote_and_highlight(input, "feedlist");
 	REQUIRE(input == "a<b>");
+
+	SECTION("encode `<` as `<>` for stfl") {
+		input = "<";
+		rxman.quote_and_highlight(input, "feedlist");
+		REQUIRE(input == "<>");
+	}
 }
 
 TEST_CASE("`highlight all` adds rules for all locations", "[RegexManager]")

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -805,3 +805,53 @@ TEST_CASE("extract_style_tags() ignores invalid characters",
 		REQUIRE(tags.size() == 2);
 	}
 }
+
+TEST_CASE("insert_style_tags() adds tags into string at correct positions",
+	"[RegexManager]")
+{
+	RegexManager rxman;
+	std::string input = "This is a sentence";
+
+	SECTION("string does not change if no tags are specified") {
+		const std::string output = "This is a sentence";
+		rxman.insert_style_tags(input, {});
+		REQUIRE(input == output);
+	}
+
+	SECTION("tags are added at the correct location") {
+		std::map<int, std::string> tags = {
+			{0, "<0>"},
+			{1, "<1>"},
+			{10, "<hello>"},
+			{18, "</>"},
+		};
+		const std::string output = "<0>T<1>his is a <hello>sentence</>";
+		rxman.insert_style_tags(input, tags);
+		REQUIRE(input == output);
+	}
+}
+
+TEST_CASE("insert_style_tags() stfl-encodes angle brackets existing in input string",
+	"[RegexManager]")
+{
+	RegexManager rxman;
+	std::string input = ">>This <is> a sentence< with brackets<<";
+	
+	SECTION("brackets are stfl-encoded") {
+		const std::string output = ">>This <>is> a sentence< with brackets<><>";
+		rxman.insert_style_tags(input, {});
+		REQUIRE(input == output);
+	}
+	
+	SECTION("brackets are stfl-encoded and tags are inserted") {
+		std::map<int, std::string> tags = {
+			{0, "<0>"},
+			{1, "<1>"},
+			{6, "<hello>"},
+			{39, "</>"},
+		};
+		const std::string output = "<0>><1>>This<hello> <>is> a sentence< with brackets<><></>";
+		rxman.insert_style_tags(input, tags);
+		REQUIRE(input == output);
+	}
+}

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -685,4 +685,15 @@ TEST_CASE("quote_and_highlight() ignores tags when matching the regular expressi
 			REQUIRE(input == output);
 		}
 	}
+
+	WHEN("matching text which contains `<u>...</>` markers (added by HTML renderer)") {
+		input = "Some<u>thing</> is underlined";
+		rxman.handle_action("highlight", {"article", "Something", "red"});
+
+		THEN("the tags should be ignored when matching text with a regular expression") {
+			const std::string output = "<0>Some<u>thing</></> is underlined";
+			rxman.quote_and_highlight(input, "article");
+			REQUIRE(input == output);
+		}
+	}
 }

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -880,7 +880,7 @@ TEST_CASE("insert_style_tags() does not crash on invalid input",
 	}
 }
 
-TEST_CASE("merge_style_tag() removes tags between start and end",
+TEST_CASE("merge_style_tag() removes tags between start and end positions",
 	"[RegexManager]")
 {
 	RegexManager rxman;
@@ -901,7 +901,7 @@ TEST_CASE("merge_style_tag() removes tags between start and end",
 	REQUIRE(tags.size() == 4);
 }
 
-TEST_CASE("merge_style_tag() restores tag at end when necessary",
+TEST_CASE("merge_style_tag() restores previous tag after the inserted tag if necessary",
 	"[RegexManager]")
 {
 	RegexManager rxman;
@@ -921,7 +921,7 @@ TEST_CASE("merge_style_tag() restores tag at end when necessary",
 		REQUIRE(tags.size() == 4);
 	}
 
-	SECTION("end on tag switch so restore second tag") {
+	SECTION("end on tag switch so no need to restore anything") {
 		rxman.merge_style_tag(tags, new_tag, 0, 5);
 		REQUIRE(tags[0] == new_tag);
 		REQUIRE(tags[5] == "<1>");

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -737,7 +737,7 @@ TEST_CASE("quote_and_highlight() keeps stfl-encoded angle brackets and allows ma
 	}
 }
 
-TEST_CASE("extract_style_tags() returns vector with tags from input string",
+TEST_CASE("extract_style_tags() returns map which links locations to tags from input string",
 	"[RegexManager]")
 {
 	RegexManager rxman;
@@ -816,8 +816,9 @@ TEST_CASE("insert_style_tags() adds tags into string at correct positions",
 	std::string input = "This is a sentence";
 
 	SECTION("string does not change if no tags are specified") {
+		std::map<size_t, std::string> tags;
 		const std::string output = "This is a sentence";
-		rxman.insert_style_tags(input, {});
+		rxman.insert_style_tags(input, tags);
 		REQUIRE(input == output);
 	}
 
@@ -841,8 +842,9 @@ TEST_CASE("insert_style_tags() stfl-encodes angle brackets existing in input str
 	std::string input = ">>This <is> a sentence with brackets<<";
 
 	SECTION("brackets are stfl-encoded") {
+		std::map<size_t, std::string> tags;
 		const std::string output = ">>This <>is> a sentence with brackets<><>";
-		rxman.insert_style_tags(input, {});
+		rxman.insert_style_tags(input, tags);
 		REQUIRE(input == output);
 	}
 

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -822,7 +822,7 @@ TEST_CASE("insert_style_tags() adds tags into string at correct positions",
 	}
 
 	SECTION("tags are added at the correct location") {
-		std::map<int, std::string> tags = {
+		std::map<size_t, std::string> tags = {
 			{0, "<0>"},
 			{1, "<1>"},
 			{10, "<hello>"},
@@ -847,7 +847,7 @@ TEST_CASE("insert_style_tags() stfl-encodes angle brackets existing in input str
 	}
 
 	SECTION("brackets are stfl-encoded and tags are inserted") {
-		std::map<int, std::string> tags = {
+		std::map<size_t, std::string> tags = {
 			{0, "<0>"},
 			{1, "<1>"},
 			{6, "<hello>"},
@@ -855,6 +855,24 @@ TEST_CASE("insert_style_tags() stfl-encodes angle brackets existing in input str
 		};
 		const std::string output =
 			"<0>><1>>This<hello> <>is> a sentence with brackets<><></>";
+		rxman.insert_style_tags(input, tags);
+		REQUIRE(input == output);
+	}
+}
+
+TEST_CASE("insert_style_tags() does not crash on invalid input",
+	"[RegexManager]")
+{
+	RegexManager rxman;
+	std::string input = "test this";
+
+	SECTION("tags with a position outside  of the string are ignored") {
+		std::map<size_t, std::string> tags = {
+			{0, "<test>"},
+			{9, "<in>"},
+			{10, "<out>"},
+		};
+		const std::string output = "<test>test this<in>";
 		rxman.insert_style_tags(input, tags);
 		REQUIRE(input == output);
 	}

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -659,3 +659,30 @@ TEST_CASE("quote_and_highlight() does not break existing tags like <unread>",
 		REQUIRE(input == output);
 	}
 }
+
+TEST_CASE("quote_and_highlight() ignores tags when matching the regular expressions",
+	"[RegexManager]")
+{
+	RegexManager rxman;
+	std::string input =  "<unread>This entry is unread now</>";
+
+	WHEN("matching text at the start of the line") {
+		rxman.handle_action("highlight", {"article", "^This", "red"});
+
+		THEN("the <unread> tag should be ignored") {
+			const std::string output = "<unread><0>This</> entry is unread now</>";
+			rxman.quote_and_highlight(input, "article");
+			REQUIRE(input == output);
+		}
+	}
+
+	WHEN("matching text at the end of the line") {
+		rxman.handle_action("highlight", {"article", "now$", "red"});
+
+		THEN("the closing tag `</>` (related to <unread>) should be ignored") {
+			const std::string output = "<unread>This entry is unread <0>now</></>";
+			rxman.quote_and_highlight(input, "article");
+			REQUIRE(input == output);
+		}
+	}
+}


### PR DESCRIPTION
This fixes several issues related to highlighting:
- Fixes #37 
- Fixes #242 
- Fixes #331 
- Fixes #488 
- Fixes #535 

The main idea in `quote_and_highlight()` now is:
1. Remove all tags (`<…>`) from the to-be-highlighted line (save tag text/position in a separate mapping)
2. Repeatedly:
    - Execute regex on the stripped line to find ranges to be highlighted
    - Add tags for those ranges in the text/position mapping (no changes to the line itself)
3.  Insert all tags from the mapping into the to-be-highlighted line

Operations on the tag text/position mapping is extracted into separate functions.

Let me know if anything is unclear or needs some descriptive comments.