### PR TITLE
Show correct error when urls file cannot be opened

### DIFF
--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -594,8 +594,9 @@ test/feedcontainer.o: test/feedcontainer.cpp 3rd-party/catch.hpp \
  include/rssitem.h include/matcher.h filter/FilterParser.h \
  include/utils.h include/logger.h config.h include/strprintf.h
 test/fileurlreader.o: test/fileurlreader.cpp include/fileurlreader.h \
- include/urlreader.h 3rd-party/catch.hpp test/test-helpers/misc.h \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+ include/urlreader.h 3rd-party/catch.hpp test/test-helpers/chmod.h \
+ test/test-helpers/misc.h test/test-helpers/tempfile.h \
+ test/test-helpers/maintempdir.h
 test/filtercontainer.o: test/filtercontainer.cpp \
  include/filtercontainer.h include/configparser.h \
  include/configactionhandler.h 3rd-party/catch.hpp \

--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -249,6 +249,11 @@ int main(int argc, char* argv[])
 				e.what())
 			<< std::endl;
 		::exit(EXIT_FAILURE);
+	} catch (const std::exception& e) {
+		std::cerr << strprintf::fmt(_("Caught std::exception with message: %s"),
+				e.what())
+			<< std::endl;
+		::exit(EXIT_FAILURE);
 	}
 
 	rsspp::Parser::global_cleanup();

--- a/po/ca.po
+++ b/po/ca.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2017-07-19 20:19+0300\n"
 "Last-Translator: Alejandro Gallo <aamsgallo@gmail.com>\n"
 "Language-Team: Alejandro Gallo <aamsgallo@gmail.com>\n"
@@ -160,6 +160,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -442,51 +447,51 @@ msgstr "comando invàlid `%s'"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: no es va poder obrir l'arxiu de configuració `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Tancar"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Anar a diàleg"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Tancar diàleg"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Cap element seleccionat!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Error: no es pot eliminar la llista de fonts!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Posició invàlida!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Guardar"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Guardar arxiu - %s"
@@ -549,8 +554,8 @@ msgid "Shared items"
 msgstr "Elements compartits"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Ninguna font seleccionada!"
 
@@ -580,131 +585,140 @@ msgstr ""
 "¿Ordenar inversament per (p)rimera etiqueta/(t)ítulo/número de (a)rtículos/"
 "número d'articles no (l)eídos/(n)ada?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Marcant font com llegida..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Error: no es va poder marcar la font com llegida: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "No hi ha fonts amb elements no llegits."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Ja estàs en la última font."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Ja estàs en la primera font."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Marcant totes les fonts com llegides..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Error: no es va poder processar el comando de filtre `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "No hi ha filtres definits."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Buscar: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "¿Realment desitjes sortir (s:Sí n:No)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "sn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "s"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Sortir"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Obrir"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Següent no llegit"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Actualitzar"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Actualitzar tot"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Marcar com llegit"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Marcar tot com llegit"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Buscar"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Ajuda"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Error: no es va poder processar el comando de filtre!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Buscant..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Error al buscar `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "No hi ha resultats."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "La posició no és visible!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Llista de fonts - %u no llegides, %u en total"
@@ -718,77 +732,82 @@ msgstr "¿Realment desitjes sobrescriure `%s' (s:Sí n:No)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Arxiu: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Guardar arxiu - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "no es va poder processar l'expressió de filtre `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "uso: definir <variable>[=<valor>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "ús: font <arxiu> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "ús: dumpconfig <arxiu>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuració guardada com %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "No és un comando: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Guardant marcadors..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Marcador guardat."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Error al guardar el marcador: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Título: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Descripció: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 #, fuzzy
 msgid "Feed title: "
 msgstr "Arxiu: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "Guardant marcats..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -796,15 +815,15 @@ msgstr ""
 "el soporte per marcadors no està configurat. Si us plau define la variable "
 "de configuració `bookmark-cmd' adecuadament."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Atajos de teclado genéricos:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Funcions no definides:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Borrar"
 
@@ -854,13 +873,7 @@ msgstr "Elements compartits"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Cambiant l'estat de lectura per l'article..."
 
@@ -869,16 +882,16 @@ msgstr "Cambiant l'estat de lectura per l'article..."
 msgid "Error while toggling read flag: %s"
 msgstr "Error al cambiar l'estat de lectura: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "llista de URLs vacía."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Indicadors: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Error: cap element seleccionat!"
 
@@ -887,19 +900,19 @@ msgid "Error: you can't reload search results."
 msgstr "Error: no es pot recarregar resultats de búsqueda."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "No hi ha elements no llegits."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Ja estàs en el último element."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Ja estàs en el primer element."
 
@@ -912,7 +925,7 @@ msgstr "No hi ha fonts no llegides."
 msgid "Marking all above as read..."
 msgstr "Marcant totes les fonts com llegides..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Encadenar article al comando: "
 
@@ -936,62 +949,62 @@ msgstr ""
 "¿Ordenar inversament per (f)echa/(t)ítulo/(i)ndicadors/(a)utor/(e)nlace/"
 "(g)uid?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Indicadors actualizats."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: va fallar aplicar el filtre: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Guardat abortat."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Guardar article com %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: no es va poder guardar l'article com %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado de la búsqueda - «%s»"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Consultar font - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Llista d'articles - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1022,15 +1035,15 @@ msgstr "URL de descàrrega del podcast: "
 msgid "type: "
 msgstr "tipus: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Adalt"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Desota"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar l'article com llegit: %s"
@@ -1055,35 +1068,35 @@ msgstr "Article guardat com %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no es va poder escriure l'article en l'arxiu %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Iniciant el navegador..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar l'article com no llegit: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Anar a URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Obrir en el navegador"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Agregar a la cua"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Article - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Error: expressió regular invàlida!"
 
@@ -1400,22 +1413,22 @@ msgstr "Anar al començament de la pàgina/llista"
 msgid "Move to the end of page/list"
 msgstr "Anar al final de la pàgina/llista"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' no és un context vàlid"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' no és un comando de tecla vàlid"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "l'atribut `%s' no està disponible."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "l'expressió regular «%s» és invàlida: %s"
@@ -1510,27 +1523,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Descarregar"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Purga finalitzades"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Cambiar a descàrrega automàtica"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Reproduir"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "Marcar com finalitzat"
@@ -1585,19 +1598,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr "Error: URL no soportada: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Seleccionar etiqueta"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Seleccionar filtre"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "atribut no trobat"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "EOF trobat al llegir l'etiqueta XML"
 
@@ -1605,23 +1618,23 @@ msgstr "EOF trobat al llegir l'etiqueta XML"
 msgid "No link selected!"
 msgstr "Cap enllaç seleccionat!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Guardar marcador"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Error: la font no conté elements!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "No hi ha etiquetes definides."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Actualitzant consulta de font..."
 

--- a/po/de.po
+++ b/po/de.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2019-12-22 10:40+0100\n"
 "Last-Translator: Lysander Trischler <github@lyse.isobeef.org>\n"
 "Language-Team: Andreas Krennmair <ak@newsbeuter.org>, Simon Nagl "
@@ -162,6 +162,11 @@ msgstr "newsboat::MatcherException gefangen mit Nachricht: %s"
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr "newsboat::Exception gefangen mit Nachricht: %s"
+
+#: newsboat.cpp:253
+#, fuzzy, c-format
+msgid "Caught std::exception with message: %s"
 msgstr "newsboat::Exception gefangen mit Nachricht: %s"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -437,51 +442,51 @@ msgstr "%s: %s: unbekannter Befehl"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fehler: Konnte Konfigurationsdatei `%s' nicht öffnen!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Schließen"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "gehe zu Dialog"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Dialog schließen"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Kein Element ausgewählt!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Fehler: Sie können die Feedliste nicht entfernen!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Ungültige Position!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr "Verzeichnis: "
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Speichern"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, c-format
 msgid "Save Files - %s"
 msgstr "Dateien speichern - %s"
@@ -544,8 +549,8 @@ msgid "Shared items"
 msgstr "empfohlene Artikel"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Kein Feed ausgewählt!"
 
@@ -572,131 +577,140 @@ msgstr ""
 "Umgekehrt sortieren nach (e)rstemtag/(t)itel/(a)rtikelzahl/"
 "(u)ngeleseneartikel/(z)uletztaktualisiert/(n)ichts?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr "Browser brach mit Rückgabestatus %i ab"
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "Query-Feeds können nicht im Browser geöffnet werden!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Markiere Feed als gelesen..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Fehler: Konnte Feed nicht als gelesen markieren: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Keine Feeds mit ungelesenen Artikeln."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Bereits beim letzten Feed."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Bereits beim ersten Feed."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Markiere alle Feeds als gelesen..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Fehler: Konnte Filterkommando `%s' nicht parsen: %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Keine Filter definiert."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Suche nach: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Wollen Sie wirklich beenden (j:Ja n:Nein)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "jn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "j"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Beenden"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "nächster Ungelesener"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "neu laden"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "alle neu laden"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "gelesen markieren"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "alle gelesen markieren"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Suchen"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Hilfe"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Fehler: Konnte Filterkommando nicht parsen!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Suche..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Fehler beim Suchen nach `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Keine Ergebnisse."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Position nicht sichtbar!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Feedliste - %u ungelesen, %u gesamt"
@@ -710,75 +724,80 @@ msgstr "Wollen Sie wirklich `%s' überschreiben (y:Ja n:Nein)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Datei: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Datei speichern - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "Fehler: Konnte Filterkommando `%s' nicht parsen: %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "Verwendung: set <variable>[=<wert>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "Verwendung: source <datei> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "Verwendung: dumpconfig <datei> [...]"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Konfiguration nach %s gespeichert"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Kein Befehl: `%s'"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Speichere Lesezeichen..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Lesezeichen gespeichert."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Fehler beim Speichern des Lesezeichens: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Titel: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Beschreibung: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Feed-Titel: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Speichere Lesezeichen im Autopilot-Modus..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -786,15 +805,15 @@ msgstr ""
 "Die Lesezeichen-Unterstützung ist nicht konfiguriert. Bitte setzen Sie die "
 "Konfigurationsvariable `bookmark-cmd' entsprechend."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Allgemeine Tastenbelegungen:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Unbelegte Funktionen:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Löschen"
 
@@ -842,13 +861,7 @@ msgstr "für gut befundene Artikel"
 msgid "Saved web pages"
 msgstr "gespeicherte Webseiten"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr "Browser brach mit Rückgabestatus %i ab"
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Schalte Gelesen-Flag für Artikel um..."
 
@@ -857,16 +870,16 @@ msgstr "Schalte Gelesen-Flag für Artikel um..."
 msgid "Error while toggling read flag: %s"
 msgstr "Fehler beim Umschalten des Gelesen-Flags: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "URL-Liste leer."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Flags: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Fehler: Keinen Artikel ausgewählt!"
 
@@ -875,19 +888,19 @@ msgid "Error: you can't reload search results."
 msgstr "Fehler: Sie können Suchergebnisse nicht neu laden."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Keine ungelesenen Artikel."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Bereits beim letzten Artikel."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Bereits beim ersten Artikel."
 
@@ -899,7 +912,7 @@ msgstr "Keine ungelesenen Feeds."
 msgid "Marking all above as read..."
 msgstr "Markiere alle obenstehenden Artikel als gelesen..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Artikel zu Befehl umleiten: "
 
@@ -921,55 +934,55 @@ msgstr ""
 "Umgekehrt sortieren nach (d)atum/(t)itel/(f)lags/(a)utor/(l)ink/(g)uid/"
 "(z)ufällig?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Flags aktualisiert."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Fehler: Anwenden des Filters fehlgeschlagen: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Speichern abgebrochen."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artikel nach %s gespeichert"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fehler: Konnte Artikel nicht nach %s speichern"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Suchergebnis - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Query-Feed - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikelliste - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "„%s“ in „%s“ überschreiben (j:Ja n:Nein)"
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr "jank"
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -978,7 +991,7 @@ msgstr ""
 "„%s“ in „%s“ überschreiben? Es gibt %d weitere Konflikte (j:Ja a:Alle "
 "überschreiben n:Nein k:Keine überschreiben)"
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1011,15 +1024,15 @@ msgstr "Podcast-Download-URL: "
 msgid "type: "
 msgstr "Typ: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Anfang"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Ende"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fehler beim Markieren des Artikels als gelesen: %s"
@@ -1044,35 +1057,35 @@ msgstr "Artikel nach %s gespeichert."
 msgid "Error: couldn't write article to file %s"
 msgstr "Fehler: Konnte Artikel nicht nach %s speichern"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Starte Browser..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Fehler beim Markieren des Artikels als ungelesen: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Gehe zu URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "im Browser öffnen"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "in Warteschlange"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Fehler: Ungültiger regulärer Ausdruck!"
 
@@ -1386,22 +1399,22 @@ msgstr "zum Anfang der Seite/Liste gehen"
 msgid "Move to the end of page/list"
 msgstr "zum Ende der Seite/Liste gehen"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' ist kein gültiger Kontext"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' ist kein gültiges Tastenkommando"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "Attribut `%s' ist nicht verfügbar."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "Regulärer Ausdruck '%s' ist ungültig: %s"
@@ -1498,27 +1511,27 @@ msgstr "MiB/s"
 msgid "GB/s"
 msgstr "GiB/s"
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Herunterladen"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Löschen"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "fertige aufräumen"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "automatisches Herunterladen umschalten"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Abspielen"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "als fertig markieren"
 
@@ -1575,19 +1588,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Fehler: Nicht unterstützte URL: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Tag auswählen"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Filter auswählen"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "Attribut nicht gefunden"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "Ende der Datei gefunden beim Lesen eines XML-Tags"
 
@@ -1595,23 +1608,23 @@ msgstr "Ende der Datei gefunden beim Lesen eines XML-Tags"
 msgid "No link selected!"
 msgstr "Kein Link ausgewählt!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Lesezeichen speichern"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Fehler: Feed enthält keine Elemente!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Keine Tags definiert."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Aktualisiere Query-Feed..."
 

--- a/po/es.po
+++ b/po/es.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2013-02-08 06:24-0500\n"
 "Last-Translator: OmeGa <omega@mailoo.org>\n"
 "Language-Team: OmeGa omega@mailoo.org\n"
@@ -160,6 +160,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -440,51 +445,51 @@ msgstr "comando inválido `%s'"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: ¡no se pudo abrir el archivo de configuración `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Ir a diálogo"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Cerrar diálogo"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "¡Ningún elemento seleccionado!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Error: ¡no puedes eliminar la lista de fuentes!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "¡Posición inválida!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Guardar"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Guardar archivo - %s"
@@ -547,8 +552,8 @@ msgid "Shared items"
 msgstr "Elementos compartidos"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "¡Ninguna fuente seleccionada!"
 
