### PR TITLE
fmtstrformatter: Add tests for empty then-else branches

### DIFF
--- a/rust/libnewsboat/src/fmtstrformatter/parser.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/parser.rs
@@ -277,4 +277,41 @@ mod tests {
         )];
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn t_parses_conditionals_with_empty_then_branch() {
+        let input = "%?x??";
+        let (leftovers, result) = parser(input).unwrap();
+
+        assert_eq!(leftovers, "");
+
+        let expected = vec![Specifier::Conditional('x', vec![], None)];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn t_parses_conditionals_with_empty_then_nonempty_else_branches() {
+        let input = "%?x?&nonempty?";
+        let (leftovers, result) = parser(input).unwrap();
+
+        assert_eq!(leftovers, "");
+
+        let expected = vec![Specifier::Conditional(
+            'x',
+            vec![],
+            Some(vec![Specifier::Text("nonempty")]),
+        )];
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn t_parses_conditionals_with_empty_then_and_else_branches() {
+        let input = "%?x?&?";
+        let (leftovers, result) = parser(input).unwrap();
+
+        assert_eq!(leftovers, "");
+
+        let expected = vec![Specifier::Conditional('x', vec![], Some(vec![]))];
+        assert_eq!(result, expected);
+    }
 }


### PR DESCRIPTION
This adds a couple more tests. Since there is no FFI bindings to fmtstrformatter, I didn't add the corresponding C++ tests.

Reviews welcome. Will merge in three days.