### PR TITLE
Don't tolerate invalid utf-8 in utils::get_command_output() input argument

### DIFF
--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -585,7 +585,8 @@ pub unsafe extern "C" fn rs_podcast_mime_to_link_type(
 pub unsafe extern "C" fn rs_get_command_output(input: *const c_char) -> *mut c_char {
     abort_on_panic(|| {
         let rs_input = CStr::from_ptr(input);
-        let rs_input = rs_input.to_string_lossy();
+        // This won't panic because all strings in Newsboat are in UTF-8
+        let rs_input = rs_input.to_str().expect("input contained invalid UTF-8");
         let output = utils::get_command_output(&rs_input);
         // String::from_utf8_lossy() will replace invalid unicode (including null bytes) with U+FFFD,
         // so this shouldn't be able to panic


### PR DESCRIPTION
Fixes #801.

I looks like our testing framework (Catch2) does not allow testing for SIGABRT.

Manual testing showed that this works as expected,
using line `REQUIRE(utils::get_command_output("echo -e \"test:\xff\"") == "expecting a test FAIL");`:
![image](https://user-images.githubusercontent.com/4629607/77763924-1d4aa000-703c-11ea-912c-bab328c9ac45.png)
