### PR TITLE
Abort macro execution if open_in_browser fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ acknowledge contributions from the following people:
   as it does for empty strings.  This allows changing the formatting of, for
   example, "unread" and "deleted" fields in articlelist-format (#869) (Dennis
   van der Schagt)
+- `open-in-browser-and-mark-read` in feedlist no longer marks articles read if
+  the browser fails. (#873) (Nikos Tsipinakis)
+- Macro execution halts if one of the operations fail. (#873) (Nikos Tsipinakis)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/include/dialogsformaction.h
+++ b/include/dialogsformaction.h
@@ -20,7 +20,7 @@ public:
 	void handle_cmdline(const std::string& cmd) override;
 
 private:
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	bool update_list;

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -29,7 +29,7 @@ public:
 	std::string title() override;
 
 private:
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);

--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -49,7 +49,7 @@ public:
 
 private:
 	int get_pos(unsigned int realidx);
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -33,7 +33,7 @@ public:
 	std::string title() override;
 
 private:
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -42,7 +42,7 @@ public:
 
 	virtual void handle_cmdline(const std::string& cmd);
 
-	void process_op(Operation op,
+	bool process_op(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr);
 
@@ -87,7 +87,7 @@ public:
 		const std::string& feed_title);
 
 protected:
-	virtual void process_operation(Operation op,
+	virtual bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) = 0;
 	virtual void set_keymap_hints();

--- a/include/helpformaction.h
+++ b/include/helpformaction.h
@@ -22,7 +22,7 @@ public:
 	void set_context(const std::string& ctx);
 
 private:
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	std::string make_colorstring(const std::vector<std::string>& colors);

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -77,7 +77,7 @@ public:
 	void set_regexmanager(RegexManager* r);
 
 private:
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	void set_head(const std::string& s,

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -53,7 +53,7 @@ public:
 	void update_percent();
 
 private:
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	void update_head(const std::shared_ptr<RssItem>& item);

--- a/include/listformaction.h
+++ b/include/listformaction.h
@@ -10,7 +10,7 @@ public:
 	ListFormAction(View*, std::string formstr, ConfigContainer* cfg);
 
 protected:
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	int open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,

--- a/include/selectformaction.h
+++ b/include/selectformaction.h
@@ -40,7 +40,7 @@ public:
 	std::string title() override;
 
 private:
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	bool quit;

--- a/include/urlviewformaction.h
+++ b/include/urlviewformaction.h
@@ -28,7 +28,7 @@ public:
 	void handle_cmdline(const std::string& cmd) override;
 
 private:
-	void process_operation(Operation op,
+	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 	std::vector<LinkPair> links;

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -74,7 +74,7 @@ KeyMapHintEntry* DialogsFormAction::get_keymap_hint()
 	return hints;
 }
 
-void DialogsFormAction::process_operation(Operation op,
+bool DialogsFormAction::process_operation(Operation op,
 	bool /* automatic */,
 	std::vector<std::string>* /* args */)
 {
@@ -111,6 +111,7 @@ void DialogsFormAction::process_operation(Operation op,
 	default:
 		break;
 	}
+	return true;
 }
 
 std::string DialogsFormAction::title()

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -60,7 +60,7 @@ char get_filetype(mode_t mode)
 	return '?';
 }
 
-void DirBrowserFormAction::process_operation(Operation op,
+bool DirBrowserFormAction::process_operation(Operation op,
 	bool /* automatic */,
 	std::vector<std::string>* /* args */)
 {
@@ -149,6 +149,7 @@ void DirBrowserFormAction::process_operation(Operation op,
 	default:
 		break;
 	}
+	return true;
 }
 
 void DirBrowserFormAction::update_title(const std::string& working_directory)

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -237,9 +237,16 @@ REDO:
 						feedpos,
 						feed->link());
 					if (!feed->link().empty()) {
-						v->open_in_browser(feed->link());
+						if (int err = v->open_in_browser(feed->link())) {
+							v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+							return false;
+						}
 					} else if (!feed->rssurl().empty()) {
-						v->open_in_browser(feed->rssurl());
+						if (int err = v->open_in_browser(feed->rssurl())) {
+							v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+							return false;
+						}
+
 					} else {
 						// rssurl can't be empty, so if we got to this branch,
 						// something is clearly wrong with Newsboat internals.
@@ -271,7 +278,11 @@ REDO:
 					"unread "
 					"items in feed at position `%s'",
 					feedpos.c_str());
-				open_unread_items_in_browser(feed, false);
+				if (int err = open_unread_items_in_browser(feed, false)) {
+					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+					return false;
+				}
+
 			}
 		} else {
 			v->show_error(_("No feed selected!"));
@@ -289,7 +300,12 @@ REDO:
 					"items in feed at position `%s' and "
 					"marking read",
 					feedpos.c_str());
