### PR TITLE
Add more FilterParser and Matcher tests

### DIFF
--- a/test/filterparser.cpp
+++ b/test/filterparser.cpp
@@ -82,3 +82,13 @@ TEST_CASE("FilterParser disallows NUL byte inside filter expressions",
 	REQUIRE(fp.get_root()->name == "attribute");
 	REQUIRE(fp.get_root()->literal == "\"hello");
 }
+
+TEST_CASE("FilterParser parses empty string literals", "[FilterParser]")
+{
+	FilterParser fp;
+
+	REQUIRE(fp.parse_string("title==\"\""));
+	REQUIRE(fp.get_root()->op == MATCHOP_EQ);
+	REQUIRE(fp.get_root()->name == "title");
+	REQUIRE(fp.get_root()->literal == "");
+}

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -40,50 +40,163 @@ private:
 
 TEST_CASE("Operator `=` checks if field has given value", "[Matcher]")
 {
-	MatcherMockMatchable mock({{"abcd", "xyz"}});
 	Matcher m;
 
-	REQUIRE(m.parse("abcd = \"xyz\""));
-	REQUIRE(m.matches(&mock));
+	SECTION("Works with strings") {
+		MatcherMockMatchable mock({{"abcd", "xyz"}});
 
-	REQUIRE(m.parse("abcd = \"uiop\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("abcd = \"xyz\""));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("abcd = \"uiop\""));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
+
+	SECTION("Works with numbers") {
+		MatcherMockMatchable mock({{"answer", "42"}});
+
+		REQUIRE(m.parse("answer = 42"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("answer = 0042"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("answer = 13"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		SECTION("...but converts arguments to strings to compare") {
+			MatcherMockMatchable mock({{"agent", "007"}});
+
+			REQUIRE(m.parse("agent = 7"));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("agent = 007"));
+			REQUIRE(m.matches(&mock));
+		}
+	}
+
+	SECTION("Doesn't work with ranges") {
+		MatcherMockMatchable mock({{"answer", "42"}});
+
+		REQUIRE(m.parse("answer = 0:100"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("answer = 100:200"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("answer = 42:200"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("answer = 0:42"));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
 }
 
 TEST_CASE("Operator `!=` checks if field doesn't have given value", "[Matcher]")
 {
-	MatcherMockMatchable mock({{"abcd", "xyz"}});
 	Matcher m;
 
-	REQUIRE(m.parse("abcd != \"uiop\""));
-	REQUIRE(m.matches(&mock));
+	SECTION("Works with strings") {
+		MatcherMockMatchable mock({{"abcd", "xyz"}});
 
-	REQUIRE(m.parse("abcd != \"xyz\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("abcd != \"uiop\""));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("abcd != \"xyz\""));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
+
+	SECTION("Works with numbers") {
+		MatcherMockMatchable mock({{"answer", "42"}});
+
+		REQUIRE(m.parse("answer != 13"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("answer != 42"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		SECTION("...but converts arguments to strings to compare") {
+			MatcherMockMatchable mock({{"agent", "007"}});
+
+			REQUIRE(m.parse("agent != 7"));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("agent != 007"));
+			REQUIRE_FALSE(m.matches(&mock));
+		}
+	}
+
+	SECTION("Doesn't work with ranges") {
+		MatcherMockMatchable mock({{"answer", "42"}});
+
+		REQUIRE(m.parse("answer != 0:100"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("answer != 100:200"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("answer != 42:200"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("answer != 0:42"));
+		REQUIRE(m.matches(&mock));
+	}
 }
 
 TEST_CASE("Operator `=~` checks if field matches given regex", "[Matcher]")
 {
-	MatcherMockMatchable mock({{"AAAA", "12345"}});
 	Matcher m;
 
-	REQUIRE(m.parse("AAAA =~ \".\""));
-	REQUIRE(m.matches(&mock));
+	SECTION("Works with strings") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
 
-	REQUIRE(m.parse("AAAA =~ \"123\""));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA =~ \".\""));
+		REQUIRE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA =~ \"234\""));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA =~ \"123\""));
+		REQUIRE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA =~ \"45\""));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA =~ \"234\""));
+		REQUIRE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA =~ \"^12345$\""));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA =~ \"45\""));
+		REQUIRE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA =~ \"^123456$\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA =~ \"^12345$\""));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA =~ \"^123456$\""));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
+
+	SECTION("Converts numbers to strings and uses them as regexes") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
+
+		REQUIRE(m.parse("AAAA =~ 12345"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA =~ 1"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA =~ 45"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA =~ 9"));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
+
+	SECTION("Doesn't work with ranges") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
+
+		REQUIRE(m.parse("AAAA =~ 0:123456"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA =~ 12345:99999"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA =~ 0:12345"));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
 }
 
 TEST_CASE("Matcher throws if expression contains undefined fields", "[Matcher]")
@@ -123,67 +236,199 @@ TEST_CASE("Matcher throws if regex passed to `=~` or `!~` is invalid",
 TEST_CASE("Operator `!~` checks if field doesn't match given regex",
 	"[Matcher]")
 {
-	MatcherMockMatchable mock({{"AAAA", "12345"}});
 	Matcher m;
 
-	REQUIRE(m.parse("AAAA !~ \".\""));
-	REQUIRE_FALSE(m.matches(&mock));
+	SECTION("Works with strings") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
 
-	REQUIRE(m.parse("AAAA !~ \"123\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA !~ \".\""));
+		REQUIRE_FALSE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA !~ \"234\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA !~ \"123\""));
+		REQUIRE_FALSE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA !~ \"45\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA !~ \"234\""));
+		REQUIRE_FALSE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA !~ \"^12345$\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA !~ \"45\""));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA !~ \"^12345$\""));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
+
+	SECTION("Converts numbers into strings and uses them as regexes") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
+
+		REQUIRE(m.parse("AAAA !~ 12345"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA !~ 1"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA !~ 45"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA !~ 9"));
+		REQUIRE(m.matches(&mock));
+	}
+
+	SECTION("Doesn't work with ranges") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
+
+		REQUIRE(m.parse("AAAA !~ 0:123456"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA !~ 12345:99999"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA !~ 0:12345"));
+		REQUIRE(m.matches(&mock));
+	}
 }
 
