### PR TITLE
cirrus: Use newer FreeBSD versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,6 +2,8 @@ freebsd_task:
     matrix:
         - name: FreeBSD 11.3
           freebsd_instance:
+            # There is no freebsd-11-3-release image. Use one of the snapshots
+            # for the upcoming 11.4-RELEASE instead.
             image: freebsd-11-3-stable-amd64-v20200326
         - name: FreeBSD 12.1
           freebsd_instance:
@@ -15,6 +17,8 @@ freebsd_task:
         HOME: /home/testuser
 
     install_script:
+        # Make sure we use the same package repository for all images. Snapshots
+        # (like 11.3-STABLE) default to latest, while releases default to quarterly.
         - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf        
         - pkg update -f
         - pkg upgrade -y

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,9 @@ freebsd_task:
     env:
         HOME: /home/testuser
 
-    install_script: pkg install -y rust gmake rubygem-asciidoctor pkgconf stfl curl json-c ncurses openssl111 sqlite3 gettext-tools libxml2
+    install_script:
+        - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
+        - pkg install -y rust gmake rubygem-asciidoctor pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools libxml2
     setup_script:
         - pw groupadd testgroup
         - pw useradd testuser -g testgroup -w none -m

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,9 @@ freebsd_task:
         HOME: /home/testuser
 
     install_script:
-        - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
+        - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf        
+        - pkg update -f
+        - pkg upgrade -y
         - pkg install -y rust gmake rubygem-asciidoctor pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools libxml2
     setup_script:
         - pw groupadd testgroup

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,11 +1,11 @@
 freebsd_task:
     matrix:
-        - name: FreeBSD 11.2
+        - name: FreeBSD 11.3
           freebsd_instance:
-            image: freebsd-11-2-release-amd64
-        - name: FreeBSD 12.0
+            image: freebsd-11-3-snap
+        - name: FreeBSD 12.1
           freebsd_instance:
-            image: freebsd-12-0-release-amd64
+            image: freebsd-12-1-release-amd64
 
     cargo_cache:
         folder: $HOME/.cargo/registry

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ freebsd_task:
     matrix:
         - name: FreeBSD 11.3
           freebsd_instance:
-            image: freebsd-11-3-snap
+            image: freebsd-11-3-stable-amd64-v20200326
         - name: FreeBSD 12.1
           freebsd_instance:
             image: freebsd-12-1-release-amd64


### PR DESCRIPTION
FreeBSD 11.2 and 12.0 are unsupported now. 

You will run into trouble sooner or later by continuing to install from the package repository otherwise since packages are only built for supported releases.

AFAICT there are no working freebsd-11-3 images, so use one of the 11.3-STABLE snapshots instead.