### PR TITLE
Cleanup UrlReader related classes

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -97,7 +97,7 @@ public:
 	}
 
 private:
-	void import_opml(const std::string& filename);
+	void import_opml(const std::string& opmlFile, const std::string& urlFile);
 	void export_opml();
 	void rec_find_rss_outlines(xmlNode* node, std::string tag);
 	int execute_commands(const std::vector<std::string>& cmds);

--- a/include/feedhqurlreader.h
+++ b/include/feedhqurlreader.h
@@ -14,7 +14,6 @@ public:
 		const std::string& url_file,
 		RemoteApi* a);
 	~FeedHqUrlReader() override;
-	void write_config() override;
 	void reload() override;
 	std::string get_source() override;
 

--- a/include/fileurlreader.h
+++ b/include/fileurlreader.h
@@ -12,11 +12,10 @@ public:
 	explicit FileUrlReader(const std::string& file = "");
 	void write_config() override;
 	void reload() override;
-	void load_config(const std::string& file);
 	std::string get_source() override;
 
 private:
-	std::string filename;
+	const std::string filename;
 };
 
 }

--- a/include/fileurlreader.h
+++ b/include/fileurlreader.h
@@ -10,9 +10,14 @@ namespace newsboat {
 class FileUrlReader : public UrlReader {
 public:
 	explicit FileUrlReader(const std::string& file = "");
-	void write_config() override;
+
 	void reload() override;
 	std::string get_source() override;
+
+	/// \brief Write URLs back to the input file.
+	///
+	/// This method is used after importing feeds from OPML.
+	void write_config();
 
 private:
 	const std::string filename;

--- a/include/inoreaderurlreader.h
+++ b/include/inoreaderurlreader.h
@@ -14,7 +14,6 @@ public:
 		const std::string& url_file,
 		RemoteApi* a);
 	virtual ~InoreaderUrlReader();
-	virtual void write_config();
 	virtual void reload();
 	virtual std::string get_source();
 

--- a/include/newsblururlreader.h
+++ b/include/newsblururlreader.h
@@ -16,7 +16,6 @@ class NewsBlurUrlReader : public UrlReader {
 public:
 	NewsBlurUrlReader(const std::string& url_file, RemoteApi* a);
 	~NewsBlurUrlReader() override;
-	void write_config() override;
 	void reload() override;
 	std::string get_source() override;
 

--- a/include/ocnewsurlreader.h
+++ b/include/ocnewsurlreader.h
@@ -11,7 +11,6 @@ class OcNewsUrlReader : public UrlReader {
 public:
 	OcNewsUrlReader(const std::string& url_file, RemoteApi* a);
 	~OcNewsUrlReader() override;
-	void write_config() override;
 	void reload() override;
 	std::string get_source() override;
 

--- a/include/oldreaderurlreader.h
+++ b/include/oldreaderurlreader.h
@@ -14,7 +14,6 @@ public:
 		const std::string& url_file,
 		RemoteApi* a);
 	~OldReaderUrlReader() override;
-	void write_config() override;
 	void reload() override;
 	std::string get_source() override;
 

--- a/include/opml.h
+++ b/include/opml.h
@@ -4,7 +4,7 @@
 #include <libxml/tree.h>
 
 #include "feedcontainer.h"
-#include "urlreader.h"
+#include "fileurlreader.h"
 
 namespace newsboat {
 
@@ -12,7 +12,7 @@ namespace opml {
 xmlDocPtr generate(const FeedContainer& feedcontainer);
 bool import(
 	const std::string& filename,
-	UrlReader* urlcfg);
+	FileUrlReader& urlcfg);
 }
 
 } // namespace newsboat

--- a/include/opmlurlreader.h
+++ b/include/opmlurlreader.h
@@ -12,7 +12,6 @@ namespace newsboat {
 class OpmlUrlReader : public UrlReader {
 public:
 	explicit OpmlUrlReader(ConfigContainer* c);
-	void write_config() override;
 	void reload() override;
 	std::string get_source() override;
 

--- a/include/ttrssurlreader.h
+++ b/include/ttrssurlreader.h
@@ -11,7 +11,6 @@ class TtRssUrlReader : public UrlReader {
 public:
 	TtRssUrlReader(const std::string& url_file, RemoteApi* a);
 	~TtRssUrlReader() override;
-	void write_config() override;
 	void reload() override;
 	std::string get_source() override;
 

--- a/include/urlreader.h
+++ b/include/urlreader.h
@@ -14,11 +14,6 @@ public:
 	UrlReader() = default;
 	virtual ~UrlReader() = default;
 
-	/// \brief Write URLs back to the input file.
-	///
-	/// This method is used after importing feeds from OPML.
-	virtual void write_config() = 0;
-
 	/// \brief Re-read the input file.
 	///
 	/// \note This overwrites the contents of `urls`, `tags`, and `alltags`, so

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -39,14 +39,14 @@ src/cache.o: src/cache.cpp include/cache.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h config.h \
  include/configcontainer.h include/controller.h include/cache.h \
  include/colormanager.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dbexception.h include/logger.h include/strprintf.h \
- include/matcherexception.h include/rssfeed.h include/utils.h \
- include/logger.h include/scopemeasure.h include/strprintf.h \
- include/utils.h
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/dbexception.h include/logger.h \
+ include/strprintf.h include/matcherexception.h include/rssfeed.h \
+ include/utils.h include/logger.h include/scopemeasure.h \
+ include/strprintf.h include/utils.h
 src/cliargsparser.o: src/cliargsparser.cpp include/cliargsparser.h \
  include/logger.h config.h include/strprintf.h include/globals.h \
  include/ruststring.h include/strprintf.h
@@ -58,17 +58,17 @@ src/colormanager.o: src/colormanager.cpp include/colormanager.h \
  filter/FilterParser.h include/regexmanager.h include/view.h \
  include/colormanager.h include/configcontainer.h include/controller.h \
  include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h \
- include/filebrowserformaction.h include/helpformaction.h \
- include/itemlistformaction.h include/listformatter.h \
- include/itemviewformaction.h include/logger.h include/strprintf.h \
- include/matcherexception.h include/pbview.h include/selectformaction.h \
- include/strprintf.h include/urlviewformaction.h include/utils.h \
- include/logger.h
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h include/filebrowserformaction.h \
+ include/helpformaction.h include/itemlistformaction.h \
+ include/listformatter.h include/itemviewformaction.h include/logger.h \
+ include/strprintf.h include/matcherexception.h include/pbview.h \
+ include/selectformaction.h include/strprintf.h \
+ include/urlviewformaction.h include/utils.h include/logger.h
 src/configcontainer.o: src/configcontainer.cpp include/configcontainer.h \
  include/configparser.h include/configactionhandler.h config.h \
  include/configparser.h include/confighandlerexception.h include/logger.h \
@@ -89,20 +89,20 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/colormanager.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/cliargsparser.h \
- include/logger.h config.h include/strprintf.h include/colormanager.h \
- include/configcontainer.h include/configexception.h \
- include/configparser.h include/configpaths.h include/cliargsparser.h \
- include/dbexception.h include/downloadthread.h include/exception.h \
- include/feedhqapi.h include/feedhqurlreader.h include/fileurlreader.h \
- include/globals.h include/inoreaderapi.h include/inoreaderurlreader.h \
- include/itemrenderer.h include/htmlrenderer.h include/textformatter.h \
- include/logger.h include/newsblurapi.h rss/feed.h rss/item.h \
- include/newsblururlreader.h include/ocnewsapi.h \
- include/ocnewsurlreader.h include/oldreaderapi.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/cliargsparser.h include/logger.h config.h include/strprintf.h \
+ include/colormanager.h include/configcontainer.h \
+ include/configexception.h include/configparser.h include/configpaths.h \
+ include/cliargsparser.h include/dbexception.h include/downloadthread.h \
+ include/exception.h include/feedhqapi.h include/feedhqurlreader.h \
+ include/fileurlreader.h include/globals.h include/inoreaderapi.h \
+ include/inoreaderurlreader.h include/itemrenderer.h \
+ include/htmlrenderer.h include/textformatter.h include/logger.h \
+ include/newsblurapi.h rss/feed.h rss/item.h include/newsblururlreader.h \
+ include/ocnewsapi.h include/ocnewsurlreader.h include/oldreaderapi.h \
  include/oldreaderurlreader.h include/opmlurlreader.h \
  include/regexmanager.h include/remoteapi.h include/rssfeed.h \
  include/utils.h include/rssparser.h include/scopemeasure.h \
@@ -120,11 +120,12 @@ src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/configcontainer.h include/logger.h include/strprintf.h \
  include/view.h include/colormanager.h include/controller.h \
  include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/dirbrowserformaction.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h \
@@ -133,12 +134,12 @@ src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/strprintf.h include/utils.h include/logger.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/filebrowserformaction.h include/dirbrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
  include/pbcontroller.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h include/fslock.h \
@@ -170,12 +171,13 @@ src/feedlistformaction.o: src/feedlistformaction.cpp \
  filter/FilterParser.h include/regexmanager.h include/view.h \
  include/colormanager.h include/configcontainer.h include/controller.h \
  include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h config.h \
- include/dbexception.h include/feedcontainer.h include/fmtstrformatter.h \
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h config.h include/dbexception.h \
+ include/feedcontainer.h include/fmtstrformatter.h \
  include/listformatter.h include/logger.h include/strprintf.h \
  include/reloader.h include/rssfeed.h include/utils.h include/logger.h \
  include/scopemeasure.h include/strprintf.h include/utils.h \
@@ -188,12 +190,12 @@ src/filebrowserformaction.o: src/filebrowserformaction.cpp \
  include/strprintf.h include/utils.h include/logger.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/filebrowserformaction.h include/dirbrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/fileurlreader.o: src/fileurlreader.cpp include/fileurlreader.h \
  include/urlreader.h include/utils.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h include/logger.h \
@@ -213,12 +215,13 @@ src/formaction.o: src/formaction.cpp include/formaction.h \
  include/configcontainer.h include/logger.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/formaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/filebrowserformaction.h include/formaction.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/fslock.o: src/fslock.cpp include/fslock.h include/logger.h config.h \
  include/strprintf.h
 src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
@@ -230,11 +233,12 @@ src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
  include/configcontainer.h include/logger.h include/strprintf.h \
  include/view.h include/colormanager.h include/controller.h \
  include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/history.o: src/history.cpp include/history.h include/ruststring.h
 src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
  include/textformatter.h include/regexmanager.h include/configparser.h \
@@ -261,9 +265,9 @@ src/itemlistformaction.o: src/itemlistformaction.cpp \
  include/view.h include/colormanager.h include/configcontainer.h \
  include/controller.h include/cache.h include/feedcontainer.h \
  include/filtercontainer.h include/fslock.h include/opml.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/filebrowserformaction.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/filebrowserformaction.h \
  include/dirbrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h config.h include/controller.h \
  include/dbexception.h include/fmtstrformatter.h include/logger.h \
@@ -290,9 +294,10 @@ src/itemviewformaction.o: src/itemviewformaction.cpp \
  include/textformatter.h include/utils.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h
 src/keymap.o: src/keymap.cpp include/keymap.h include/configparser.h \
  include/configactionhandler.h config.h include/confighandlerexception.h \
  include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
@@ -305,11 +310,11 @@ src/listformaction.o: src/listformaction.cpp include/listformaction.h \
  include/configcontainer.h include/logger.h config.h include/strprintf.h \
  include/view.h include/colormanager.h include/controller.h \
  include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/regexmanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/filebrowserformaction.h include/dirbrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/listformatter.o: src/listformatter.cpp include/listformatter.h \
  include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
@@ -356,10 +361,10 @@ src/oldreaderurlreader.o: src/oldreaderurlreader.cpp \
  include/configcontainer.h include/utils.h include/logger.h
 src/opml.o: src/opml.cpp include/opml.h include/feedcontainer.h \
  include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/urlreader.h include/rssfeed.h \
- include/matchable.h include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h
+ include/configactionhandler.h include/fileurlreader.h \
+ include/urlreader.h include/rssfeed.h include/matchable.h \
+ include/rssitem.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h
 src/opmlurlreader.o: src/opmlurlreader.cpp include/opmlurlreader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/urlreader.h include/utils.h \
@@ -407,15 +412,15 @@ src/reloader.o: src/reloader.cpp include/reloader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/controller.h include/cache.h \
  include/colormanager.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/curlhandle.h include/dbexception.h include/downloadthread.h \
- include/fmtstrformatter.h include/reloadrangethread.h \
- include/reloadthread.h include/controller.h rss/exception.h \
- include/rssfeed.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/rssparser.h rss/feed.h rss/item.h \
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/curlhandle.h include/dbexception.h \
+ include/downloadthread.h include/fmtstrformatter.h \
+ include/reloadrangethread.h include/reloadthread.h include/controller.h \
+ rss/exception.h include/rssfeed.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/rssparser.h rss/feed.h rss/item.h \
  include/scopemeasure.h include/utils.h include/view.h \
  include/filebrowserformaction.h include/formaction.h include/history.h \
  include/keymap.h include/stflpp.h include/dirbrowserformaction.h \
@@ -427,11 +432,11 @@ src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/controller.h include/cache.h \
  include/colormanager.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/logger.h config.h include/strprintf.h
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/logger.h config.h include/strprintf.h
 src/remoteapi.o: src/remoteapi.cpp include/remoteapi.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/utils.h include/logger.h config.h \
@@ -485,9 +490,9 @@ src/selectformaction.o: src/selectformaction.cpp \
  include/logger.h include/strprintf.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/fslock.h include/opml.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/filebrowserformaction.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/filebrowserformaction.h \
  include/dirbrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h
 src/stflpp.o: src/stflpp.cpp include/stflpp.h include/exception.h \
@@ -528,9 +533,10 @@ src/urlviewformaction.o: src/urlviewformaction.cpp \
  include/strprintf.h include/utils.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h
 src/utils.o: src/utils.cpp include/utils.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h include/logger.h \
  config.h include/strprintf.h include/logger.h include/ruststring.h \
@@ -539,24 +545,25 @@ src/view.o: src/view.cpp include/view.h include/colormanager.h \
  include/configparser.h include/configactionhandler.h \
  include/configcontainer.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/formaction.h include/history.h include/keymap.h include/stflpp.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h config.h include/dbexception.h stfl/dialogs.h \
- include/dialogsformaction.h include/exception.h stfl/feedlist.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- stfl/filebrowser.h include/fmtstrformatter.h include/formaction.h \
- stfl/help.h include/helpformaction.h include/htmlrenderer.h \
- stfl/itemlist.h include/itemlistformaction.h include/listformatter.h \
- stfl/itemview.h include/itemviewformaction.h include/keymap.h \
- include/logger.h include/strprintf.h include/matcherexception.h \
- include/regexmanager.h include/reloadthread.h include/rssfeed.h \
- include/utils.h include/logger.h include/selectformaction.h \
- stfl/selecttag.h include/strprintf.h stfl/urlview.h \
- include/urlviewformaction.h include/utils.h
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/filebrowserformaction.h include/formaction.h include/history.h \
+ include/keymap.h include/stflpp.h include/dirbrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h config.h \
+ include/dbexception.h stfl/dialogs.h include/dialogsformaction.h \
+ include/exception.h stfl/feedlist.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h stfl/filebrowser.h \
+ include/fmtstrformatter.h include/formaction.h stfl/help.h \
+ include/helpformaction.h include/htmlrenderer.h stfl/itemlist.h \
+ include/itemlistformaction.h include/listformatter.h stfl/itemview.h \
+ include/itemviewformaction.h include/keymap.h include/logger.h \
+ include/strprintf.h include/matcherexception.h include/regexmanager.h \
+ include/reloadthread.h include/rssfeed.h include/utils.h \
+ include/logger.h include/selectformaction.h stfl/selecttag.h \
+ include/strprintf.h stfl/urlview.h include/urlviewformaction.h \
+ include/utils.h
 test/cache.o: test/cache.cpp include/cache.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h 3rd-party/catch.hpp \
  include/configcontainer.h include/rssfeed.h include/matchable.h \
@@ -622,9 +629,9 @@ test/itemlistformaction.o: test/itemlistformaction.cpp \
  include/view.h include/colormanager.h include/configcontainer.h \
  include/controller.h include/cache.h include/feedcontainer.h \
  include/filtercontainer.h include/fslock.h include/opml.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/filebrowserformaction.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/filebrowserformaction.h \
  include/dirbrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h 3rd-party/catch.hpp include/cache.h \
  include/configpaths.h include/cliargsparser.h include/logger.h config.h \
@@ -653,12 +660,13 @@ test/matcherexception.o: test/matcherexception.cpp \
  include/matcherexception.h 3rd-party/catch.hpp
 test/opml.o: test/opml.cpp include/opml.h include/feedcontainer.h \
  include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/urlreader.h 3rd-party/catch.hpp \
- include/cache.h include/fileurlreader.h include/rssfeed.h \
- include/matchable.h include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h test/test-helpers/misc.h \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+ include/configactionhandler.h include/fileurlreader.h \
+ include/urlreader.h 3rd-party/catch.hpp include/cache.h \
+ include/fileurlreader.h include/rssfeed.h include/matchable.h \
+ include/rssitem.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ test/test-helpers/misc.h test/test-helpers/tempfile.h \
+ test/test-helpers/maintempdir.h
 test/opmlurlreader.o: test/opmlurlreader.cpp include/opmlurlreader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/urlreader.h 3rd-party/catch.hpp \

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-03-20 17:58+0300\n"
+"POT-Creation-Date: 2020-04-14 01:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -267,125 +267,130 @@ msgstr ""
 msgid "unknown command `%s'"
 msgstr ""
 
-#: src/controller.cpp:152 src/pbcontroller.cpp:248
+#: src/controller.cpp:148 src/pbcontroller.cpp:248
 #, c-format
 msgid "Starting %s %s..."
 msgstr ""
 
-#: src/controller.cpp:162 src/controller.cpp:220 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr ""
 
-#: src/controller.cpp:174 src/pbcontroller.cpp:263
+#: src/controller.cpp:170 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr ""
 
-#: src/controller.cpp:209 src/controller.cpp:254 src/controller.cpp:320
-#: src/controller.cpp:373 src/controller.cpp:377 src/controller.cpp:413
-#: src/controller.cpp:427 src/controller.cpp:445 src/controller.cpp:456
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
+#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
+#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
+#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr ""
 
-#: src/controller.cpp:230 src/controller.cpp:368
+#: src/controller.cpp:226 src/controller.cpp:364
 msgid "Opening cache..."
 msgstr ""
 
-#: src/controller.cpp:237 src/controller.cpp:245
+#: src/controller.cpp:233 src/controller.cpp:241
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr ""
 
-#: src/controller.cpp:276
+#: src/controller.cpp:272
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:284
+#: src/controller.cpp:280
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:309
+#: src/controller.cpp:298
+#, c-format
+msgid "ERROR: Unknown urls-source `%s'"
+msgstr ""
+
+#: src/controller.cpp:305
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr ""
 
-#: src/controller.cpp:328
+#: src/controller.cpp:324
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr ""
 
-#: src/controller.cpp:334
+#: src/controller.cpp:330
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr ""
 
-#: src/controller.cpp:339
+#: src/controller.cpp:335
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:344
+#: src/controller.cpp:340
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:349
+#: src/controller.cpp:345
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:354
+#: src/controller.cpp:350
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:365
+#: src/controller.cpp:361
 msgid "Loading articles from cache..."
 msgstr ""
 
-#: src/controller.cpp:374
+#: src/controller.cpp:370
 msgid "Cleaning up cache thoroughly..."
 msgstr ""
 
-#: src/controller.cpp:394
+#: src/controller.cpp:390
 msgid "Error while loading feeds from database: "
 msgstr ""
 
-#: src/controller.cpp:400
+#: src/controller.cpp:396
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr ""
 
-#: src/controller.cpp:420
+#: src/controller.cpp:416
 msgid "Prepopulating query feeds..."
 msgstr ""
 
-#: src/controller.cpp:442
+#: src/controller.cpp:438
 msgid "Importing list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:453
+#: src/controller.cpp:449
 msgid "Exporting list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:493
+#: src/controller.cpp:489
 msgid "Cleaning up cache..."
 msgstr ""
 
-#: src/controller.cpp:505
+#: src/controller.cpp:501
 msgid "failed: "
 msgstr ""
 
-#: src/controller.cpp:531
+#: src/controller.cpp:527
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr ""
@@ -395,71 +400,71 @@ msgstr ""
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:633
+#: src/controller.cpp:632
 #, c-format
 msgid "Import of %s finished."
 msgstr ""
 
-#: src/controller.cpp:763
+#: src/controller.cpp:762
 #, c-format
 msgid "%u unread articles"
 msgstr ""
 
-#: src/controller.cpp:768
+#: src/controller.cpp:767
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr ""
 
-#: src/controller.cpp:881
+#: src/controller.cpp:880
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:67
+#: src/dialogsformaction.cpp:69
 msgid "Close"
 msgstr ""
 
-#: src/dialogsformaction.cpp:68
+#: src/dialogsformaction.cpp:70
 msgid "Goto Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:69
+#: src/dialogsformaction.cpp:71
 msgid "Close Dialog"
 msgstr ""
 
-#: src/dialogsformaction.cpp:85 src/dialogsformaction.cpp:102
+#: src/dialogsformaction.cpp:87 src/dialogsformaction.cpp:104
 #: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:104
 #: src/itemlistformaction.cpp:163 src/itemlistformaction.cpp:182
 #: src/itemlistformaction.cpp:315 src/itemlistformaction.cpp:346
 #: src/itemlistformaction.cpp:372 src/itemlistformaction.cpp:593
-#: src/itemlistformaction.cpp:832
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:98
+#: src/dialogsformaction.cpp:100
 msgid "Error: you can't remove the feed list!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:126 src/feedlistformaction.cpp:977
-#: src/itemlistformaction.cpp:1261 src/urlviewformaction.cpp:151
+#: src/dialogsformaction.cpp:129 src/feedlistformaction.cpp:994
+#: src/itemlistformaction.cpp:1265 src/urlviewformaction.cpp:154
 msgid "Invalid position!"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:241
+#: src/dirbrowserformaction.cpp:242
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:269 src/filebrowserformaction.cpp:260
-#: src/pbview.cpp:367 src/selectformaction.cpp:196 src/selectformaction.cpp:200
+#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
+#: src/pbview.cpp:372 src/selectformaction.cpp:199 src/selectformaction.cpp:203
 msgid "Cancel"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:270 src/filebrowserformaction.cpp:261
-#: src/itemlistformaction.cpp:1239 src/itemviewformaction.cpp:431
+#: src/dirbrowserformaction.cpp:271 src/filebrowserformaction.cpp:262
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:441
 msgid "Save"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:382
+#: src/dirbrowserformaction.cpp:383
 #, c-format
 msgid "Save Files - %s"
 msgstr ""
@@ -508,22 +513,22 @@ msgstr ""
 msgid "invalid feed index (bug)"
 msgstr ""
 
-#: src/feedhqurlreader.cpp:52 src/oldreaderurlreader.cpp:53
+#: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr ""
 
-#: src/feedhqurlreader.cpp:54 src/inoreaderurlreader.cpp:54
-#: src/oldreaderurlreader.cpp:55
+#: src/feedhqurlreader.cpp:49 src/inoreaderurlreader.cpp:49
+#: src/oldreaderurlreader.cpp:50
 msgid "Starred items"
 msgstr ""
 
-#: src/feedhqurlreader.cpp:55 src/oldreaderurlreader.cpp:56
+#: src/feedhqurlreader.cpp:50 src/oldreaderurlreader.cpp:51
 msgid "Shared items"
 msgstr ""
 
 #: src/feedlistformaction.cpp:121 src/feedlistformaction.cpp:134
-#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:277
-#: src/feedlistformaction.cpp:334
+#: src/feedlistformaction.cpp:267 src/feedlistformaction.cpp:288
+#: src/feedlistformaction.cpp:350
 msgid "No feed selected!"
 msgstr ""
 
@@ -546,131 +551,140 @@ msgid ""
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:255
+#: src/feedlistformaction.cpp:241 src/feedlistformaction.cpp:246
+#: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
+#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
+#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
+#: src/itemviewformaction.cpp:220 src/itemviewformaction.cpp:402
+#, c-format
+msgid "Browser returned error code %i"
+msgstr ""
+
+#: src/feedlistformaction.cpp:262
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:317 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:491
 msgid "Marking feed read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:329 src/itemlistformaction.cpp:539
+#: src/feedlistformaction.cpp:345 src/itemlistformaction.cpp:539
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:354 src/feedlistformaction.cpp:363
-#: src/feedlistformaction.cpp:389
+#: src/feedlistformaction.cpp:370 src/feedlistformaction.cpp:379
+#: src/feedlistformaction.cpp:405
 msgid "No feeds with unread items."
 msgstr ""
 
-#: src/feedlistformaction.cpp:371 src/itemlistformaction.cpp:481
+#: src/feedlistformaction.cpp:387 src/itemlistformaction.cpp:481
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:380 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:396 src/itemlistformaction.cpp:486
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:395
+#: src/feedlistformaction.cpp:411
 msgid "Marking all feeds read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:443 src/itemlistformaction.cpp:634
+#: src/feedlistformaction.cpp:459 src/itemlistformaction.cpp:634
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:456 src/itemlistformaction.cpp:647
+#: src/feedlistformaction.cpp:472 src/itemlistformaction.cpp:647
 msgid "No filters defined."
 msgstr ""
 
-#: src/feedlistformaction.cpp:470 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:244
+#: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:248
 msgid "Search for: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:487 src/itemlistformaction.cpp:660
+#: src/feedlistformaction.cpp:503 src/itemlistformaction.cpp:660
 msgid "Filter: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:504 src/view.cpp:225
+#: src/feedlistformaction.cpp:520 src/view.cpp:229
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr ""
 
-#: src/feedlistformaction.cpp:505 src/filebrowserformaction.cpp:123
-#: src/itemlistformaction.cpp:1464 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/filebrowserformaction.cpp:123
+#: src/itemlistformaction.cpp:1468 src/view.cpp:231
 msgid "yn"
 msgstr ""
 
-#: src/feedlistformaction.cpp:505 src/view.cpp:227
+#: src/feedlistformaction.cpp:521 src/view.cpp:231
 msgid "y"
 msgstr ""
 
-#: src/feedlistformaction.cpp:606 src/helpformaction.cpp:222
-#: src/itemlistformaction.cpp:1237 src/itemviewformaction.cpp:430
-#: src/pbview.cpp:358 src/pbview.cpp:365 src/urlviewformaction.cpp:138
+#: src/feedlistformaction.cpp:623 src/helpformaction.cpp:225
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:440
+#: src/pbview.cpp:363 src/pbview.cpp:370 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr ""
 
-#: src/feedlistformaction.cpp:607 src/itemlistformaction.cpp:1238
+#: src/feedlistformaction.cpp:624 src/itemlistformaction.cpp:1242
 msgid "Open"
 msgstr ""
 
-#: src/feedlistformaction.cpp:608 src/itemlistformaction.cpp:1241
-#: src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
+#: src/itemviewformaction.cpp:442
 msgid "Next Unread"
 msgstr ""
 
-#: src/feedlistformaction.cpp:609 src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:626 src/itemlistformaction.cpp:1244
 msgid "Reload"
 msgstr ""
 
-#: src/feedlistformaction.cpp:610
+#: src/feedlistformaction.cpp:627
 msgid "Reload All"
 msgstr ""
 
-#: src/feedlistformaction.cpp:611
+#: src/feedlistformaction.cpp:628
 msgid "Mark Read"
 msgstr ""
 
-#: src/feedlistformaction.cpp:612 src/itemlistformaction.cpp:1242
+#: src/feedlistformaction.cpp:629 src/itemlistformaction.cpp:1246
 msgid "Mark All Read"
 msgstr ""
 
-#: src/feedlistformaction.cpp:613 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1243
+#: src/feedlistformaction.cpp:630 src/helpformaction.cpp:226
+#: src/itemlistformaction.cpp:1247
 msgid "Search"
 msgstr ""
 
-#: src/feedlistformaction.cpp:614 src/helpformaction.cpp:254
-#: src/itemlistformaction.cpp:1244 src/itemviewformaction.cpp:435
-#: src/pbview.cpp:296 src/pbview.cpp:373
+#: src/feedlistformaction.cpp:631 src/helpformaction.cpp:257
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:445
+#: src/pbview.cpp:296 src/pbview.cpp:378
 msgid "Help"
 msgstr ""
 
-#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:818
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:819
 msgid "Error: couldn't parse filter command!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:854
+#: src/feedlistformaction.cpp:956 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:867
+#: src/feedlistformaction.cpp:966 src/itemlistformaction.cpp:868
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:874
+#: src/feedlistformaction.cpp:978 src/itemlistformaction.cpp:875
 msgid "No results."
 msgstr ""
 
-#: src/feedlistformaction.cpp:972 src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:989 src/itemlistformaction.cpp:1260
 msgid "Position not visible!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:1046
+#: src/feedlistformaction.cpp:1063
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr ""
@@ -684,89 +698,89 @@ msgstr ""
 msgid "n"
 msgstr ""
 
-#: src/filebrowserformaction.cpp:232
+#: src/filebrowserformaction.cpp:233
 msgid "File: "
 msgstr ""
 
-#: src/filebrowserformaction.cpp:393
+#: src/filebrowserformaction.cpp:394
 #, c-format
 msgid "Save File - %s"
 msgstr ""
 
-#: src/filtercontainer.cpp:29 src/regexmanager.cpp:380 src/rssignores.cpp:41
+#: src/filtercontainer.cpp:35 src/regexmanager.cpp:380 src/rssignores.cpp:41
 #, c-format
 msgid "couldn't parse filter expression `%s': %s"
 msgstr ""
 
-#: src/formaction.cpp:255 src/formaction.cpp:285
+#: src/formaction.cpp:260 src/formaction.cpp:290
 msgid "usage: set <variable>[=<value>]"
 msgstr ""
 
-#: src/formaction.cpp:293
+#: src/formaction.cpp:298
 msgid "usage: source <file> [...]"
 msgstr ""
 
-#: src/formaction.cpp:308
+#: src/formaction.cpp:313
 msgid "usage: dumpconfig <file>"
 msgstr ""
 
-#: src/formaction.cpp:313
+#: src/formaction.cpp:318
 #, c-format
 msgid "Saved configuration to %s"
 msgstr ""
 
-#: src/formaction.cpp:320
+#: src/formaction.cpp:325
 #, c-format
 msgid "Not a command: %s"
 msgstr ""
 
-#: src/formaction.cpp:370
+#: src/formaction.cpp:375
 msgid "Saving bookmark..."
 msgstr ""
 
-#: src/formaction.cpp:376 src/formaction.cpp:450
+#: src/formaction.cpp:381 src/formaction.cpp:455
 msgid "Saved bookmark."
 msgstr ""
 
-#: src/formaction.cpp:379 src/formaction.cpp:453
+#: src/formaction.cpp:384 src/formaction.cpp:458
 msgid "Error while saving bookmark: "
 msgstr ""
 
-#: src/formaction.cpp:418
+#: src/formaction.cpp:423
 msgid "URL: "
 msgstr ""
 
-#: src/formaction.cpp:422 src/formaction.cpp:424 src/itemrenderer.cpp:62
+#: src/formaction.cpp:427 src/formaction.cpp:429 src/itemrenderer.cpp:62
 msgid "Title: "
 msgstr ""
 
-#: src/formaction.cpp:426
+#: src/formaction.cpp:431
 msgid "Description: "
 msgstr ""
 
-#: src/formaction.cpp:427
+#: src/formaction.cpp:432
 msgid "Feed title: "
 msgstr ""
 
-#: src/formaction.cpp:444
+#: src/formaction.cpp:449
 msgid "Saving bookmark on autopilot..."
 msgstr ""
 
-#: src/formaction.cpp:556
+#: src/formaction.cpp:561
 msgid ""
 "bookmarking support is not configured. Please set the configuration variable "
 "`bookmark-cmd' accordingly."
 msgstr ""
 
-#: src/helpformaction.cpp:193
+#: src/helpformaction.cpp:196
 msgid "Generic bindings:"
 msgstr ""
 
-#: src/helpformaction.cpp:201
+#: src/helpformaction.cpp:204
 msgid "Unbound functions:"
 msgstr ""
 
-#: src/helpformaction.cpp:224
+#: src/helpformaction.cpp:227
 msgid "Clear"
 msgstr ""
 
@@ -802,25 +816,19 @@ msgstr ""
 msgid "unknown (bug)"
 msgstr ""
 
-#: src/inoreaderurlreader.cpp:56
+#: src/inoreaderurlreader.cpp:51
 msgid "Broadcast items"
 msgstr ""
 
-#: src/inoreaderurlreader.cpp:57
+#: src/inoreaderurlreader.cpp:52
 msgid "Liked items"
 msgstr ""
 
-#: src/inoreaderurlreader.cpp:59
+#: src/inoreaderurlreader.cpp:54
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
-#: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#, c-format
-msgid "Browser returned error code %i"
-msgstr ""
-
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:355
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:359
 msgid "Toggling read flag for article..."
 msgstr ""
 
@@ -829,16 +837,16 @@ msgstr ""
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:286
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:290
 msgid "URL list empty."
 msgstr ""
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:274
+#: src/itemviewformaction.cpp:278
 msgid "Flags: "
 msgstr ""
 
-#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1289
+#: src/itemlistformaction.cpp:393 src/itemlistformaction.cpp:1293
 msgid "Error: no item selected!"
 msgstr ""
 
@@ -847,19 +855,19 @@ msgid "Error: you can't reload search results."
 msgstr ""
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:308
-#: src/itemviewformaction.cpp:319 src/itemviewformaction.cpp:349
-#: src/view.cpp:797 src/view.cpp:873
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:312
+#: src/itemviewformaction.cpp:323 src/itemviewformaction.cpp:353
+#: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:329
-#: src/view.cpp:946
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:333
+#: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:339
-#: src/view.cpp:911
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:343
+#: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
 
@@ -871,7 +879,7 @@ msgstr ""
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:260
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:264
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -890,62 +898,62 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:840 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:517
 msgid "Flags updated."
 msgstr ""
 
-#: src/itemlistformaction.cpp:941 src/view.cpp:437 src/view.cpp:463
+#: src/itemlistformaction.cpp:942 src/view.cpp:441 src/view.cpp:467
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:201
-#: src/itemviewformaction.cpp:477
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:201
+#: src/itemviewformaction.cpp:487
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlistformaction.cpp:1335 src/itemviewformaction.cpp:483
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:493
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:487
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:497
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1423
+#: src/itemlistformaction.cpp:1427
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1426
+#: src/itemlistformaction.cpp:1430
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1433
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Article List - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1466
+#: src/itemlistformaction.cpp:1470
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1518
+#: src/itemlistformaction.cpp:1522
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1540
+#: src/itemlistformaction.cpp:1544
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1547
+#: src/itemlistformaction.cpp:1551
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -976,15 +984,15 @@ msgstr ""
 msgid "type: "
 msgstr ""
 
-#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:585
+#: src/itemviewformaction.cpp:57 src/itemviewformaction.cpp:595
 msgid "Top"
 msgstr ""
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:587
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:597
 msgid "Bottom"
 msgstr ""
 
-#: src/itemviewformaction.cpp:166 src/view.cpp:580
+#: src/itemviewformaction.cpp:166 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
@@ -1009,35 +1017,35 @@ msgstr ""
 msgid "Error: couldn't write article to file %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:395
-#: src/itemviewformaction.cpp:532 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:218 src/itemviewformaction.cpp:399
+#: src/itemviewformaction.cpp:542 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr ""
 
-#: src/itemviewformaction.cpp:361
+#: src/itemviewformaction.cpp:365
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:410 src/keymap.cpp:183
+#: src/itemviewformaction.cpp:419 src/keymap.cpp:183
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:433 src/urlviewformaction.cpp:139
+#: src/itemviewformaction.cpp:443 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr ""
 
-#: src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:444
 msgid "Enqueue"
 msgstr ""
 
-#: src/itemviewformaction.cpp:598
+#: src/itemviewformaction.cpp:608
 #, c-format
 msgid "Article - %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:648
+#: src/itemviewformaction.cpp:658
 msgid "Error: invalid regular expression!"
 msgstr ""
 
@@ -1349,22 +1357,22 @@ msgstr ""
 msgid "Move to the end of page/list"
 msgstr ""
 
-#: src/keymap.cpp:708
+#: src/keymap.cpp:712
 #, c-format
 msgid "`%s' is not a valid context"
 msgstr ""
 
-#: src/keymap.cpp:712 src/keymap.cpp:758
+#: src/keymap.cpp:716 src/keymap.cpp:759
 #, c-format
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/matcherexception.cpp:14
+#: src/matcherexception.cpp:15
 #, c-format
 msgid "attribute `%s' is not available."
 msgstr ""
 
-#: src/matcherexception.cpp:18
+#: src/matcherexception.cpp:19
 #, c-format
 msgid "regular expression '%s' is invalid: %s"
 msgstr ""
@@ -1451,27 +1459,27 @@ msgstr ""
 msgid "GB/s"
 msgstr ""
 
-#: src/pbview.cpp:366
+#: src/pbview.cpp:371
 msgid "Download"
 msgstr ""
 
-#: src/pbview.cpp:368
+#: src/pbview.cpp:373
 msgid "Delete"
 msgstr ""
 
-#: src/pbview.cpp:369
+#: src/pbview.cpp:374
 msgid "Purge Finished"
 msgstr ""
 
-#: src/pbview.cpp:370
+#: src/pbview.cpp:375
 msgid "Toggle Automatic Download"
 msgstr ""
 
-#: src/pbview.cpp:371
+#: src/pbview.cpp:376
 msgid "Play"
 msgstr ""
 
-#: src/pbview.cpp:372
+#: src/pbview.cpp:377
 msgid "Mark as Finished"
 msgstr ""
 
@@ -1525,19 +1533,19 @@ msgstr ""
 msgid "Error: unsupported URL: %s"
 msgstr ""
 
-#: src/selectformaction.cpp:197 src/selectformaction.cpp:217
+#: src/selectformaction.cpp:200 src/selectformaction.cpp:220
 msgid "Select Tag"
 msgstr ""
 
-#: src/selectformaction.cpp:201 src/selectformaction.cpp:219
+#: src/selectformaction.cpp:204 src/selectformaction.cpp:222
 msgid "Select Filter"
 msgstr ""
 
-#: src/tagsouppullparser.cpp:47
+#: src/tagsouppullparser.cpp:46
 msgid "attribute not found"
 msgstr ""
 
-#: src/tagsouppullparser.cpp:145
+#: src/tagsouppullparser.cpp:130
 msgid "EOF found while reading XML tag"
 msgstr ""
 
@@ -1545,23 +1553,23 @@ msgstr ""
 msgid "No link selected!"
 msgstr ""
 
-#: src/urlviewformaction.cpp:140
+#: src/urlviewformaction.cpp:143
 msgid "Save Bookmark"
 msgstr ""
 
-#: src/urlviewformaction.cpp:162
+#: src/urlviewformaction.cpp:165
 msgid "URLs"
 msgstr ""
 
-#: src/view.cpp:493 src/view.cpp:519
+#: src/view.cpp:497 src/view.cpp:523
 msgid "Error: feed contains no items!"
 msgstr ""
 
-#: src/view.cpp:658
+#: src/view.cpp:662
 msgid "No tags defined."
 msgstr ""
 
-#: src/view.cpp:1006
+#: src/view.cpp:1010
 msgid "Updating query feed..."
 msgstr ""
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -299,9 +299,9 @@ int Controller::run(const CliArgsParser& args)
 		urlcfg = new InoreaderUrlReader(
 			&cfg, configpaths.url_file(), api);
 	} else {
-		LOG(Level::ERROR,
-			"unknown urls-source `%s'",
-			urlcfg->get_source());
+		std::cerr << strprintf::fmt("ERROR: Unknown urls-source `%s'",
+				type) << std::endl;
+		return EXIT_FAILURE;
 	}
 
 	if (!args.do_export() && !args.silent()) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -295,7 +295,7 @@ int Controller::run(const CliArgsParser& args)
 		urlcfg = new InoreaderUrlReader(
 			&cfg, configpaths.url_file(), api);
 	} else {
-		std::cerr << strprintf::fmt("ERROR: Unknown urls-source `%s'",
+		std::cerr << strprintf::fmt(_("ERROR: Unknown urls-source `%s'"),
 				type) << std::endl;
 		return EXIT_FAILURE;
 	}

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -136,12 +136,8 @@ int Controller::run(const CliArgsParser& args)
 	}
 
 	if (args.do_import()) {
-		LOG(Level::INFO,
-			"Importing OPML file from %s",
-			args.importfile());
-		urlcfg = new FileUrlReader(configpaths.url_file());
-		urlcfg->reload();
-		import_opml(args.importfile());
+		LOG(Level::INFO, "Importing OPML file from %s", args.importfile());
+		import_opml(args.importfile(), configpaths.url_file());
 		return EXIT_SUCCESS;
 	}
 
@@ -620,17 +616,20 @@ void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
 	}
 }
 
