### PR TITLE
Add unread flag field which allows formatting with conditional sequence

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1002,7 +1002,8 @@ Identifier:Meaning
 [[feedlist-format-i]]<<feedlist-format-i,+i+>>:Feed index
 [[feedlist-format-l]]<<feedlist-format-l,+l+>>:Feed link
 [[feedlist-format-L]]<<feedlist-format-L,+L+>>:Feed RSS URL
-[[feedlist-format-n]]<<feedlist-format-n,+n+>>:"unread" flag field
+[[feedlist-format-n]]<<feedlist-format-n,+n+>>:"unread" flag field ("N" if unread, " " if read)
+[[feedlist-format-N]]<<feedlist-format-N,+N+>>:"unread" flag field ("N" if unread, empty if read). Can be used with the conditional sequence (e.g. "%?N?unread&  read?")
 [[feedlist-format-S]]<<feedlist-format-S,+S+>>:download status
 [[feedlist-format-t]]<<feedlist-format-t,+t+>>:Feed title
 [[feedlist-format-T]]<<feedlist-format-T,+T+>>:First tag of a feed in the URLs file

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1024,6 +1024,7 @@ Identifier:Meaning
 [[articlelist-format-a]]<<articlelist-format-a,+a+>>:Article author
 [[articlelist-format-D]]<<articlelist-format-D,+D+>>:Publication date. This can be tweaked further with <<datetime-format,+datetime-format+>>
 [[articlelist-format-f]]<<articlelist-format-f,+f+>>:Article flags
+[[articlelist-format-N]]<<articlelist-format-N,+N+>>:"unread" flag field ("N" if unread, empty if read). Can be used with the conditional sequence (e.g. "%?N?unread&  read?")
 [[articlelist-format-i]]<<articlelist-format-i,+i+>>:Article index
 [[articlelist-format-t]]<<articlelist-format-t,+t+>>:Article title
 [[articlelist-format-T]]<<articlelist-format-T,+T+>>:If the article list displays articles from different feeds, then this identifier contains the title of the feed to which the article belongs.

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -1026,6 +1026,7 @@ std::string FeedListFormAction::format_line(const std::string& feedlist_format,
 	fmt.register_fmt('U', std::to_string(unread_count));
 	fmt.register_fmt('c', std::to_string(feed->total_item_count()));
 	fmt.register_fmt('n', unread_count > 0 ? "N" : " ");
+	fmt.register_fmt('N', unread_count > 0 ? "N" : "");
 	fmt.register_fmt('S', feed->get_status());
 	fmt.register_fmt('t', utils::quote_for_stfl(get_title(feed)));
 	fmt.register_fmt('T', feed->get_firsttag());

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1019,6 +1019,7 @@ std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	FmtStrFormatter fmt;
 	fmt.register_fmt('i', strprintf::fmt("%u", item.second + 1));
 	fmt.register_fmt('f', gen_flags(item.first));
+	fmt.register_fmt('N', item.first->unread() ? "N" : "");
 	fmt.register_fmt('D',
 		utils::mt_strf_localtime(
 			datetime_format,


### PR DESCRIPTION
From irc:
```
07Apr-07:33:15 < _Warl0ck> Is there any way to change the characters for flags? For example if I wanted a fancy unicode character instead of N for unread article. I just customized neomutt like this so I would like to do it here as well
07Apr-07:35:44 < yitz> Yes. You can set key bindings in the config somewhere
07Apr-07:45:10 < _Warl0ck> yitz: Key bindings? I am simply interested in formatting the article list
07Apr-07:48:19 < yitz> Oh. Totally misunderstood.
07Apr-07:48:19 < yitz> https://newsboat.org/releases/2.18/docs/newsboat.html#_format_strings
07Apr-07:48:20 -url:#newsboat- _ The Newsboat RSS Feedreader
07Apr-07:49:21 < yitz> Hrm. Not sure if you can customize what %n gets replaced with
07Apr-07:50:13 < _Warl0ck> yeah that's what I'm trying to do :/
07Apr-07:50:49 < _Warl0ck> pasted a bunch of FontAwesome icons into my neomutt config and it looks amazing
07Apr-07:51:33 < yitz> https://github.com/newsboat/newsboat/blob/09ec32244dca3f5699cb736636c8b5a2105d31ef/src/itemlistformaction.cpp#L1380
07Apr-07:51:34 -url:#newsboat- _ newsboat/itemlistformaction.cpp at 09ec32244dca3f5699cb736636c8b5a2105d31ef _ newsboat/newsboat _ GitHub
07Apr-07:52:01 < yitz> If you are up for building it yourself, it's a one char change
07Apr-07:52:49 < yitz> Man. It's been years since I opened the sourcecode for this project...
07Apr-07:53:03 < _Warl0ck> Nice. Maybe I could make a quick patchfile that substitutes some of the common flags
07Apr-09:07:35 < nikos> Maybe %?n?new-char? would work?
```

The suggested `%?n?new-char?` does not work because the `%n` specifier is not empty when the article is read (it still contains whitespace for alignment).

This PR adds a new `%N` specifier which results in an empty string, allowing use of the conditional sequence.