### PR TITLE
Escape "<" (into "<>" for stfl) feed/article title and author

### DIFF
--- a/include/htmlrenderer.h
+++ b/include/htmlrenderer.h
@@ -113,7 +113,6 @@ private:
 	unsigned int add_link(std::vector<LinkPair>& links,
 		const std::string& link,
 		LinkType type);
-	std::string quote_for_stfl(std::string str);
 	std::string absolute_url(const std::string& url,
 		const std::string& link);
 	std::string type2str(LinkType type);

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -640,9 +640,10 @@ test/itemrenderer.o: test/itemrenderer.cpp include/itemrenderer.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
  include/configparser.h include/configactionhandler.h include/matcher.h \
  filter/FilterParser.h 3rd-party/catch.hpp include/cache.h \
- include/configcontainer.h include/configcontainer.h include/rssfeed.h \
- include/matchable.h include/rssitem.h include/utils.h include/logger.h \
- config.h include/strprintf.h test/test-helpers.h include/utils.h
+ include/configcontainer.h include/configcontainer.h \
+ include/regexmanager.h include/rssfeed.h include/matchable.h \
+ include/rssitem.h include/utils.h include/logger.h config.h \
+ include/strprintf.h test/test-helpers.h include/utils.h
 test/keymap.o: test/keymap.cpp include/keymap.h include/configparser.h \
  include/configactionhandler.h 3rd-party/catch.hpp \
  include/confighandlerexception.h

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -1027,7 +1027,7 @@ std::string FeedListFormAction::format_line(const std::string& feedlist_format,
 	fmt.register_fmt('c', std::to_string(feed->total_item_count()));
 	fmt.register_fmt('n', unread_count > 0 ? "N" : " ");
 	fmt.register_fmt('S', feed->get_status());
-	fmt.register_fmt('t', get_title(feed));
+	fmt.register_fmt('t', utils::quote_for_stfl(get_title(feed)));
 	fmt.register_fmt('T', feed->get_firsttag());
 	fmt.register_fmt('l', utils::censor_url(feed->link()));
 	fmt.register_fmt('L', utils::censor_url(feed->rssurl()));

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -47,9 +47,11 @@ void prepare_header(
 	};
 
 	const std::string feedtitle = item_renderer::get_feedtitle(item);
-	add_line(feedtitle, _("Feed: "));
-	add_line(utils::utf8_to_locale(item->title()), _("Title: "));
-	add_line(utils::utf8_to_locale(item->author()), _("Author: "));
+	add_line(utils::quote_for_stfl(feedtitle), _("Feed: "));
+	add_line(utils::quote_for_stfl(utils::utf8_to_locale(item->title())),
+		_("Title: "));
+	add_line(utils::quote_for_stfl(utils::utf8_to_locale(item->author())),
+		_("Author: "));
 	add_line(item->pubDate(), _("Date: "));
 	add_line(item->link(), _("Link: "), LineType::softwrappable);
 	add_line(item->flags(), _("Flags: "));

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -364,7 +364,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 }
 
 TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
-	"[item_renderer][broken]")
+	"[item_renderer]")
 {
 	TestHelpers::EnvVar tzEnv("TZ");
 	tzEnv.set("UTC");

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -4,6 +4,7 @@
 
 #include "cache.h"
 #include "configcontainer.h"
+#include "regexmanager.h"
 #include "rssfeed.h"
 #include "test-helpers.h"
 
@@ -545,4 +546,63 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed URL "
 
 	const auto result = item_renderer::get_feedtitle(item);
 	REQUIRE(result == feedurl);
+}
+
+TEST_CASE("Functions used for rendering articles escape '<' into `<>` for use with stfl",
+	"[item_renderer]")
+{
+	TestHelpers::EnvVar tzEnv("TZ");
+	tzEnv.set("UTC");
+
+	ConfigContainer cfg;
+	RegexManager rxman;
+
+	Cache rsscache(":memory:", &cfg);
+
+	std::shared_ptr<RssItem> item;
+	std::shared_ptr<RssFeed> feed;
+	std::tie(item, feed) = create_test_item(&rsscache);
+
+	feed->set_title("<" + FEED_TITLE + ">");
+	item->set_title("<" + ITEM_TITLE + ">");
+	item->set_author("<" + ITEM_AUTHOR + ">");
+	item->set_description("<html>&lt;test&gt;</html>");
+
+	SECTION("to_stfl_list()") {
+		const auto expected = std::string() +
+			"{list" +
+			"{listitem text:\"Feed: <>" + FEED_TITLE + ">\"}" +
+			"{listitem text:\"Title: <>" + ITEM_TITLE + ">\"}" +
+			"{listitem text:\"Author: <>" + ITEM_AUTHOR + ">\"}" +
+			"{listitem text:\"Date: Sun, 30 Sep 2018 19:34:25 +0000\"}" +
+			"{listitem text:\"Link: " + ITEM_LINK + "\"}" +
+			"{listitem text:\"Flags: " + ITEM_FLAGS_RENDERED + "\"}" +
+			"{listitem text:\" \"}" +
+			"{listitem text:\"<>test>\"}" +
+			"}";
+
+		std::vector<LinkPair> links;
+		const auto result = item_renderer::to_stfl_list(cfg, item, 80, 80, &rxman,
+				"article", links);
+		REQUIRE(result.first == expected);
+	}
+
+	SECTION("source_to_stfl_list()") {
+		const auto expected = std::string() +
+			"{list" +
+			"{listitem text:\"Feed: <>" + FEED_TITLE + ">\"}" +
+			"{listitem text:\"Title: <>" + ITEM_TITLE + ">\"}" +
+			"{listitem text:\"Author: <>" + ITEM_AUTHOR + ">\"}" +
+			"{listitem text:\"Date: Sun, 30 Sep 2018 19:34:25 +0000\"}" +
+			"{listitem text:\"Link: " + ITEM_LINK + "\"}" +
+			"{listitem text:\"Flags: " + ITEM_FLAGS_RENDERED + "\"}" +
+			"{listitem text:\" \"}" +
+			"{listitem text:\"<>html>&lt;test&gt;<>/html>\"}" +
+			"}";
+
+		std::vector<LinkPair> links;
+		const auto result = item_renderer::source_to_stfl_list(item, 80, 80, &rxman,
+				"article");
+		REQUIRE(result.first == expected);
+	}
 }


### PR DESCRIPTION
Fixes #796 

Also fixes old Newsbeuter issues:
- Fixes https://github.com/akrennmair/newsbeuter/issues/554
- Fixes https://github.com/akrennmair/newsbeuter/issues/589

@Minoru: I haven't forgotten about [your suggestion to introduce a type called StflString](https://github.com/newsboat/newsboat/pull/797#discussion_r388350769).
I'm not yet sure how that will work out so I will postpone it for now.