### PR TITLE
Pass up,down,pageup,pagedown,home,end to STFL

### DIFF
--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cinttypes>
+#include <ncurses.h>
 
 #include "config.h"
 #include "configexception.h"
@@ -172,6 +173,36 @@ bool FormAction::process_op(Operation op,
 		break;
 	case OP_PREVDIALOG:
 		v->goto_prev_dialog();
+		break;
+	case OP_SK_UP:
+		if (ungetch(KEY_UP) == OK) {
+			get_form()->run(0);
+		}
+		break;
+	case OP_SK_DOWN:
+		if (ungetch(KEY_DOWN) == OK) {
+			get_form()->run(0);
+		}
+		break;
+	case OP_SK_PGUP:
+		if (ungetch(KEY_PPAGE) == OK) {
+			get_form()->run(0);
+		}
+		break;
+	case OP_SK_PGDOWN:
+		if (ungetch(KEY_NPAGE) == OK) {
+			get_form()->run(0);
+		}
+		break;
+	case OP_SK_HOME:
+		if (ungetch(KEY_HOME) == OK) {
+			get_form()->run(0);
+		}
+		break;
+	case OP_SK_END:
+		if (ungetch(KEY_END) == OK) {
+			get_form()->run(0);
+		}
 		break;
 	default:
 		return this->process_operation(op, automatic, args);


### PR DESCRIPTION
These operations were ignored when encountered in macros.
For regular keypresses, the actions were already handled by STFL
(configured using STFL variables like `bind_page_up`).

We call `get_form()->run(0)` to let STFL directly process the input.
This is needed to ensure that the commands of a macro are executed in
the correct order.

Fixes #890 