-				open_unread_items_in_browser(feed, true);
+
+				if (int err = open_unread_items_in_browser(feed, true)) {
+					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+					return false;
+				}
+
 				do_redraw = true;
 			}
 		}

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -97,7 +97,7 @@ void FeedListFormAction::prepare()
 	}
 }
 
-void FeedListFormAction::process_operation(Operation op,
+bool FeedListFormAction::process_operation(Operation op,
 	bool automatic,
 	std::vector<std::string>* args)
 {
@@ -522,6 +522,7 @@ REDO:
 			v->pop_current_formaction();
 		}
 	}
+	return true;
 }
 
 void FeedListFormAction::update_visible_feeds(

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -38,7 +38,7 @@ FileBrowserFormAction::FileBrowserFormAction(View* vv,
 
 FileBrowserFormAction::~FileBrowserFormAction() {}
 
-void FileBrowserFormAction::process_operation(Operation op,
+bool FileBrowserFormAction::process_operation(Operation op,
 	bool /* automatic */,
 	std::vector<std::string>* /* args */)
 {
@@ -149,6 +149,7 @@ void FileBrowserFormAction::process_operation(Operation op,
 	default:
 		break;
 	}
+	return true;
 }
 
 void FileBrowserFormAction::update_title(const std::string& working_directory)

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -174,7 +174,7 @@ bool FormAction::process_op(Operation op,
 		v->goto_prev_dialog();
 		break;
 	default:
-		this->process_operation(op, automatic, args);
+		return this->process_operation(op, automatic, args);
 	}
 	return true;
 }

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -101,7 +101,7 @@ void FormAction::start_cmdline(std::string default_value)
 	this->start_qna(qna, OP_INT_END_CMDLINE, &FormAction::cmdlinehistory);
 }
 
-void FormAction::process_op(Operation op,
+bool FormAction::process_op(Operation op,
 	bool automatic,
 	std::vector<std::string>* args)
 {
@@ -176,6 +176,7 @@ void FormAction::process_op(Operation op,
 	default:
 		this->process_operation(op, automatic, args);
 	}
+	return true;
 }
 
 std::vector<std::string> FormAction::get_suggestions(

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -24,7 +24,7 @@ HelpFormAction::HelpFormAction(View* vv,
 
 HelpFormAction::~HelpFormAction() {}
 
-void HelpFormAction::process_operation(Operation op,
+bool HelpFormAction::process_operation(Operation op,
 	bool /* automatic */,
 	std::vector<std::string>* /* args */)
 {
@@ -56,6 +56,7 @@ void HelpFormAction::process_operation(Operation op,
 	} else if (quit) {
 		v->pop_current_formaction();
 	}
+	return true;
 }
 
 void HelpFormAction::prepare()

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -47,7 +47,7 @@ ItemListFormAction::ItemListFormAction(View* vv,
 
 ItemListFormAction::~ItemListFormAction() {}
 
-void ItemListFormAction::process_operation(Operation op,
+bool ItemListFormAction::process_operation(Operation op,
 	bool automatic,
 	std::vector<std::string>* args)
 {
@@ -762,6 +762,7 @@ void ItemListFormAction::process_operation(Operation op,
 	} else if (quit) {
 		v->pop_current_formaction();
 	}
+	return true;
 }
 
 void ItemListFormAction::finished_qna(Operation op)

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -173,7 +173,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				auto link = visible_items[itempos].first->link();
 				if (int err = v->open_in_browser(link)) {
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
-					break;
+					return false;
 				}
 				invalidate(itempos);
 			}
@@ -191,7 +191,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				"browser");
 			if (int err = open_unread_items_in_browser(feed, false)) {
 				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
-				break;
+				return false;
 			}
 		}
 	}
@@ -204,7 +204,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				"browser and marking read");
 			if (int err = open_unread_items_in_browser(feed, true)) {
 				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
-				break;
+				return false;
 			}
 			invalidate_everything();
 		}

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -142,7 +142,7 @@ void ItemViewFormAction::prepare()
 	}
 }
 
