### PR TITLE
Add Rust bindings for regex.h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,9 @@ name = "regex-rs"
 version = "0.1.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gettext-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strprintf 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -49,7 +49,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -146,7 +146,7 @@ name = "dirs"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -255,7 +255,7 @@ dependencies = [
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gettext-rs 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gettext-sys 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -275,7 +275,7 @@ dependencies = [
 name = "libnewsboat-ffi"
 version = "2.19.0"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "libnewsboat 2.19.0",
 ]
 
@@ -285,7 +285,7 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -320,7 +320,7 @@ version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -371,7 +371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -390,7 +390,7 @@ name = "parking_lot_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,7 +453,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -466,7 +466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -477,7 +477,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -532,7 +532,7 @@ name = "rand_jitter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -544,7 +544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -601,6 +601,14 @@ dependencies = [
  "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-rs"
+version = "0.1.0"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -698,7 +706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "strprintf"
 version = "0.1.0"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -728,7 +736,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -756,7 +764,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -822,7 +830,7 @@ name = "wait-timeout"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -890,7 +898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum lexical-core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
-"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+"checksum libc 0.2.69 (registry+https://github.com/rust-lang/crates.io-index)" = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 "checksum libz-sys 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "44ebbc760fd2d2f4d93de09a0e13d97e057612052e871da9985cedcb451e6bd5"
 "checksum locale_config 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "14fbee0e39bc2dd6a2427c4fdea66e9826cc1fd09b0a0b7550359f5f6efe1dab"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@ members = [
     "rust/libnewsboat",
     "rust/libnewsboat-ffi",
     "rust/strprintf",
+    "rust/regex-rs",
 ]

--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ mo-files: $(MOFILES)
 extract:
 	$(RM) $(POTFILE)
 	xgettext -c/ -k_ -k_s -o po/cpp.pot *.cpp src/*.cpp rss/*.cpp
-	xtr rust/libnewsboat/src/lib.rs --omit-header -o po/rust.pot
+	xtr rust/libnewsboat/src/lib.rs rust/regex-rs/src/lib.rs --omit-header -o po/rust.pot
 	cat po/cpp.pot po/rust.pot > $(POTFILE)
 	$(RM) -f po/cpp.pot po/rust.pot
 	sed -i 's#Report-Msgid-Bugs-To: \\n#Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\\n#' $(POTFILE)

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-14 01:37+0200\n"
+"POT-Creation-Date: 2020-04-16 00:17+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -460,7 +460,7 @@ msgid "Cancel"
 msgstr ""
 
 #: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
 msgid "Save"
 msgstr ""
 
@@ -555,7 +555,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -600,7 +600,7 @@ msgid "No filters defined."
 msgstr ""
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
 msgid "Search for: "
 msgstr ""
 
@@ -622,7 +622,7 @@ msgid "y"
 msgstr ""
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
 #: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr ""
@@ -632,7 +632,7 @@ msgid "Open"
 msgstr ""
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:442
+#: src/itemviewformaction.cpp:452
 msgid "Next Unread"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgid "Search"
 msgstr ""
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
 #: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr ""
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
 msgid "Toggling read flag for article..."
 msgstr ""
 
@@ -837,12 +837,12 @@ msgstr ""
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
 msgid "URL list empty."
 msgstr ""
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:278
+#: src/itemviewformaction.cpp:288
 msgid "Flags: "
 msgstr ""
 
@@ -855,18 +855,18 @@ msgid "Error: you can't reload search results."
 msgstr ""
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
-#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
+#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -898,7 +898,7 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
 msgid "Flags updated."
 msgstr ""
 
@@ -907,17 +907,17 @@ msgstr ""
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
+#: src/itemviewformaction.cpp:497
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
@@ -984,68 +984,68 @@ msgstr ""
 msgid "type: "
 msgstr ""
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
 msgid "Top"
 msgstr ""
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
 msgid "Bottom"
 msgstr ""
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:584
+#: src/itemviewformaction.cpp:176 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:181
+#: src/itemviewformaction.cpp:191
 #, c-format
 msgid "Added %s to download queue."
 msgstr ""
 
-#: src/itemviewformaction.cpp:185
+#: src/itemviewformaction.cpp:195
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr ""
 
-#: src/itemviewformaction.cpp:206
+#: src/itemviewformaction.cpp:216
 #, c-format
 msgid "Saved article to %s."
 msgstr ""
 
-#: src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:219
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
-#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
+#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr ""
 
-#: src/itemviewformaction.cpp:365
+#: src/itemviewformaction.cpp:375
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:429 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr ""
 
-#: src/itemviewformaction.cpp:444
+#: src/itemviewformaction.cpp:454
 msgid "Enqueue"
 msgstr ""
 
-#: src/itemviewformaction.cpp:608
+#: src/itemviewformaction.cpp:618
 #, c-format
 msgid "Article - %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:658
+#: src/itemviewformaction.cpp:668
 msgid "Error: invalid regular expression!"
 msgstr ""
 
@@ -1614,18 +1614,31 @@ msgstr ""
 msgid "unsupported feed format"
 msgstr ""
 
+#: rust/libnewsboat/src/cliargsparser.rs:288
 msgid "%s: %s: invalid loglevel value"
 msgstr ""
 
+#: rust/libnewsboat/src/configpaths.rs:73
 msgid "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr ""
 
+#: rust/libnewsboat/src/configpaths.rs:134
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
+#: rust/libnewsboat/src/configpaths.rs:190
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Aborting migration because mkdir on `%s' failed: %s"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+msgid "regcomp returned code %i"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+msgid "regexec returned code %i"
 msgstr ""

--- a/rust/regex-rs/Cargo.toml
+++ b/rust/regex-rs/Cargo.toml
@@ -8,5 +8,8 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+strprintf = { path="../strprintf" }
+
 bitflags = "1.0"
 libc = ">=0.2.69"
+gettext-rs = "0.4.1"

--- a/rust/regex-rs/Cargo.toml
+++ b/rust/regex-rs/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "regex-rs"
+version = "0.1.0"
+authors = ["Alexander Batischev <eual.jp@gmail.com>"]
+edition = "2018"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bitflags = "1.0"
+libc = ">=0.2.69"

--- a/rust/regex-rs/src/lib.rs
+++ b/rust/regex-rs/src/lib.rs
@@ -147,9 +147,9 @@ impl Regex {
                 errmsg.pop();
 
                 match OsString::from_vec(errmsg).into_string() {
-                    Ok(errmsg) => Err(format!("({}) {}", errcode, errmsg)),
+                    Ok(errmsg) => Err(format!("regcomp returned code {}: {}", errcode, errmsg)),
 
-                    Err(_errmsg_ostring) => Err(format!("({})", errcode)),
+                    Err(_errmsg_ostring) => Err(format!("regcomp returned code {}", errcode)),
                 }
             }
         }
@@ -226,7 +226,7 @@ impl Regex {
 
             // POSIX only specifies two return codes for regexec(), but implementations are free to
             // extend that.
-            _ => Err(format!("({}) match failure", errcode)),
+            _ => Err(format!("regexec returned code {}", errcode)),
         }
     }
 }

--- a/rust/regex-rs/src/lib.rs
+++ b/rust/regex-rs/src/lib.rs
@@ -29,11 +29,13 @@
 //! ```
 
 use bitflags::bitflags;
+use gettextrs::gettext;
 use libc::{regcomp, regerror, regex_t, regexec, regfree, regmatch_t};
 use std::ffi::{CString, OsString};
 use std::mem;
 use std::os::unix::ffi::OsStringExt;
 use std::ptr;
+use strprintf::fmt;
 
 /// POSIX regular expression.
 pub struct Regex {
@@ -152,9 +154,13 @@ impl Regex {
                 Ok(Regex { regex })
             } else {
                 match regex_error_to_str(errcode, &regex) {
-                    Some(errmsg) => Err(format!("regcomp returned code {}: {}", errcode, errmsg)),
+                    Some(regcomp_errmsg) => {
+                        let msg = fmt!(&gettext("regcomp returned code %i"), errcode);
+                        let msg = format!("{}: {}", msg, regcomp_errmsg);
+                        Err(msg)
+                    }
 
-                    None => Err(format!("regcomp returned code {}", errcode)),
+                    None => Err(fmt!(&gettext("regcomp returned code %i"), errcode)),
                 }
             }
         }
@@ -233,8 +239,12 @@ impl Regex {
             // extend that.
             _ => unsafe {
                 match regex_error_to_str(errcode, &self.regex) {
-                    Some(errmsg) => Err(format!("regexec returned code {}: {}", errcode, errmsg)),
-                    None => Err(format!("regexec returned code {}", errcode)),
+                    Some(regexec_errmsg) => {
+                        let msg = fmt!(&gettext("regexec returned code %i"), errcode);
+                        let msg = format!("{}: {}", msg, regexec_errmsg);
+                        Err(msg)
+                    }
+                    None => Err(fmt!(&gettext("regexec returned code %i"), errcode)),
                 }
             },
         }

--- a/rust/regex-rs/src/lib.rs
+++ b/rust/regex-rs/src/lib.rs
@@ -1,0 +1,285 @@
+//! Safe wrapper for [POSIX regular expressions API][regex-h] (provided by libc on POSIX-compliant OSes).
+//!
+//! [regex-h]: https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/basedefs/regex.h.html#tag_13_37
+//!
+//! ```
+//! use regex_rs::*;
+//!
+//! let pattern = "This( often)? repeats time and again(, and again)*\\.";
+//! let compilation_flags = CompFlags::EXTENDED;
+//! let regex = Regex::new(pattern, compilation_flags)
+//!     .expect("Failed to compile pattern as POSIX extended regular expression");
+//!
+//! let input = "This repeats time and again, and again, and again.";
+//! // We're only interested in the first match, i.e. the part of text
+//! // that's matched by the whole regex
+//! let max_matches = 1;
+//! let match_flags = MatchFlags::empty();
+//! let matches = regex
+//!     .matches(input, max_matches, match_flags)
+//!     .expect("Error matching input against regex");
+//!
+//! // Found a match
+//! assert_eq!(matches.len(), 1);
+//!
+//! // Match spans from the beginning to the end of the input
+//! assert_eq!(matches[0].start_pos, 0);
+//! // `end_pos` holds one-past-the-end index
+//! assert_eq!(matches[0].end_pos, input.len());
+//! ```
+
+use bitflags::bitflags;
+use libc::{regcomp, regerror, regex_t, regexec, regfree, regmatch_t};
+use std::ffi::{CString, OsString};
+use std::mem;
+use std::os::unix::ffi::OsStringExt;
+use std::ptr;
+
+/// POSIX regular expression.
+pub struct Regex {
+    /// Compiled POSIX regular expression.
+    regex: regex_t,
+}
+
+bitflags! {
+    /// Compilation flags.
+    ///
+    /// These affect what features are available inside the regex, and also how it's matched
+    /// against the input string.
+    pub struct CompFlags: i32 {
+        /// Use Extended Regular Expressions.
+        ///
+        /// POSIX calls this `REG_EXTENDED`.
+        const EXTENDED = libc::REG_EXTENDED;
+
+        /// Ignore case when matching.
+        ///
+        /// POSIX calls this `REG_ICASE`.
+        const IGNORE_CASE = libc::REG_ICASE;
+
+        /// Report only success or fail of the compilation.
+        ///
+        /// POSIX calls this `REG_NOSUB`.
+        const NO_SUB = libc::REG_NOSUB;
+
+        /// Give special meaning to newline characters.
+        ///
+        /// POSIX calls this `REG_NEWLINE`.
+        ///
+        /// Without this flag, newlines match themselves.
+        ///
+        /// With this flag, newlines match themselves except:
+        ///
+        /// 1. newline is not matched by `.` outside of bracket expressions or by any form of
+        ///    non-matching lists;
+        ///
+        /// 2. beginning-of-line (`^`) matches zero-width string right after newline, regardless of
+        ///    `CompFlag::NOTBOL`;
+        ///
+        /// 3. end-of-line (`$`) matches zero-width string right before a newline, regardless of
+        ///    `CompFlags::NOTEOL`.
+        const NEWLINE = libc::REG_NEWLINE;
+    }
+}
+
+bitflags! {
+    /// Matching flags.
+    ///
+    /// These affect how regex is matched against the input string.
+    pub struct MatchFlags: i32 {
+        /// The circumflex character (`^`), when taken as a special character, does not match the
+        /// beginning of string.
+        const NOTBOL = libc::REG_NOTBOL;
+
+        /// The dollar-sign (`$`), when taken as a special character, does not match the end of
+        /// string.
+        const NOTEOL = libc::REG_NOTEOL;
+    }
+}
+
+/// Start and end positions of a matched substring.
+pub struct Match {
+    /// Start position (counting from zero).
+    pub start_pos: usize,
+
+    /// One-past-end position (counting from zero).
+    pub end_pos: usize,
+}
+
+impl Regex {
+    /// Compiles pattern as a regular expression.
+    ///
+    /// By default, pattern is assumed to be a basic regular expression. To interpret it as an
+    /// extended regular expression, add `CompFlags::EXTENDED` to the `flags`. See also other
+    /// `CompFlags` values to control some other aspects of the regex.
+    ///
+    /// # Returns
+    ///
+    /// Compiled regex or an error message.
+    pub fn new(pattern: &str, flags: CompFlags) -> Result<Regex, String> {
+        let pattern = CString::new(pattern)
+            .map_err(|_| String::from("Regular expression contains NUL byte"))?;
+
+        unsafe {
+            let mut regex: regex_t = mem::zeroed();
+            let errcode = regcomp(&mut regex, pattern.into_raw(), flags.bits());
+
+            if errcode == 0 {
+                Ok(Regex { regex })
+            } else {
+                // Find out the size of the buffer needed to hold the error message
+                let errmsg_length = regerror(errcode, &regex, ptr::null_mut(), 0);
+
+                // Allocate the buffer and get the message.
+                // Casting u64 to usize is safe since the error message is unlikely to hit usize's
+                // upper bound.
+                let mut errmsg: Vec<u8> = vec![0; errmsg_length as usize];
+                // Casting `*mut u8` to `*mut c_char` should be safe since C doesn't really care:
+                // it can store any ASCII symbol in a `char`, disregarding signedness.
+                regerror(
+                    errcode,
+                    &regex,
+                    errmsg.as_mut_ptr() as *mut std::os::raw::c_char,
+                    errmsg_length,
+                );
+
+                // Drop the trailing NUL byte that C uses to terminate strings
+                errmsg.pop();
+
+                match OsString::from_vec(errmsg).into_string() {
+                    Ok(errmsg) => Err(format!("({}) {}", errcode, errmsg)),
+
+                    Err(_errmsg_ostring) => Err(format!("({})", errcode)),
+                }
+            }
+        }
+    }
+
+    /// Matches input string against regex, looking for up to `max_matches` matches.
+    ///
+    /// Regexes can contain parenthesized subexpressions. This method will return up to
+    /// `max_matches`-1 of those. First match is reserved for the text that the whole regex
+    /// matched.
+    ///
+    /// `flags` dictate how matching is performed. See `MatchFlags` for details.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok` with an empty vector if no match found, or if `max_matches` is 0 and there were no
+    ///   errors.
+    /// - `Ok` with a non-empty vector if `max_matches` was non-zero and a match was found. First
+    ///   element of the vector is the text that regex as a whole matched. The rest of the elements
+    ///   are pieces of text that were matched by parenthesized subexpressions.
+    /// - `Err` with an error message.
+    pub fn matches(
+        &self,
+        input: &str,
+        max_matches: usize,
+        flags: MatchFlags,
+    ) -> Result<Vec<Match>, String> {
+        let input =
+            CString::new(input).map_err(|_| String::from("Input string contains NUL byte"))?;
+
+        let mut pmatch: Vec<regmatch_t>;
+
+        let errcode = unsafe {
+            pmatch = vec![mem::zeroed(); max_matches];
+
+            regexec(
+                &self.regex,
+                input.into_raw(),
+                max_matches as libc::size_t,
+                pmatch.as_mut_ptr(),
+                flags.bits(),
+            )
+        };
+
+        match errcode {
+            0 => {
+                // Success. Let's copy results
+                let mut matches: Vec<Match> = Vec::new();
+
+                for m in pmatch {
+                    if m.rm_so < 0 || m.rm_eo < 0 {
+                        // Since `max_matches` can be bigger than the number of parenthesized
+                        // blocks in the regex, it's possible that some of the `pmatch` values are
+                        // empty. We exit the loop after detecting first such value.
+                        break;
+                    }
+
+                    // It's safe to cast i32 to usize here:
+                    // - we already checked that the values aren't negative
+                    // - usize's upper bound is higher than i32's
+                    matches.push(Match {
+                        start_pos: m.rm_so as usize,
+                        end_pos: m.rm_eo as usize,
+                    });
+                }
+
+                Ok(matches)
+            }
+
+            libc::REG_NOMATCH => {
+                // Matching went okay, but nothing found
+                Ok(Vec::new())
+            }
+
+            // POSIX only specifies two return codes for regexec(), but implementations are free to
+            // extend that.
+            _ => Err(format!("({}) match failure", errcode)),
+        }
+    }
+}
+
+impl Drop for Regex {
+    fn drop(&mut self) {
+        unsafe {
+            regfree(&mut self.regex);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_basic_posix_regular_expression() {
+        let regex = Regex::new("abc+", CompFlags::empty()).unwrap();
+        let matches = regex.matches("abc+others", 1, MatchFlags::empty()).unwrap();
+
+        assert_eq!(matches.len(), 1);
+
+        // Match spans from the start of the input until the 4th character
+        assert_eq!(matches[0].start_pos, 0);
+        assert_eq!(matches[0].end_pos, 4); // one-past-last offset
+    }
+
+    #[test]
+    fn matches_extended_posix_regular_expression() {
+        let regex = Regex::new("aBc+", CompFlags::EXTENDED | CompFlags::IGNORE_CASE).unwrap();
+        let matches = regex
+            .matches("AbCcCcCC and others", 1, MatchFlags::empty())
+            .unwrap();
+
+        assert_eq!(matches.len(), 1);
+
+        // Match spans from the start of the input until the 4th character
+        assert_eq!(matches[0].start_pos, 0);
+        assert_eq!(matches[0].end_pos, 8); // one-past-last offset
+    }
+
+    #[test]
+    fn new_returns_error_on_invalid_regex() {
+        let result = Regex::new("(abc", CompFlags::EXTENDED);
+
+        assert!(result.is_err());
+        if let Err(msg) = result {
+            // There should be at least an error code, so string can't possibly be empty
+            assert!(!msg.is_empty());
+
+            // The message shouldn't contain a C string terminator (NUL) at the end
+            assert!(!msg.ends_with('\0'));
+        }
+    }
+}


### PR DESCRIPTION
I'm bending my own rules here, adding code that is not used by anything but its own test suite. Motivation for this is the same as with #857: this PR is a stepping stone to new filter parser and matcher implementations, which I split into multiple PRs to make it more reviewable.

This PR adds two creates, regex-sys and regex-rs. The first one is a set of unsafe FFI bindings, the second one is a safe wrapper. I expect that libc create will eventually add their own bindings for POSIX regex, and we will drop regex-sys. For now, it's faster for us to roll our own.

Reviews are welcome as always. Will merge in three days.