### PR TITLE
Display all authors for an atom entry

### DIFF
--- a/rss/atomparser.cpp
+++ b/rss/atomparser.cpp
@@ -78,7 +78,10 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 				authornode != nullptr;
 				authornode = authornode->next) {
 				if (node_is(authornode, "name", ns)) {
-					it.author = get_content(authornode);
+					if (!it.author.empty()) {
+						it.author += ", ";
+					}
+					it.author += get_content(authornode);
 				} // TODO: is there more?
 			}
 		} else if (node_is(node, "title", ns)) {

--- a/test/data/atom10_1.xml
+++ b/test/data/atom10_1.xml
@@ -34,8 +34,12 @@
 
 <entry>
 <author>
-<name>A Person</name>
-<uri>http://example.com/</uri>
+<name>Person A</name>
+<uri>http://example.com/A</uri>
+</author>
+<author>
+<name>Person B</name>
+<uri>http://example.com/B</uri>
 </author>
 <title type="html"><![CDATA[alternate link isn't first]]></title>
 <link rel="comments" type="text/html" href="http://example.com/atom_bad.html" />

--- a/test/data/atom10_1.xml
+++ b/test/data/atom10_1.xml
@@ -21,7 +21,7 @@
 
 <entry xml:base="http://example.com/entry/atom_testing.html">
 <author>
-<name>A Person</name>
+<name>A different Person</name>
 <uri>http://example.com/</uri>
 </author>
 <title type="html"><![CDATA[A missing rel attribute]]></title>

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -215,5 +215,5 @@ TEST_CASE("Extracts data from Atom 1.0", "[rsspp::Parser]")
 	REQUIRE(f.items[2].description == "some content");
 	REQUIRE(f.items[2].base ==
 		"http://example.com/content/atom_testing.html");
-	REQUIRE(f.items[2].author == "A Person");
+	REQUIRE(f.items[2].author == "Person A, Person B");
 }

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -197,6 +197,7 @@ TEST_CASE("Extracts data from Atom 1.0", "[rsspp::Parser]")
 	REQUIRE(f.items[0].guid == "tag:example.com,2008-12-30:/atom_testing");
 	REQUIRE(f.items[0].description == "some content");
 	REQUIRE(f.items[0].base == "http://example.com/feed/atom_testing.html");
+	REQUIRE(f.items[0].author == "A Person");
 
 	REQUIRE(f.items[1].title == "A missing rel attribute");
 	REQUIRE(f.items[1].title_type == "html");
@@ -205,6 +206,7 @@ TEST_CASE("Extracts data from Atom 1.0", "[rsspp::Parser]")
 	REQUIRE(f.items[1].description == "some content");
 	REQUIRE(f.items[1].base ==
 		"http://example.com/entry/atom_testing.html");
+	REQUIRE(f.items[1].author == "A different Person");
 
 	REQUIRE(f.items[2].title == "alternate link isn't first");
 	REQUIRE(f.items[2].title_type == "html");
@@ -213,4 +215,5 @@ TEST_CASE("Extracts data from Atom 1.0", "[rsspp::Parser]")
 	REQUIRE(f.items[2].description == "some content");
 	REQUIRE(f.items[2].base ==
 		"http://example.com/content/atom_testing.html");
+	REQUIRE(f.items[2].author == "A Person");
 }


### PR DESCRIPTION
From [documentation of `<author>`](http://www.atomenabled.org/developers/syndication/#recommendedEntryElements) element:
> Names one author of the entry. An entry may have multiple authors. An entry must contain at least one author element unless there is an author element in the enclosing feed, or there is an author element in the enclosed source element.