-void Controller::import_opml(const std::string& filename)
+void Controller::import_opml(const std::string& opmlFile,
+	const std::string& urlFile)
 {
-	if (!opml::import(filename, urlcfg)) {
+	auto urlReader = FileUrlReader(urlFile);
+	urlReader.reload(); // Load existing URLs
+
+	if (!opml::import(opmlFile, urlReader)) {
 		std::cout << strprintf::fmt(
-				_("An error occurred while parsing %s."),
-				filename)
+				_("An error occurred while parsing %s."), opmlFile)
 			<< std::endl;
 		return;
 	} else {
 		std::cout << strprintf::fmt(
-				_("Import of %s finished."), filename)
+				_("Import of %s finished."), opmlFile)
 			<< std::endl;
 	}
 }

--- a/src/feedhqurlreader.cpp
+++ b/src/feedhqurlreader.cpp
@@ -19,11 +19,6 @@ FeedHqUrlReader::FeedHqUrlReader(ConfigContainer* c,
 
 FeedHqUrlReader::~FeedHqUrlReader() {}
 
-void FeedHqUrlReader::write_config()
-{
-	// NOTHING
-}
-
 #define BROADCAST_FRIENDS_URL                                    \
 	"http://feedhq.org/reader/atom/user/-/state/com.google/" \
 	"broadcast-friends"

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -52,12 +52,6 @@ void FileUrlReader::reload()
 	};
 }
 
