### PR TITLE
HtmlRenderer (<OL>): Guard against pop_back() if vector is empty

### DIFF
--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -605,8 +605,10 @@ void HtmlRenderer::render(std::istream& input,
 				break;
 
 			case HtmlTag::OL:
-				ol_types.pop_back();
-				ol_counts.pop_back();
+				if (!ol_types.empty()) {
+					ol_types.pop_back();
+					ol_counts.pop_back();
+				}
 			// fall-through
 			case HtmlTag::UL:
 				if (inside_li) {


### PR DESCRIPTION
Fixes #659 

More info at https://github.com/newsboat/newsboat/issues/659#issuecomment-601465547