### PR TITLE
Use wordier file descriptions in --help

### DIFF
--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -119,11 +119,11 @@ void print_usage(const std::string& argv0, const std::string& config_path,
 	std::cout << '\n';
 
 	std::cout << _("Files:") << '\n';
-	/// This string is the 'config' file description used in a table.
-	const std::string tr_config = _("config");
-	/// This string is the 'urls' file description used in a table.
-	const std::string tr_urls = _("urls");
-	/// This string is the 'cache' file description used in a table.
+	/// This is printed out by --help before the path to the config file
+	const std::string tr_config = _("configuration");
+	/// This is printed out by --help before the path to the urls file
+	const std::string tr_urls = _("feed URLs");
+	/// This is printed out by --help before the path to the cache file
 	const std::string tr_cache = _("cache");
 	const auto widest = std::max({tr_config.length(), tr_urls.length(), tr_cache.length()});
 


### PR DESCRIPTION
In #874 the translator was confused by these descriptions, because they look the same as the file names. This commit changes the wording somewhat to amend this. "Cache" is still a "cache", though; no idea how to improve that one.

Blocked on #873 and #874. Those two PRs change the template and/or translations, I don't want to conflict with them. Generally I'd say that whoever got their PR into a mergeable shape wins, but my changes here are too small to warrant this, so I'll just wait :)

Reviews welcome!