### PR TITLE
Test: Use DYNAMIC_SECTION instead of manually formatting name

### DIFF
--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -569,8 +569,7 @@ TEST_CASE("<h[2-6]> and <p>", "[HtmlRenderer]")
 	for (auto tag : {
 			"<h2>", "<h3>", "<h4>", "<h5>", "<h6>", "<p>"
 		}) {
-		SECTION(std::string("When alone, ") + tag +
-			" generates only one line") {
+		DYNAMIC_SECTION("When alone, " << tag << " generates only one line") {
 			std::string closing_tag = tag;
 			closing_tag.insert(1, "/");
 
@@ -976,7 +975,7 @@ TEST_CASE(
 	std::vector<LinkPair> links;
 
 	for (auto border_width = 1; border_width < 10; ++border_width) {
-		SECTION(strprintf::fmt("`border' = %u", border_width)) {
+		DYNAMIC_SECTION("`border' = " << border_width) {
 			const std::string input_template =
 				"<table border='%u'>"
 				"<tr>"


### PR DESCRIPTION
@Minoru: I saw you closed #237.

If you are still interested, this PR shows some use of DYNAMIC_SECTION.

There are a few more places where a SECTION is placed in a loop but those don't need formatting to generate a locally unique section name, e.g.:
https://github.com/newsboat/newsboat/blob/4b850932d242cb7c0126ae679ac858f7fdd88d9c/test/htmlrenderer.cpp#L109-L119