@@ -578,131 +583,140 @@ msgstr ""
 "¿Ordenar inversamente por (p)rimera etiqueta/(t)ítulo/número de (a)rtículos/"
 "número de artículos no (l)eídos/(n)ada?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Marcando fuente como leída..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Error: no se pudo marcar la fuente como leída: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "No hay fuentes con elementos no leídos."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Ya estás en la última fuente."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Ya estás en la primera fuente."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Marcando todas las fuentes como leídas..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Error: no se pudo procesar el comando de filtro `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "No hay filtros definidos."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Buscar: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "¿Realmente deseas salir (s:Sí n:No)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "sn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "s"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Salir"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Abrir"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Siguiente no leído"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Actualizar"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Actualizar todo"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Marcar como leído"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Marcar todo como leído"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Buscar"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Ayuda"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Error: ¡no se pudo procesar el comando de filtro!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Buscando..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Error al buscar `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "No hay resultados."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "¡La posición no es visible!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista de fuentes - %u no leídas, %u en total"
@@ -716,77 +730,82 @@ msgstr "¿Realmente deseas sobrescribir `%s' (s:Sí n:No)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Archivo: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Guardar archivo - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "no se pudo procesar la expresión de filtro `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "uso: definir <variable>[=<valor>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "uso: fuente <archivo> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "uso: dumpconfig <archivo>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuración guardada como %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "No es un comando: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Guardando marcados..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Marcador guardado."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Error al guardar el marcados: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Título: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Descripción: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 #, fuzzy
 msgid "Feed title: "
 msgstr "Archivo: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "Guardando marcados..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -794,15 +813,15 @@ msgstr ""
 "el soporte para marcadores no está configurado. Por favor define la variable "
 "de configuración `bookmark-cmd' adecuadamente."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Atajos de teclado genéricos:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Funciones no definidas:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Borrar"
 
@@ -852,13 +871,7 @@ msgstr "Elementos compartidos"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Cambiando el estado de lectura para el artículo..."
 
@@ -867,16 +880,16 @@ msgstr "Cambiando el estado de lectura para el artículo..."
 msgid "Error while toggling read flag: %s"
 msgstr "Error al cambiar el estado de lectura: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "lista de URLs vacía."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Indicadores: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Error: ¡ningún elemento seleccionado!"
 
@@ -885,19 +898,19 @@ msgid "Error: you can't reload search results."
 msgstr "Error: no puedes recargar resultados de búsqueda."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "No hay elementos no leídos."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Ya estás en el último elemento."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Ya estás en el primer elemento."
 
@@ -910,7 +923,7 @@ msgstr "No hay fuentes no leídas."
 msgid "Marking all above as read..."
 msgstr "Marcando todas las fuentes como leídas..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Encadenar artículo al comando: "
 
@@ -934,62 +947,62 @@ msgstr ""
 "¿Ordenar inversamente por (f)echa/(t)ítulo/(i)ndicadores/(a)utor/(e)nlace/"
 "(g)uid?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Indicadores actualizados."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: falló aplicar el filtro: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Guardado abortado."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Guardar artículo como %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: no se pudo guardar el artículo como %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado de la búsqueda - «%s»"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Consultar fuente - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista de artículos - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1020,15 +1033,15 @@ msgstr "URL de descarga del podcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Arriba"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Abajo"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar el artículo como leído: %s"
@@ -1053,35 +1066,35 @@ msgstr "Artículo guardado como %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no se pudo escribir el artículo en el archivo %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Iniciando el navegador..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar el artículo como no leído: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Ir a URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Abrir en el navegador"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Agregar a la cola"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Artículo - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Error: ¡expresión regular inválida!"
 
@@ -1397,22 +1410,22 @@ msgstr "Ir al comienzo de la página/lista"
 msgid "Move to the end of page/list"
 msgstr "Ir al final de la página/lista"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' no es un contexto válido"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' no es un comando de tecla válido"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "el atributo `%s' no está disponible."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "la expresión regular «%s» es inválida: %s"
@@ -1508,27 +1521,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Descargar"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Purgar finalizadas"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Cambiar a descarga automática"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Reproducir"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "Purgar finalizadas"
@@ -1583,19 +1596,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr "Error: URL no soportada: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Seleccionar etiqueta"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Seleccionar filtro"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "atributo no encontrado"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "EOF encontrado al leer la etiqueta XML"
 
@@ -1603,23 +1616,23 @@ msgstr "EOF encontrado al leer la etiqueta XML"
 msgid "No link selected!"
 msgstr "¡Ningún enlace seleccionado!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Guardar marcador"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Error: ¡la fuente no contiene elementos!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "No hay etiquetas definidas."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Actualizando consulta de fuente..."
 

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2017-12-10 18:12+0100\n"
 "Last-Translator: José Manuel García-Patos <josemanuel@gesaku.es>\n"
 "Language-Team:  <>\n"
@@ -158,6 +158,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -433,51 +438,51 @@ msgstr "%s: %s: comando desconocido"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: ¡no se pudo abrir el archivo de configuración `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Ir a Diálogo"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Cerrar Diálogo"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "¡Ningún objeto seleccionado!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Error: ¡no puedes eliminar la lista de feeds!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "¡Posicion inválida!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Guardar"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Salvar Archivo - %s"
@@ -540,8 +545,8 @@ msgid "Shared items"
 msgstr "Elementos compartidos"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "¡No hay feeds seleccionados!"
 
@@ -571,131 +576,140 @@ msgstr ""
 "¿Orden inverso por primera etiqueta (f)/(t)ítulo/número de (a)rtíclulos/"
 "n(u)mero de artículos no leídos/(n)ada?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "¡No puedo abrir los feeds en el navegador!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Marcando feed como leido..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Error: no se pudo marcar el feed como leido: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "No hay feeds con elementos no leídos"
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Ya estás en el último feed."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Ya estás en el primer feed."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Marcando todos los feeds como leídos... "
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Error: no he podido entender el comando de filtrado `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "No hay filtros definidos."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Buscar: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "¿Realmente quieres salir (y:Si n:No)?"
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Salir"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Abrir"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Siguiente no leido"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Recargar"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Recargar todos"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Marcar como leido"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Marcar todo como leido"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Buscar"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Ayuda"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Error: ¡no he podido entender el comando de filtrado!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Buscando... "
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Error buscando `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Sin resultados."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "¡Posición no visible!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista de Feeds - %u no leídos, %u total"
@@ -709,75 +723,80 @@ msgstr "¿Realmente quieres sobreescribir `%s' (y:Si n:No)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Archivo: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Salvar Archivo - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "No se pudo analizar el comando de filtrado `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "Uso: set <variable>[=<valor>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "uso: fuente <archivo> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "uso: dumpconfig <archivo>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuracion guardada en %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "No es un comando: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Guardando marcador..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Marcador guardado."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Error guardando marcador: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Título: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Descripción: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Título del feed: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Guardando marcador automáticamente... "
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -785,15 +804,15 @@ msgstr ""
 "El soporte para marcadores no está connfigurado. Por favor configure la "
 "variable `bookmark-cmd'."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Atajos de teclado genéricos:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Funciones sin atajo de teclado:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Limpiar"
 
@@ -841,13 +860,7 @@ msgstr "Elementos favoritos"
 msgid "Saved web pages"
 msgstr "Páginas web guardadas"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Cambiando marca de lectura para el artículo..."
 
@@ -856,16 +869,16 @@ msgstr "Cambiando marca de lectura para el artículo..."
 msgid "Error while toggling read flag: %s"
 msgstr "Error cambiando la marca de lectura: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "Lista de URL vacia."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Marcas: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Error: ¡ningun objeto seleccionado!"
 
@@ -874,19 +887,19 @@ msgid "Error: you can't reload search results."
 msgstr "Error: no puedes recargar los resultados de la busqueda."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Ningun elemento por leer."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Ya estás en el último elemento"
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Ya estás en el primer elemento."
 
@@ -899,7 +912,7 @@ msgstr "Ningún feed por leer."
 msgid "Marking all above as read..."
 msgstr "Marcando todos los feeds como leídos... "
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Conectar artículo a comando: "
 
@@ -922,62 +935,62 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "¿Orden inverso por fecha (d)/(t)ítulo/marcas (f)/(a)utor/en(l)ace/(g)uid?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Marcas actualizadas."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: Fallo al aplicar el filtro: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Guardado abortado."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artículo guardado como %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: No se pudo guardar el artículo como %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado de la búsqueda - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Consultar Feed - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista de artículos - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1008,15 +1021,15 @@ msgstr "URL de descarga de podcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Arriba"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Abajo"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar artículo como leido: %s"
@@ -1041,35 +1054,35 @@ msgstr "Artículo guardado como %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no se pudo escribir el artículo en el fichero %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Iniciando navegador..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar artículo como no leido: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Ir a URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Abrir en navegador"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Encolado"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Artículo - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Error: ¡expresión regular inválida!"
 
@@ -1386,22 +1399,22 @@ msgstr "Ir al principio de la página/lista"
 msgid "Move to the end of page/list"
 msgstr "Ir al final de la página/lista"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' no es un contexto válido"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' no es un atajo de teclado válido"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "El atributo `%s' no está disponible."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "la expresión regular '%s' no es válida: %s"
@@ -1494,27 +1507,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Descarga"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Borrar"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Limpiar finalizadas"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Activar/Desactivar Descarga Automatica"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Ejecutar"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Marcar como finalizada/s"
 
@@ -1568,19 +1581,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Error: URL no soportada: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Selecciona Etiqueta"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Selecciona Filtro"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "atributo no encontrado"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "Fin De Fichero (EOF) encontrado leyendo etiqueta XML"
 
@@ -1588,23 +1601,23 @@ msgstr "Fin De Fichero (EOF) encontrado leyendo etiqueta XML"
 msgid "No link selected!"
 msgstr "¡Ningún enlace seleccionado!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Guardar Marcador"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URL"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Error: ¡el feed no contiene elementos!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "No hay etiquetas definidas."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Actualizando consulta de feed..."
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2017-07-11 10:22+0200\n"
 "Last-Translator: rugie <fliehen@posteo.net>\n"
 "Language-Team: Nicolas Martyanoff <khaelin@gmail.com>\n"
@@ -166,6 +166,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -440,51 +445,51 @@ msgstr "%s : %s : commande inconnue"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Erreur : échec de l'ouverture du fichier de configuration `%s' !"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Fermer"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Passer à la vue"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Fermer la vue"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Aucun élément sélectionné !"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Erreur : la liste de fils ne peut être supprimée !"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Position invalide !"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Enregistrer"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Enregistrer le fichier - %s"
@@ -547,8 +552,8 @@ msgid "Shared items"
 msgstr "Éléments partagés"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Aucun fil sélectionné !"
 
@@ -578,132 +583,141 @@ msgstr ""
 "Trier en sens inverse par (p)remier tag/(t)itre/(n)nombre d'articles/nombre "
 "d'articles à l(i)re/(a)ucun ?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 "Les fils de requête ne sont pas faits pour être ouverts dans un navigateur !"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Fil marqué comme étant lu..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Erreur : Le fil n'a pu être marqué comme étant lu : %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Aucun fil ne possède des éléments à lire"
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Vous êtes déjà au dernier fil."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Vous êtes déjà au premier fil."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Tous les fils sont marqués comme lus..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Erreur : échec lors de l'analyse de l'expression de filtrage `%s' : %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Aucun filtre défini."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Rechercher : "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filtre : "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Souhaitez-vous réellement quitter (o : Oui n : Non) ? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "on"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "o"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Quitter"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Ouvrir"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Suivant"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Recharger"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Tout recharger"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Marquer comme lu"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Tout marquer comme lu"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Rechercher"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Aide"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Erreur : l'analyse de l'expression de filtrage a échoué !"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Recherche en cours..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Erreur lors de la recherche de '%s' : %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Aucun résultat."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Position non visible !"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Liste de fils - %u à lire, %u au total"
@@ -717,75 +731,80 @@ msgstr "Souhaitez-vous réellement écraser `%s' (y : Oui n : No)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Fichier : "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Enregistrer le fichier - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "échec de l'analyse de l'expression de filtrage `%s' : %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "utilisation : set <variable>[=<valeur>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "utilisation : source <fichier> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "utilisation : dumpconfig <fichier>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuration enregistrée dans %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "commande inconnue : %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Enregistrement du signet..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Signet enregistré."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Erreur lors de l'enregistrement du signet : "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "Lien : "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Titre : "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Description : "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Titre : "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Enregistrement du signet automatiquement..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -793,15 +812,15 @@ msgstr ""
 "Le support des signets n'est pas configuré. Veuillez modifier la variable de "
 "configuration 'bookmark-cmd' puis réessayer."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Raccourcis habituels :"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Fonctions non attribuées :"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Effacer"
 
@@ -849,13 +868,7 @@ msgstr "Éléments favoris"
 msgid "Saved web pages"
 msgstr "Pages web sauvegardées"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Basculement de l'état de lecture de l'article..."
 
@@ -864,16 +877,16 @@ msgstr "Basculement de l'état de lecture de l'article..."
 msgid "Error while toggling read flag: %s"
 msgstr "Erreur lors du basculement de l'état de lecture : %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "L'article ne contient aucun lien."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Signaux : "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Erreur : aucun élément sélectionné !"
 
@@ -882,19 +895,19 @@ msgid "Error: you can't reload search results."
 msgstr "Erreur : les résultats de recherche ne peuvent être rechargés."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Aucun élément à lire."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Déjà au dernier élément."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Déjà au premier élément."
 
@@ -907,7 +920,7 @@ msgstr "Aucun fil ne contient d'éléments à lire."
 msgid "Marking all above as read..."
 msgstr "Tous les fils sont marqués comme lus..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Passer l'article à la commande : "
 
@@ -930,62 +943,62 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Trier en sens inverse par (d)ate/(t)itre/signau(x)/(a)uteur/(l)ien/(g)uid ?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Signaux actualisés."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Erreur : l'application du filtre a échoué : %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Enregistrement annulé."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Article enregistré dans %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Erreur : l'article n'a pu être enregistré dans %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Résultats de la recherche - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Fil de requête - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Articles - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1016,15 +1029,15 @@ msgstr "Lien de téléchargement du podcast : "
 msgid "type: "
 msgstr "type : "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Début"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Fin"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Erreur lors du passage de l'article à l'état lu : %s"
@@ -1049,35 +1062,35 @@ msgstr "Article enregistré dans %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Erreur : échec lors de l'enregistrement vers %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Lancement du navigateur..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Erreur en marquant l'article comme lu : %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Aller à l'addresse #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Ouvrir dans le navigateur"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Ajouter à la file d'attente"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Article - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Erreur : expression régulière incorrecte !"
 
@@ -1394,22 +1407,22 @@ msgstr "Aller au début de la page/liste"
 msgid "Move to the end of page/list"
 msgstr "Aller à la fin de la page/liste"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' n'est pas un contexte valide"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' n'est pas un raccourci correct"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "l'attribut '%s' n'est pas disponible."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "l'expression régulière '%s' est invalide : %s"
@@ -1507,27 +1520,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Télécharger"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Supprimer"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Nettoyer"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Téléchargement automatique"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Lire"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Marquer comme terminé"
 
@@ -1581,19 +1594,19 @@ msgstr "%a %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Erreur : le format du lien n'est pas pris en charge : %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Choisir une étiquette"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Choisir un filtre"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "attribut non trouvé"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "EOF rencontré durant la lecture d'une balise XML"
 
@@ -1601,23 +1614,23 @@ msgstr "EOF rencontré durant la lecture d'une balise XML"
 msgid "No link selected!"
 msgstr "Aucun lien sélectionné !"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Créer un signet"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "Liens"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Erreur : le fil est vide !"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Aucune étiquette définie."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Mise à jour du fil de requête..."
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2008-01-28 10:00+0100\n"
 "Last-Translator: Zsolt Udvari <udvzsolt@gmail.com>\n"
 "Language-Team: \n"
