### PR TITLE
Fix and improve `KeyMap::get_keymap_descriptions()`

### DIFF
--- a/include/keymap.h
+++ b/include/keymap.h
@@ -177,11 +177,11 @@ public:
 	void handle_action(const std::string& action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) override;
-	std::vector<KeyMapDesc> get_keymap_descriptions(unsigned short flags);
-	unsigned short get_flag_from_context(const std::string& context);
+	std::vector<KeyMapDesc> get_keymap_descriptions(std::string context);
 
 private:
 	bool is_valid_context(const std::string& context);
+	unsigned short get_flag_from_context(const std::string& context);
 	std::map<std::string, Operation> get_internal_operations() const;
 	std::string getopname(Operation op);
 	std::map<std::string, std::map<std::string, Operation>> keymap_;

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -177,8 +177,7 @@ public:
 	void handle_action(const std::string& action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) override;
-	void get_keymap_descriptions(std::vector<KeyMapDesc>& descs,
-		unsigned short flags);
+	std::vector<KeyMapDesc> get_keymap_descriptions(unsigned short flags);
 	unsigned short get_flag_from_context(const std::string& context);
 
 private:

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -74,9 +74,8 @@ void HelpFormAction::prepare()
 			fmt.do_format(cfg->get_configvalue("help-title-format"),
 				width));
 
-		std::vector<KeyMapDesc> descs;
-		v->get_keymap()->get_keymap_descriptions(
-			descs, v->get_keymap()->get_flag_from_context(context));
+		const auto descs = v->get_keymap()->get_keymap_descriptions(
+				v->get_keymap()->get_flag_from_context(context));
 
 		std::string highlighted_searchphrase =
 			strprintf::fmt("<hl>%s</>", searchphrase);

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -74,8 +74,7 @@ void HelpFormAction::prepare()
 			fmt.do_format(cfg->get_configvalue("help-title-format"),
 				width));
 
