### PR TITLE
README: add CII Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Newsboat [![Travis CI Build Status](https://travis-ci.org/newsboat/newsboat.svg?branch=master)](https://travis-ci.org/newsboat/newsboat) [![Cirrus CI Build Status](https://api.cirrus-ci.com/github/newsboat/newsboat.svg)](https://cirrus-ci.com/github/newsboat/newsboat) [![Coverage Status](https://coveralls.io/repos/github/newsboat/newsboat/badge.svg?branch=master)](https://coveralls.io/github/newsboat/newsboat?branch=master)
+Newsboat [![Travis CI Build Status](https://travis-ci.org/newsboat/newsboat.svg?branch=master)](https://travis-ci.org/newsboat/newsboat) [![Cirrus CI Build Status](https://api.cirrus-ci.com/github/newsboat/newsboat.svg)](https://cirrus-ci.com/github/newsboat/newsboat) [![Coverage Status](https://coveralls.io/repos/github/newsboat/newsboat/badge.svg?branch=master)](https://coveralls.io/github/newsboat/newsboat?branch=master) [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3328/badge)](https://bestpractices.coreinfrastructure.org/projects/3328)
 ========
 
 <a href="https://newsboat.org">


### PR DESCRIPTION
I recognize the merit of CII Best Practices list, and I think Newsboat should achieve the passing level. [We already have the basics covered](https://bestpractices.coreinfrastructure.org/en/projects/3328), but there's still some work to be done, especially in areas security and analysis. Let's show off our in-progress badge, so people know that we share those values and want to get better at living by them.

There really isn't anything to review here, but if you have some thoughts on the matter, please comment. I'll merge this in three days (perhaps someone only looks at the PR list once in a while, let's give them a chance to notice this).