@@ -158,6 +158,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -437,51 +442,51 @@ msgstr "ismeretlen parancs: `%s'"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Hiba: nem tudtam megnyitni a(z) `%s' konfigurációs fájlt!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Bezár"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Goto Dialógus"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Bezár Dialógus"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Nincs elem kijelölve!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Hiba: nem törölheted a cikk listát!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Érvénytelen pozíció!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Mentés"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "File mentése - %s"
@@ -544,8 +549,8 @@ msgid "Shared items"
 msgstr "Megosztott elemek"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Nincs forrás kijelölve"
 
@@ -575,131 +580,140 @@ msgstr ""
 "Visszafele rendezés (e)lső cimke/(c)ím/cikk(s)zám/(o)olvasatlan források "
 "száma/semmi szeri(n)t?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Forrás olvasottá tétele..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Hiba: nem tudtam olvasottnak megjelölni: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Nincs forrás olvasatlan elemekkel."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Az összes forrás olvasottként jelölése..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Hiba: nem tudtam feldolgozni a filter parancsot: `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Nincs szűrő (filter) definiálva."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Keresés: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Biztos kilépsz (i:Igen n:Nem)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "in"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "i"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Kilép"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Megnyit"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Köv. olvasatlan"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Újratölt"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Mind újratölt"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Olvasottnak megjelöl"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Mindet olvasottnak"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Keres"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Súgó"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Hiba: nem tudtam feldolgozni a filter parancsot!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Keresés..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Hiba `%s' keresése közben: %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Nincs találat."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "A pozíció nem látható!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Forrás lista - %u olvasatlan, %u összesen"
@@ -713,77 +727,82 @@ msgstr "Biztos felülírod `%s'-t (y:Yes n:No)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "File: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "File mentése - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "nem tudtam feldolgozni a filter parancsot `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "használat: set <változó>[=<érték>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "használat: source <file> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "használat: dumpconfig <file>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Konfiguráció elmentve %s-be"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Nem parancs: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Könyvjelző mentése..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Könyvjelző elmentve."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Hiba a könyvjelző mentése közben: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Cím: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Leírás: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 #, fuzzy
 msgid "Feed title: "
 msgstr "File: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "Könyvjelző mentése..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -791,15 +810,15 @@ msgstr ""
 "könyvjelző lehetőség nem konfigurált. Kérlek állítsd be a `bookmark-cmd' "
 "változót megfelelően."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Általános kötések:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Kötetlen funkciók:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Vissza"
 
@@ -848,13 +867,7 @@ msgstr "Megosztott elemek"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Az olvasott jelző ki/beállítása a cikkre..."
 
@@ -863,16 +876,16 @@ msgstr "Az olvasott jelző ki/beállítása a cikkre..."
 msgid "Error while toggling read flag: %s"
 msgstr "Hiba az olvasott jelző állítása közben: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "URL lista üres."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Jelzõk: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Hiba: nincs elem kijelölve!"
 
@@ -881,19 +894,19 @@ msgid "Error: you can't reload search results."
 msgstr "Hiba: nem töltheted újra a keresési eredményt."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Nincs olvasatlan elem."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
 
@@ -906,7 +919,7 @@ msgstr "Nincs olvasatlan forrás."
 msgid "Marking all above as read..."
 msgstr "Az összes forrás olvasottként jelölése..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "A cikk pipe-olása a parancsnak: "
 
@@ -929,62 +942,62 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Fordított rendezés (d)átum/(c)ím/(j)elzők/(s)zerző/(l)ink/(g)uid alapján?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Jelzők frissítve."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Hiba: szűrő alkalmazása nem sikerült: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Mentés megszakítva."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Cikk mentése %s-be"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Hiba: nem tudtam a cikket %s fájlba menteni"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Keresés eredménye . '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Lekérdezési lista - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Cikk lista - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1015,15 +1028,15 @@ msgstr "Podcast letöltés URL: "
 msgid "type: "
 msgstr "típus: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Fent"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Lent"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Hiba a cikk olvasottá tétele közben: %s "
@@ -1048,35 +1061,35 @@ msgstr "Cikk mentve %s-be."
 msgid "Error: couldn't write article to file %s"
 msgstr "Hiba: nem tudtam a cikket a(z) %s file-ba menteni"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Böngésző indítása..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Hiba a cikk olvasatlanná tétele közben: %s "
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Ugrás: URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Megnyitás böngészőben"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Lista"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Cikk %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Hiba: érvénytelen reguláris kifejezés!"
 
@@ -1397,22 +1410,22 @@ msgstr "Mozgatás az oldal/lista elejére"
 msgid "Move to the end of page/list"
 msgstr "Mozgatás az oldal/lista végére"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' nem valódi környezet"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' nem érvényes billentyűparancs"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "%s argumentum nem elérhető."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "'%s' reguláris kifejezés érvénytelen: %s"
@@ -1506,27 +1519,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Letöltés"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Törlés"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Takarítás befejezve"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Automatikus letöltés"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Lejátszás"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "Takarítás befejezve"
@@ -1581,19 +1594,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr "Hiba: nem támogatott URL: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Cimke kijelölése"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Szűrő kijelölése"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "argumentumot nem találom"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "EOF-t találtam XML cimke olvasása közben"
 
@@ -1601,23 +1614,23 @@ msgstr "EOF-t találtam XML cimke olvasása közben"
 msgid "No link selected!"
 msgstr "Nincs link kijelölve!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Könyvjelző mentése"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URL-ek: "
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Hiba: a forrás nem tartalmaz elemeket!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Nincs cimke definiálva."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Források lekérdezése..."
 

--- a/po/it.po
+++ b/po/it.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2019-08-26 23:02+0200\n"
 "Last-Translator: Leandro Noferini <leandro@noferini.org>\n"
 "Language-Team: Claudio M. Alessi <somppy@gmail.com>\n"
@@ -163,6 +163,11 @@ msgstr "Ricevuto newsboat::MatcherException con messaggio: %s"
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr "Ricevuto newsboat::Exception con messaggio: %s"
+
+#: newsboat.cpp:253
+#, fuzzy, c-format
+msgid "Caught std::exception with message: %s"
 msgstr "Ricevuto newsboat::Exception con messaggio: %s"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -437,51 +442,51 @@ msgstr "%s: %s: comando sconosciuto"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Errore: impossibile aprire il file di configurazione `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Chiudi"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Vai alla schermata"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Chiudi schermata"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Nessuna voce selezionata!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Errore: non puoi rimuovere la lista dei feed!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Posizione non valida!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr "Directory: "
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Cancella"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Salva"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, c-format
 msgid "Save Files - %s"
 msgstr "Salva File - %s"
@@ -544,8 +549,8 @@ msgid "Shared items"
 msgstr "Item condivisi"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Nessun feed selezionato!"
 
@@ -572,131 +577,140 @@ msgstr ""
 "Ordina al contrario per (p)rimotag/(t)itolo/n(u)meroarticolo/"
 "nu(m)eroarticolononletto/ultimo(a)ggiornamento/(n)iente?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "Non posso aprire i query feed nel browser!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Sto contrassegnando il feed come letto..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Errore: impossibile contrassegnare il feed come letto: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Nessun feed con voci non lette."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Già all'ultimo feed."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Già al primo feed."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Sto segnando tutti i feed come letti..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Errore: impossibile analizzare il comando di filtro `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Nessun filtro definito."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Ricerca: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Vuoi veramente uscire (s:Sì n:No)?"
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "sn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "s"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Esci"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Apri"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Prossimo non letto"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Ricarica"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Ricarica tutti"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Segna come letto"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Marca tutti come letti"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Cerca"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Aiuto"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Errore: impossibile analizzare il comando di filtro!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Sto cercando..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Errore durante la ricerca di `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Nessun risultato."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Posizione non visibile!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista feed - %u non letti, %u totali"
@@ -710,75 +724,80 @@ msgstr "Vuoi veramente sovrascrivere `%s' (s:Sì n:No)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "File: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Salva File - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "impossibile analizzare l'espressione di filtro `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "uso: set <variabile>[=<valore>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "uso: source <file> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "uso: dumpconfig <file>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configurazione salvata su %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Non è un comando: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Sto salvando il segnalibro..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Segnalibro salvato."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Errore durante il salvataggio del segnalibro: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Titolo: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Descrizione: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Titolo del feed: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Sto salvando il segnalibro su autopilot..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -786,15 +805,15 @@ msgstr ""
 "funzionalità per i segnalibri non configurata. Per favore, imposta "
 "appropriatamente la variabile di configurazione `bookmark-cmd'."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Associazioni di tasti generiche:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Funzioni non associate:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Pulisci"
 
@@ -842,13 +861,7 @@ msgstr "Elementi preferiti"
 msgid "Saved web pages"
 msgstr "Pagine web salvate"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Cambiando la flag \"letto\" per l'articolo..."
 
@@ -857,16 +870,16 @@ msgstr "Cambiando la flag \"letto\" per l'articolo..."
 msgid "Error while toggling read flag: %s"
 msgstr "Errore cambiando la flag \"letto\": %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "Lista URL vuota."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Flag: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Errore: nessuna voce selezionata!"
 
@@ -875,19 +888,19 @@ msgid "Error: you can't reload search results."
 msgstr "Errore: non puoi ricaricare i risultati della ricerca."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Nessuna voce non letta."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Già all'ultimo elemento."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Già al primo elemento."
 
@@ -899,7 +912,7 @@ msgstr "Nessun feed non letto."
 msgid "Marking all above as read..."
 msgstr "Contrassegno i feed al di sopra come letti..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Metti in pipe l'articolo col comando: "
 
@@ -921,55 +934,55 @@ msgstr ""
 "Ordina al contrario per (d)ata/(t)itolo/(f)lag/(a)utore/(c)ollegamento/"
 "(g)uid/(r)andom?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Flag aggiornate."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Errore: applicazione del filtro fallita: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Salvataggio annullato."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Articolo salvato su %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Errore: impossibile salvare l'articolo su %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Risultati della ricerca - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Feed interrogati - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista articoli - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, fuzzy, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "Sovrascrivere `%s` in `%s`? (s:Sì n:No)"
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr "sanq"
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -978,7 +991,7 @@ msgstr ""
 "Sovrascrivere `%s` in `%s`? Ci sono ancora %d conflitti come il presente (s:"
 "Sì a:Sì a tutti n:No q:No a tutti)"
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1011,15 +1024,15 @@ msgstr "URL scaricamento podcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Su"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Giù"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Errore contrassegnando l'articolo come letto: %s"
@@ -1044,35 +1057,35 @@ msgstr "Articolo salvato su %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Errore: impossibile scrivere l'articolo sul file %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Sto avviando il browser..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Errore contrassegnando l'articolo come non letto: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Vai a URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Apri nel browser"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Accoda"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Articolo - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Errore: espressione regolare non valida!"
 
@@ -1384,22 +1397,22 @@ msgstr "Spostati all'inizio della pagina/lista"
 msgid "Move to the end of page/list"
 msgstr "Spostati alla fine della pagina/lista"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' non è un contesto valido"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' non è una tasto di comando valido"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "l'attributo `%s' non è disponibile."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "l'espressione regolare `%s' non è valida: %s"
@@ -1494,27 +1507,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Scarica"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Elimina"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Pulisci terminati"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Attiva/Disattiva Download Automatico"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Avvia"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Segna come completato"
 
@@ -1571,19 +1584,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Errore: URL non supportato: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Seleziona Tag"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Seleziona Filtro"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "attributo non trovato"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "EOF trovato durante la lettura del tag XML"
 
@@ -1591,23 +1604,23 @@ msgstr "EOF trovato durante la lettura del tag XML"
 msgid "No link selected!"
 msgstr "Nessun collegamento selezionato!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Salva Segnalibro"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URL"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Errore: il feed non contiene voci!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Nessun tag definito."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Aggiornamento interrogazione feed..."
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.9\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2015-04-26 05:55+0900\n"
 "Last-Translator: Grady Martin <GradyMartin@gmail.com>\n"
 "Language-Team: Japanese <GradyMartin@gmail.com>\n"
@@ -158,6 +158,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -418,51 +423,51 @@ msgstr ""
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr ""
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "保存"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, c-format
 msgid "Save Files - %s"
 msgstr ""
@@ -525,8 +530,8 @@ msgid "Shared items"
 msgstr ""
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr ""
 
@@ -549,131 +554,140 @@ msgid ""
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr ""
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr ""
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "終了してもよろしいですか（y/n）"
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr ""
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr ""
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "閉じる"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "開く"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "次"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "同期"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "全フィードを同期"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "既読にする"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "全件を既読にする"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "検索"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "ヘルプ"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "検索中…"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "検索結果がありませんでした。"
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr ""
@@ -687,90 +701,95 @@ msgstr "%sを上書きしてもよろしいですか（y/n）"
 msgid "n"
 msgstr ""
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr ""
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr ""
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr ""
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr ""
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr ""
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr ""
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr ""
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr ""
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr ""
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr ""
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr ""
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr ""
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "見出し："
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr ""
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 #, fuzzy
 msgid "Feed title: "
 msgstr "フィード："
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr ""
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
 msgstr ""
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr ""
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr ""
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr ""
 
@@ -818,13 +837,7 @@ msgstr ""
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr ""
 
@@ -833,16 +846,16 @@ msgstr ""
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr ""
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr ""
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr ""
 
@@ -851,19 +864,19 @@ msgid "Error: you can't reload search results."
 msgstr ""
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
 
@@ -875,7 +888,7 @@ msgstr ""
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -894,62 +907,62 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr ""
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -980,15 +993,15 @@ msgstr "コンテンツ："
 msgid "type: "
 msgstr ""
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr ""
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr ""
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
@@ -1013,35 +1026,35 @@ msgstr ""
 msgid "Error: couldn't write article to file %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "ブラウザーを起動中…"
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "ブラウザーで開く"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "コンテンツをダウンロード"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr ""
 
@@ -1354,22 +1367,22 @@ msgstr ""
 msgid "Move to the end of page/list"
 msgstr ""
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr ""
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr ""
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr ""
@@ -1461,27 +1474,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr ""
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr ""
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr ""
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr ""
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr ""
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr ""
 
@@ -1535,19 +1548,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr ""
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr ""
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr ""
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr ""
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr ""
 
@@ -1555,23 +1568,23 @@ msgstr ""
 msgid "No link selected!"
 msgstr ""
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr ""
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr ""
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "記事がありません！"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr ""
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr ""
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2012-08-08 20:07+0100\n"
 "Last-Translator: Daniel Aleksandersen <code@daniel.priv.no>\n"
 "Language-Team: \n"
