### PR TITLE
Add support for upcoming json-c 0.14.0.

### DIFF
--- a/src/newsblurapi.cpp
+++ b/src/newsblurapi.cpp
@@ -9,6 +9,19 @@
 #include "strprintf.h"
 #include "utils.h"
 
+/* json-c 0.13.99 does not define TRUE/FALSE anymore
+ * the json-c maintainers replaced them with pure 1/0
+ * https://github.com/json-c/json-c/commit/0992aac61f8b
+ */
+#if defined JSON_C_VERSION_NUM && JSON_C_VERSION_NUM >= ((13 << 8) | 99)
+#ifndef FALSE
+#define FALSE 0
+#endif
+#ifndef TRUE
+#define TRUE  1
+#endif
+#endif
+
 #define NEWSBLUR_ITEMS_PER_PAGE 6
 
 namespace newsboat {


### PR DESCRIPTION
TRUE/FALSE are not defined anymore.  1 and 0 are used instead.