-TEST_CASE("Operator `#` checks if \"tags\" field contains given value",
+TEST_CASE("Operator `#` checks if space-separated list contains given value",
 	"[Matcher]")
 {
-	MatcherMockMatchable mock({{"tags", "foo bar baz quux"}});
 	Matcher m;
 
-	REQUIRE(m.parse("tags # \"foo\""));
-	REQUIRE(m.matches(&mock));
+	SECTION("Works with strings") {
+		MatcherMockMatchable mock({{"tags", "foo bar baz quux"}});
 
-	REQUIRE(m.parse("tags # \"baz\""));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("tags # \"foo\""));
+		REQUIRE(m.matches(&mock));
 
-	REQUIRE(m.parse("tags # \"quux\""));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("tags # \"baz\""));
+		REQUIRE(m.matches(&mock));
 
-	REQUIRE(m.parse("tags # \"xyz\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("tags # \"quux\""));
+		REQUIRE(m.matches(&mock));
 
-	REQUIRE(m.parse("tags # \"foo bar\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("tags # \"xyz\""));
+		REQUIRE_FALSE(m.matches(&mock));
 
-	REQUIRE(m.parse("tags # \"foo\" and tags # \"bar\""));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("tags # \"foo bar\""));
+		REQUIRE_FALSE(m.matches(&mock));
 
-	REQUIRE(m.parse("tags # \"foo\" and tags # \"xyz\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("tags # \"foo\" and tags # \"bar\""));
+		REQUIRE(m.matches(&mock));
 
-	REQUIRE(m.parse("tags # \"foo\" or tags # \"xyz\""));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("tags # \"foo\" and tags # \"xyz\""));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("tags # \"foo\" or tags # \"xyz\""));
+		REQUIRE(m.matches(&mock));
+	}
+
+	SECTION("Works with numbers") {
+		MatcherMockMatchable mock({{"fibonacci", "1 1 2 3 5 8 13 21 34"}});
+
+		REQUIRE(m.parse("fibonacci # 1"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("fibonacci # 3"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("fibonacci # 4"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		SECTION("...but convers them to strings to look them up") {
+			REQUIRE(m.parse("fibonacci # \"1\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("fibonacci # \"3\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("fibonacci # \"4\""));
+			REQUIRE_FALSE(m.matches(&mock));
+		}
+	}
+
+	SECTION("Doesn't work with ranges") {
+		MatcherMockMatchable mock({{"fibonacci", "1 1 2 3 5 8 13 21 34"}});
+
+		REQUIRE(m.parse("fibonacci # 1:5"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("fibonacci # 3:100"));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
+
+	SECTION("Works even on single-value lists") {
+		MatcherMockMatchable mock({{"values", "one"}, {"number", "1"}});
+
+		REQUIRE(m.parse("values # \"one\""));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("number # 1"));
+		REQUIRE(m.matches(&mock));
+	}
 }
 
-TEST_CASE("Operator `!#` checks if \"tags\" field doesn't contain given value",
+TEST_CASE("Operator `!#` checks if field doesn't contain given value",
 	"[Matcher]")
 {
-	MatcherMockMatchable mock({{"tags", "foo bar baz quux"}});
 	Matcher m;
 
-	REQUIRE(m.parse("tags !# \"nein\""));
-	REQUIRE(m.matches(&mock));
+	SECTION("Works with strings") {
+		MatcherMockMatchable mock({{"tags", "foo bar baz quux"}});
 
-	REQUIRE(m.parse("tags !# \"foo\""));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("tags !# \"nein\""));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("tags !# \"foo\""));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
+
+	SECTION("Works with numbers") {
+		MatcherMockMatchable mock({{"fibonacci", "1 1 2 3 5 8 13 21 34"}});
+
+		REQUIRE(m.parse("fibonacci !# 1"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("fibonacci !# 9"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("fibonacci !# 4"));
+		REQUIRE(m.matches(&mock));
+
+		SECTION("...but convers them to strings to look them up") {
+			REQUIRE(m.parse("fibonacci !# \"1\""));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("fibonacci !# \"9\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("fibonacci !# \"4\""));
+			REQUIRE(m.matches(&mock));
+		}
+	}
+
+	SECTION("Doesn't work with ranges") {
+		MatcherMockMatchable mock({{"fibonacci", "1 1 2 3 5 8 13 21 34"}});
+
+		REQUIRE(m.parse("fibonacci !# 1:5"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("fibonacci !# 7:35"));
+		REQUIRE(m.matches(&mock));
+	}
+
+	SECTION("Works even on single-value lists") {
+		MatcherMockMatchable mock({{"values", "one"}, {"number", "1"}});
+
+		REQUIRE(m.parse("values !# \"one\""));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("values !# \"two\""));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("number !# 1"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("number !# 2"));
+		REQUIRE(m.matches(&mock));
+	}
 }
 
 TEST_CASE(
@@ -191,45 +436,201 @@ TEST_CASE(
 	"value",
 	"[Matcher]")
 {
-	MatcherMockMatchable mock({{"AAAA", "12345"}});
 	Matcher m;
 
-	REQUIRE(m.parse("AAAA > 12344"));
-	REQUIRE(m.matches(&mock));
+	SECTION("With string arguments, converts arguments to numbers") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
 
-	REQUIRE(m.parse("AAAA > 12345"));
-	REQUIRE_FALSE(m.matches(&mock));
+		SECTION(">") {
+			REQUIRE(m.parse("AAAA > \"12344\""));
+			REQUIRE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA >= 12345"));
-	REQUIRE(m.matches(&mock));
+			REQUIRE(m.parse("AAAA > \"12345\""));
+			REQUIRE_FALSE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA < 12345"));
-	REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE(m.parse("AAAA > \"123456\""));
+			REQUIRE_FALSE(m.matches(&mock));
+		}
 
-	REQUIRE(m.parse("AAAA <= 12345"));
-	REQUIRE(m.matches(&mock));
+		SECTION("<") {
+			REQUIRE(m.parse("AAAA < \"12345\""));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA < \"12346\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA < \"123456\""));
+			REQUIRE(m.matches(&mock));
+		}
+
+		SECTION(">=") {
+			REQUIRE(m.parse("AAAA >= \"12344\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA >= \"12345\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA >= \"12346\""));
+			REQUIRE_FALSE(m.matches(&mock));
+		}
+
+		SECTION("<=") {
+			REQUIRE(m.parse("AAAA <= \"12344\""));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA <= \"12345\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA <= \"12346\""));
+			REQUIRE(m.matches(&mock));
+		}
+
+		SECTION("Only numeric prefix is used for conversion") {
+			MatcherMockMatchable mock({{"AAAA", "12345xx"}});
+
+			REQUIRE(m.parse("AAAA >= \"12345\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA > \"1234a\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA < \"12345a\""));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA < \"1234a\""));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("AAAA < \"9999b\""));
+			REQUIRE_FALSE(m.matches(&mock));
+		}
+
+		SECTION("If conversion fails, zero is used") {
+			MatcherMockMatchable mock({{"zero", "0"}, {"same_zero", "yeah"}});
+
+			REQUIRE(m.parse("zero < \"unknown\""));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("zero > \"unknown\""));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("zero <= \"unknown\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("zero >= \"unknown\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("same_zero < \"0\""));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("same_zero > \"0\""));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("same_zero <= \"0\""));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("same_zero >= \"0\""));
+			REQUIRE(m.matches(&mock));
+		}
+	}
+
+	SECTION("Work with numbers") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
+
+		REQUIRE(m.parse("AAAA > 12344"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA > 12345"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA >= 12345"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA < 12345"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA <= 12345"));
+		REQUIRE(m.matches(&mock));
+	}
+
+	SECTION("Don't work with ranges") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
+
+		REQUIRE(m.parse("AAAA > 0:99999"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA < 0:99999"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA >= 0:99999"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA <= 0:99999"));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
 }
 
 TEST_CASE("Operator `between` checks if field's value is in given range",
 	"[Matcher]")
 {
-	MatcherMockMatchable mock({{"AAAA", "12345"}});
 	Matcher m;
 
-	REQUIRE(m.parse("AAAA between 0:12345"));
-	REQUIRE(m.matches(&mock));
+	SECTION("Doesn't work with strings") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
 
-	REQUIRE(m.parse("AAAA between 12345:12345"));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA between \"123\""));
+		REQUIRE_FALSE(m.matches(&mock));
 
