### PR TITLE
RegexManager: Stop `^.` from matching after a previous regex match

### DIFF
--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -184,7 +184,9 @@ void RegexManager::quote_and_highlight(std::string& str,
 		}
 		regmatch_t pmatch;
 		unsigned int offset = 0;
-		while (regexec(regex, str.c_str() + offset, 1, &pmatch, 0) == 0) {
+		int eflags = 0;
+		while (regexec(regex, str.c_str() + offset, 1, &pmatch, eflags) == 0) {
+			eflags |= REG_NOTBOL; // Don't match beginning-of-line operator (^) in following checks
 			if (pmatch.rm_so != pmatch.rm_eo) {
 				const std::string marker = strprintf::fmt("<%u>", i);
 				const int match_start = offset + pmatch.rm_so;

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -82,6 +82,25 @@ TEST_CASE("RegexManager highlights according to definition", "[RegexManager]")
 	}
 }
 
+TEST_CASE("quote_and_highlight() only matches `^` at the start of the line",
+	"[RegexManager]")
+{
+	RegexManager rxman;
+	std::string input = "This is a test";
+
+	SECTION("^.") {
+		rxman.handle_action("highlight", {"article", "^.", "blue", "red"});
+		rxman.quote_and_highlight(input, "article");
+		REQUIRE(input == "<0>T</>his is a test");
+	}
+
+	SECTION("(^Th|^is)") {
+		rxman.handle_action("highlight", {"article", "(^Th|^is)", "blue", "red"});
+		rxman.quote_and_highlight(input, "article");
+		REQUIRE(input == "<0>Th</>is is a test");
+	}
+}
+
 // This test might seem totally out of the blue, but we do need it: as of this
 // writing, `highlight-article` add a nullptr for a regex to "articlelist"
 // context, which would've crashed the program if it were to be dereferenced.


### PR DESCRIPTION
Fixes #795 

@Minoru: Thanks for the helpful suggestion (`REG_NOTBOL`)