### PR TITLE
Podboat: Document operations which were missing

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1270,9 +1270,13 @@ include::podboat-cmds-linked.dsv[]
 [frame="all", grid="all", format="dsv", options="header", cols="20,20,60"]
 |=========================================================================
 Operation:Default key:Description
+[[pb-quit]]<<pb-quit,+quit+>>:q:Quit the program.
+[[pb-hard-quit]]<<pb-hard-quit,+hard-quit+>>:Q:Quit the program without confirmation.
+[[pb-help]]<<pb-help,+help+>>:?:Show the help screen.
 [[pb-download]]<<pb-download,+pb-download+>>:d:Download the currently selected URL.
 [[pb-cancel]]<<pb-cancel,+pb-cancel+>>:c:Cancel the currently selected download.
 [[pb-play]]<<pb-play,+pb-play+>>:p:Start player with currently selected download.
+[[pb-mark-as-finished]]<<pb-mark-as-finished,+pb-mark-as-finished+>>:m:Mark currently selected entry as finished.
 [[pb-delete]]<<pb-delete,+pb-delete+>>:D:Delete the currently selected URL from the queue.
 [[pb-purge]]<<pb-purge,+pb-purge+>>:P:Remove all finished and deleted downloads from the queue and load URLs that were newly added to the queue.
 [[pb-toggle-download-all]]<<pb-toggle-download-all,+pb-toggle-download-all+>>:a:Toggle the "automatic download" feature where all queued URLs are downloaded one after the other. The "max-downloads" configuration option controls how many downloads are done in parallel.


### PR DESCRIPTION
Fixes #876.

Found the operations missing from documentation by looking through [src/keymap.cpp](https://github.com/newsboat/newsboat/blob/7112a9436b292d264649a43af7a5bd66d6cdaa5d/src/keymap.cpp) (searched for `KM_PODBOAT` and `KM_BOTH`).