-	REQUIRE(m.parse("AAAA between 23:12344"));
-	REQUIRE_FALSE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA between \"12399\""));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
 
-	REQUIRE(m.parse("AAAA between 0"));
-	REQUIRE_FALSE(m.matches(&mock));
+	SECTION("Doesn't work with numbers") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
 
-	REQUIRE(m.parse("AAAA between 12346:12344"));
-	REQUIRE(m.matches(&mock));
+		REQUIRE(m.parse("AAAA between 1"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA between 12345"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA between 99999"));
+		REQUIRE_FALSE(m.matches(&mock));
+	}
+
+	SECTION("Works with ranges") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}});
+
+		REQUIRE(m.parse("AAAA between 0:12345"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA between 12345:12345"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA between 23:12344"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA between 0"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA between 12346:12344"));
+		REQUIRE(m.matches(&mock));
+
+		SECTION("...converting numering prefix of the attribute if necessary") {
+			MatcherMockMatchable mock({{"value", "123four"}, {"practically_zero", "sure"}});
+
+			REQUIRE(m.parse("value between 0:124"));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("value between 124:130"));
+			REQUIRE_FALSE(m.matches(&mock));
+
+			REQUIRE(m.parse("practically_zero between 0:1"));
+			REQUIRE(m.matches(&mock));
+
+			REQUIRE(m.parse("practically_zero between 1:100"));
+			REQUIRE_FALSE(m.matches(&mock));
+		}
+	}
 }
 
 TEST_CASE("Invalid expression results in parsing error", "[Matcher]")

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -43,10 +43,10 @@ TEST_CASE("Operator `=` checks if field has given value", "[Matcher]")
 	MatcherMockMatchable mock({{"abcd", "xyz"}});
 	Matcher m;
 