-void ItemViewFormAction::process_operation(Operation op,
+bool ItemViewFormAction::process_operation(Operation op,
 	bool automatic,
 	std::vector<std::string>* args)
 {
@@ -423,6 +423,7 @@ void ItemViewFormAction::process_operation(Operation op,
 	} else if (quit) {
 		v->pop_current_formaction();
 	}
+	return true;
 }
 
 KeyMapHintEntry* ItemViewFormAction::get_keymap_hint()

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -216,7 +216,11 @@ bool ItemViewFormAction::process_operation(Operation op,
 	case OP_OPENINBROWSER:
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: starting browser");
 		v->set_status(_("Starting browser..."));
-		v->open_in_browser(item->link());
+		if (int err = v->open_in_browser(item->link())) {
+			v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+			return false;
+		}
+
 		v->set_status("");
 		break;
 	case OP_BOOKMARK:
@@ -393,7 +397,12 @@ bool ItemViewFormAction::process_operation(Operation op,
 			idx);
 		if (idx < links.size()) {
 			v->set_status(_("Starting browser..."));
-			v->open_in_browser(links[idx].first);
+
+			if (int err = v->open_in_browser(links[idx].first)) {
+				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+				return false;
+			}
+
 			v->set_status("");
 		}
 	}

--- a/src/listformaction.cpp
+++ b/src/listformaction.cpp
@@ -12,7 +12,7 @@ ListFormAction::ListFormAction(View* v,
 {
 }
 
-void ListFormAction::process_operation(Operation op,
+bool ListFormAction::process_operation(Operation op,
 	bool,
 	std::vector<std::string>*)
 {
@@ -47,6 +47,7 @@ void ListFormAction::process_operation(Operation op,
 	default:
 		break;
 	}
+	return true;
 }
 
 int ListFormAction::open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -45,7 +45,7 @@ void SelectFormAction::handle_cmdline(const std::string& cmd)
 	}
 }
 
-void SelectFormAction::process_operation(Operation op,
+bool SelectFormAction::process_operation(Operation op,
 	bool /* automatic */,
 	std::vector<std::string>* /* args */)
 {
@@ -95,6 +95,7 @@ void SelectFormAction::process_operation(Operation op,
 	} else if (quit) {
 		v->pop_current_formaction();
 	}
+	return true;
 }
 
 void SelectFormAction::prepare()

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -30,7 +30,7 @@ UrlViewFormAction::UrlViewFormAction(View* vv,
 
 UrlViewFormAction::~UrlViewFormAction() {}
 
-void UrlViewFormAction::process_operation(Operation op,
+bool UrlViewFormAction::process_operation(Operation op,
 	bool /* automatic */,
 	std::vector<std::string>* /* args */)
 {
@@ -97,6 +97,7 @@ void UrlViewFormAction::process_operation(Operation op,
 	} else if (quit) {
 		v->pop_current_formaction();
 	}
+	return true;
 }
 
 void UrlViewFormAction::prepare()

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -209,7 +209,7 @@ int View::run()
 
 			fa->get_form()->run(-1);
 			if (fa->process_op(
-				macrocmds[0].op, true, &macrocmds[0].args)) {
+					macrocmds[0].op, true, &macrocmds[0].args)) {
 
 				// Operation failed, abort
 				macrocmds.clear();

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -213,8 +213,6 @@ int View::run()
 
 				// Operation failed, abort
 				macrocmds.clear();
-				show_error(strprintf::fmt(_("Macro execution failed!")));
-
 			} else {
 				// remove first macro command, since it has already been processed
 				macrocmds.erase(macrocmds.begin());

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -208,7 +208,7 @@ int View::run()
 			// so
 
 			fa->get_form()->run(-1);
-			if (fa->process_op(
+			if (!fa->process_op(
 					macrocmds[0].op, true, &macrocmds[0].args)) {
 
 				// Operation failed, abort

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -208,11 +208,17 @@ int View::run()
 			// so
 
 			fa->get_form()->run(-1);
-			fa->process_op(
-				macrocmds[0].op, true, &macrocmds[0].args);
+			if (fa->process_op(
+				macrocmds[0].op, true, &macrocmds[0].args)) {
 
-			// remove first macro command, since it has already been processed
-			macrocmds.erase(macrocmds.begin());
+				// Operation failed, abort
+				macrocmds.clear();
+				show_error(strprintf::fmt(_("Macro execution failed!")));
+
+			} else {
+				// remove first macro command, since it has already been processed
+				macrocmds.erase(macrocmds.begin());
+			}
 		} else {
 			// we then receive the event and ignore timeouts.
 			const char* event = fa->get_form()->run(60000);


### PR DESCRIPTION
I noticed today that macro execution continues when an operation fails. I think it's a no-brainer that I would want to know of an operation failing and act accordingly rather than blindly continuing execution.

Unfortunately somewhere in the pipeline the error bar is cleared (couldn't find the exact place), so currently the error is simply 'Macro execution failed'.