### PR TITLE
Reloader: Use ScopeMeasure and apply some small refactoring/cleanup

### DIFF
--- a/include/reloader.h
+++ b/include/reloader.h
@@ -71,6 +71,7 @@ public:
 		unsigned int size,
 		bool unattended = false);
 
+private:
 	/// \brief Notify in various ways that there are new unread feeds or
 	/// articles.
 	///
@@ -82,7 +83,6 @@ public:
 	/// notification will contain \a msg passed.
 	void notify(const std::string& msg);
 
-private:
 	Controller* ctrl;
 	Cache* rsscache;
 	ConfigContainer* cfg;

--- a/include/reloader.h
+++ b/include/reloader.h
@@ -14,13 +14,6 @@ class CurlHandle;
 
 /// \brief Updates feeds (fetches, parses, puts results into Controller).
 class Reloader {
-	Controller* ctrl;
-	Cache* rsscache;
-	ConfigContainer* cfg;
-	std::mutex reload_mutex;
-
-	std::string prepare_message(unsigned int pos, unsigned int max);
-
 public:
 	Reloader(Controller* c, Cache* cc, ConfigContainer* cfg);
 
@@ -88,6 +81,15 @@ public:
 	/// If "notify-screen", "notify-xterm" or "notify-program" is chosen, the
 	/// notification will contain \a msg passed.
 	void notify(const std::string& msg);
+
+private:
+	Controller* ctrl;
+	Cache* rsscache;
+	ConfigContainer* cfg;
+	std::mutex reload_mutex;
+
+	std::string prepare_message(unsigned int pos, unsigned int max);
+
 
 };
 

--- a/include/reloader.h
+++ b/include/reloader.h
@@ -83,6 +83,9 @@ private:
 	/// notification will contain \a msg passed.
 	void notify(const std::string& msg);
 
+	void notify_reload_finished(unsigned int unread_feeds_before,
+		unsigned int unread_articles_before);
+
 	Controller* ctrl;
 	Cache* rsscache;
 	ConfigContainer* cfg;

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -300,6 +300,9 @@ void Reloader::notify_reload_finished(unsigned int unread_feeds_before,
 
 	if (notify_always || unread_feeds > unread_feeds_before ||
 		unread_articles > unread_articles_before) {
+		// TODO: Determine what should be done if `unread_articles < unread_articles_before`.
+		// It is expected this can happen if the user marks an article as read
+		// while a reload is in progress.
 		const int article_count = unread_articles - unread_articles_before;
 		const int feed_count = unread_feeds - unread_feeds_before;
 

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -136,12 +136,13 @@ std::string Reloader::prepare_message(unsigned int pos, unsigned int max)
 
 void Reloader::reload_all(bool unattended)
 {
+	ScopeMeasure sm("Reloader::reload_all");
+
 	const auto unread_feeds =
 		ctrl->get_feedcontainer()->unread_feed_count();
 	const auto unread_articles =
 		ctrl->get_feedcontainer()->unread_item_count();
 	int num_threads = cfg->get_configvalue_as_int("reload-threads");
-	time_t t1, t2, dt;
 
 	ctrl->get_feedcontainer()->reset_feeds_status();
 	const auto num_feeds = ctrl->get_feedcontainer()->feeds_size();
@@ -150,8 +151,6 @@ void Reloader::reload_all(bool unattended)
 	const int min_threads = 1;
 	const int max_threads = num_feeds;
 	num_threads = std::max(min_threads, std::min(num_threads, max_threads));
-
-	t1 = time(nullptr);
 
 	LOG(Level::DEBUG, "Reloader::reload_all: starting with reload all...");
 	if (num_threads == 1) {
@@ -194,15 +193,6 @@ void Reloader::reload_all(bool unattended)
 
 	ctrl->get_feedcontainer()->sort_feeds(cfg->get_feed_sort_strategy());
 	ctrl->update_feedlist();
-
-	t2 = time(nullptr);
-	dt = t2 - t1;
-	// On GCC, `time_t` is `long int`, which is at least 32 bits. On x86_64,
-	// it's 64 bits. Thus, this cast is either a no-op, or an up-cast which are
-	// always safe.
-	LOG(Level::INFO,
-		"Reloader::reload_all: reload took %" PRId64 " seconds",
-		static_cast<int64_t>(dt));
 
 	notify_reload_finished(unread_feeds, unread_articles);
 }

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -296,12 +296,12 @@ void Reloader::notify_reload_finished(unsigned int unread_feeds_before,
 		ctrl->get_feedcontainer()->unread_feed_count();
 	const auto unread_articles =
 		ctrl->get_feedcontainer()->unread_item_count();
-	bool notify_always = cfg->get_configvalue_as_bool("notify-always");
+	const bool notify_always = cfg->get_configvalue_as_bool("notify-always");
 
 	if (notify_always || unread_feeds > unread_feeds_before ||
 		unread_articles > unread_articles_before) {
-		int article_count = unread_articles - unread_articles_before;
-		int feed_count = unread_feeds - unread_feeds_before;
+		const int article_count = unread_articles - unread_articles_before;
+		const int feed_count = unread_feeds - unread_feeds_before;
 
 		LOG(Level::DEBUG, "unread article count: %d", article_count);
 		LOG(Level::DEBUG, "unread feed count: %d", feed_count);

--- a/src/scopemeasure.cpp
+++ b/src/scopemeasure.cpp
@@ -33,7 +33,7 @@ ScopeMeasure::~ScopeMeasure()
 	const uint64_t diff =
 		(((tv2.tv_sec - tv1.tv_sec) * 1000000) + tv2.tv_usec) -
 		tv1.tv_usec;
-	LOG(Level::INFO,
+	LOG(lvl,
 		"ScopeMeasure: function `%s' took %" PRIu64 ".%06" PRIu64 " s",
 		funcname,
 		diff / 1000000,


### PR DESCRIPTION
I noticed that the `Reloader` class was still using manual calculations with `time()` instead of `ScopeMeasure`.
While fixing that, I noticed some related code which could use some improvement.