### PR TITLE
Run "startup" macro when starting Newsboat

### DIFF
--- a/src/view.cpp
+++ b/src/view.cpp
@@ -192,6 +192,8 @@ int View::run()
 
 	curs_set(0);
 
+	macrocmds = keys->get_macro("startup");
+
 	/*
 	 * This is the main "event" loop of newsboat.
 	 */


### PR DESCRIPTION
Possible implementation for #888.

Can be used by adding a macro called "startup" to the config, e.g.:
- `macro startup open` (for the behavior requested in the linked issue)
- `macro startup next ; next ; open ; open` (to open the first article of the 3rd feed)

---
@Minoru: Marking as draft as I first want to see if you agree with this approach.

If you agree, I need to do at least the following things before merging:
- [ ] Document this feature
- [ ] Make sure there are tests which guarantee that the macro system will keep supporting this "special" macro
- [ ] Make sure this special macro does not show up in regular lists of macros (#228)
- [x] Look into supporting operations like `home`, `end`, `up` , … (broken for macros, see #890)