### PR TITLE
trim_right_matches -> trim_end_matches

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -96,11 +96,11 @@ macos_task:
               CC: gcc
               CXX: g++
               RUST: stable
-        - name: macOS GCC Rust 1.26.0
+        - name: macOS GCC Rust 1.33.0
           env:
               CC: gcc
               CXX: g++
-              RUST: 1.26.0
+              RUST: 1.33.0
 
 formatting_task:
     name: Code formatting

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ matrix:
     - compiler: gcc-4.9
       os: linux
       dist: xenial
-      rust: 1.26.0
+      rust: 1.33.0
       addons:
         apt:
           sources:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Newsboat can be compiled.
 -->
 - GCC 4.9 or newer, or Clang 3.6 or newer
 - Stable [Rust](https://www.rust-lang.org/en-US/) and Cargo (Rust's package
-    manager) (1.26.0 or newer)
+    manager) (1.33.0 or newer)
 - [STFL (version 0.21 or newer)](http://www.clifford.at/stfl/)
 - [SQLite3 (version 3.5 or newer)](http://www.sqlite.org/download.html)
 - [libcurl (version 7.21.6 or newer)](http://curl.haxx.se/download.html)

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -68,7 +68,7 @@ Debian and derivatives, headers are in `-dev` packages, e.g. `libsqlite3-dev`.)
 // UPDATE README.md IF YOU CHANGE THIS LIST
 - GCC 4.9 or newer, or Clang 3.6 or newer
 - Stable https://www.rust-lang.org/en-US/[Rust] and Cargo (Rust's package
-  manager) (1.26.0 or newer)
+  manager) (1.33.0 or newer)
 - http://www.clifford.at/stfl/[STFL (version 0.21 or newer)]
 - http://www.sqlite.org/download.html[SQLite3 (version 3.5 or newer)]
 - http://curl.haxx.se/download.html[libcurl (version 7.21.6 or newer)]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -229,7 +229,7 @@ pub fn trim(rs_str: String) -> String {
 
 pub fn trim_end(rs_str: String) -> String {
     let x: &[_] = &['\n', '\r'];
-    rs_str.trim_right_matches(x).to_string()
+    rs_str.trim_end_matches(x).to_string()
 }
 
 pub fn quote(input: String) -> String {
@@ -537,7 +537,7 @@ pub fn make_title(rs_str: String) -> String {
      * http://domain.com/story/yy/mm/dd/title-with-dashes?a=b
      */
     // Strip out trailing slashes
-    let mut result = rs_str.trim_right_matches('/');
+    let mut result = rs_str.trim_end_matches('/');
 
     // get to the final part of the URI's path and
     // extract just the juicy part 'title-with-dashes?a=b'
@@ -551,10 +551,10 @@ pub fn make_title(rs_str: String) -> String {
 
     // Throw away common webpage suffixes: .html, .php, .aspx, .htm
     result = result
-        .trim_right_matches(".html")
-        .trim_right_matches(".php")
-        .trim_right_matches(".aspx")
-        .trim_right_matches(".htm");
+        .trim_end_matches(".html")
+        .trim_end_matches(".php")
+        .trim_end_matches(".aspx")
+        .trim_end_matches(".htm");
 
     // 'title with dashes'
     let result = result.replace('-', " ").replace('_', " ");


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/52037

```
   --> rust/libnewsboat/src/utils.rs:232:12
    |
232 |     rs_str.trim_right_matches(x).to_string()
    |            ^^^^^^^^^^^^^^^^^^ help: replace the use of the deprecated item: `trim_end_matches`
    |
    = note: `#[warn(deprecated)]` on by default
```