### PR TITLE
Error on zero params to `always-download` or `reset-unread-on-update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ acknowledge contributions from the following people:
 ### Changed
 - Allow binding multiple keys to general operations: up, down, pageup, pagedown,
   home, end (#847) (Dennis van der Schagt)
+- It's now an error to have `always-download` or `reset-unread-on-update`
+    without parameters (Alexander Batischev)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -30,30 +30,39 @@ void RssIgnores::handle_action(const std::string& action,
 	const std::vector<std::string>& params)
 {
 	if (action == "ignore-article") {
-		if (params.size() < 2)
-			throw ConfigHandlerException(
-				ActionHandlerStatus::TOO_FEW_PARAMS);
+		if (params.size() < 2) {
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
 		std::string ignore_rssurl = params[0];
 		std::string ignore_expr = params[1];
 		Matcher m;
-		if (!m.parse(ignore_expr))
+		if (!m.parse(ignore_expr)) {
 			throw ConfigHandlerException(strprintf::fmt(
 					_("couldn't parse filter expression `%s': %s"),
 					ignore_expr,
 					m.get_parse_error()));
-		ignores.push_back(FeedUrlExprPair(
-				ignore_rssurl, new Matcher(ignore_expr)));
+		}
+		ignores.push_back(FeedUrlExprPair(ignore_rssurl, new Matcher(ignore_expr)));
 	} else if (action == "always-download") {
+		if (params.empty()) {
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
+
 		for (const auto& param : params) {
 			ignores_lastmodified.push_back(param);
 		}
 	} else if (action == "reset-unread-on-update") {
+		if (params.empty()) {
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
+
 		for (const auto& param : params) {
 			resetflag.push_back(param);
 		}
-	} else
+	} else {
 		throw ConfigHandlerException(
 			ActionHandlerStatus::INVALID_COMMAND);
+	}
 }
 
 void RssIgnores::dump_config(std::vector<std::string>& config_output)

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -75,8 +75,11 @@ TEST_CASE("RssIgnores::handle_action() handles `always-download`",
 
 	const std::string action = "always-download";
 
-	SECTION("Doesn't throw, regardless of how many params are passed") {
-		REQUIRE_NOTHROW(ignores.handle_action(action, {}));
+	SECTION("Throws ConfigHandlerException if given zero parameters") {
+		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
+	}
+
+	SECTION("Doesn't trow if given one or more parameters") {
 		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
 		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
 		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
@@ -90,8 +93,11 @@ TEST_CASE("RssIgnores::handle_action() handles `reset-unread-on-update`",
 
 	const std::string action = "reset-unread-on-update";
 
-	SECTION("Doesn't throw, regardless of how many params are passed") {
-		REQUIRE_NOTHROW(ignores.handle_action(action, {}));
+	SECTION("Throws ConfigHandlerException if given zero parameters") {
+		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
+	}
+
+	SECTION("Doesn't throw if given one or more parameters") {
 		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
 		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
 		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
@@ -145,7 +151,6 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 		const std::string action = "always-download";
 
 		ignores.handle_action(action, {"url1"});
-		ignores.handle_action(action, {});
 		ignores.handle_action(action, {"url2", "url3", "url4"});
 
 		std::vector<std::string> config;
@@ -167,7 +172,6 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 		const std::string action = "reset-unread-on-update";
 
 		ignores.handle_action(action, {"url1"});
-		ignores.handle_action(action, {});
 		ignores.handle_action(action, {"url2", "url3", "url4"});
 
 		std::vector<std::string> config;


### PR DESCRIPTION
There's really no point in having these without arguments.

Prompted by @dennisschagt during the review in #850: https://github.com/newsboat/newsboat/pull/850#discussion_r401673813

Reviews from everyone welcome. Will merge in three days.