### PR TITLE
Makefile: install manpages via install-docs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,17 +242,13 @@ cppcheck:
 		2>cppcheck.log
 	@echo "Done! See cppcheck.log for details."
 
-install-newsboat: $(NEWSBOAT) doc/$(NEWSBOAT).1
+install-newsboat: $(NEWSBOAT)
 	$(MKDIR) $(DESTDIR)$(prefix)/bin
 	$(INSTALL) $(NEWSBOAT) $(DESTDIR)$(prefix)/bin
-	$(MKDIR) $(DESTDIR)$(mandir)/man1
-	$(INSTALL) -m 644 doc/$(NEWSBOAT).1 $(DESTDIR)$(mandir)/man1 || true
 
-install-podboat: $(PODBOAT) doc/$(PODBOAT).1
+install-podboat: $(PODBOAT)
 	$(MKDIR) $(DESTDIR)$(prefix)/bin
 	$(INSTALL) $(PODBOAT) $(DESTDIR)$(prefix)/bin
-	$(MKDIR) $(DESTDIR)$(mandir)/man1
-	$(INSTALL) -m 644 doc/$(PODBOAT).1 $(DESTDIR)$(mandir)/man1 || true
 
 install-docs: doc
 	$(MKDIR) $(DESTDIR)$(docdir)
@@ -267,6 +263,9 @@ install-docs: doc
 	$(MKDIR) $(DESTDIR)$(docdir)/contrib/getpocket.com
 	$(INSTALL) -m 755 contrib/getpocket.com/*.sh $(DESTDIR)$(docdir)/contrib/getpocket.com || true
 	$(INSTALL) -m 644 contrib/getpocket.com/*.md $(DESTDIR)$(docdir)/contrib/getpocket.com || true
+	$(MKDIR) $(DESTDIR)$(mandir)/man1
+	$(INSTALL) -m 644 doc/$(NEWSBOAT).1 $(DESTDIR)$(mandir)/man1 || true
+	$(INSTALL) -m 644 doc/$(PODBOAT).1 $(DESTDIR)$(mandir)/man1 || true
 
 install-examples: doc/example-config
 	$(MKDIR) $(DESTDIR)$(docdir)/examples

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ clean: clean-newsboat clean-podboat clean-libboat clean-libfilter clean-doc clea
 distclean: clean clean-mo clean-test profclean
 	$(RM) core *.core core.* config.mk
 
-doc: doc/newsboat.1 doc/podboat.1 doc/xhtml/newsboat.html doc/xhtml/faq.html
+doc: doc/$(NEWSBOAT).1 doc/$(PODBOAT).1 doc/xhtml/newsboat.html doc/xhtml/faq.html
 
 doc/xhtml/newsboat.html: doc/newsboat.asciidoc doc/chapter-firststeps.asciidoc \
 		doc/configcommands-linked.dsv doc/keycmds-linked.dsv \
@@ -197,7 +197,7 @@ doc/generate2: doc/generate2.cpp
 doc/newsboat-keycmds.asciidoc: doc/generate2 doc/keycmds.dsv
 	doc/generate2 doc/keycmds.dsv > doc/newsboat-keycmds.asciidoc
 
-doc/newsboat.1: doc/manpage-newsboat.asciidoc doc/chapter-firststeps.asciidoc \
+doc/$(NEWSBOAT).1: doc/manpage-newsboat.asciidoc doc/chapter-firststeps.asciidoc \
 		doc/newsboat-cfgcmds.asciidoc doc/newsboat-keycmds.asciidoc \
 		doc/chapter-tagging.asciidoc doc/chapter-snownews.asciidoc \
 		doc/chapter-cmdline.asciidoc \
@@ -207,7 +207,7 @@ doc/newsboat.1: doc/manpage-newsboat.asciidoc doc/chapter-firststeps.asciidoc \
 doc/podboat-cfgcmds.asciidoc: doc/generate doc/podboat-cmds.dsv
 	doc/generate doc/podboat-cmds.dsv 'pb-' > doc/podboat-cfgcmds.asciidoc
 
-doc/podboat.1: doc/manpage-podboat.asciidoc doc/chapter-podcasts.asciidoc \
+doc/$(PODBOAT).1: doc/manpage-podboat.asciidoc doc/chapter-podcasts.asciidoc \
 		doc/podboat-cfgcmds.asciidoc \
 		doc/chapter-environment-variables.asciidoc
 	$(ASCIIDOCTOR) --backend=manpage doc/manpage-podboat.asciidoc

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Newsboat can be compiled.
 - [pkg-config](http://pkg-config.freedesktop.org/wiki/)
 - [libxml2](http://xmlsoft.org/downloads.html)
 - [json-c (version 0.11 or newer)](https://github.com/json-c/json-c/wiki)
-- [Asciidoctor](https://asciidoctor.org/)
+- [Asciidoctor](https://asciidoctor.org/) (1.5.3 or newer)
 <!--
     UPDATE doc/newsboat.asciidoc IF YOU CHANGE THIS LIST
 -->
@@ -60,7 +60,7 @@ Developers will also need:
 - [`xtr`](https://github.com/woboq/tr) (can be installed with `cargo install
   xtr`)
 - [Coco/R for C++](http://www.ssw.uni-linz.ac.at/coco/), needed to re-generate
-- filter language parser using `regenerate-parser` target.
+    filter language parser using `regenerate-parser` target.
 
 Installation
 ------------

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -81,7 +81,7 @@ Debian and derivatives, headers are in `-dev` packages, e.g. `libsqlite3-dev`.)
 - http://pkg-config.freedesktop.org/wiki/[pkg-config]
 - http://xmlsoft.org/downloads.html[libxml2]
 - https://github.com/json-c/json-c/wiki[json-c (version 0.11 or newer)]
-- https://asciidoctor.org/[Asciidoctor]
+- https://asciidoctor.org/[Asciidoctor] (1.5.3 or newer)
 // UPDATE README.md IF YOU CHANGE THIS LIST
 
 Developers will also need:


### PR DESCRIPTION
This lets users install binaries without installing the docs, which will help e.g. users who don't have a new enough Asciidoc: https://github.com/newsboat/newsboat/issues/829

Reviews welcome! Will merge in three days.