@@ -159,6 +159,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -443,51 +448,51 @@ msgstr "ukjent kommando `%s'"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Feil: kunne ikke åpne oppsettsfilen `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Lukk"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Gå til dialogen"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Lukk dialogen"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Ingen innlegg merket!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Feil: du kan ikke fjerne nyhetsstrømlisten!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "ugyldig posisjon!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Lagre"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Lagre fil - %s"
@@ -550,8 +555,8 @@ msgid "Shared items"
 msgstr "Delte innlegg"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Ingen nyhetsstrømmer merket!"
 
@@ -581,131 +586,140 @@ msgstr ""
 "Sorter synkende etter (f)ørste etikett/(t)ittel/antall (a)artikler/antall "
 "(u)leste artikler/(i)ngen?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Markerer nyhetsstrømmen som lest..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Feil: kunne ikke markere nyhetsstrømmen som lest: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Ingen nyhetsstrømmer med uleste innlegg."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Allerede i den siste nyhetsstrømmen."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Allerede i den første nyhetsstrømmen."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Markerer alle nyhetsstrømmer som lest..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Feil: kunne ikke tolke filterkommandoen `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Ingen angitte filtere."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Søk etter: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Vil du virkelig avslutte (j:Ja n:Nei)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "jn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "j"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Avslutt"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Åpne"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Neste uleste"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Oppdater"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Oppdater alle"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Merk som lest"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Marker alle som lest"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Søk"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Hjelp"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Feil: kunne ikke  tolke filterkommandoen!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Leter..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Feil under søket etter `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Ingen resultater."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Posisjonen er ikke synlig!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Nyhetsstrømliste  - %u uleste, %u totalt"
@@ -719,77 +733,82 @@ msgstr "Vil du virkelig overskrive `%s' (j:Ja n:Nei)? "
 msgid "n"
 msgstr "i"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Fil: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Lagre fil - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "kunne ikke tolke filteruttrykket `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "bruk: set <variabel>[=<verdi>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "bruk: source <fil> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "bruk: dumpconfig <fil>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Lagret oppsettsfilen til %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Ikke en kommando: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Lagrer bokmerke..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Lagret bokmerke."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Feil under lagring av bokmerke: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Tittel: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Beskrivelse: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 #, fuzzy
 msgid "Feed title: "
 msgstr "Fil: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "Lagrer bokmerke..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -797,15 +816,15 @@ msgstr ""
 "bokmerkestøtte er ikke satt opp. Vennligst sett valgvariabelen `bookmark-"
 "cmd' etter ønske."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Generelle bindinger:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Utilknyttede funksjoner:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Tøm"
 
@@ -855,13 +874,7 @@ msgstr "Delte innlegg"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Setter lestflagg for artikkelen..."
 
@@ -870,16 +883,16 @@ msgstr "Setter lestflagg for artikkelen..."
 msgid "Error while toggling read flag: %s"
 msgstr "Feil under setting av lestflagg: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "URL-listen er tom."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Flagg: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Feil: ingen markerte innlegg!"
 
@@ -888,19 +901,19 @@ msgid "Error: you can't reload search results."
 msgstr "Feil: du kan ikke oppdatere søkeresultater."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Ingen uleste innlegg."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Allerede på siste innlegg."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Allerede på første innlegg."
 
@@ -913,7 +926,7 @@ msgstr "Ingen uleste nyhetsstrømmer."
 msgid "Marking all above as read..."
 msgstr "Markerer alle nyhetsstrømmer som lest..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Send artikkel til kommando: "
 
@@ -936,62 +949,62 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sorter synkende etter (d)ato)/(t)ittel/(f)lagg/f(o)rfatter/(l)enke/(g)uide?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Flagg oppdatert."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Feil: bruk av filteret feilet: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Avbrøt lagringen."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Lagret artikkelen til %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Feil: kunne ikke lagre artikkelen til %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Søkeresultater - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Spørringsstrøm - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikkelliste - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1022,15 +1035,15 @@ msgstr "Podkastnedlastings-URL: "
 msgid "type: "
 msgstr "slag: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Toppen"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Bunnen"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Feil mens artikkelen ble markert som lest: %s"
@@ -1055,35 +1068,35 @@ msgstr "Lagret artikkel til %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Feil: kunne ikke skrive artikkelen til filen %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Åpner nettleseren..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Feil mens artikkelen ble markert som lest: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Gå til URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Åpne i nettleseren"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Legg til i køen"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Artikkel - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Feil: ugyldig regulært uttrykk!"
 
@@ -1399,22 +1412,22 @@ msgstr "Gå til starten av siden/listen"
 msgid "Move to the end of page/list"
 msgstr "Gå til slutten av siden/listen"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' er ikke en gyldig kontekst"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' er en ugyldig nøkkelkommando"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "attributten `%s' er ikke tilgjengelig."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "det regulære uttrykket '%s' er ugyldig: %s"
@@ -1508,27 +1521,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Last ned"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Slett"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Fjern fullførte"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Automatisk nedlasting [av/på]"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Spill av"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "Fjern fullførte"
@@ -1583,19 +1596,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr "Feil: URLen støttes ikke: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Velg etikett"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Velg filter"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "attributten ble ikke funnet"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "fant EOF mens XML-element ble lest inn"
 
@@ -1603,23 +1616,23 @@ msgstr "fant EOF mens XML-element ble lest inn"
 msgid "No link selected!"
 msgstr "Ingen lenke valgt!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Lagre bokmerke"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URLer"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Feil: nyhetsstrømmen inneholder ingen innlegg!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Ingen etiketter angitt."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Frisker opp spørringsstrømmen..."
 

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -155,6 +155,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -415,51 +420,51 @@ msgstr ""
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr ""
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, c-format
 msgid "Save Files - %s"
 msgstr ""
@@ -522,8 +527,8 @@ msgid "Shared items"
 msgstr ""
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr ""
 
@@ -546,131 +551,140 @@ msgid ""
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr ""
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr ""
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr ""
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr ""
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr ""
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr ""
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr ""
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr ""
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr ""
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr ""
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr ""
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr ""
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr ""
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr ""
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr ""
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr ""
@@ -684,89 +698,94 @@ msgstr ""
 msgid "n"
 msgstr ""
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr ""
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr ""
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr ""
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr ""
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr ""
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr ""
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr ""
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr ""
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr ""
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr ""
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr ""
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr ""
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr ""
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr ""
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr ""
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr ""
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
 msgstr ""
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr ""
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr ""
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr ""
 
@@ -814,13 +833,7 @@ msgstr ""
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr ""
 
@@ -829,16 +842,16 @@ msgstr ""
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr ""
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr ""
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr ""
 
@@ -847,19 +860,19 @@ msgid "Error: you can't reload search results."
 msgstr ""
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
 
@@ -871,7 +884,7 @@ msgstr ""
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -890,62 +903,62 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr ""
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -976,15 +989,15 @@ msgstr ""
 msgid "type: "
 msgstr ""
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr ""
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr ""
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
@@ -1009,35 +1022,35 @@ msgstr ""
 msgid "Error: couldn't write article to file %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr ""
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr ""
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr ""
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr ""
 
@@ -1349,22 +1362,22 @@ msgstr ""
 msgid "Move to the end of page/list"
 msgstr ""
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr ""
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr ""
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr ""
@@ -1451,27 +1464,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr ""
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr ""
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr ""
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr ""
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr ""
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr ""
 
@@ -1525,19 +1538,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr ""
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr ""
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr ""
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr ""
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr ""
 
@@ -1545,23 +1558,23 @@ msgstr ""
 msgid "No link selected!"
 msgstr ""
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr ""
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr ""
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr ""
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr ""
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2020-02-08 00:10+0100\n"
 "Last-Translator: Dennis van der Schagt <dennisschagt@gmail.com>\n"
 "Language-Team: Dutch <vertalen@vrijschrift.org>, Erwin Poeze <donnut@outlook."
@@ -161,6 +161,11 @@ msgstr "Fout (newsboat::MatcherException): %s"
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr "Fout (newsboat::Exception): %s"
+
+#: newsboat.cpp:253
+#, fuzzy, c-format
+msgid "Caught std::exception with message: %s"
 msgstr "Fout (newsboat::Exception): %s"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -437,51 +442,51 @@ msgstr "%s: %s: onbekende opdracht"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fout: configuratiebestand ‘%s’ openen is mislukt!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Sluiten"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Ga naar dialoogvenster"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Sluit dialoogvenster"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Geen item geselecteerd!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Fout: feedlijst verwijderen is mislukt!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Ongeldige positie!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr "Map: "
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Opslaan"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, c-format
 msgid "Save Files - %s"
 msgstr "Bestanden opslaan - %s"
@@ -544,8 +549,8 @@ msgid "Shared items"
 msgstr "Gedeelde items"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Geen feeds geselecteerd!"
 
@@ -572,131 +577,140 @@ msgstr ""
 "Omgekeerd sorteren op (e)erste tag/(t)itel/(a)antal artikelen/aantal "
 "(o)ngelezen artikelen/(l)aatst aangepast/(n)iets?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr "Browser gaf error code %i terug"
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "Feed-zoekopdrachten kunnen niet in een browser geopend worden!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Bezig met feed als gelezen te markeren…"
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Fout: feed als gelezen markeren is mislukt: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Geen feeds met ongelezen items."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Dit is reeds de laatste feed."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Dit is reeds de eerste feed."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Bezig met alle feeds als gelezen te markeren…"
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Fout: filteropdracht ‘%s’ ontleden is mislukt: %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Geen filters gedefinieerd."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Zoeken naar: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Zeker dat u wilt afsluiten (j:ja n:nee)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "jn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "j"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Openen"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Volgende Ongelezen"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Vernieuwen"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Alles vernieuwen"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Markeer als gelezen"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Alles als gelezen markeren"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Zoeken"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Hulp"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Fout: filteropdracht ontleden is mislukt!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Bezig met zoeken…"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Fout tijdens het zoeken naar ‘%s’: %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Geen resultaten."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Positie niet zichtbaar!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Feedlijst - %u ongelezen, %u totaal"
@@ -710,75 +724,80 @@ msgstr "Bent u zeker dat u ‘%s’ wilt overschrijven (j:ja n:nee)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Bestand: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Bestand opslaan - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "filterexpressie ‘%s’ ontleden is mislukt: %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "gebruik: set <variabele>[=<waarde>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "gebruik: source <bestand> […]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "gebruik: dumpconfig <bestand>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuratie opgeslagen in %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Geen opdracht: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Bezig met opslaan van bladwijzer…"
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Bladwijzer opgeslagen."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Bladwijzer opslaan is mislukt: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Titel: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Omschrijving: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Feed titel: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Automatisch opslaan van bladwijzer…"
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -786,15 +805,15 @@ msgstr ""
 "bladwijzerondersteuning is niet geconfigureerd. Corrigeer de waarde van de "
 "configuratievariabele ‘bookmark-cmd’."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Algemene sneltoetsen:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Ongekoppelde functies:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Wissen"
 
@@ -842,13 +861,7 @@ msgstr "Liked items"
 msgid "Saved web pages"
 msgstr "Opgeslagen webpagina's"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr "Browser gaf error code %i terug"
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Gelezen-vlag van artikel omschakelen…"
 
@@ -857,16 +870,16 @@ msgstr "Gelezen-vlag van artikel omschakelen…"
 msgid "Error while toggling read flag: %s"
 msgstr "Gelezen-vlag omschakelen is mislukt: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "URL-lijst is leeg."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Vlaggen: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Fout: geen item geselecteerd!"
 
@@ -875,19 +888,19 @@ msgid "Error: you can't reload search results."
 msgstr "Fout: zoekresultaten vernieuwen is mislukt."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Er zijn geen ongelezen items."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Dit is reeds het laatste item."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Dit is reeds het eerste item."
 
@@ -899,7 +912,7 @@ msgstr "Geen ongelezen feeds."
 msgid "Marking all above as read..."
 msgstr "Bezig met alle voorgaande feeds als gelezen te markeren…"
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Pipe artikel naar commando: "
 
@@ -922,55 +935,55 @@ msgstr ""
 "Omgekeerd sorteren op (d)atum/(t)itel/(v)laggen/(a)uteur/(k)oppeling/(g)uid/"
 "(w)illekeurig?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Vlaggen zijn bijgewerkt."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Fout: toepassen van filter is mislukt: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Opslaan afgebroken."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artikel opgeslagen in %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fout: opslaan artikel in %s is mislukt"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Zoekresultaat - ‘%s’"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Feed-zoekopdracht - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikellijst - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "Wilt u `%s' in `%s' overschrijven? (y:Ja n:No)"
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr "janq"
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -979,7 +992,7 @@ msgstr ""
 "Wilt u `%s' in `%s' overschrijven? Er zijn %d vergelijkbare conflicten (j:Ja "
 "a:Alles overschrijven n:Nee q:Niks overschrijven)"
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1012,15 +1025,15 @@ msgstr "Download-URL podcast: "
 msgid "type: "
 msgstr "type: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Boven"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Onder"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fout bij het als gelezen markeren van het artikel: %s"
@@ -1045,35 +1058,35 @@ msgstr "Artikel opgeslagen in %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Fout: artikel opslaan in bestand ‘%s’ is mislukt"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Bezig met starten van browser…"
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Het als ongelezen markeren van het artikel ‘%s’ is mislukt"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Ga naar URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Openen in browser"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Aan downloadlijst toevoegen"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Fout: ongeldige reguliere expressie!"
 
@@ -1385,22 +1398,22 @@ msgstr "Ga naar begin van pagina/lijst"
 msgid "Move to the end of page/list"
 msgstr "Ga naar einde van pagina/lijst"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "‘%s’ is een ongeldige context"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "‘%s’ is een ongeldige toetsopdracht"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "attribuut ‘%s’ is niet beschikbaar."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "reguliere expressie ‘%s’ is ongeldig: %s"
@@ -1493,27 +1506,27 @@ msgstr "MB/s"
 msgid "GB/s"
 msgstr "GB/s"
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Download"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Afgeronde download opruimen"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Automatisch downloaden omschakelen"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Afspelen"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Maarkeer als afgerond"
 
@@ -1570,19 +1583,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Fout: niet ondersteunde URL: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Tag selecteren"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Filter selecteren"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "attribuut niet gevonden"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "EOF gevonden tijdens het lezen van XML-tag"
 
@@ -1590,23 +1603,23 @@ msgstr "EOF gevonden tijdens het lezen van XML-tag"
 msgid "No link selected!"
 msgstr "Geen koppeling geselecteerd!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Bladwijzer opslaan"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Fout: feed bevat geen items!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Geen tags gedefinieerd."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Feed-zoekopdracht bijwerken…"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: newsboat 2.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
 "POT-Creation-Date: 2020-04-12 18:17+0200\n"
-"PO-Revision-Date: 2020-02-08 00:10+0100\n"
+"PO-Revision-Date: 2020-04-12 17:20+0200\n"
 "Last-Translator: Dennis van der Schagt <dennisschagt@gmail.com>\n"
 "Language-Team: Dutch <vertalen@vrijschrift.org>, Erwin Poeze <donnut@outlook."
 "com>, Dennis van der Schagt <dennisschagt@gmail.com>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 2.3\n"
 
 #: newsboat.cpp:31
 #, c-format
@@ -164,9 +164,9 @@ msgid "Caught newsboat::Exception with message: %s"
 msgstr "Fout (newsboat::Exception): %s"
 
 #: newsboat.cpp:253
-#, fuzzy, c-format
+#, c-format
 msgid "Caught std::exception with message: %s"
-msgstr "Fout (newsboat::Exception): %s"
+msgstr "Fout (std::exception): %s"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
 #: src/regexmanager.cpp:260 src/regexmanager.cpp:342 src/regexmanager.cpp:354
@@ -736,7 +736,7 @@ msgstr "Bestand opslaan - %s"
 #: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
 #, c-format
 msgid "failed to open urls file (%s)"