-		const auto descs = v->get_keymap()->get_keymap_descriptions(
-				v->get_keymap()->get_flag_from_context(context));
+		const auto descs = v->get_keymap()->get_keymap_descriptions(context);
 
 		std::string highlighted_searchphrase =
 			strprintf::fmt("<hl>%s</>", searchphrase);

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -520,12 +520,16 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 
 		for (unsigned int j = 0; opdescs[j].op != OP_NIL; ++j) {
 			const OpDesc& opdesc = opdescs[j];
+			if (!(opdesc.flags & flags)) {
+				// Ignore operation if it is not valid in this context
+				continue;
+			}
+
 			bool already_added = false;
 			for (const auto& keymap : keymap_[ctx]) {
 				Operation op = keymap.second;
 				if (op != OP_NIL) {
-					if (opdesc.op == op &&
-						opdesc.flags & flags) {
+					if (opdesc.op == op) {
 						KeyMapDesc desc;
 						desc.key = keymap.first;
 						desc.ctx = ctx;
@@ -544,24 +548,22 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 				}
 			}
 			if (!already_added) {
-				if (opdesc.flags & flags) {
-					LOG(Level::DEBUG,
-						"KeyMap::get_keymap_"
-						"descriptions: "
-						"found unbound function: %s "
-						"ctx = "
-						"%s",
-						opdesc.opstr,
-						ctx);
-					KeyMapDesc desc;
-					desc.ctx = ctx;
-					desc.cmd = opdesc.opstr;
-					if (opdesc.help_text) {
-						desc.desc = opdesc.help_text;
-					}
-					desc.flags = opdesc.flags;
-					descs.push_back(desc);
+				LOG(Level::DEBUG,
+					"KeyMap::get_keymap_"
+					"descriptions: "
+					"found unbound function: %s "
+					"ctx = "
+					"%s",
+					opdesc.opstr,
+					ctx);
+				KeyMapDesc desc;
+				desc.ctx = ctx;
+				desc.cmd = opdesc.opstr;
+				if (opdesc.help_text) {
+					desc.desc = opdesc.help_text;
 				}
+				desc.flags = opdesc.flags;
+				descs.push_back(desc);
 			}
 		}
 	}

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -532,10 +532,9 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 							desc.cmd =
 								opdescs[j]
 								.opstr;
-							if (opdescs[j].help_text)
-								desc.desc = gettext(
-										opdescs[j]
-										.help_text);
+							if (opdescs[j].help_text) {
+								desc.desc = opdescs[j].help_text;
+							}
 							already_added = true;
 						}
 						desc.flags = opdescs[j].flags;
@@ -556,9 +555,9 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 					KeyMapDesc desc;
 					desc.ctx = ctx;
 					desc.cmd = opdescs[j].opstr;
-					if (opdescs[j].help_text)
-						desc.desc = gettext(
-								opdescs[j].help_text);
+					if (opdescs[j].help_text) {
+						desc.desc = opdescs[j].help_text;
+					}
 					desc.flags = opdescs[j].flags;
 					descs.push_back(desc);
 				}

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -508,48 +508,39 @@ KeyMap::KeyMap(unsigned flags)
 std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 {
 	unsigned short flags = get_flag_from_context(context);
-	std::vector<KeyMapDesc> descs;
-	for (unsigned int i = 1; contexts[i] != nullptr; i++) {
-		std::string ctx(contexts[i]);
 
-		if (flags & KM_PODBOAT && ctx != "podboat") {
-			continue;
-		} else if (flags & KM_NEWSBOAT && ctx == "podboat") {
+	std::vector<KeyMapDesc> descs;
+	for (unsigned int j = 0; opdescs[j].op != OP_NIL; ++j) {
+		const OpDesc& opdesc = opdescs[j];
+		if (!(opdesc.flags & flags)) {
+			// Ignore operation if it is not valid in this context
 			continue;
 		}
 
-		for (unsigned int j = 0; opdescs[j].op != OP_NIL; ++j) {
-			const OpDesc& opdesc = opdescs[j];
-			if (!(opdesc.flags & flags)) {
-				// Ignore operation if it is not valid in this context
-				continue;
-			}
-
-			bool already_added = false;
-			for (const auto& keymap : keymap_[ctx]) {
-				Operation op = keymap.second;
-				if (op != OP_NIL) {
-					if (opdesc.op == op) {
-						if (!already_added) {
-							descs.push_back({keymap.first, opdesc.opstr, opdesc.help_text, ctx, opdesc.flags});
-							already_added = true;
-						} else {
-							descs.push_back({keymap.first, "", "", ctx, opdesc.flags});
-						}
+		bool already_added = false;
+		for (const auto& keymap : keymap_[context]) {
+			Operation op = keymap.second;
+			if (op != OP_NIL) {
+				if (opdesc.op == op) {
+					if (!already_added) {
+						descs.push_back({keymap.first, opdesc.opstr, opdesc.help_text, context, opdesc.flags});
+						already_added = true;
+					} else {
+						descs.push_back({keymap.first, "", "", context, opdesc.flags});
 					}
 				}
 			}
-			if (!already_added) {
-				LOG(Level::DEBUG,
-					"KeyMap::get_keymap_"
-					"descriptions: "
-					"found unbound function: %s "
-					"ctx = "
-					"%s",
-					opdesc.opstr,
-					ctx);
-				descs.push_back({"", opdesc.opstr, opdesc.help_text, ctx, opdesc.flags});
-			}
+		}
+		if (!already_added) {
+			LOG(Level::DEBUG,
+				"KeyMap::get_keymap_"
+				"descriptions: "
+				"found unbound function: %s "
+				"context = "
+				"%s",
+				opdesc.opstr,
+				context);
+			descs.push_back({"", opdesc.opstr, opdesc.help_text, context, opdesc.flags});
 		}
 	}
 	return descs;

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -495,6 +495,11 @@ KeyMap::KeyMap(unsigned flags)
 			continue;
 		}
 
+		// Skip operations without a default key
+		if (!op_desc.default_key || std::string() == op_desc.default_key) {
+			continue;
+		}
+
 		for (unsigned int j = 1; contexts[j] != nullptr; j++) {
 			const std::string context(contexts[j]);
 			const uint32_t context_flag = (1 << (j - 1));

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -530,20 +530,12 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 				Operation op = keymap.second;
 				if (op != OP_NIL) {
 					if (opdesc.op == op) {
-						KeyMapDesc desc;
-						desc.key = keymap.first;
-						desc.ctx = ctx;
 						if (!already_added) {
-							desc.cmd =
-								opdesc
-								.opstr;
-							if (opdesc.help_text) {
-								desc.desc = opdesc.help_text;
-							}
+							descs.push_back({keymap.first, opdesc.opstr, opdesc.help_text, ctx, opdesc.flags});
 							already_added = true;
+						} else {
+							descs.push_back({keymap.first, "", "", ctx, opdesc.flags});
 						}
-						desc.flags = opdesc.flags;
-						descs.push_back(desc);
 					}
 				}
 			}
@@ -556,14 +548,7 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 					"%s",
 					opdesc.opstr,
 					ctx);
-				KeyMapDesc desc;
-				desc.ctx = ctx;
-				desc.cmd = opdesc.opstr;
-				if (opdesc.help_text) {
-					desc.desc = opdesc.help_text;
-				}
-				desc.flags = opdesc.flags;
-				descs.push_back(desc);
+				descs.push_back({"", opdesc.opstr, opdesc.help_text, ctx, opdesc.flags});
 			}
 		}
 	}

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -505,13 +505,13 @@ KeyMap::KeyMap(unsigned flags)
 	}
 }
 