-	m.parse("abcd = \"xyz\"");
+	REQUIRE(m.parse("abcd = \"xyz\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("abcd = \"uiop\"");
+	REQUIRE(m.parse("abcd = \"uiop\""));
 	REQUIRE_FALSE(m.matches(&mock));
 }
 
@@ -55,10 +55,10 @@ TEST_CASE("Operator `!=` checks if field doesn't have given value", "[Matcher]")
 	MatcherMockMatchable mock({{"abcd", "xyz"}});
 	Matcher m;
 
-	m.parse("abcd != \"uiop\"");
+	REQUIRE(m.parse("abcd != \"uiop\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("abcd != \"xyz\"");
+	REQUIRE(m.parse("abcd != \"xyz\""));
 	REQUIRE_FALSE(m.matches(&mock));
 }
 
@@ -67,22 +67,22 @@ TEST_CASE("Operator `=~` checks if field matches given regex", "[Matcher]")
 	MatcherMockMatchable mock({{"AAAA", "12345"}});
 	Matcher m;
 
-	m.parse("AAAA =~ \".\"");
+	REQUIRE(m.parse("AAAA =~ \".\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("AAAA =~ \"123\"");
+	REQUIRE(m.parse("AAAA =~ \"123\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("AAAA =~ \"234\"");
+	REQUIRE(m.parse("AAAA =~ \"234\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("AAAA =~ \"45\"");
+	REQUIRE(m.parse("AAAA =~ \"45\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("AAAA =~ \"^12345$\"");
+	REQUIRE(m.parse("AAAA =~ \"^12345$\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("AAAA =~ \"^123456$\"");
+	REQUIRE(m.parse("AAAA =~ \"^123456$\""));
 	REQUIRE_FALSE(m.matches(&mock));
 }
 
@@ -91,19 +91,19 @@ TEST_CASE("Matcher throws if expression contains undefined fields", "[Matcher]")
 	MatcherMockMatchable mock;
 	Matcher m;
 
-	m.parse("BBBB =~ \"foo\"");
+	REQUIRE(m.parse("BBBB =~ \"foo\""));
 	REQUIRE_THROWS_AS(m.matches(&mock), MatcherException);
 
-	m.parse("BBBB # \"foo\"");
+	REQUIRE(m.parse("BBBB # \"foo\""));
 	REQUIRE_THROWS_AS(m.matches(&mock), MatcherException);
 
-	m.parse("BBBB < 0");
+	REQUIRE(m.parse("BBBB < 0"));
 	REQUIRE_THROWS_AS(m.matches(&mock), MatcherException);
 
-	m.parse("BBBB > 0");
+	REQUIRE(m.parse("BBBB > 0"));
 	REQUIRE_THROWS_AS(m.matches(&mock), MatcherException);
 
-	m.parse("BBBB between 1:23");
+	REQUIRE(m.parse("BBBB between 1:23"));
 	REQUIRE_THROWS_AS(m.matches(&mock), MatcherException);
 }
 
@@ -113,10 +113,10 @@ TEST_CASE("Matcher throws if regex passed to `=~` or `!~` is invalid",
 	MatcherMockMatchable mock({{"AAAA", "12345"}});
 	Matcher m;
 
-	m.parse("AAAA =~ \"[[\"");
+	REQUIRE(m.parse("AAAA =~ \"[[\""));
 	REQUIRE_THROWS_AS(m.matches(&mock), MatcherException);
 
-	m.parse("AAAA !~ \"[[\"");
+	REQUIRE(m.parse("AAAA !~ \"[[\""));
 	REQUIRE_THROWS_AS(m.matches(&mock), MatcherException);
 }
 
@@ -126,19 +126,19 @@ TEST_CASE("Operator `!~` checks if field doesn't match given regex",
 	MatcherMockMatchable mock({{"AAAA", "12345"}});
 	Matcher m;
 
-	m.parse("AAAA !~ \".\"");
+	REQUIRE(m.parse("AAAA !~ \".\""));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("AAAA !~ \"123\"");
+	REQUIRE(m.parse("AAAA !~ \"123\""));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("AAAA !~ \"234\"");
+	REQUIRE(m.parse("AAAA !~ \"234\""));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("AAAA !~ \"45\"");
+	REQUIRE(m.parse("AAAA !~ \"45\""));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("AAAA !~ \"^12345$\"");
+	REQUIRE(m.parse("AAAA !~ \"^12345$\""));
 	REQUIRE_FALSE(m.matches(&mock));
 }
 
@@ -148,28 +148,28 @@ TEST_CASE("Operator `#` checks if \"tags\" field contains given value",
 	MatcherMockMatchable mock({{"tags", "foo bar baz quux"}});
 	Matcher m;
 
-	m.parse("tags # \"foo\"");
+	REQUIRE(m.parse("tags # \"foo\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("tags # \"baz\"");
+	REQUIRE(m.parse("tags # \"baz\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("tags # \"quux\"");
+	REQUIRE(m.parse("tags # \"quux\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("tags # \"xyz\"");
+	REQUIRE(m.parse("tags # \"xyz\""));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("tags # \"foo bar\"");
+	REQUIRE(m.parse("tags # \"foo bar\""));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("tags # \"foo\" and tags # \"bar\"");
+	REQUIRE(m.parse("tags # \"foo\" and tags # \"bar\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("tags # \"foo\" and tags # \"xyz\"");
+	REQUIRE(m.parse("tags # \"foo\" and tags # \"xyz\""));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("tags # \"foo\" or tags # \"xyz\"");
+	REQUIRE(m.parse("tags # \"foo\" or tags # \"xyz\""));
 	REQUIRE(m.matches(&mock));
 }
 
@@ -179,10 +179,10 @@ TEST_CASE("Operator `!#` checks if \"tags\" field doesn't contain given value",
 	MatcherMockMatchable mock({{"tags", "foo bar baz quux"}});
 	Matcher m;
 
-	m.parse("tags !# \"nein\"");
+	REQUIRE(m.parse("tags !# \"nein\""));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("tags !# \"foo\"");
+	REQUIRE(m.parse("tags !# \"foo\""));
 	REQUIRE_FALSE(m.matches(&mock));
 }
 
@@ -194,19 +194,19 @@ TEST_CASE(
 	MatcherMockMatchable mock({{"AAAA", "12345"}});
 	Matcher m;
 
-	m.parse("AAAA > 12344");
+	REQUIRE(m.parse("AAAA > 12344"));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("AAAA > 12345");
+	REQUIRE(m.parse("AAAA > 12345"));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("AAAA >= 12345");
+	REQUIRE(m.parse("AAAA >= 12345"));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("AAAA < 12345");
+	REQUIRE(m.parse("AAAA < 12345"));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("AAAA <= 12345");
+	REQUIRE(m.parse("AAAA <= 12345"));
 	REQUIRE(m.matches(&mock));
 }
 
@@ -216,20 +216,19 @@ TEST_CASE("Operator `between` checks if field's value is in given range",
 	MatcherMockMatchable mock({{"AAAA", "12345"}});
 	Matcher m;
 
-	m.parse("AAAA between 0:12345");
-	REQUIRE(m.get_parse_error() == "");
+	REQUIRE(m.parse("AAAA between 0:12345"));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("AAAA between 12345:12345");
+	REQUIRE(m.parse("AAAA between 12345:12345"));
 	REQUIRE(m.matches(&mock));
 
-	m.parse("AAAA between 23:12344");
+	REQUIRE(m.parse("AAAA between 23:12344"));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("AAAA between 0");
+	REQUIRE(m.parse("AAAA between 0"));
 	REQUIRE_FALSE(m.matches(&mock));
 
-	m.parse("AAAA between 12346:12344");
+	REQUIRE(m.parse("AAAA between 12346:12344"));
 	REQUIRE(m.matches(&mock));
 }
 
@@ -238,7 +237,6 @@ TEST_CASE("Invalid expression results in parsing error", "[Matcher]")
 	Matcher m;
 
 	REQUIRE_FALSE(m.parse("AAAA between 0:15:30"));
-	REQUIRE(m.get_parse_error() != "");
 }
 
 TEST_CASE("get_expression() returns previously parsed expression", "[Matcher]")
@@ -255,7 +253,7 @@ TEST_CASE("Regexes are matched case-insensitively", "[Matcher]")
 		MatcherMockMatchable mock({{"abcd", "xyz"}});
 		Matcher m;
 
-		m.parse("abcd =~ \"" + regex + "\"");
+		REQUIRE(m.parse("abcd =~ \"" + regex + "\""));
 		REQUIRE(m.matches(&mock));
 	};
 
@@ -290,40 +288,40 @@ TEST_CASE("=~ and !~ use POSIX extended regex syntax", "[Matcher]")
 	SECTION("No support for escape sequence") {
 		MatcherMockMatchable mock({{"attr", "*]+"}});
 
-		m.parse(R"#(attr =~ "\Q*]+\E")#");
+		REQUIRE(m.parse(R"#(attr =~ "\Q*]+\E")#"));
 		REQUIRE_FALSE(m.matches(&mock));
 
-		m.parse(R"#(attr !~ "\Q*]+\E")#");
+		REQUIRE(m.parse(R"#(attr !~ "\Q*]+\E")#"));
 		REQUIRE(m.matches(&mock));
 	}
 
 	SECTION("No support for hexadecimal escape") {
 		MatcherMockMatchable mock({{"attr", "value"}});
 
-		m.parse(R"#(attr =~ "^va\x6Cue")#");
+		REQUIRE(m.parse(R"#(attr =~ "^va\x6Cue")#"));
 		REQUIRE_FALSE(m.matches(&mock));
 
-		m.parse(R"#(attr !~ "^va\x6Cue")#");
+		REQUIRE(m.parse(R"#(attr !~ "^va\x6Cue")#"));
 		REQUIRE(m.matches(&mock));
 	}
 
 	SECTION("No support for \\a as alert/bell control character") {
 		MatcherMockMatchable mock({{"attr", "\x07"}});
 
-		m.parse(R"#(attr =~ "\a")#");
+		REQUIRE(m.parse(R"#(attr =~ "\a")#"));
 		REQUIRE_FALSE(m.matches(&mock));
 
-		m.parse(R"#(attr !~ "\a")#");
+		REQUIRE(m.parse(R"#(attr !~ "\a")#"));
 		REQUIRE(m.matches(&mock));
 	}
 
 	SECTION("No support for \\b as backspace control character") {
 		MatcherMockMatchable mock({{"attr", "\x08"}});
 
-		m.parse(R"#(attr =~ "\b")#");
+		REQUIRE(m.parse(R"#(attr =~ "\b")#"));
 		REQUIRE_FALSE(m.matches(&mock));
 
-		m.parse(R"#(attr !~ "\b")#");
+		REQUIRE(m.parse(R"#(attr !~ "\b")#"));
 		REQUIRE(m.matches(&mock));
 	}
 
@@ -349,8 +347,7 @@ TEST_CASE("Space characters in filter expression don't affect parsing",
 		MatcherMockMatchable mock({{"array", "foo bar baz"}});
 		Matcher m;
 
-		m.parse(expression);
-		REQUIRE(m.get_parse_error() == "");
+		REQUIRE(m.parse(expression));
 		REQUIRE(m.matches(&mock));
 	};
 
@@ -372,8 +369,7 @@ TEST_CASE("Only space characters are considered whitespace by filter parser",
 		MatcherMockMatchable mock({{"attr", "value"}});
 		Matcher m;
 
-		m.parse(expression);
-		REQUIRE_FALSE(m.get_parse_error() == "");
+		REQUIRE_FALSE(m.parse(expression));
 	};
 
 	check("attr\t= \"value\"");

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -185,8 +185,8 @@ TEST_CASE("Operator `=~` checks if field matches given regex", "[Matcher]")
 		REQUIRE_FALSE(m.matches(&mock));
 	}
 
-	SECTION("Doesn't work with ranges") {
-		MatcherMockMatchable mock({{"AAAA", "12345"}});
+	SECTION("Treats ranges as strings") {
+		MatcherMockMatchable mock({{"AAAA", "12345"}, {"range", "0:123"}});
 
 		REQUIRE(m.parse("AAAA =~ 0:123456"));
 		REQUIRE_FALSE(m.matches(&mock));
@@ -195,6 +195,15 @@ TEST_CASE("Operator `=~` checks if field matches given regex", "[Matcher]")
 		REQUIRE_FALSE(m.matches(&mock));
 
 		REQUIRE(m.parse("AAAA =~ 0:12345"));
+		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("range =~ 0:123"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("range =~ 0:12"));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("range =~ 0:1234"));
 		REQUIRE_FALSE(m.matches(&mock));
 	}
 }
@@ -255,6 +264,12 @@ TEST_CASE("Operator `!~` checks if field doesn't match given regex",
 
 		REQUIRE(m.parse("AAAA !~ \"^12345$\""));
 		REQUIRE_FALSE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA !~ \"567\""));
+		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("AAAA !~ \"number\""));
+		REQUIRE(m.matches(&mock));
 	}
 
 	SECTION("Converts numbers into strings and uses them as regexes") {
@@ -303,6 +318,9 @@ TEST_CASE("Operator `#` checks if space-separated list contains given value",
 
 		REQUIRE(m.parse("tags # \"quux\""));
 		REQUIRE(m.matches(&mock));
+
+		REQUIRE(m.parse("tags # \"uu\""));
+		REQUIRE_FALSE(m.matches(&mock));
 
 		REQUIRE(m.parse("tags # \"xyz\""));
 		REQUIRE_FALSE(m.matches(&mock));
@@ -609,16 +627,13 @@ TEST_CASE("Operator `between` checks if field's value is in given range",
 		REQUIRE(m.parse("AAAA between 23:12344"));
 		REQUIRE_FALSE(m.matches(&mock));
 
-		REQUIRE(m.parse("AAAA between 0"));
-		REQUIRE_FALSE(m.matches(&mock));
-
 		REQUIRE(m.parse("AAAA between 12346:12344"));
 		REQUIRE(m.matches(&mock));
 
 		SECTION("...converting numering prefix of the attribute if necessary") {
 			MatcherMockMatchable mock({{"value", "123four"}, {"practically_zero", "sure"}});
 
-			REQUIRE(m.parse("value between 0:124"));
+			REQUIRE(m.parse("value between 122:124"));
 			REQUIRE(m.matches(&mock));
 
 			REQUIRE(m.parse("value between 124:130"));

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -638,6 +638,8 @@ TEST_CASE("Invalid expression results in parsing error", "[Matcher]")
 	Matcher m;
 
 	REQUIRE_FALSE(m.parse("AAAA between 0:15:30"));
+	REQUIRE_FALSE(m.parse("x = 42andy=0"));
+	REQUIRE_FALSE(m.parse("x = 42 andy=0"));
 }
 
 TEST_CASE("get_expression() returns previously parsed expression", "[Matcher]")
@@ -778,4 +780,19 @@ TEST_CASE("Only space characters are considered whitespace by filter parser",
 	check("attr\n=\t\"value\"");
 	check("attr\v=\"value\"");
 	check("attr=\"value\"\r\n");
+}
+
+TEST_CASE("Whitespace before and/or is not required", "[Matcher]")
+{
+	MatcherMockMatchable mock({{"x", "42"}, {"y", "0"}});
+	Matcher m;
+
+	REQUIRE(m.parse("x = 42and y=0"));
+	REQUIRE(m.matches(&mock));
+
+	REQUIRE(m.parse("x = \"42\"and y=0"));
+	REQUIRE(m.matches(&mock));
+
+	REQUIRE(m.parse("x = \"42\"or y=42"));
+	REQUIRE(m.matches(&mock));
 }


### PR DESCRIPTION
These new tests expose different quirks in our existing C++ parser and matcher. Some Matcher tests actually check the behaviour of FilterParser; this is simply because Matcher's interface is way easier to use.

Reviews from everyone are welcome. Will merge in three days.