-void FileUrlReader::load_config(const std::string& file)
-{
-	filename = file;
-	reload();
-}
-
 void FileUrlReader::write_config()
 {
 	std::fstream f;

--- a/src/inoreaderurlreader.cpp
+++ b/src/inoreaderurlreader.cpp
@@ -19,11 +19,6 @@ InoreaderUrlReader::InoreaderUrlReader(ConfigContainer* c,
 
 InoreaderUrlReader::~InoreaderUrlReader() {}
 
-void InoreaderUrlReader::write_config()
-{
-	// NOTHING
-}
-
 #define STARRED_ITEMS_URL \
 	"http://inoreader.com/reader/atom/user/-/state/com.google/starred"
 #define BROADCAST_ITEMS_URL \

--- a/src/newsblururlreader.cpp
+++ b/src/newsblururlreader.cpp
@@ -16,11 +16,6 @@ NewsBlurUrlReader::NewsBlurUrlReader(const std::string& url_file,
 
 NewsBlurUrlReader::~NewsBlurUrlReader() {}
 
-void NewsBlurUrlReader::write_config()
-{
-	// NOTHING
-}
-
 void NewsBlurUrlReader::reload()
 {
 	urls.clear();

--- a/src/newsblururlreader.cpp
+++ b/src/newsblururlreader.cpp
@@ -49,6 +49,5 @@ std::string NewsBlurUrlReader::get_source()
 {
 	return "NewsBlur";
 }
-// TODO
 
 } // namespace newsboat

--- a/src/ocnewsurlreader.cpp
+++ b/src/ocnewsurlreader.cpp
@@ -15,11 +15,6 @@ OcNewsUrlReader::OcNewsUrlReader(const std::string& url_file, RemoteApi* a)
 
 OcNewsUrlReader::~OcNewsUrlReader() {}
 
-void OcNewsUrlReader::write_config()
-{
-	// NOTHING
-}
-
 void OcNewsUrlReader::reload()
 {
 	urls.clear();

--- a/src/oldreaderurlreader.cpp
+++ b/src/oldreaderurlreader.cpp
@@ -19,11 +19,6 @@ OldReaderUrlReader::OldReaderUrlReader(ConfigContainer* c,
 
 OldReaderUrlReader::~OldReaderUrlReader() {}
 
-void OldReaderUrlReader::write_config()
-{
-	// NOTHING
-}
-
 #define BROADCAST_FRIENDS_URL                                           \
 	"https://theoldreader.com/reader/atom/user/-/state/com.google/" \
 	"broadcast-friends"

--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -54,7 +54,7 @@ xmlDocPtr opml::generate(const FeedContainer& feedcontainer)
 }
 
 void rec_find_rss_outlines(
-	UrlReader* urlcfg,
+	FileUrlReader& urlcfg,
 	xmlNode* node,
 	std::string tag)
 {
@@ -121,11 +121,11 @@ void rec_find_rss_outlines(
 
 				LOG(Level::DEBUG,
 					"opml::import: size = %" PRIu64,
-					static_cast<uint64_t>(urlcfg->get_urls().size()));
+					static_cast<uint64_t>(urlcfg.get_urls().size()));
 				// TODO: replace with algorithm::any or something
-				if (urlcfg->get_urls().size() > 0) {
+				if (urlcfg.get_urls().size() > 0) {
 					for (const auto& u :
-						urlcfg->get_urls()) {
+						urlcfg.get_urls()) {
 						if (u == url) {
 							found = true;
 						}
@@ -136,7 +136,7 @@ void rec_find_rss_outlines(
 					LOG(Level::DEBUG,
 						"opml::import: added url = %s",
 						url);
-					urlcfg->get_urls().push_back(
+					urlcfg.get_urls().push_back(
 						std::string(url));
 					if (tag.length() > 0) {
 						LOG(Level::DEBUG,
@@ -145,7 +145,7 @@ void rec_find_rss_outlines(
 							"tag %s to url %s",
 							tag,
 							url);
-						urlcfg->get_tags(url).push_back(
+						urlcfg.get_tags(url).push_back(
 							tag);
 					}
 				} else {
@@ -180,7 +180,7 @@ void rec_find_rss_outlines(
 
 bool opml::import(
 	const std::string& filename,
-	UrlReader* urlcfg)
+	FileUrlReader& urlcfg)
 {
 	xmlDoc* doc = xmlReadFile(filename.c_str(), nullptr, 0);
 	if (doc == nullptr) {
@@ -194,7 +194,7 @@ bool opml::import(
 		if (strcmp((const char*)node->name, "body") == 0) {
 			LOG(Level::DEBUG, "opml::import: found body");
 			rec_find_rss_outlines(urlcfg, node->children, "");
-			urlcfg->write_config();
+			urlcfg.write_config();
 		}
 	}
 

--- a/src/opmlurlreader.cpp
+++ b/src/opmlurlreader.cpp
@@ -11,11 +11,6 @@ OpmlUrlReader::OpmlUrlReader(ConfigContainer* c)
 {
 }
 
-void OpmlUrlReader::write_config()
-{
-	// do nothing.
-}
-
 void OpmlUrlReader::reload()
 {
 	urls.clear();

--- a/src/ttrssurlreader.cpp
+++ b/src/ttrssurlreader.cpp
@@ -24,7 +24,6 @@ void TtRssUrlReader::reload()
 	FileUrlReader ur(file);
 	ur.reload();
 
-	// std::vector<std::string>& file_urls(ur.get_urls());
 	auto& file_urls(ur.get_urls());
 	for (const auto& url : file_urls) {
 		if (utils::is_query_url(url)) {
@@ -54,6 +53,5 @@ std::string TtRssUrlReader::get_source()
 {
 	return "Tiny Tiny RSS";
 }
-// TODO
 
 } // namespace newsboat

--- a/src/ttrssurlreader.cpp
+++ b/src/ttrssurlreader.cpp
@@ -15,11 +15,6 @@ TtRssUrlReader::TtRssUrlReader(const std::string& url_file, RemoteApi* a)
 
 TtRssUrlReader::~TtRssUrlReader() {}
 
-void TtRssUrlReader::write_config()
-{
-	// NOTHING
-}
-
 void TtRssUrlReader::reload()
 {
 	urls.clear();

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -15,16 +15,16 @@ TEST_CASE("URL reader remembers the file name from which it read the URLs",
 {
 	const std::string url("data/test-urls.txt");
 
-	FileUrlReader u;
-	REQUIRE(u.get_source() != url);
-	u.load_config(url);
+	FileUrlReader u(url);
+	REQUIRE(u.get_source() == url);
+	u.reload();
 	REQUIRE(u.get_source() == url);
 }
 
 TEST_CASE("URL reader extracts all URLs from the file", "[FileUrlReader]")
 {
-	FileUrlReader u;
-	u.load_config("data/test-urls.txt");
+	FileUrlReader u("data/test-urls.txt");
+	u.reload();
 
 	REQUIRE(u.get_urls().size() == 3);
 	REQUIRE(u.get_urls()[0] == "http://test1.url.cc/feed.xml");
@@ -34,8 +34,8 @@ TEST_CASE("URL reader extracts all URLs from the file", "[FileUrlReader]")
 
 TEST_CASE("URL reader extracts feeds' tags", "[FileUrlReader]")
 {
-	FileUrlReader u;
-	u.load_config("data/test-urls.txt");
+	FileUrlReader u("data/test-urls.txt");
+	u.reload();
 
 	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml").size() == 2);
 	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml")[0] == "tag1");
@@ -47,8 +47,8 @@ TEST_CASE("URL reader extracts feeds' tags", "[FileUrlReader]")
 
 TEST_CASE("URL reader keeps track of unique tags", "[FileUrlReader]")
 {
-	FileUrlReader u;
-	u.load_config("data/test-urls.txt");
+	FileUrlReader u("data/test-urls.txt");
+	u.reload();
 
 	REQUIRE(u.get_alltags().size() == 3);
 }

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -121,7 +121,7 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 	REQUIRE_NOTHROW(
 		opml::import(
 			"file://" + utils::getcwd() + "/data/example.opml",
-			&urlcfg));
+			urlcfg));
 
 	const std::map<URL, Tags> opmlUrls {
 		{"https://example.com/feed.xml", {}},
@@ -161,7 +161,7 @@ TEST_CASE("import() turns URLs that start with a pipe symbol (\"|\") "
 	REQUIRE_NOTHROW(
 		opml::import(
 			"file://" + utils::getcwd() + "/data/piped.opml",
-			&urlcfg));
+			urlcfg));
 
 	using URL = std::string;
 	using Tag = std::string;
@@ -196,7 +196,7 @@ TEST_CASE("import() turns \"filtercmd\" attribute into a `filter:` URL "
 	REQUIRE_NOTHROW(
 		opml::import(
 			"file://" + utils::getcwd() + "/data/filtered.opml",
-			&urlcfg));
+			urlcfg));
 
 	using URL = std::string;
 	using Tag = std::string;
@@ -253,7 +253,7 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 	REQUIRE_NOTHROW(
 		opml::import(
 			"file://" + utils::getcwd() + "/data/test-urls+.opml",
-			&urlcfg));
+			urlcfg));
 
 	const std::map<URL, Tags> opmlUrls {
 		{"https://example.com/another_feed.atom", {}},

--- a/test/opmlurlreader.cpp
+++ b/test/opmlurlreader.cpp
@@ -198,33 +198,3 @@ TEST_CASE("OpmlUrlReader::reload() skips things that can't be parsed",
 	tags.insert(alltags.cbegin(), alltags.cend());
 	REQUIRE(tags == expected_tags);
 }
-
-TEST_CASE("OpmlUrlReader::write_config() doesn't change the input file",
-	"[OpmlUrlReader]")
-{
-	const std::string testDataPath("data/example.opml");
-	TestHelpers::TempFile urlsFile;
-
-	TestHelpers::copy_file(testDataPath, urlsFile.get_path());
-
-	ConfigContainer cfg;
-	cfg.set_configvalue("opml-url", "file://" + urlsFile.get_path());
-
-	OpmlUrlReader u(&cfg);
-	REQUIRE_NOTHROW(u.reload());
-
-	const std::string sentry("wasn't touched by OpmlUrlReader at all");
-	std::ofstream urlsFileStream(urlsFile.get_path());
-	REQUIRE(urlsFileStream.is_open());
-	urlsFileStream << sentry;
-	urlsFileStream.close();
-
-	REQUIRE_NOTHROW(u.write_config());
-
-	std::ifstream urlsFileReadStream;
-	urlsFileReadStream.open(urlsFile.get_path());
-	REQUIRE(urlsFileReadStream.is_open());
-	std::string line;
-	std::getline(urlsFileReadStream, line);
-	REQUIRE(line == sentry);
-}


### PR DESCRIPTION
While looking into error handling for `FileUrlReader` I found some unused and/or empty methods.
Created a separate PR for this so it is easier to review (and cherry-pick if any changes are unwanted).