-void KeyMap::get_keymap_descriptions(std::vector<KeyMapDesc>& descs,
-	unsigned short flags)
+std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(unsigned short flags)
 {
 	/*
 	 * Here we return the keymap descriptions for the specified application
 	 * (handed to us via flags) This is used for the help screen.
 	 */
+	std::vector<KeyMapDesc> descs;
 	for (unsigned int i = 1; contexts[i] != nullptr; i++) {
 		std::string ctx(contexts[i]);
 
@@ -568,6 +568,7 @@ void KeyMap::get_keymap_descriptions(std::vector<KeyMapDesc>& descs,
 			}
 		}
 	}
+	return descs;
 }
 
 KeyMap::~KeyMap() {}

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -519,46 +519,47 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 		}
 
 		for (unsigned int j = 0; opdescs[j].op != OP_NIL; ++j) {
+			const OpDesc& opdesc = opdescs[j];
 			bool already_added = false;
 			for (const auto& keymap : keymap_[ctx]) {
 				Operation op = keymap.second;
 				if (op != OP_NIL) {
-					if (opdescs[j].op == op &&
-						opdescs[j].flags & flags) {
+					if (opdesc.op == op &&
+						opdesc.flags & flags) {
 						KeyMapDesc desc;
 						desc.key = keymap.first;
 						desc.ctx = ctx;
 						if (!already_added) {
 							desc.cmd =
-								opdescs[j]
+								opdesc
 								.opstr;
-							if (opdescs[j].help_text) {
-								desc.desc = opdescs[j].help_text;
+							if (opdesc.help_text) {
+								desc.desc = opdesc.help_text;
 							}
 							already_added = true;
 						}
-						desc.flags = opdescs[j].flags;
+						desc.flags = opdesc.flags;
 						descs.push_back(desc);
 					}
 				}
 			}
 			if (!already_added) {
-				if (opdescs[j].flags & flags) {
+				if (opdesc.flags & flags) {
 					LOG(Level::DEBUG,
 						"KeyMap::get_keymap_"
 						"descriptions: "
 						"found unbound function: %s "
 						"ctx = "
 						"%s",
-						opdescs[j].opstr,
+						opdesc.opstr,
 						ctx);
 					KeyMapDesc desc;
 					desc.ctx = ctx;
-					desc.cmd = opdescs[j].opstr;
-					if (opdescs[j].help_text) {
-						desc.desc = opdescs[j].help_text;
+					desc.cmd = opdesc.opstr;
+					if (opdesc.help_text) {
+						desc.desc = opdesc.help_text;
 					}
-					desc.flags = opdescs[j].flags;
+					desc.flags = opdesc.flags;
 					descs.push_back(desc);
 				}
 			}

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -522,12 +522,8 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 			Operation op = keymap.second;
 			if (op != OP_NIL) {
 				if (opdesc.op == op) {
-					if (!already_added) {
-						descs.push_back({keymap.first, opdesc.opstr, opdesc.help_text, context, opdesc.flags});
-						already_added = true;
-					} else {
-						descs.push_back({keymap.first, "", "", context, opdesc.flags});
-					}
+					descs.push_back({keymap.first, opdesc.opstr, opdesc.help_text, context, opdesc.flags});
+					already_added = true;
 				}
 			}
 		}

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -505,12 +505,9 @@ KeyMap::KeyMap(unsigned flags)
 	}
 }
 
-std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(unsigned short flags)
+std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 {
-	/*
-	 * Here we return the keymap descriptions for the specified application
-	 * (handed to us via flags) This is used for the help screen.
-	 */
+	unsigned short flags = get_flag_from_context(context);
 	std::vector<KeyMapDesc> descs;
 	for (unsigned int i = 1; contexts[i] != nullptr; i++) {
 		std::string ctx(contexts[i]);

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -512,33 +512,26 @@ KeyMap::KeyMap(unsigned flags)
 
 std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 {
-	unsigned short flags = get_flag_from_context(context);
-
 	std::vector<KeyMapDesc> descs;
-	for (unsigned int j = 0; opdescs[j].op != OP_NIL; ++j) {
-		const OpDesc& opdesc = opdescs[j];
-		if (!(opdesc.flags & flags)) {
+	for (unsigned int i = 0; opdescs[i].op != OP_NIL; ++i) {
+		const OpDesc& opdesc = opdescs[i];
+		if (!(opdesc.flags & get_flag_from_context(context))) {
 			// Ignore operation if it is not valid in this context
 			continue;
 		}
 
-		bool already_added = false;
+		bool bound_to_key = false;
 		for (const auto& keymap : keymap_[context]) {
-			Operation op = keymap.second;
-			if (op != OP_NIL) {
-				if (opdesc.op == op) {
-					descs.push_back({keymap.first, opdesc.opstr, opdesc.help_text, context, opdesc.flags});
-					already_added = true;
-				}
+			const std::string& key = keymap.first;
+			const Operation op = keymap.second;
+			if (opdesc.op == op) {
+				descs.push_back({key, opdesc.opstr, opdesc.help_text, context, opdesc.flags});
+				bound_to_key = true;
 			}
 		}
-		if (!already_added) {
+		if (!bound_to_key) {
 			LOG(Level::DEBUG,
-				"KeyMap::get_keymap_"
-				"descriptions: "
-				"found unbound function: %s "
-				"context = "
-				"%s",
+				"KeyMap::get_keymap_descriptions: found unbound function: %s context = %s",
 				opdesc.opstr,
 				context);
 			descs.push_back({"", opdesc.opstr, opdesc.help_text, context, opdesc.flags});

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -295,8 +295,7 @@ void PbView::run_help()
 
 	help_form.set("head", _("Help"));
 
-	std::vector<KeyMapDesc> descs;
-	keys->get_keymap_descriptions(descs, KM_PODBOAT);
+	const auto descs = keys->get_keymap_descriptions(KM_PODBOAT);
 
 	std::string code = "{list";
 

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -295,7 +295,7 @@ void PbView::run_help()
 
 	help_form.set("head", _("Help"));
 
-	const auto descs = keys->get_keymap_descriptions(KM_PODBOAT);
+	const auto descs = keys->get_keymap_descriptions("podboat");
 
 	std::string code = "{list";
 

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -224,9 +224,9 @@ TEST_CASE("handle_action()", "[KeyMap]")
 TEST_CASE("test current get_keymap_descriptions() behavior, including its flaws",
 	"[KeyMap]")
 {
-	WHEN("calling get_keymap_descriptions(KM_FEEDLIST)") {
+	WHEN("calling get_keymap_descriptions(\"feedlist\")") {
 		KeyMap k(KM_NEWSBOAT);
-		const auto descriptions = k.get_keymap_descriptions(KM_FEEDLIST);
+		const auto descriptions = k.get_keymap_descriptions("feedlist");
 
 		THEN("the descriptions do not include any entries with context \"podboat\"") {
 			REQUIRE(descriptions.size() > 0);
@@ -250,7 +250,7 @@ TEST_CASE("test current get_keymap_descriptions() behavior, including its flaws"
 
 	WHEN("calling get_keymap_descriptions(KM_PODBOAT)") {
 		KeyMap k(KM_PODBOAT);
-		const auto descriptions = k.get_keymap_descriptions(KM_PODBOAT);
+		const auto descriptions = k.get_keymap_descriptions("podboat");
 
 		THEN("the descriptions only include entries with context \"podboat\"") {
 			REQUIRE(descriptions.size() > 0);
@@ -260,9 +260,9 @@ TEST_CASE("test current get_keymap_descriptions() behavior, including its flaws"
 		}
 	}
 
-	WHEN("calling get_keymap_descriptions(KM_FEEDLIST)") {
+	WHEN("calling get_keymap_descriptions(\"feedlist\")") {
 		KeyMap k(KM_NEWSBOAT);
-		const auto descriptions = k.get_keymap_descriptions(KM_FEEDLIST);
+		const auto descriptions = k.get_keymap_descriptions("feedlist");
 
 		THEN("by default it does always set .cmd (command) and .desc (command description)") {
 			for (const auto& description : descriptions) {
@@ -277,8 +277,8 @@ TEST_CASE("test current get_keymap_descriptions() behavior, including its flaws"
 		k.set_key(OP_QUIT, "a", "feedlist");
 		k.set_key(OP_QUIT, "b", "feedlist");
 
-		WHEN("calling get_keymap_descriptions(KM_FEEDLIST)") {
-			const auto descriptions = k.get_keymap_descriptions(KM_FEEDLIST);
+		WHEN("calling get_keymap_descriptions(\"feedlist\")") {
+			const auto descriptions = k.get_keymap_descriptions("feedlist");
 
 			THEN("some entries have no description and command configured") {
 				REQUIRE(std::any_of(descriptions.begin(), descriptions.end(),
@@ -302,8 +302,8 @@ TEST_CASE("test current get_keymap_descriptions() behavior, including its flaws"
 		const std::string key = "O";
 		k.set_key(OP_OPENALLUNREADINBROWSER_AND_MARK, key, "feedlist");
 
-		WHEN("calling get_keymap_descriptions(KM_FEEDLIST)") {
-			const auto descriptions = k.get_keymap_descriptions(KM_FEEDLIST);
+		WHEN("calling get_keymap_descriptions(\"feedlist\")") {
+			const auto descriptions = k.get_keymap_descriptions("feedlist");
 
 			THEN("there is an entry with the configured key") {
 				REQUIRE(std::any_of(descriptions.begin(), descriptions.end(),


### PR DESCRIPTION
Fixes #843 

I squashed several refactoring commits into one.
If you are interested, the separate small commits can still be found on a temporary branch: https://github.com/newsboat/newsboat/compare/master...dennisschagt:bugfix/issue-843-before-rebase