-msgstr ""
+msgstr "fout bij openen van urls bestand (%s)"
 
 #: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2019-01-09 20:42+0100\n"
 "Last-Translator: Michal Siemek <carnophage@dobramama.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -164,6 +164,11 @@ msgstr "Złapano wyjątek newsboat::matcherexception o treści: %s"
 #: newsboat.cpp:247 podboat.cpp:37
 #, fuzzy, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr "Złapano wyjątek newsboat::dbexception o treści: %s"
+
+#: newsboat.cpp:253
+#, fuzzy, c-format
+msgid "Caught std::exception with message: %s"
 msgstr "Złapano wyjątek newsboat::dbexception o treści: %s"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -441,51 +446,51 @@ msgstr "%s: %s: nieznana komenda"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Błąd: nie można otworzyć pliku konfiguracyjnego `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Zamknij"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Idź do"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Zamknij okno"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Nie wybrano żadnej pozycji!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Błąd: nie możesz usunąć listy kanałów!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Błędna pozycja!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Zapisz"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Zapisz plik - %s"
@@ -548,8 +553,8 @@ msgid "Shared items"
 msgstr "Pozycje współdzielone"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Nie wybrano żadnego kanału!"
 
@@ -576,131 +581,140 @@ msgstr ""
 "Sortuj odwrotnie wg (p)ierwszego taga/(t)ytułu/(l)iczby artykułów/liczby "
 "(n)ieprzeczytanych artykułów/(o)statnio aktualizowane/(b)rak?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "Nie można otworzyć wybranych kanałów w przeglądarce!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Oznaczam kanał jako przeczytany..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Błąd: nie udało się oznaczyć kanału jako przeczytanego: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Brak kanałów z nieprzeczytanymi artykułami."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "To już ostatni kanał."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "To już pierwszy kanał."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Oznaczam wszystkie kanały jako przeczytane..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Błąd składniowy komendy filtra `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Brak zdefiniowanych filtrów."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Szukaj: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filtr: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Czy na pewno chcesz wyjść (t:Tak n:Nie)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "tn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "t"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Wyjście"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Otwórz"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Następny nieprzeczytany"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Odśwież"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Odśwież wszystkie"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Oznacz jako przeczytane"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Oznacz wszystkie jako przeczytane"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Szukaj"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Pomoc"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Błąd składniowy komendy filtra!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Wyszukiwanie..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Błąd podczas wyszukiwania `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Brak wyników."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Pozycja niewidoczna!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista kanałów - %u nieprzeczytanych, %u wszystkich"
@@ -714,75 +728,80 @@ msgstr "Czy na pewno chcesz nadpisać `%s' (t:Tak n:Nie)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Plik: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Zapisz plik - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "błąd składniowy komendy filtra `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "użycie: set <zmienna>[=<wartość>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "użycie: source <plik> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "użycie: dumpconfig <plik>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Zapisano konfiguracje do %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Nieznana komenda '%s'"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Zapisywanie zakładki..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Zakładka zapisana."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Błąd podczas zapisywania zakładki: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "Adres: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Tytuł: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Opis: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Tytuł kanału: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Automatyczne zapisywanie zakładki..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -790,15 +809,15 @@ msgstr ""
 "obsługa zakładek nie jest skonfigurowana. Proszę odpowiednio ustawić zmienną "
 "'bookmark-cmd' w pliku konfiguracyjnym."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Ogólne skróty:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Nieprzypisane funkcje:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Wyczyść"
 
@@ -846,13 +865,7 @@ msgstr "Polubione pozycje"
 msgid "Saved web pages"
 msgstr "Zapisane strony internetowe"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Przełączam znacznik przeczytania dla artykułu..."
 
@@ -861,16 +874,16 @@ msgstr "Przełączam znacznik przeczytania dla artykułu..."
 msgid "Error while toggling read flag: %s"
 msgstr "Błąd podczas przełączania znacznika przeczytania: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "Lista adresów jest pusta."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Flagi: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Błąd: nie wybrano żadnej pozycji!"
 
@@ -879,19 +892,19 @@ msgid "Error: you can't reload search results."
 msgstr "Błąd: nie możesz odświeżyć wyników wyszukiwania."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Brak nieprzeczytanych pozycji."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "To już ostatnia pozycja."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "To już pierwsza pozycja."
 
@@ -903,7 +916,7 @@ msgstr "Brak nieprzeczytanych kanałów."
 msgid "Marking all above as read..."
 msgstr "Oznaczam powyższe jako przeczytane..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Prześlij artykuł do polecenia: "
 
@@ -926,62 +939,62 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sortuj odwrotnie wg (d)aty/(t)ytułu/(f)lag/(a)utora/(o)dnośnika/(g)uid?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Znaczniki uaktualnione."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Błąd: użycie filtra nie powiodło się: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Zapisywanie przerwane."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Zapisano artykuł do %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Błąd: nie można zapisać artykułu do %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Wyniki wyszukiwania - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Kanał zapytania - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista artykułów - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1012,15 +1025,15 @@ msgstr "Adres podcastu: "
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Góra"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Dół"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Błąd podczas oznaczania artykułu jako przeczytanego: %s"
@@ -1045,35 +1058,35 @@ msgstr "Zapisano artykuł do %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Błąd: nie można zapisać artykułu do pliku %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Uruchamiam przeglądarkę..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Błąd podczas oznaczania artykułu jako nieprzeczytanego: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Idź do adresu URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Otwórz w przeglądarce"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Zakolejkuj"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Artykuł - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Błąd: nieprawidłowe wyrażenie regularne!"
 
@@ -1388,22 +1401,22 @@ msgstr "Przejdź do początku strony/listy"
 msgid "Move to the end of page/list"
 msgstr "Przejdź do końca strony/listy"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' nie jest dopuszczalnym kontekstem"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' nie jest dopuszczalnym poleceniem"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "atrybut '%s' nie jest dostępny."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "wyrażenie regularne: '%s' jest nieprawidłowe: %s"
@@ -1496,27 +1509,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Pobierz"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Usuń"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Wyczyść zakończone"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Przełącz automatyczne pobieranie"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Odtwórz"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Oznacz jako zakończone"
 
@@ -1570,19 +1583,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Błąd: nieobsługiwany adres: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Wybierz tag"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Wybierz filtr"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "atrybut nie znaleziony"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "Trafiono na koniec pliku podczas odczytu tagu XML"
 
@@ -1590,23 +1603,23 @@ msgstr "Trafiono na koniec pliku podczas odczytu tagu XML"
 msgid "No link selected!"
 msgstr "Brak wybranego odnośnika!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Zapisz zakładkę"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "Adresy URL"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Błąd: kanał jest pusty!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Brak zdefiniowanych tagów."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Odświeżam kanał kolejki..."
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.8\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2018-03-06 20:35-0300\n"
 "Last-Translator: Alexandre Erwin Ittner <alexandre@ittner.com.br>\n"
 "Language-Team: \n"
@@ -166,6 +166,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -441,51 +446,51 @@ msgstr "%s: %s: comando desconhecido"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Erro: não foi possível abrir o arquivo de configuração '%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Fechar"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Pular para Tela"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Fechar Tela"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Nenhum item selecionado!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Erro: você não pode remover a lista de fontes!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Posição inválida!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Salvar"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Salvar Arquivo - %s"
@@ -548,8 +553,8 @@ msgid "Shared items"
 msgstr "Itens compartilhados"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Nenhuma fonte RSS selecionada!"
 
@@ -579,131 +584,140 @@ msgstr ""
 "Classificar inversamente por (p)rimeiraetiqueta/(t)ítulo/(q)uantidadeartigos/"
 "quantidadeartigos(n)ãolidos/nenhu(m)?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "Não é possível abrir fontes de consulta no navegador!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Marcando fonte como lida..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Erro: não foi possível marcar fonte como lida: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Nenhuma fonte RSS com artigos não lidos."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Já na última fonte"
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Já na primeira fonte"
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Marcando todas fontes RSS como lidas..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Erro: não foi possível analisar o comando de filtro '%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Nenhum filtro definido."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Procurar por: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Tem certeza que deseja sair (s: Sim n: Não)?"
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "sn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "s"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Sair"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Abrir"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Próxima Não Lida"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Recarregar"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Recarregar Todas"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Marcar como Lida"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Marcar Todos como Lidos"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Procurar"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Ajuda"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Erro: não foi possível analisar o comando de filtro!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Procurando..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Erro procurando por '%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Nenhum resultado."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "A posição não está visível!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista de Fontes - %u não lidas, %u no total"
@@ -717,75 +731,80 @@ msgstr "Tem certeza que deseja sobrescrever '%s' (s: Sim n:Não)?"
 msgid "n"
 msgstr "m"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Arquivo: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Salvar Arquivo - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "não foi possível analisar a expressão de filtro '%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "uso: set <variável>[=<valor>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "uso: source <arquivo> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "uso: dumpconfig <arquivo>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Configuração salva em %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Não é um comando: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Salvando marcador..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Marcador salvo."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Erro ao salvar marcador: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Título: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Descrição: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Título da fonte: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Salvando marcador no autopilot..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -793,15 +812,15 @@ msgstr ""
 "o suporte a marcadores não está configurado. Por favor defina a variável de "
 "configuração 'bookmark-cmd' conforme necessário."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Ligações genéricas:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Funções sem ligações:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Limpar"
 
@@ -849,13 +868,7 @@ msgstr "Itens gostados"
 msgid "Saved web pages"
 msgstr "Páginas web salvas"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Alternando estado lido/não lido do artigo..."
 
@@ -864,16 +877,16 @@ msgstr "Alternando estado lido/não lido do artigo..."
 msgid "Error while toggling read flag: %s"
 msgstr "Erro ao alternar estado lido/não lido do artigo: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "A lista de URLs está vazia."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Sinalizações: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Erro: nenhum item selecionado!"
 
@@ -882,19 +895,19 @@ msgid "Error: you can't reload search results."
 msgstr "Erro: você não pode recarregar os resultados da busca."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Nenhum artigo não lido."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Já no último item"
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Já no primeiro item"
 
@@ -907,7 +920,7 @@ msgstr "Nenhuma fonte não lida."
 msgid "Marking all above as read..."
 msgstr "Marcando todas fontes RSS como lidas..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Passar o artigo por pipe ao comando: "
 
@@ -931,62 +944,62 @@ msgstr ""
 "Classificar inversamente por (d)ata/(t)ítulo/(s)inalizações/(a)utor/(l)ink/"
 "(g)uid?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Sinalizações atualizadas."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Erro: aplicação do filtro falhou: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Salvamento cancelado."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artigo salvo em %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Erro: não foi possível salvar artigo em %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado da Busca - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Fonte de Consulta - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista de Artigos - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1017,15 +1030,15 @@ msgstr "URL para baixar Podcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Início"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Fim"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Erro marcando artigo como lido: %s"
@@ -1050,35 +1063,35 @@ msgstr "Artigo salvo em %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Erro: não foi possível gravar o artigo no arquivo %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Iniciando navegador..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Erro marcando artigo como não lido: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Ir para a URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Abrir no Navegador"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Pôr na Fila"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Artigo - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Erro: expressão regular inválida!"
 
@@ -1395,22 +1408,22 @@ msgstr "Ir para o início da página/lista"
 msgid "Move to the end of page/list"
 msgstr "Ir para o fim da página/lista"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "'%s' não é um contexto válido"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "'%s' não é um comando de tecla válido"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "atributo '%s' não está disponível."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "a expressão regular '%s' é inválida: %s"
@@ -1503,27 +1516,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Baixar"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Excluir"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Eliminar Concluídos"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Alternar Transferência Automática"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Tocar"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Marcar como Concluído"
 
@@ -1577,19 +1590,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Erro: URL não suportada: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Selecionar Etiqueta"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Selecionar Filtro"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "atributo não encontrado"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "Fim de arquivo encontrado ao ler etiqueta XML"
 
@@ -1597,23 +1610,23 @@ msgstr "Fim de arquivo encontrado ao ler etiqueta XML"
 msgid "No link selected!"
 msgstr "Nenhum link selecionado!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Salvar Marcador"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Erro: fonte não possui nenhum item!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Nenhuma etiqueta definida."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Atualizando fonte de consulta..."
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2020-03-20 17:59+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Konstantin Shakhnov <kastian@mail.ru>, Alexander Batischev "
@@ -162,6 +162,11 @@ msgstr "Поймали newsboat::MatcherException с сообщением: %s"
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr "Поймали newsboat::Exception с сообщением: %s"
+
+#: newsboat.cpp:253
+#, fuzzy, c-format
+msgid "Caught std::exception with message: %s"
 msgstr "Поймали newsboat::Exception с сообщением: %s"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -436,51 +441,51 @@ msgstr "%s: %s: неизвестная команда"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Ошибка: невозможно открыть конфигурационный файл `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Закрыть"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Открыть диалог"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Закрыть диалог"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Не выбранно ни одного элемента!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Ошибка: невозможно убрать список лент!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Неверная позиция!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr "Директория: "
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Сохранить"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, c-format
 msgid "Save Files - %s"
 msgstr "Сохранить файлы - %s"
@@ -543,8 +548,8 @@ msgid "Shared items"
 msgstr "Опубликованные элементы"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Не выбрано ни одной ленты!"
 
