### PR TITLE
Don't quote for stfl in plaintext output

### DIFF
--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -71,6 +71,8 @@ size_t rs_strwidth(const char* str);
 
 size_t rs_strwidth_stfl(const char* str);
 
+char* rs_substr_with_width(const char* str, size_t max_width);
+
 char* rs_substr_with_width_stfl(const char* str, size_t max_width);
 
 char* rs_remove_soft_hyphens(const char* str);

--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -71,7 +71,7 @@ size_t rs_strwidth(const char* str);
 
 size_t rs_strwidth_stfl(const char* str);
 
-char* rs_substr_with_width(const char* str, size_t max_width);
+char* rs_substr_with_width_stfl(const char* str, size_t max_width);
 
 char* rs_remove_soft_hyphens(const char* str);
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -72,7 +72,7 @@ size_t strwidth(const std::string& s);
 size_t strwidth_stfl(const std::string& str);
 size_t wcswidth_stfl(const std::wstring& str, size_t size);
 
-std::string substr_with_width(const std::string& str,
+std::string substr_with_width_stfl(const std::string& str,
 	const size_t max_width);
 
 unsigned int to_u(const std::string& str,

--- a/include/utils.h
+++ b/include/utils.h
@@ -72,6 +72,9 @@ size_t strwidth(const std::string& s);
 size_t strwidth_stfl(const std::string& str);
 size_t wcswidth_stfl(const std::wstring& str, size_t size);
 
+std::string substr_with_width(const std::string& str,
+	const size_t max_width);
+
 std::string substr_with_width_stfl(const std::string& str,
 	const size_t max_width);
 

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -439,6 +439,22 @@ pub unsafe extern "C" fn rs_strwidth_stfl(input: *const c_char) -> usize {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn rs_substr_with_width(
+    string: *const c_char,
+    max_width: usize,
+) -> *mut c_char {
+    abort_on_panic(|| {
+        let rs_str = CStr::from_ptr(string);
+        let rs_str = rs_str.to_string_lossy().into_owned();
+        let output = utils::substr_with_width(&rs_str, max_width);
+        // `output` contains a subset of `string`, which is a C string. Thus, we conclude that
+        // `output` doesn't contain null bytes. Therefore, `CString::new` always returns `Some`.
+        let result = CString::new(output).unwrap();
+        result.into_raw()
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rs_substr_with_width_stfl(
     string: *const c_char,
     max_width: usize,

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -439,14 +439,14 @@ pub unsafe extern "C" fn rs_strwidth_stfl(input: *const c_char) -> usize {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_substr_with_width(
+pub unsafe extern "C" fn rs_substr_with_width_stfl(
     string: *const c_char,
     max_width: usize,
 ) -> *mut c_char {
     abort_on_panic(|| {
         let rs_str = CStr::from_ptr(string);
         let rs_str = rs_str.to_string_lossy().into_owned();
-        let output = utils::substr_with_width(&rs_str, max_width);
+        let output = utils::substr_with_width_stfl(&rs_str, max_width);
         // `output` contains a subset of `string`, which is a C string. Thus, we conclude that
         // `output` doesn't contain null bytes. Therefore, `CString::new` always returns `Some`.
         let result = CString::new(output).unwrap();

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -310,14 +310,14 @@ pub fn strwidth_stfl(rs_str: &str) -> usize {
 /// returns None, the character width is treated as 0. A STFL tag (e.g. `<b>`, `<foobar>`, `</>`)
 /// width is treated as 0, but escaped less-than (`<>`) width is treated as 1.
 /// ```
-/// use libnewsboat::utils::substr_with_width;
-/// assert_eq!(substr_with_width("a", 1), "a");
-/// assert_eq!(substr_with_width("a", 2), "a");
-/// assert_eq!(substr_with_width("ab", 1), "a");
-/// assert_eq!(substr_with_width("abc", 1), "a");
-/// assert_eq!(substr_with_width("A\u{3042}B\u{3044}C\u{3046}", 5), "A\u{3042}B")
+/// use libnewsboat::utils::substr_with_width_stfl;
+/// assert_eq!(substr_with_width_stfl("a", 1), "a");
+/// assert_eq!(substr_with_width_stfl("a", 2), "a");
+/// assert_eq!(substr_with_width_stfl("ab", 1), "a");
+/// assert_eq!(substr_with_width_stfl("abc", 1), "a");
+/// assert_eq!(substr_with_width_stfl("A\u{3042}B\u{3044}C\u{3046}", 5), "A\u{3042}B")
 ///```
-pub fn substr_with_width(string: &str, max_width: usize) -> String {
+pub fn substr_with_width_stfl(string: &str, max_width: usize) -> String {
     let mut result = String::new();
     let mut in_bracket = false;
     let mut tagbuf = Vec::<char>::new();
@@ -898,44 +898,44 @@ mod tests {
     }
 
     #[test]
-    fn t_substr_with_width_given_string_empty() {
-        assert!(substr_with_width("", 0).is_empty());
-        assert!(substr_with_width("", 1).is_empty());
+    fn t_substr_with_width_stfl_given_string_empty() {
+        assert!(substr_with_width_stfl("", 0).is_empty());
+        assert!(substr_with_width_stfl("", 1).is_empty());
     }
 
     #[test]
-    fn t_substr_with_width_max_width_zero() {
-        assert!(substr_with_width("world", 0).is_empty());
-        assert!(substr_with_width("", 0).is_empty());
+    fn t_substr_with_width_stfl_max_width_zero() {
+        assert!(substr_with_width_stfl("world", 0).is_empty());
+        assert!(substr_with_width_stfl("", 0).is_empty());
     }
 
     #[test]
-    fn t_substr_with_width_max_width_dont_split_codepoints() {
-        assert_eq!(substr_with_width("ＡＢＣ<b>ＤＥ</b>Ｆ", 9), "ＡＢＣ<b>Ｄ");
-        assert_eq!(substr_with_width("<foobar>ＡＢＣ", 4), "<foobar>ＡＢ");
-        assert_eq!(substr_with_width("a<<xyz>>bcd", 3), "a<<xyz>>b"); // tag: "<<xyz>"
-        assert_eq!(substr_with_width("ＡＢＣ<b>ＤＥ", 10), "ＡＢＣ<b>ＤＥ");
-        assert_eq!(substr_with_width("a</>b</>c</>", 2), "a</>b</>");
+    fn t_substr_with_width_stfl_max_width_dont_split_codepoints() {
+        assert_eq!(substr_with_width_stfl("ＡＢＣ<b>ＤＥ</b>Ｆ", 9), "ＡＢＣ<b>Ｄ");
+        assert_eq!(substr_with_width_stfl("<foobar>ＡＢＣ", 4), "<foobar>ＡＢ");
+        assert_eq!(substr_with_width_stfl("a<<xyz>>bcd", 3), "a<<xyz>>b"); // tag: "<<xyz>"
+        assert_eq!(substr_with_width_stfl("ＡＢＣ<b>ＤＥ", 10), "ＡＢＣ<b>ＤＥ");
+        assert_eq!(substr_with_width_stfl("a</>b</>c</>", 2), "a</>b</>");
     }
 
     #[test]
-    fn t_substr_with_width_max_width_do_not_count_stfl_tag() {
-        assert_eq!(substr_with_width("ＡＢＣ<b>ＤＥ</b>Ｆ", 9), "ＡＢＣ<b>Ｄ");
-        assert_eq!(substr_with_width("<foobar>ＡＢＣ", 4), "<foobar>ＡＢ");
-        assert_eq!(substr_with_width("a<<xyz>>bcd", 3), "a<<xyz>>b"); // tag: "<<xyz>"
-        assert_eq!(substr_with_width("ＡＢＣ<b>ＤＥ", 10), "ＡＢＣ<b>ＤＥ");
-        assert_eq!(substr_with_width("a</>b</>c</>", 2), "a</>b</>");
+    fn t_substr_with_width_stfl_max_width_do_not_count_stfl_tag() {
+        assert_eq!(substr_with_width_stfl("ＡＢＣ<b>ＤＥ</b>Ｆ", 9), "ＡＢＣ<b>Ｄ");
+        assert_eq!(substr_with_width_stfl("<foobar>ＡＢＣ", 4), "<foobar>ＡＢ");
+        assert_eq!(substr_with_width_stfl("a<<xyz>>bcd", 3), "a<<xyz>>b"); // tag: "<<xyz>"
+        assert_eq!(substr_with_width_stfl("ＡＢＣ<b>ＤＥ", 10), "ＡＢＣ<b>ＤＥ");
+        assert_eq!(substr_with_width_stfl("a</>b</>c</>", 2), "a</>b</>");
     }
 
     #[test]
-    fn t_substr_with_width_max_width_count_escaped_less_than_mark() {
-        assert_eq!(substr_with_width("<><><>", 2), "<><>");
-        assert_eq!(substr_with_width("a<>b<>c", 3), "a<>b");
+    fn t_substr_with_width_stfl_max_width_count_escaped_less_than_mark() {
+        assert_eq!(substr_with_width_stfl("<><><>", 2), "<><>");
+        assert_eq!(substr_with_width_stfl("a<>b<>c", 3), "a<>b");
     }
 
     #[test]
-    fn t_substr_with_width_max_width_non_printable() {
-        assert_eq!(substr_with_width("\x01\x02abc", 1), "\x01\x02a");
+    fn t_substr_with_width_stfl_max_width_non_printable() {
+        assert_eq!(substr_with_width_stfl("\x01\x02abc", 1), "\x01\x02a");
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -980,7 +980,10 @@ mod tests {
 
     #[test]
     fn t_substr_with_width_stfl_max_width_dont_split_codepoints() {
-        assert_eq!(substr_with_width_stfl("ＡＢＣ<b>ＤＥ</b>Ｆ", 9), "ＡＢＣ<b>Ｄ");
+        assert_eq!(
+            substr_with_width_stfl("ＡＢＣ<b>ＤＥ</b>Ｆ", 9),
+            "ＡＢＣ<b>Ｄ"
+        );
         assert_eq!(substr_with_width_stfl("<foobar>ＡＢＣ", 4), "<foobar>ＡＢ");
         assert_eq!(substr_with_width_stfl("a<<xyz>>bcd", 3), "a<<xyz>>b"); // tag: "<<xyz>"
         assert_eq!(substr_with_width_stfl("ＡＢＣ<b>ＤＥ", 10), "ＡＢＣ<b>ＤＥ");
@@ -989,7 +992,10 @@ mod tests {
 
     #[test]
     fn t_substr_with_width_stfl_max_width_do_not_count_stfl_tag() {
-        assert_eq!(substr_with_width_stfl("ＡＢＣ<b>ＤＥ</b>Ｆ", 9), "ＡＢＣ<b>Ｄ");
+        assert_eq!(
+            substr_with_width_stfl("ＡＢＣ<b>ＤＥ</b>Ｆ", 9),
+            "ＡＢＣ<b>Ｄ"
+        );
         assert_eq!(substr_with_width_stfl("<foobar>ＡＢＣ", 4), "<foobar>ＡＢ");
         assert_eq!(substr_with_width_stfl("a<<xyz>>bcd", 3), "a<<xyz>>b"); // tag: "<<xyz>"
         assert_eq!(substr_with_width_stfl("ＡＢＣ<b>ＤＥ", 10), "ＡＢＣ<b>ＤＥ");

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -852,7 +852,12 @@ void HtmlRenderer::render(std::istream& input,
 			break;
 
 		case TagSoupPullParser::Event::TEXT: {
-			auto text = utils::quote_for_stfl(xpp.get_text());
+
+			auto text = xpp.get_text();
+			if (!raw_) {
+				text = utils::quote_for_stfl(text);
+			}
+
 			if (itunes_hack) {
 				std::vector<std::string> paragraphs =
 					utils::tokenize_nl(text);

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -33,7 +33,7 @@ std::string item_renderer::get_feedtitle(std::shared_ptr<RssItem> item)
 void prepare_header(
 	std::shared_ptr<RssItem> item,
 	std::vector<std::pair<LineType, std::string>>& lines,
-	std::vector<LinkPair>& /*links*/)
+	std::vector<LinkPair>& /*links*/, bool raw = false)
 {
 	const auto add_line =
 		[&lines]
@@ -46,11 +46,21 @@ void prepare_header(
 		}
 	};
 
+	const auto stfl_quote_if_needed =
+		[raw]
+	(const std::string& str) {
+		if (raw) {
+			return str;
+		} else {
+			return utils::quote_for_stfl(str);
+		};
+	};
+
 	const std::string feedtitle = item_renderer::get_feedtitle(item);
-	add_line(utils::quote_for_stfl(feedtitle), _("Feed: "));
-	add_line(utils::quote_for_stfl(utils::utf8_to_locale(item->title())),
+	add_line(stfl_quote_if_needed(feedtitle), _("Feed: "));
+	add_line(stfl_quote_if_needed(utils::utf8_to_locale(item->title())),
 		_("Title: "));
-	add_line(utils::quote_for_stfl(utils::utf8_to_locale(item->author())),
+	add_line(stfl_quote_if_needed(utils::utf8_to_locale(item->author())),
 		_("Author: "));
 	add_line(item->pubDate(), _("Date: "));
 	add_line(item->link(), _("Link: "), LineType::softwrappable);
@@ -127,7 +137,7 @@ std::string item_renderer::to_plain_text(
 	std::vector<std::pair<LineType, std::string>> lines;
 	std::vector<LinkPair> links;
 
-	prepare_header(item, lines, links);
+	prepare_header(item, lines, links, true);
 	const auto base = get_item_base_link(item);
 	render_html(cfg, utils::utf8_to_locale(item->description()), lines, links,
 		base, true);

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -56,7 +56,7 @@ std::vector<std::string> wrap_line(const std::string& line, const size_t width)
 		});
 	};
 	if (iswhitespace(words[0])) {
-		prefix = utils::substr_with_width(words[0], width);
+		prefix = utils::substr_with_width_stfl(words[0], width);
 		prefix_width = utils::strwidth_stfl(prefix);
 		words.erase(words.cbegin());
 	}
@@ -72,7 +72,7 @@ std::vector<std::string> wrap_line(const std::string& line, const size_t width)
 		while (word_width > (width - prefix_width)) {
 			size_t space_left = width - curline_width;
 			std::string part =
-				utils::substr_with_width(word, space_left);
+				utils::substr_with_width_stfl(word, space_left);
 			curline.append(part);
 			word.erase(0, part.length());
 			result.push_back(curline);

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -37,7 +37,8 @@ void TextFormatter::add_lines(
 	}
 }
 
-std::vector<std::string> wrap_line(const std::string& line, const size_t width, bool raw)
+std::vector<std::string> wrap_line(const std::string& line, const size_t width,
+	bool raw)
 {
 	if (line.empty()) {
 		return {""};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -647,10 +647,10 @@ size_t utils::wcswidth_stfl(const std::wstring& str, size_t size)
 	return width - reduce_count;
 }
 
-std::string utils::substr_with_width(const std::string& str,
+std::string utils::substr_with_width_stfl(const std::string& str,
 	const size_t max_width)
 {
-	return RustString(rs_substr_with_width(str.c_str(), max_width));
+	return RustString(rs_substr_with_width_stfl(str.c_str(), max_width));
 }
 
 std::string utils::join(const std::vector<std::string>& strings,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -647,6 +647,12 @@ size_t utils::wcswidth_stfl(const std::wstring& str, size_t size)
 	return width - reduce_count;
 }
 
+std::string utils::substr_with_width(const std::string& str,
+	const size_t max_width)
+{
+	return RustString(rs_substr_with_width(str.c_str(), max_width));
+}
+
 std::string utils::substr_with_width_stfl(const std::string& str,
 	const size_t max_width)
 {

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -247,25 +247,6 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 		REQUIRE(result == expected);
 	}
 
-
-	SECTION("angle brackets are only counted as one character") {
-		cfg.set_configvalue("text-width", "37");
-
-		item->set_description(
-			"&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;"
-			"&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;"
-			"&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;"
-			"&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;");
-
-		const auto result = item_renderer::to_plain_text(cfg, item);
-
-		const auto expected = header +
-			"<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n" +
-			"<\n";
-
-		REQUIRE(result == expected);
-	}
-
 	SECTION("angle brackets are only counted as one character") {
 		cfg.set_configvalue("text-width", "37");
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -859,54 +859,54 @@ TEST_CASE("remove_soft_hyphens remove all U+00AD characters from a string",
 }
 
 TEST_CASE(
-	"substr_with_width() returns a longest substring fits to the given "
+	"substr_with_width_stfl() returns a longest substring fits to the given "
 	"width",
 	"[utils]")
 {
-	REQUIRE(utils::substr_with_width("a", 1) == "a");
-	REQUIRE(utils::substr_with_width("a", 2) == "a");
-	REQUIRE(utils::substr_with_width("ab", 1) == "a");
-	REQUIRE(utils::substr_with_width("abc", 1) == "a");
-	REQUIRE(utils::substr_with_width("A\u3042B\u3044C\u3046", 5) ==
+	REQUIRE(utils::substr_with_width_stfl("a", 1) == "a");
+	REQUIRE(utils::substr_with_width_stfl("a", 2) == "a");
+	REQUIRE(utils::substr_with_width_stfl("ab", 1) == "a");
+	REQUIRE(utils::substr_with_width_stfl("abc", 1) == "a");
+	REQUIRE(utils::substr_with_width_stfl("A\u3042B\u3044C\u3046", 5) ==
 		"A\u3042B");
 
 	SECTION("returns an empty string if the given string is empty") {
-		REQUIRE(utils::substr_with_width("", 0).empty());
-		REQUIRE(utils::substr_with_width("", 1).empty());
+		REQUIRE(utils::substr_with_width_stfl("", 0).empty());
+		REQUIRE(utils::substr_with_width_stfl("", 1).empty());
 	}
 
 	SECTION("returns an empty string if the given width is zero") {
-		REQUIRE(utils::substr_with_width("world", 0).empty());
-		REQUIRE(utils::substr_with_width("", 0).empty());
+		REQUIRE(utils::substr_with_width_stfl("world", 0).empty());
+		REQUIRE(utils::substr_with_width_stfl("", 0).empty());
 	}
 
 	SECTION("doesn't split single codepoint in two") {
 		std::string data = "\u3042\u3044\u3046";
-		REQUIRE(utils::substr_with_width(data, 1) == "");
-		REQUIRE(utils::substr_with_width(data, 3) == "\u3042");
-		REQUIRE(utils::substr_with_width(data, 5) == "\u3042\u3044");
+		REQUIRE(utils::substr_with_width_stfl(data, 1) == "");
+		REQUIRE(utils::substr_with_width_stfl(data, 3) == "\u3042");
+		REQUIRE(utils::substr_with_width_stfl(data, 5) == "\u3042\u3044");
 	}
 
 	SECTION("doesn't count a width of STFL tag") {
-		REQUIRE(utils::substr_with_width("ＡＢＣ<b>ＤＥ</b>Ｆ", 9) ==
+		REQUIRE(utils::substr_with_width_stfl("ＡＢＣ<b>ＤＥ</b>Ｆ", 9) ==
 			"ＡＢＣ<b>Ｄ");
-		REQUIRE(utils::substr_with_width("<foobar>ＡＢＣ", 4) ==
+		REQUIRE(utils::substr_with_width_stfl("<foobar>ＡＢＣ", 4) ==
 			"<foobar>ＡＢ");
-		REQUIRE(utils::substr_with_width("a<<xyz>>bcd", 3) ==
+		REQUIRE(utils::substr_with_width_stfl("a<<xyz>>bcd", 3) ==
 			"a<<xyz>>b"); // tag: "<<xyz>"
-		REQUIRE(utils::substr_with_width("ＡＢＣ<b>ＤＥ", 10) ==
+		REQUIRE(utils::substr_with_width_stfl("ＡＢＣ<b>ＤＥ", 10) ==
 			"ＡＢＣ<b>ＤＥ");
-		REQUIRE(utils::substr_with_width("a</>b</>c</>", 2) ==
+		REQUIRE(utils::substr_with_width_stfl("a</>b</>c</>", 2) ==
 			"a</>b</>");
 	}
 
 	SECTION("count a width of escaped less-than mark") {
-		REQUIRE(utils::substr_with_width("<><><>", 2) == "<><>");
-		REQUIRE(utils::substr_with_width("a<>b<>c", 3) == "a<>b");
+		REQUIRE(utils::substr_with_width_stfl("<><><>", 2) == "<><>");
+		REQUIRE(utils::substr_with_width_stfl("a<>b<>c", 3) == "a<>b");
 	}
 
 	SECTION("treat non-printable has zero width") {
-		REQUIRE(utils::substr_with_width("\x01\x02"
+		REQUIRE(utils::substr_with_width_stfl("\x01\x02"
 				"abc",
 				1) ==
 			"\x01\x02"

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -859,6 +859,59 @@ TEST_CASE("remove_soft_hyphens remove all U+00AD characters from a string",
 }
 
 TEST_CASE(
+	"substr_with_width() returns a longest substring fits to the given "
+	"width",
+	"[utils]")
+{
+	REQUIRE(utils::substr_with_width("a", 1) == "a");
+	REQUIRE(utils::substr_with_width("a", 2) == "a");
+	REQUIRE(utils::substr_with_width("ab", 1) == "a");
+	REQUIRE(utils::substr_with_width("abc", 1) == "a");
+	REQUIRE(utils::substr_with_width("A\u3042B\u3044C\u3046", 5) ==
+		"A\u3042B");
+
+	SECTION("returns an empty string if the given string is empty") {
+		REQUIRE(utils::substr_with_width("", 0).empty());
+		REQUIRE(utils::substr_with_width("", 1).empty());
+	}
+
+	SECTION("returns an empty string if the given width is zero") {
+		REQUIRE(utils::substr_with_width("world", 0).empty());
+		REQUIRE(utils::substr_with_width("", 0).empty());
+	}
+
+	SECTION("doesn't split single codepoint in two") {
+		std::string data = "\u3042\u3044\u3046";
+		REQUIRE(utils::substr_with_width(data, 1) == "");
+		REQUIRE(utils::substr_with_width(data, 3) == "\u3042");
+		REQUIRE(utils::substr_with_width(data, 5) == "\u3042\u3044");
+	}
+
+	SECTION("handles angular brackets as regular characters") {
+		REQUIRE(utils::substr_with_width("ＡＢＣ<b>ＤＥ</b>Ｆ", 9) ==
+			"ＡＢＣ<b>");
+		REQUIRE(utils::substr_with_width("<foobar>ＡＢＣ", 4) ==
+			"<foo");
+		REQUIRE(utils::substr_with_width("a<<xyz>>bcd", 3) ==
+			"a<<");
+		REQUIRE(utils::substr_with_width("ＡＢＣ<b>ＤＥ", 10) ==
+			"ＡＢＣ<b>");
+		REQUIRE(utils::substr_with_width("a</>b</>c</>", 2) ==
+			"a<");
+		REQUIRE(utils::substr_with_width("<><><>", 2) == "<>");
+		REQUIRE(utils::substr_with_width("a<>b<>c", 3) == "a<>");
+	}
+
+	SECTION("treat non-printable has zero width") {
+		REQUIRE(utils::substr_with_width("\x01\x02"
+				"abc",
+				1) ==
+			"\x01\x02"
+			"a");
+	}
+}
+
+TEST_CASE(
 	"substr_with_width_stfl() returns a longest substring fits to the given "
 	"width",
 	"[utils]")


### PR DESCRIPTION
Follow-up to https://github.com/newsboat/newsboat/pull/804#issuecomment-598702621

> The rest of the commits can become a new PR.

I've slightly changed the approach.
Instead of quoting for stfl and then undoing that, now the stfl quoting is not applied at all for plaintext output.