### PR TITLE
Ignore whitespace when rendering conditional sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ acknowledge contributions from the following people:
   home, end (#847) (Dennis van der Schagt)
 - It's now an error to have `always-download` or `reset-unread-on-update`
     without parameters (Alexander Batischev)
+- The conditional sequence now acts the same for strings with only whitespace
+  as it does for empty strings.  This allows changing the formatting of, for
+  example, "unread" and "deleted" fields in articlelist-format (#869) (Dennis
+  van der Schagt)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Lists below only mention user-visible changes, but I would also like to
 acknowledge contributions from the following people:
 
 ### Added
+- New format specifiers (%n, %d, and %F) for articlelist-format which
+  correspond respectively to article fields "unread", "deleted", and article
+  flags (#869) (Dennis van der Schagt)
 ### Changed
 - Allow binding multiple keys to general operations: up, down, pageup, pagedown,
   home, end (#847) (Dennis van der Schagt)

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -986,10 +986,10 @@ In addition, newsboat provides other, more powerful sequences, such as
 right on the screen, and characters between the text on the left and the text
 on the right will be filled by `[char]`. Another powerful format is the
 conditional sequence, `%?[char]?[format 1]&[format 2]?`: if the text of the
-sequence identifier `[char]` is non-empty, then `[format 1]` will be evaluated
-and inserted, otherwise `[format 2]` will be evaluated and inserted. The `&` and
-`[format 2]` are optional, i.e. if the identifier's text is empty, then an
-empty string will be inserted.
+sequence identifier `[char]` contains any non-whitespace characters, then
+`[format 1]` will be evaluated and inserted, otherwise `[format 2]` will be
+evaluated and inserted. The `&` and `[format 2]` are optional, i.e. if the
+identifier's text is empty, then an empty string will be inserted.
 
 The following tables show what sequence identifiers are available for which
 format:

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1022,7 +1022,10 @@ by " ") and "download error" (indicated by "x").
 Identifier:Meaning
 [[articlelist-format-a]]<<articlelist-format-a,+a+>>:Article author
 [[articlelist-format-D]]<<articlelist-format-D,+D+>>:Publication date. This can be tweaked further with <<datetime-format,+datetime-format+>>
-[[articlelist-format-f]]<<articlelist-format-f,+f+>>:Article flags
+[[articlelist-format-f]]<<articlelist-format-f,+f+>>:Combination of unread/deleted fields and article flags
+[[articlelist-format-n]]<<articlelist-format-n,+n+>>:"unread" field
+[[articlelist-format-d]]<<articlelist-format-d,+d+>>:"deleted" field
+[[articlelist-format-F]]<<articlelist-format-F,+F+>>:Article flags
 [[articlelist-format-i]]<<articlelist-format-i,+i+>>:Article index
 [[articlelist-format-t]]<<articlelist-format-t,+t+>>:Article title
 [[articlelist-format-T]]<<articlelist-format-T,+T+>>:If the article list displays articles from different feeds, then this identifier contains the title of the feed to which the article belongs.

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1022,7 +1022,7 @@ by " ") and "download error" (indicated by "x").
 Identifier:Meaning
 [[articlelist-format-a]]<<articlelist-format-a,+a+>>:Article author
 [[articlelist-format-D]]<<articlelist-format-D,+D+>>:Publication date. This can be tweaked further with <<datetime-format,+datetime-format+>>
-[[articlelist-format-f]]<<articlelist-format-f,+f+>>:Combination of unread/deleted fields and article flags
+[[articlelist-format-f]]<<articlelist-format-f,+f+>>:Two characters\: 1) "N" if article is unread, "D" if article is deleted, a space otherwise; 2) "!" if article has flags, a space otherwise.
 [[articlelist-format-n]]<<articlelist-format-n,+n+>>:"unread" field
 [[articlelist-format-d]]<<articlelist-format-d,+d+>>:"deleted" field
 [[articlelist-format-F]]<<articlelist-format-F,+F+>>:Article flags

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -131,7 +131,7 @@ impl FmtStrFormatter {
         result: &mut LimitedString,
     ) {
         match self.fmts.get(&cond) {
-            Some(value) if !value.is_empty() => {
+            Some(value) if !value.trim().is_empty() => {
                 result.push_str(&self.formatting_helper(then, width))
             }
             _ => {

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -548,6 +548,17 @@ mod tests {
     }
 
     #[test]
+    fn t_conditional_whitespace_is_handled_as_empty() {
+        let mut fmt = FmtStrFormatter::new();
+
+        fmt.register_fmt('a', " \t ".to_string());
+        fmt.register_fmt('b', "  some whitespace  ".to_string());
+
+        assert_eq!(fmt.do_format("%?a?non-empty&empty?", 0), "empty");
+        assert_eq!(fmt.do_format("%?b?non-empty&empty?", 0), "non-empty");
+    }
+
+    #[test]
     fn t_do_format_replaces_double_percent_sign_with_a_percent_sign() {
         let fmt = FmtStrFormatter::new();
         assert_eq!(fmt.do_format("%%", 0), "%");

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1019,6 +1019,9 @@ std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	FmtStrFormatter fmt;
 	fmt.register_fmt('i', strprintf::fmt("%u", item.second + 1));
 	fmt.register_fmt('f', gen_flags(item.first));
+	fmt.register_fmt('n', item.first->unread() ? "N" : " ");
+	fmt.register_fmt('d', item.first->deleted() ? "D" : " ");
+	fmt.register_fmt('F', item.first->flags());
 	fmt.register_fmt('D',
 		utils::mt_strf_localtime(
 			datetime_format,

--- a/test/fmtstrformatter.cpp
+++ b/test/fmtstrformatter.cpp
@@ -353,6 +353,14 @@ TEST_CASE("%?[char]?[then-format]&[else-format]? is replaced by "
 		REQUIRE(fmt.do_format("%?t?непустое?") == "непустое");
 		REQUIRE(fmt.do_format("%?m?непустое?") == "");
 	}
+
+	SECTION("Whitespace on its own is handled same as empty") {
+		fmt.register_fmt('a', " \t ");
+		fmt.register_fmt('b', "  some whitespace  ");
+
+		REQUIRE(fmt.do_format("%?a?non-empty&empty?") == "empty");
+		REQUIRE(fmt.do_format("%?b?non-empty&empty?") == "non-empty");
+	}
 }
 
 TEST_CASE("do_format replaces \"%%\" with a percent sign",


### PR DESCRIPTION
[Idea](https://github.com/newsboat/newsboat/pull/868#issuecomment-610831063) by @tsipinakis:
> How about ignoring whitespace in conditionals instead, it's technically 'empty'? IMO I'd expect an all whitespace string to be considered empty.

Replaces PR #868.

Also adding format specifiers for unread/deleted/flags to have more control over formatting (`%f` combined some flags [using gen_flags](https://github.com/newsboat/newsboat/blob/09ec32244dca3f5699cb736636c8b5a2105d31ef/src/itemlistformaction.cpp#L1374-L1390).