### PR TITLE
Docker i686: use Rust 1.41.1

### DIFF
--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -63,7 +63,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain stable \
+        --default-toolchain 1.41.1 \
         # Install only rustc, rust-std, and cargo
         --profile minimal \
     && chmod a+w $HOME/.cargo


### PR DESCRIPTION
Fixes #594. See https://github.com/newsboat/newsboat/issues/594#issuecomment-595948701 for explanation.

Will merge in three days unless someone stops me for a review. (I'm AFK for the weekend, so I won't address your comments before Monday.)