### PR TITLE
Let STFL compute widget dimensions before retrieving those dimensions

### DIFF
--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -25,6 +25,8 @@ void DialogsFormAction::init()
 {
 	set_keymap_hints();
 
+	f->run(-3); // compute all widget dimensions
+
 	unsigned int width = utils::to_u(f->get("dialogs:w"));
 	std::string title_format = cfg->get_configvalue("dialogs-title-format");
 	FmtStrFormatter fmt;

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -61,6 +61,8 @@ void HelpFormAction::process_operation(Operation op,
 void HelpFormAction::prepare()
 {
 	if (do_redraw) {
+		f->run(-3); // compute all widget dimensions
+
 		std::string listwidth = f->get("helptext:w");
 		unsigned int width = utils::to_u(listwidth);
 

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -140,6 +140,8 @@ void SelectFormAction::init()
 	quit = false;
 	value = "";
 
+	f->run(-3); // compute all widget dimensions
+
 	std::string viewwidth = f->get("taglist:w");
 	unsigned int width = utils::to_u(viewwidth, 80);
 

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -118,6 +118,8 @@ void UrlViewFormAction::init()
 {
 	v->set_status("");
 
+	f->run(-3); // compute all widget dimensions
+
 	std::string viewwidth = f->get("urls:w");
 	unsigned int width = utils::to_u(viewwidth, 80);
 


### PR DESCRIPTION
Fixes usage of `%>[char]` for format strings in:
- Dialogs form
- Help form
- Select-tag form
- Select-filter form
- URLs form

Related to #88 and PR #815 


There is still a small issue with `selecttag-format` for which `%>[char]` does not yet work.
I expect to fix that together with the resizing issue (#390).
At that time I also expect to move the multiple `f->run(-3);` calls into one generic place (in `FormAction` base class).