@@ -571,131 +576,140 @@ msgstr ""
 "Сортировать в обратном порядке по первой метке (f)/заголовку (t)/количеству "
 "записей (a)/непрочитанным (u)/времени последнего обновления (l)/никак (n)?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr "Браузер вернул код ошибки %i"
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "Динамические ленты нельзя открывать в браузере!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Отмечаю ленту как прочитанную..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Ошибка: невозможно отметить ленту как прочитанную: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Нет лент с непрочитанными элементами."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Уже на последней ленте."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Уже на первой ленте."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Отмечаю все ленты как прочитанные..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Ошибка: невозможно разобрать команду фильтрации `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Не определено ни одного фильтра."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Искать: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Фильтр: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Вы правда хотите выйти (y:Да n:Нет)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Выход"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Открыть"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Следующая непрочитанная"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Обновить"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Обновить все"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Отметить как прочитанную"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Отметить все как прочитанные"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Искать"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Помощь"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Ошибка: невозможно разобрать команду фильтрации!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Ищу..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Ошибка во время поиска `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Нет результатов."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Позицию не видно!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Список лент - %u непрочитанных, %u всего"
@@ -709,75 +723,80 @@ msgstr "Вы правда хотите перезаписать `%s' (y:Да n:�
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Файл: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Сохранить файл - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "не удалось разобрать команду фильтрации `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "использование: set <переменная>[=<значение>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "использование: source <file> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "использование: dumpconfig <файл>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Конфигурация сохранена в %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Неизвестная команда: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Сохраняю закладку..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Сохранённая закладка."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Ошибка во время сохранения закладки: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "Источник: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Заголовок: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Описание: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Заголовок ленты: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Сохраняю закладку автоматически..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -785,15 +804,15 @@ msgstr ""
 "поддержка закладок не настроена. Пожалуйста, настройте переменную `bookmark-"
 "cmd'."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Общие привязки:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Отвязанные функции:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Чистый"
 
@@ -841,13 +860,7 @@ msgstr "Понравившиеся статьи"
 msgid "Saved web pages"
 msgstr "Сохранённые веб-страницы"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr "Браузер вернул код ошибки %i"
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Переключение флага прочтения у заметки..."
 
@@ -856,16 +869,16 @@ msgstr "Переключение флага прочтения у заметки
 msgid "Error while toggling read flag: %s"
 msgstr "Ошибка во время переключения флага прочтения: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "Список ссылок пуст."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Флаги: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Ошибка: не выбранно ни одного элемента!"
 
@@ -874,19 +887,19 @@ msgid "Error: you can't reload search results."
 msgstr "Ошибка: вы не можете обновить результаты поиска."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Непрочитанных элементов нет."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Уже на последней записи."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Уже на первой записи."
 
@@ -898,7 +911,7 @@ msgstr "Непрочитанных лент нет."
 msgid "Marking all above as read..."
 msgstr "Отмечаю все, что выше, как прочитанные..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Обработать заметку командой: "
 
@@ -921,55 +934,55 @@ msgstr ""
 "Сортировать в обратном порядке по дате (d)/заголовку (t)/флагам (f)/автору "
 "(a)/ссылке (l)/(g)uid/(r)случайно?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Флаги обновлены."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Ошибка: применение фильтра завершилось неудачей: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Прерванное сохранение."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Заметка сохранена в %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Ошибка: невозможно сохранить заметку в %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Результат поиска - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Динамическая лента - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Список заметок - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "Перезаписать `%s' в `%s'? (y:Да n:Нет)"
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr "yanq"
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -978,7 +991,7 @@ msgstr ""
 "Перезаписать `%s' в `%s'? Осталось таких конфликтов: %d (y:Да a:Да для всех "
 "n:Нет q:Нет для всех)"
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1011,15 +1024,15 @@ msgstr "Ссылка загрузки подкаста: "
 msgid "type: "
 msgstr "тип: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Верх"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Низ"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Ошибка во время пометки заметки как прочитанной: %s"
@@ -1044,35 +1057,35 @@ msgstr "Заметка сохранена в %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Ошибка: невозможно записать заметку в файл %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Запускаю браузер..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Ошибка во время пометки заметки как непрочитанной: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Открыть ссылку №"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Открыть в браузере"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Поставить в очередь"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Заметка - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Ошибка: неправильное регулярное выражение!"
 
@@ -1386,22 +1399,22 @@ msgstr "Перейти к началу страницы/списка"
 msgid "Move to the end of page/list"
 msgstr "Перейти к концу страницы/списка"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "контекста `%s' не существует"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "команда `%s' не поддерживается"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "атрибут `%s' недоступен."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "регулярное выражение '%s' неверно: %s"
@@ -1493,27 +1506,27 @@ msgstr "Мб/с"
 msgid "GB/s"
 msgstr "Гб/с"
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Загрузить"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Удалить"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Очистить от завершённых"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Переключить автоматическую загрузку"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Проиграть"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Отметить как завершенную"
 
@@ -1570,19 +1583,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Ошибка: ссылка не поддерживается: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Выбрать метку"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Выбрать фильтр"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "атрибут не найден"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "Во время чтения тега XML обнаружен конец файла"
 
@@ -1590,23 +1603,23 @@ msgstr "Во время чтения тега XML обнаружен конец 
 msgid "No link selected!"
 msgstr "Не выбрано ни одной ссылки!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Сохранить закладку"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "Источники"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Ошибка: лента не содержит ни одного элемента!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Не определено ни одной метки."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Обновляю динамическую ленту..."
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.10.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2017-12-25 00:38+0100\n"
 "Last-Translator: František Hájik <ferko.hajik@gmail.com>\n"
 "Language-Team: František Hájik <ferko.hajik@gmail.com>\n"
@@ -161,6 +161,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -437,51 +442,51 @@ msgstr "%s: %s: neznámy príkaz"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Chyba: nemožno otvoriť konfiguračný súbor `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Zatvoriť"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Prejsť na dialóg"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Zatvoriť na dialóg"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Žiadna položka nebola označená!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Chyba: nemožno odstrániť zoznam informačných kanálov (feed list)!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Neplatná pozícia!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Uložiť"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Uložiť súbor - %s"
@@ -544,8 +549,8 @@ msgid "Shared items"
 msgstr "Zdieľané položky"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Nebol vybraný žiadny kanál!"
 
@@ -575,131 +580,140 @@ msgstr ""
 "Zotriediť spätne podľa (f)prvého_tagu/(t)itulkov/(p)očtu_článkov/"
 "(u)neprečítaných_článkov/(n)etriediť?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "V prehliadači sa nedajú otvoriť požiadavky z kanálov!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Označiť kanál za prečítaný..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Chyba: nemožno označiť čítanie kanála: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Žiaden kanál s neprečítanými položkami."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Celkom posledný kanál."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Celkom prvý kanál."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Označenie všetkých kanálov za prečítané..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Chyba: príkaz filtra nedá analyzovať `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Neboli definované žiadne filtre."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Vyhľadať: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Skutočne skončiť (a:Áno n:Nie)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "an"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "a"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Ukončiť"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Otvoriť"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Ďalší neprečítaný"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Obnoviť"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Obnoviť všetko"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Označiť ako prečítané"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Označiť všetko ako prečítané"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Hľadať"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Pomocník"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Chyba: nebolo možné analyzovať príkaz filtra!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Vyhľadávanie..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Chyba pri vyhľadávaní `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Žiadny výsledok."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Pozícia nie je viditeľná!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Zoznam informačných kanálov - %u neprečítané, %u celkom"
@@ -713,75 +727,80 @@ msgstr "Naozaj chcete prepísať `%s' (a:Áno n:Nie)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Súbor: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Uložiť súbor - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "nemožno analyzovať výraz filtra `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "použitie: set <variable>[=<value>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "použitie: zdrojový súbor <file> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "použítie: dumpconfig <file>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Konfigurácia uložená do %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Nie je príkaz: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Záložka sa ukladá..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Záložka uložená."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Chyba pri ukladaní záložky: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Titulok: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Popis: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Názov titulu: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Ukladanie záložiek na \"autopilota\"..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -789,15 +808,15 @@ msgstr ""
 "podpora záložiek nie je nakonfigurovaná. Nastavte prosím adekvátne premennú "
 "`bookmark-cmd' v konfigurácii."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Zabudované príkazy:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Neviazané funkcie:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Vyčistiť"
 
@@ -845,13 +864,7 @@ msgstr "Obľúbené položky"
 msgid "Saved web pages"
 msgstr "Web stránka uložená"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Prepínanie príznaku čítania článku..."
 
@@ -860,16 +873,16 @@ msgstr "Prepínanie príznaku čítania článku..."
 msgid "Error while toggling read flag: %s"
 msgstr "Chyba pri prepínaní príznaku čítania: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "Zoznam URL je prázdny."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Príznaky (flags): "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Chyba: žiadna položka nebola vybratá!"
 
@@ -878,19 +891,19 @@ msgid "Error: you can't reload search results."
 msgstr "Chyba: nemožno načítať výsledky vyhľadávania."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Všetky položky prečítané."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Celkom posledná položka."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Celkom prvá položka."
 
@@ -903,7 +916,7 @@ msgstr "Všetko prečítané."
 msgid "Marking all above as read..."
 msgstr "Označenie všetkých kanálov za prečítané..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Odoslať (Pipe) článok do príkazu: "
 
@@ -929,62 +942,62 @@ msgstr ""
 "Zotriediť spätne podľa (d)átumu/(n)ázvu/(p)ríznaku/(a)utora/(o)dkazu/"
 "(i)dentifikátora?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Príznaky aktualizované."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Chyba: použitie filtra zlyhalo: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Ukladanie bolo prerušené."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Článok bol uložený do %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Chyba: článok nemožno uložiť do %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Výsledok vyhľadávania - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Dotaz informačného kanála - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Zoznam článkov - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1015,15 +1028,15 @@ msgstr "Podcast Download URL: "
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Vrch"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Spodok"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Chyba pri označovaní článku za prečítaný: %s"
@@ -1048,35 +1061,35 @@ msgstr "Článok uložený do %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Chyba: nemožno zapísať článok do súboru %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Spustenie prehliadača..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Chyba pri označovaní článku ako neprečítaného: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Choď na URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Otvoriť v prehliadači"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Do fronty"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Článok - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Chyba: neplatný regulárny výraz!"
 
@@ -1395,22 +1408,22 @@ msgstr "Prejsť na začiatok stránky / zoznamu"
 msgid "Move to the end of page/list"
 msgstr "Prejsť na koniec stránky/zoznamu"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' nie je platný kontext"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' nie je platný príkaz kľúča"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "atribút `%s' nie je k dispozícii."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "regulárny výraz '%s' je vadný: %s"
@@ -1503,27 +1516,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Stiahnuť"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Zmazať"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Čistenie dokončené"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Prepnúť automatické stiahnutie"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Prehrať"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Označiť ako ukončené"
 
@@ -1577,19 +1590,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Chyba: nepodporovaná URL: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Vyber Tag"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Vyber Filter"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "atribút nebol nájdený"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "Bol nájdený \"EOF\" pri načítaní XML tagu"
 
@@ -1597,23 +1610,23 @@ msgstr "Bol nájdený \"EOF\" pri načítaní XML tagu"
 msgid "No link selected!"
 msgstr "Link nebol vybraný!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Uložiť záložku"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Chyba: informačný kanál neobsahuje žiadne položky!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Neboli definované žiadne \"tagy\"."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Aktualizácia dopytu informačného kanála..."
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat-2.12\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2018-08-08 10:17+0200\n"
 "Last-Translator: Dennis Öberg <contact@dennisoberg.se>\n"
 "Language-Team: Niklas Grahn <terra.unknown@yahoo.com>\n"
@@ -163,6 +163,11 @@ msgstr "Fångade newsboat::matcherexception med meddelande: %s"
 #: newsboat.cpp:247 podboat.cpp:37
 #, fuzzy, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr "Fångade newsboat::exception med meddelande: %s"
+
+#: newsboat.cpp:253
+#, fuzzy, c-format
+msgid "Caught std::exception with message: %s"
 msgstr "Fångade newsboat::exception med meddelande: %s"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -437,51 +442,51 @@ msgstr "%s: %s: okänt kommando"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fel: kunde inte öppna konfigurationsfil `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Stäng"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Gå till-dialogruta"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Stäng dialogruta"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Ingen post markerad!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Fel: du kan inte ta bort listan över webbflöden!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Ogiltig position!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Spara"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Spara fil - %s"
@@ -544,8 +549,8 @@ msgid "Shared items"
 msgstr "Delade poster"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Ingen kanal markerad!"
 
@@ -572,131 +577,140 @@ msgstr ""
 "Sortera omvänt utifrån (f)örstatagg/(t)itel/(a)rtikelmängd/"
 "(o)lästartikelmängd/(s)enastuppdaterad/(i)nget?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "Kan inte öppna query feeds i webbläsaren!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Markerar webbflöde som läst..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Fel: kunde inte markera webbflöde som läst: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Inga webbflöden med olästa poster."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Redan på sista webbflödet."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Redan på första webbflödet."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Markerar alla webbflöden som lästa..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Fel: kunde inte tolka filterkommando `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Inga filter definierade."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Sök efter: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Vill du verkligen avsluta (j:Ja n:Nej)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "jn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "j"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Avsluta"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Öppna"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Nästa olästa"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Läs om"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Läs om alla"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Markera som läst"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Markera alla som lästa"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Sök"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Hjälp"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Fel: kunde inte tolka filterkommando!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Söker..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Fel vid sökning efter `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Inga resultat."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Position inte synlig!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista över webbflöden - %u olästa, %u totalt"
@@ -710,75 +724,80 @@ msgstr "Vill du verkligen skriva över %s' (j:Ja n:Nej)? "
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Fil: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Spara fil - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "kunde inte tolka filteruttryck `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "användning: set <variabel>[=<värde>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "användning: source <fil> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "användning: dumpconfig <fil>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Sparade konfiguration till %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Inte ett kommando: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Sparar bokmärke..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Sparade bokmärke."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Fel vid sparande av bokmärke: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Titel: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Beskrivning: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Webbflödestitel: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Sparar bokmärke på autopilot..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -786,15 +805,15 @@ msgstr ""
 "stöd för bokmarkering är inte konfigurerat. Var god ställ in "
 "konfigurationsvariablen `bookmark-cdm' korrekt."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Allmänna bindningar:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Icke-bundna funktioner:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Töm"
 
@@ -842,13 +861,7 @@ msgstr "Gillade poster"
 msgid "Saved web pages"
 msgstr "Sparade webbsidor"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Växlar läsflagga för artikel..."
 
@@ -857,16 +870,16 @@ msgstr "Växlar läsflagga för artikel..."
 msgid "Error while toggling read flag: %s"
 msgstr "Fel vid växling av läsflagga: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "URL-lista tom."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Flaggor: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Fel: ingen post markerad!"
 
@@ -875,19 +888,19 @@ msgid "Error: you can't reload search results."
 msgstr "Fel: du kan inte läsa om sökresultat."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Inga olästa poster."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Redan på sista posten."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Redan på första posten."
 
@@ -899,7 +912,7 @@ msgstr "Inga olästa webbflöden."
 msgid "Marking all above as read..."
 msgstr "Markerar allt ovanför som läst..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Skicka artikel genom pipe till kommando: "
 
@@ -922,62 +935,62 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sortera omvänt utifrån (d)atum/(t)itel/(F)laggor/(f)örfattare/(l)änk/(g)uid?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Flaggor uppdaterade."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Fel: verkställande av filtret misslyckades: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Avbröt sparande."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Sparade artikel till %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fel: kunde inte spara artikel till %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Sökresultat - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Förfrågansflöde - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikellista - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1008,15 +1021,15 @@ msgstr "Hämtnings-URL för poddsändning: "
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Överkant"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Nederkant"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fel vid markering av artikel som läst: %s"
@@ -1041,35 +1054,35 @@ msgstr "Sparade artikel till %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Fel: kunde inte skriva artikel till fil %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Startar webbläsare..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Fel vid markering av artikel som oläst: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Gå till URL #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Öppna i webbläsare"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Kölägg"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Fel: ogiltigt reguljärt uttryck!"
 
@@ -1385,22 +1398,22 @@ msgstr "Flytta till början av sida/lista"
 msgid "Move to the end of page/list"
 msgstr "Flytta till slutet av sida/lista"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' är inte en giltig kontext"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' är inte ett giltigt tangentkommando"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "attribut `%s' är inte tillgängligt."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "reguljärt uttryck '%s' är ogiltigt: %s"
@@ -1491,27 +1504,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Hämta"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Ta bort"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Rensa färdiga"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Växla automatisk hämtning"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Spela upp"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Markera som klar"
 
@@ -1565,19 +1578,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Fel: URL stöds inte: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Välj tagg"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Välj filter"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "attribut hittades inte"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "EOF hittades vid inläsning av XML-tagg"
 
@@ -1585,23 +1598,23 @@ msgstr "EOF hittades vid inläsning av XML-tagg"
 msgid "No link selected!"
 msgstr "Ingen länk markerad!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Spara bokmärke"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URL:er"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Fel: webbflöde innehåller inga poster!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Inga taggar definierade."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Uppdaterar query feed..."
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2020-04-03 19:00+0300\n"
 "Last-Translator: Emir SARI <bitigchi@me.com>, 2020\n"
 "Language-Team: H. Gökhan SARI <hsa2@difuzyon.net>\n"
@@ -156,6 +156,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -352,16 +357,16 @@ msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
 msgstr ""
-"Görünüşe göre NewsBlur hesabınızda herhangi bir besleme "
-"ayarlamamışsınız. Lütfen bir tane ayarlayıp yeniden deneyin."
+"Görünüşe göre NewsBlur hesabınızda herhangi bir besleme ayarlamamışsınız. "
+"Lütfen bir tane ayarlayıp yeniden deneyin."
 
 #: src/controller.cpp:354
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
 msgstr ""
-"Görünüşe göre Inoreader hesabınızda herhangi bir besleme "
-"ayarlamamışsınız. Lütfen bir tane ayarlayıp yeniden deneyin."
+"Görünüşe göre Inoreader hesabınızda herhangi bir besleme ayarlamamışsınız. "
+"Lütfen bir tane ayarlayıp yeniden deneyin."
 
 #: src/controller.cpp:365
 msgid "Loading articles from cache..."
@@ -430,51 +435,51 @@ msgstr "%s: %s: Bilinmeyen komut"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Hata: ayar dosyası `%s' kaydedilemedi!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr ""
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Hiçbiri seçilmedi!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Hata: besleme listesini silemezsiniz!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Geçersiz konum!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Kaydet"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, c-format
 msgid "Save Files - %s"
 msgstr "Dosyaları Kaydet - %s"
@@ -537,8 +542,8 @@ msgid "Shared items"
 msgstr "Paylaşılan ögeler."
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Hiçbir besleme seçilmedi!"
 
@@ -561,131 +566,140 @@ msgid ""
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Besleme okundu olarak imleniyor..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Hata: besleme okundu olarak imlenemedi: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Okunmamış besleme yok."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Tüm beslemeler okundu olarak imleniyor..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Hata: filtre komutu `%s' ayrıştırılamadı: %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Hiçbir filtre tanımlanmadı."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Ara: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Filtre: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Çıkmak istediğinize emin misiniz (e:Evet h:Hayır)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "eh"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "e"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Çık"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Aç"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Sonraki Okunmamış"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Yenile"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Tümünü Yenile"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Okundu Olarak İmle"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Tümünü Okundu Olarak İmle"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Ara"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Yardım"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Hata: filtre komutu ayrıştırılamadı!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Aranıyor..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "`%s' aranırken hata: %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Sonuç yok."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Konum görünür değil!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Besleme Listesi %u okunmamuş, %u toplam"
@@ -699,75 +713,80 @@ msgstr "`%s'in üzerine yazmak istediğinize emin misiniz (e:Evet h:Hayır)? "
 msgid "n"
 msgstr "h"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Dosya: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Kaydet - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "filtre ifadesi `%s' ayrıştırılamadı: %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "kullanım: set <variable>[=<value>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "kullanım: kaynak <dosya> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "kullanım: dumpconfig <dosya>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Ayarlar %s dosyasına kaydedildi"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "bilinmeyen komut: %s"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Yer imi kaydediliyor..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Yer imi kaydedildi."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Yer imi kaydedilirken hata oluştu: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "Adres: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Başlık: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Açıklama: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Besleme başlığı: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Yer imi otomatik pilotta kaydediliyor..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -775,15 +794,15 @@ msgstr ""
 "yer imleme desteği ayarlanmadı. Ayar değişkenini `bookmark-cmd'ye göre "
 "ayarlayın."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr ""
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr ""
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Temizle"
 
@@ -831,13 +850,7 @@ msgstr "Beğenilen ögeler"
 msgid "Saved web pages"
 msgstr "Kayıtlı web sayfaları"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Bayrak okuma açılıyor/kapatılıyor..."
 
@@ -846,16 +859,16 @@ msgstr "Bayrak okuma açılıyor/kapatılıyor..."
 msgid "Error while toggling read flag: %s"
 msgstr "Hata: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "Adres listesi boş."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Bayraklar: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Hata: Hiçbiri seçilmedi!"
 
@@ -864,19 +877,19 @@ msgid "Error: you can't reload search results."
 msgstr "Hata: arama sonuçlarını yeniden yükleyemezsiniz."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Okunmamış yok."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
 
@@ -888,7 +901,7 @@ msgstr "Okunmamış besleme yok."
 msgid "Marking all above as read..."
 msgstr "Yukarıdakilerin tümü okundu olarak imleniyor..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -907,62 +920,62 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Bayraklar güncellendi."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Hata: filtre uygulanırken hata oluştu: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Kayıt işlemi iptal edildi."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Yazı %s'e kaydedildi"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Hata: yazı %s'e kaydedilemedi"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Yazı Listesi - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -993,15 +1006,15 @@ msgstr "Podcast İndirme Adresi: "
 msgid "type: "
 msgstr "biçim: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Yukarı"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Aşağı"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Yazı okundu olarak imlenirken hata oluştu: %s"
@@ -1026,35 +1039,35 @@ msgstr "Yazı %s'e kaydedildi."
 msgid "Error: couldn't write article to file %s"
 msgstr "Hata: yazı %s'e kaydedilemedi"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Tarayıcı başlatılıyor..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Yazı yeni olarak imlenirken hata oluştu: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Tarayıcıda Görüntüle"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Kuyruktan Çıkar"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Yazı - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Hata: geçersiz düzenli ifade!"
 
@@ -1366,22 +1379,22 @@ msgstr "Sayfanın/listenin başına taşı"
 msgid "Move to the end of page/list"
 msgstr "Sayfanın/listenin sonuna taşı"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr ""
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "`%s' özelliği mevcut değil."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr ""
@@ -1473,27 +1486,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "İndir"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Sil"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Tamamlananları Temizle"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Otomatik İndirmeyi Aç/Kapat"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Oynat"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Bitti olarak imle"
 
@@ -1547,19 +1560,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr "Hata: desteklenmeyen adres: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Etiket Seç"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Filtre Seç"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "özellik bulunamadı"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "XML etiketi okunurken EOF (dosya sonu) bulundu"
 
@@ -1567,23 +1580,23 @@ msgstr "XML etiketi okunurken EOF (dosya sonu) bulundu"
 msgid "No link selected!"
 msgstr "Hiçbir bağlantı seçilmedi!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Yerimlerine Ekle"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "Adresler"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Hata: besleme boş!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Hiçbir etiket tanımlanmadı."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Sorgu beslemesi güncelleniyor..."
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2020-03-20 18:00+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Ivan Kovnatsky <sevenfourk@gmail.com>, Alexander Batischev "
@@ -161,6 +161,11 @@ msgstr "Впіймали newsboat::MatcherException із повідомленн�
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr "Впіймали newsboat::Exception із повідомленням: %s"
+
+#: newsboat.cpp:253
+#, fuzzy, c-format
+msgid "Caught std::exception with message: %s"
 msgstr "Впіймали newsboat::Exception із повідомленням: %s"
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -436,51 +441,51 @@ msgstr "%s: %s: невідома команда"
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Помилка: не можу відкрити файл конфігурації `%s'!"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "Закрити"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "Перейти до Діалогу"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "Закрити Діалог"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Не вибрано нічого!"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "Помилка: не можна видаляти список тем!"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "Непрацездатна позиція!"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr "Директорія: "
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "Відміна"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "Зберегти"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, c-format
 msgid "Save Files - %s"
 msgstr "Зберегти файли - %s"
@@ -543,8 +548,8 @@ msgid "Shared items"
 msgstr "Розшарені статті"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "Не вибрано тем!"
 
@@ -571,131 +576,140 @@ msgstr ""
 "Сортувати реверсно за (f)першимТаґом/(t)назвою/(a)кількістьСтатей/"
 "(u)кількістьНепрочитанихСтатей/(l)останнімОновленням/(n)ніяк?"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr "Браузер повернув код помилки %i"
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr "Динамічні теми не можна відкрити у браузері!"
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "Позначаю теми як прочитані..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Помилка: не можу позначити тему: %s як прочитану"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "Немає тем з непрочитаними статтями."
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr "Вже на останній темі."
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr "Вже на першій темі."
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "Позначаю всі теми як прочитані..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Помилка: неможливо парсувати команду фільтра `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "Не визначено фільтри."
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "Шукати: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "Фільтр: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Ви впевнені, що хочете вийти (y:Так n:Ні)? "
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Вихід"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "Відкрити"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "Наступна непрочитана"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "Перезавантажити"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "Перезавантажити усі"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "Позначити як прочитано"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "Позначити всі як прочитані"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "Пошук"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "Довідка"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "Помилка: неможливо розібрати помилку фільтра!"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Шукаю..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Помилка при пошуку `%s': %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "Безрезультатно."
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "Не видно позицію!"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Список Тем - %u непрочитано, загалом - %u"
@@ -709,75 +723,80 @@ msgstr "Ви впевнені, що хочете перезаписати `%s' (
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "Файл: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "Зберегти Файл - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "неможливо парсувати вираз фільра `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "використання: set <змінна>[=<значення>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "використання: <файл> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "використання: конфігурація дампу <файл>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "Конфігурацію збережено у %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "Не є командою: `%s'"
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "Зберігаю закладки..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "Збережені закладки."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "Помилка при зберіганні закладок: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "URL: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "Назва: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "Опис: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr "Назва теми: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr "Зберігаю закладку на автоматі..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
@@ -785,15 +804,15 @@ msgstr ""
 "підтримка закладок не налаштована. Будь ласка, встановіть змінну `bookmark-"
 "cmd' відповідно."
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "Загальні клавіші:"
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "Незастосовані функції:"
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "Очистити"
 
@@ -841,13 +860,7 @@ msgstr "Вподобані статті"
 msgid "Saved web pages"
 msgstr "Збережені веб-сторінки"
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr "Браузер повернув код помилки %i"
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "Переключення флагу прочитано для статей..."
 
@@ -856,16 +869,16 @@ msgstr "Переключення флагу прочитано для стате
 msgid "Error while toggling read flag: %s"
 msgstr "Помилка при переключенні флагу прочитано: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "Список URL пустий."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "Флаги: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "Помилка: нічого не вибрано!"
 
@@ -874,19 +887,19 @@ msgid "Error: you can't reload search results."
 msgstr "Помилка: не можна перезавантажувати результати пошуку."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Немає непрочитаних статей."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Вже на останній статті."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Вже на першій статті."
 
@@ -898,7 +911,7 @@ msgstr "Немає непрочитаних тем."
 msgid "Marking all above as read..."
 msgstr "Позначаю все, що вище, як прочитані..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Пайпувати статтю до каманди: "
 
@@ -921,55 +934,55 @@ msgstr ""
 "Сортувати реверсно за (d)датою/(t)назвою/(f)флагами/(a)автором/(l)посиланням/"
 "(g)uid/(r)випадково?"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "Флаги поновлено."
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Помилка: примінення фільтру невдале: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "Збереження перервано."
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "Стаття збережена у %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Помилка: не можу зберегти у %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Результати Пошуку - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Динамічна тема - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "Список Статей - %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "Перезаписати `%s' в `%s'? (y:Так n:Ні)"
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr "yanq"
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -978,7 +991,7 @@ msgstr ""
 "Перезаписати `%s' в `%s'? Залишилось таких конфліктів: %d (y:Так a:"
 "Перезаписати усі n:Ні q:Не перезаписувати нічого)"
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1011,15 +1024,15 @@ msgstr "Посилання на завантаження Podcast: "
 msgid "type: "
 msgstr "тип: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "Вершина"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "Низ"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Помилка при позначенні статті як прочитано: %s"
@@ -1044,35 +1057,35 @@ msgstr "Збережено статтю у %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Помилка: не можу записати статтю у файл %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Запускаю браузер..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Помилка при позначенні статті як непрочитано: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "Перейти за посиланням №"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Відкрити у браузері"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "Поставити у чергу"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "Стаття - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "Помилка: неправильний вираз!"
 
@@ -1386,22 +1399,22 @@ msgstr "Перемістити до початку сторінки/списку
 msgid "Move to the end of page/list"
 msgstr "Перемістити до кінця сторінки/списку"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' недійсний контекст"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' недійсна ключова команда"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "атрибут `%s' не доступний."
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "вживаний вираз '%s' неправильний %s"
@@ -1493,27 +1506,27 @@ msgstr "Мб/с"
 msgid "GB/s"
 msgstr "Гб/с"
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "Завантаження"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "Видалити"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "Очищення закінчено"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "Увімкнути автоматичне завантаження"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "Програти"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr "Позначити як завершене"
 
@@ -1570,19 +1583,19 @@ msgstr "%a, %d %b %Y %T %z"
 msgid "Error: unsupported URL: %s"
 msgstr "Помилка: посилання не підтримується: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "Виберіть мітку"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "Виберіть фільтр"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "атрибут не знайдено"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "При читанні мітки з XML був виявлений кінець файлу"
 
@@ -1590,23 +1603,23 @@ msgstr "При читанні мітки з XML був виявлений кін
 msgid "No link selected!"
 msgstr "Не вибрано посилання!"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "Зберегти закладку"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "Помилка: теми не містять елементів!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "Не визначено жодної мітки."
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "Оновлюю динамічну тему..."
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2007-11-21 22:51+0100\n"
 "Last-Translator: josh yu <joshyupeng@gmail.com>\n"
 "Language-Team: Chinese <joshyupeng@gmail.com>\n"
@@ -157,6 +157,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -429,52 +434,52 @@ msgstr "未知的命令 `%s' "
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "错误：无法将文章写至 %s"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr ""
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "没有选择任何项目"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 #, fuzzy
 msgid "Error: you can't remove the feed list!"
 msgstr "错误：你不能重新加载所选项目"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "无效位置！"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "取消"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "保存"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "%s %s - 保存文件 - %s"
@@ -539,8 +544,8 @@ msgid "Shared items"
 msgstr "没有未读的文章"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "没有选择种子"
 
@@ -563,131 +568,140 @@ msgid ""
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "标记该种子已读"
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "错误：无法将种子标记为已读: %s"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "任何种子里都没有未读的文章"
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "将所有种子都标记为已读..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, fuzzy, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "错误：无法分析过滤器（filter）命令"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "没有定义任何过滤器（filter）"
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "查找: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "过滤器: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "你真的想离开么（y:是的 n:不是)?"
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "放弃"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "打开"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "下一篇未读"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "重新加载当前种子"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "重新加载所有种子"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "标记为已读"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "将所有都标记为已读"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "查找"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "帮助"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "错误：无法分析过滤器（filter）命令"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "查找..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "当查找 `%s'的时候出错: %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "没有结果"
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "找不到这个位置"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, fuzzy, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "%N %V - 查找结果 (%u 未读, 共有 %t)"
@@ -701,92 +715,97 @@ msgstr "你真的想覆盖 `%s'么(y:是的  n:不是)?"
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "文件: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, fuzzy, c-format
 msgid "Save File - %s"
 msgstr "%s %s - 保存文件 - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, fuzzy, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "错误：无法分析过滤器（filter）命令"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "用法: set <变量>[=<值>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr ""
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 #, fuzzy
 msgid "usage: dumpconfig <file>"
 msgstr "<配置文件>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, fuzzy, c-format
 msgid "Saved configuration to %s"
 msgstr "把文章保存到 %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, fuzzy, c-format
 msgid "Not a command: %s"
 msgstr "未知的命令 `%s' "
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "保存书签..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "已保存的书签."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "当保存书签时出错: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "链接: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "标题: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "描述: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 #, fuzzy
 msgid "Feed title: "
 msgstr "文件: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "保存书签..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
 msgstr "书签支持尚未配置，请在配置文件里设置相应变量 `bookmark-cmd' "
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr ""
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr ""
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "清空"
 
@@ -835,13 +854,7 @@ msgstr "没有未读的文章"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "切换文章阅读标记（已读/未读）"
 
@@ -850,16 +863,16 @@ msgstr "切换文章阅读标记（已读/未读）"
 msgid "Error while toggling read flag: %s"
 msgstr "当切换阅读标记（已读/未读）时出错: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "空空如也的链接列表"
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "标记: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "错误：没有选择任何项目！"
 
@@ -868,19 +881,19 @@ msgid "Error: you can't reload search results."
 msgstr "错误：你不能重新加载所选项目"
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "没有未读的文章"
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
 
@@ -893,7 +906,7 @@ msgstr "没有未读的种子"
 msgid "Marking all above as read..."
 msgstr "将所有种子都标记为已读..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -913,62 +926,62 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "标记已更新"
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "错误: 应用过滤器失败: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "放弃保存"
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "错误：无法保存文章到 %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, fuzzy, c-format
 msgid "Article List - %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -999,15 +1012,15 @@ msgstr "播客下载的地址: "
 msgid "type: "
 msgstr "类型: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "顶部"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "底部"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "当标记文章为已读的时候出错: %s"
@@ -1032,35 +1045,35 @@ msgstr "将文章保存至 %s "
 msgid "Error: couldn't write article to file %s"
 msgstr "错误：无法将文章写至 %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "启动浏览器..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "当标记文章为未读的时候出错: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "在浏览器里打开"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "加入队列"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, fuzzy, c-format
 msgid "Article - %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 #, fuzzy
 msgid "Error: invalid regular expression!"
 msgstr "错误:无效的种子!"
@@ -1393,22 +1406,22 @@ msgstr "转到下一篇未读文章"
 msgid "Move to the end of page/list"
 msgstr "转到下一篇未读文章"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr ""
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "无效属性 `%s'"
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr ""
@@ -1500,27 +1513,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "下载"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "删除"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "清除完毕的项目"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "切换自动下载"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "播放"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "清除完毕的项目"
@@ -1576,19 +1589,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr "错误：不支持的链接: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "选择标签"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "选择过滤器"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "属性没有发现"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "当读取XML标签时遇到EOF标记"
 
@@ -1596,24 +1609,24 @@ msgstr "当读取XML标签时遇到EOF标记"
 msgid "No link selected!"
 msgstr "没有选择任何链接！"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "保存书签"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 #, fuzzy
 msgid "URLs"
 msgstr "链接: "
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "错误: 种子里没有包含任何项目!"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "没有定义任何标签"
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "更新查询种子..."
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-12 18:17+0200\n"
 "PO-Revision-Date: 2010-03-03 16:55+0800\n"
 "Last-Translator: Aeglos <aeglos.lin@gmail.com>\n"
 "Language-Team: Traditional Chinese <aeglos.lin@gmail.com>\n"
@@ -160,6 +160,11 @@ msgstr ""
 #: newsboat.cpp:247 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
+msgstr ""
+
+#: newsboat.cpp:253
+#, c-format
+msgid "Caught std::exception with message: %s"
 msgstr ""
 
 #: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:244
@@ -430,51 +435,51 @@ msgstr "未知的命令 `%s' "
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "錯誤：無法開啟組態檔案`%s'！"
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr "關閉"
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr "前往對話窗"
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr "關閉對話窗"
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "沒有選擇任何項目"
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr "錯誤：你不能移除來源列表！"
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr "無效位置！"
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr "取消"
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr "儲存"
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "儲存檔案 - %s"
@@ -537,8 +542,8 @@ msgid "Shared items"
 msgstr "分享的文章"
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr "沒有選擇的來源！"
 
@@ -564,131 +569,140 @@ msgid ""
 "(l)astupdated/(n)one?"
 msgstr "排序依照：(f)第一項Tag/(t)標題/(a)文章數量/(u)未讀文章數量/(n)無？"
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr "將來源標為已讀..."
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "錯誤：無法將來源%s標記為已讀"
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr "沒有含未讀文章的來源"
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr "將所有來源標為已讀..."
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "錯誤：無法分析過濾的命令 `%s': %s"
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr "沒有定義任何過濾器(filter)"
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr "搜尋: "
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr "過濾器: "
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "你確定要離開嗎(y:是的 n:不是)？"
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr "yn"
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr "y"
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "放棄"
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr "打開"
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr "下一篇未讀"
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr "重新載入"
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr "全部重新載入"
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr "標為已讀"
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr "標記全部為已讀"
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr "搜尋"
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr "說明"
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr "錯誤：無法分析過濾器(filter)命令"
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "搜尋中..."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "在搜尋 `%s'的時候出錯: %s"
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr "沒有結果"
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr "找不到這個位置"
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "來源列表 - %u 未讀, 總共 %u"
@@ -702,91 +716,96 @@ msgstr "你確定要覆蓋 `%s'嗎(y:是的  n:不是)?"
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr "檔案: "
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr "儲存檔案 - %s"
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/fileurlreader.cpp:31 src/fileurlreader.cpp:70
+#, c-format
+msgid "failed to open urls file (%s)"
+msgstr ""
+
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr "無法分析過濾的表示式 `%s': %s"
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr "用法: set <變數>[=<值>]"
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr "使用方式：source <檔案> [...]"
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr "使用方式： dumpconfig <檔案>"
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr "把組態儲存到 %s"
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr "未知的命令： `%s' "
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr "儲存書籤..."
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr "已儲存的書籤."
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr "在儲存書籤時發生錯誤: "
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr "鏈結: "
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr "標題: "
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr "描述: "
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 #, fuzzy
 msgid "Feed title: "
 msgstr "檔案: "
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 #, fuzzy
 msgid "Saving bookmark on autopilot..."
 msgstr "儲存書籤..."
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
 msgstr "書籤功能還未設定，請在設定檔中設定變數 `bookmark-cmd' "
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr "一般的綁定方式："
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr "未綁定的功能："
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr "清除"
 
@@ -835,13 +854,7 @@ msgstr "分享的文章"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr "切換文章閱讀標記（已讀/未讀）"
 
@@ -850,16 +863,16 @@ msgstr "切換文章閱讀標記（已讀/未讀）"
 msgid "Error while toggling read flag: %s"
 msgstr "當切換閱讀標記（已讀/未讀）時出錯: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr "空白的鏈結列表"
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr "標記: "
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr "錯誤：沒有選擇任何項目！"
 
@@ -868,19 +881,19 @@ msgid "Error: you can't reload search results."
 msgstr "錯誤：你不能重新載入所選項目"
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "沒有未讀的文章"
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
 
@@ -893,7 +906,7 @@ msgstr "沒有未讀的來源"
 msgid "Marking all above as read..."
 msgstr "將所有來源標為已讀..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr "Pipe article to command: "
 
@@ -915,62 +928,62 @@ msgstr "排序依照：(d)日期/(t)標題/(f)"
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "反向排序依(d)日期/(t)標題/(f)標誌/(a)作者/(l)連結/(g)用戶號碼"
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr "標記已更新"
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "錯誤: 套用過濾器失敗: %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr "放棄儲存"
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr "把文章儲存到 %s"
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "錯誤：無法儲存文章到 %s"
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "搜尋結果 - '%s'"
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr "查詢來源 - %s"
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr "文章列表 %s"
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1001,15 +1014,15 @@ msgstr "Pocast下載網址: "
 msgid "type: "
 msgstr "類型: "
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr "頂端"
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr "底端"
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "當標記文章為已讀的時候發生錯誤: %s"
@@ -1034,35 +1047,35 @@ msgstr "將文章保存至 %s "
 msgid "Error: couldn't write article to file %s"
 msgstr "錯誤：無法將文章寫至 %s"
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "啟動瀏覽器..."
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "將文章標為未讀時發生錯誤: %s"
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr "前往網址 #"
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "在瀏覽器裡打開"
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr "加入隊列"
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr "文章 - %s"
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr "錯誤:無效的正規表示式！"
 
@@ -1383,22 +1396,22 @@ msgstr "跳到頁面/列表的開始"
 msgid "Move to the end of page/list"
 msgstr "跳到頁面/列表的最後"
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr "`%s' 不是有效的內容"
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr "`%s' 不是有效的按鍵命令"
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr "無效屬性 `%s'"
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr "正規表示式 '%s' 是無效的: %s"
@@ -1490,27 +1503,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr "下載"
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr "刪除"
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr "清除完畢的項目"
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr "切換自動下載"
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr "播放"
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 #, fuzzy
 msgid "Mark as Finished"
 msgstr "清除完畢的項目"
@@ -1565,19 +1578,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr "錯誤：不支持的鏈結: %s"
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr "選擇標籤"
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr "選擇過濾器"
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr "未發現屬性"
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr "當讀取XML標籤時遇到EOF標記"
 
@@ -1585,23 +1598,23 @@ msgstr "當讀取XML標籤時遇到EOF標記"
 msgid "No link selected!"
 msgstr "沒有選擇任何鏈結！"
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr "儲存書籤"
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr "網址"
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr "錯誤: 來源裡沒有任何項目！"
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr "沒有定義任何標籤"
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr "更新查詢的來源..."
 

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -1,6 +1,8 @@
 #include "fileurlreader.h"
 
+#include <cerrno>
 #include <fstream>
+#include <system_error>
 
 #include "utils.h"
 
@@ -25,7 +27,8 @@ void FileUrlReader::reload()
 	std::fstream f;
 	f.open(filename.c_str(), std::fstream::in);
 	if (!f.is_open()) {
-		return;
+		throw std::system_error(errno, std::system_category(),
+			strprintf::fmt(_("failed to open urls file (%s)"), filename));
 	}
 
 	for (std::string line; std::getline(f, line); /* nothing */) {
@@ -62,16 +65,19 @@ void FileUrlReader::write_config()
 {
 	std::fstream f;
 	f.open(filename.c_str(), std::fstream::out);
-	if (f.is_open()) {
-		for (const auto& url : urls) {
-			f << url;
-			if (tags[url].size() > 0) {
-				for (const auto& tag : tags[url]) {
-					f << " \"" << tag << "\"";
-				}
+	if (!f.is_open()) {
+		throw std::system_error(errno, std::system_category(),
+			strprintf::fmt(_("failed to open urls file (%s)"), filename));
+	}
+
+	for (const auto& url : urls) {
+		f << url;
+		if (tags[url].size() > 0) {
+			for (const auto& tag : tags[url]) {
+				f << " \"" << tag << "\"";
 			}
-			f << std::endl;
 		}
+		f << std::endl;
 	}
 }
 

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -25,7 +25,7 @@ void FileUrlReader::reload()
 	alltags.clear();
 
 	std::fstream f;
-	f.open(filename.c_str(), std::fstream::in);
+	f.open(filename, std::fstream::in);
 	if (!f.is_open()) {
 		throw std::system_error(errno, std::system_category(),
 			strprintf::fmt(_("failed to open urls file (%s)"), filename));
@@ -64,7 +64,7 @@ void FileUrlReader::load_config(const std::string& file)
 void FileUrlReader::write_config()
 {
 	std::fstream f;
-	f.open(filename.c_str(), std::fstream::out);
+	f.open(filename, std::fstream::out);
 	if (!f.is_open()) {
 		throw std::system_error(errno, std::system_category(),
 			strprintf::fmt(_("failed to open urls file (%s)"), filename));

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "3rd-party/catch.hpp"
+#include "test-helpers/chmod.h"
 #include "test-helpers/misc.h"
 #include "test-helpers/tempfile.h"
 
@@ -81,5 +82,61 @@ TEST_CASE("URL reader writes files that it can understand later",
 	REQUIRE(u.get_urls() == u2.get_urls());
 	for (const auto& url : u.get_urls()) {
 		REQUIRE(u.get_tags(url) == u2.get_tags(url));
+	}
+}
+
+TEST_CASE("URL reader throws exception if file cannot be opened",
+	"[FileUrlReader]")
+{
+	const std::string testDataPath("data/test-urls.txt");
+	TestHelpers::TempFile urlsFile;
+
+	FileUrlReader u(urlsFile.get_path());
+
+	SECTION("reload() and load_config() throw if file does not exist") {
+		REQUIRE_THROWS_AS(u.reload(), std::exception);
+		REQUIRE_THROWS_AS(u.load_config(urlsFile.get_path()), std::exception);
+	}
+
+	SECTION("write_config() works fine if file does not exist") {
+		REQUIRE_NOTHROW(u.write_config());
+
+		SECTION("after writing file, reload() and load_config() succeed") {
+			REQUIRE_NOTHROW(u.reload());
+			REQUIRE_NOTHROW(u.load_config(urlsFile.get_path()));
+		}
+	}
+
+	TestHelpers::copy_file(testDataPath, urlsFile.get_path());
+
+	SECTION("reload() and load_config() succeed if url file exists") {
+		REQUIRE_NOTHROW(u.reload());
+		REQUIRE_NOTHROW(u.load_config(urlsFile.get_path()));
+	}
+
+	GIVEN("that the urls file is not readable") {
+		TestHelpers::Chmod notReadable(urlsFile.get_path(), S_IWUSR);
+
+		THEN("reload() and load_config() throw") {
+			REQUIRE_THROWS_AS(u.reload(), std::exception);
+			REQUIRE_THROWS_AS(u.load_config(urlsFile.get_path()), std::exception);
+		}
+
+		THEN("write_config() still works fine") {
+			REQUIRE_NOTHROW(u.write_config());
+		}
+	}
+
+	GIVEN("that the urls file is not writable") {
+		TestHelpers::Chmod notWritable(urlsFile.get_path(), S_IRUSR);
+
+		THEN("write_config() throws") {
+			REQUIRE_THROWS_AS(u.write_config(), std::exception);
+		}
+
+		THEN("reload() and load_config() still work fine") {
+			REQUIRE_NOTHROW(u.reload());
+			REQUIRE_NOTHROW(u.load_config(urlsFile.get_path()));
+		}
 	}
 }

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -156,7 +156,6 @@ TEST_CASE("import() turns URLs that start with a pipe symbol (\"|\") "
 	TestHelpers::TempFile urlsFile;
 
 	FileUrlReader urlcfg(urlsFile.get_path());
-	urlcfg.reload();
 
 	REQUIRE_NOTHROW(
 		opml::import(
@@ -191,7 +190,6 @@ TEST_CASE("import() turns \"filtercmd\" attribute into a `filter:` URL "
 	TestHelpers::TempFile urlsFile;
 
 	FileUrlReader urlcfg(urlsFile.get_path());
-	urlcfg.reload();
 
 	REQUIRE_NOTHROW(
 		opml::import(


### PR DESCRIPTION
Fixes #439.

## Test output/demo
### Output when not readable

![image](https://user-images.githubusercontent.com/4629607/79074529-3fefe080-7ced-11ea-8d7b-4ec90f4e4842.png)

### Output when file does not exist

This shows that the type of error changes depending on the actual reason of failing (`Permission denied` vs `No such file or directory`):
![image](https://user-images.githubusercontent.com/4629607/79074603-a674fe80-7ced-11ea-8cd2-1c001a89b6f0.png)

### Output when using different language

This shows that the type of error (e.g. `Permission denied`) is also translated:
![image](https://user-images.githubusercontent.com/4629607/79074634-cd333500-7ced-11ea-8d1a-25b5f9bfb90c.png)
