### PR TITLE
Add exec command for executing binded commands

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -732,6 +732,7 @@ Command:Syntax:Description:Example
 [[cmd-source]]<<cmd-source,+source+>>:source <filename> [...]:Load the specified configuration files. This allows it to load alternative configuration files or reload already loaded configuration files on-the-fly from the filesystem.:source ~/.newsboat/colors
 [[cmd-dumpconfig]]<<cmd-dumpconfig,+dumpconfig+>>:dumpconfig <filename>:Save current internal state of configuration to file, so that it can be instantly reused as configuration file.:dumpconfig ~/.newsboat/config.saved
 [[cmd-dumpform]]<<cmd-dumpform,+dumpform+>>:dumpform:Dump current dialog to text file. This is meant for debugging purposes only.:dumpform
+[[cmd-exec]]<<cmd-exec,+exec+>>:exec <operation>:Run a keybind operation in the current context.:exec open-all-unread-in-browser-and-mark-read
 [[cmd-number]]<<cmd-number,n/a>>:<number>:Jump to the entry with the index <number> (usually seen at the left side of the list). This currently works for the feed list and the article list.:30
 |=============================================================================
 

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -344,7 +344,10 @@ void FormAction::handle_cmdline(const std::string& cmdline)
 			if (tokens.size() != 1) {
 				v->show_error(_("usage: exec <cmd>"));
 			} else {
-				process_op(v->get_keymap()->get_opcode(tokens[0]));
+				const auto op = v->get_keymap()->get_opcode(tokens[0]);
+				if (op != OP_NIL) {
+					process_op(op);
+				}
 			}
 		} else {
 			v->show_error(strprintf::fmt(

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -234,8 +234,8 @@ std::vector<std::string> FormAction::get_suggestions(
 				if (tokens.size() <= 2) {
 					const std::string start = (tokens.size() == 2) ? tokens[1] : "";
 					const std::vector<KeyMapDesc> descs = v->get_keymap()->get_keymap_descriptions(
-						this->id()
-					);
+							this->id()
+						);
 					for (const KeyMapDesc& desc: descs) {
 						const std::string cmd = desc.cmd;
 						if (cmd.rfind(start, 0) == 0) {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -232,7 +232,21 @@ std::vector<std::string> FormAction::get_suggestions(
 				}
 			} else if (tokens[0] == "exec") {
 				if (tokens.size() <= 2) {
-					// TODO: handle suggestions
+					std::string start;
+					if (tokens.size() == 2) {
+						start = tokens[1];
+					} else {
+						start = "";
+					}
+					const std::vector<KeyMapDesc> descs = v->get_keymap()->get_keymap_descriptions(
+						this->id()
+					);
+					for (const KeyMapDesc& desc: descs) {
+						const std::string cmd = desc.cmd;
+						if (cmd.rfind(start, 0) == 0) {
+							result.push_back(std::string("exec ") + cmd);
+						}
+					}
 				}
 			}
 		}

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -232,12 +232,7 @@ std::vector<std::string> FormAction::get_suggestions(
 				}
 			} else if (tokens[0] == "exec") {
 				if (tokens.size() <= 2) {
-					std::string start;
-					if (tokens.size() == 2) {
-						start = tokens[1];
-					} else {
-						start = "";
-					}
+					const std::string start = (tokens.size() == 2) ? tokens[1] : "";
 					const std::vector<KeyMapDesc> descs = v->get_keymap()->get_keymap_descriptions(
 						this->id()
 					);

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -340,10 +340,10 @@ void FormAction::handle_cmdline(const std::string& cmdline)
 				v->show_error(_("usage: exec <operation>"));
 			} else {
 				const auto op = v->get_keymap()->get_opcode(tokens[0]);
-				if (op == OP_NIL) {
-					v->show_error(_("Operation not found"));
-				} else {
+				if (op != OP_NIL) {
 					process_op(op);
+				} else {
+					v->show_error(_("Operation not found"));
 				}
 			}
 		} else {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -47,6 +47,7 @@ FormAction::FormAction(View* vv, std::string formstr, ConfigContainer* cfg)
 	valid_cmds.push_back("source");
 	valid_cmds.push_back("dumpconfig");
 	valid_cmds.push_back("dumpform");
+	valid_cmds.push_back("exec");
 }
 
 void FormAction::set_keymap_hints()
@@ -229,6 +230,10 @@ std::vector<std::string> FormAction::get_suggestions(
 							line);
 					}
 				}
+			} else if (tokens[0] == "exec") {
+				if (tokens.size() <= 2) {
+					// TODO: handle suggestions
+				}
 			}
 		}
 	}
@@ -321,6 +326,12 @@ void FormAction::handle_cmdline(const std::string& cmdline)
 			}
 		} else if (cmd == "dumpform") {
 			v->dump_current_form();
+		} else if (cmd == "exec") {
+			if (tokens.size() != 1) {
+				v->show_error(_("usage: exec <cmd>"));
+			} else {
+				process_op(v->get_keymap()->get_opcode(tokens[0]));
+			}
 		} else {
 			v->show_error(strprintf::fmt(
 					_("Not a command: %s"), cmdline));

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -342,10 +342,12 @@ void FormAction::handle_cmdline(const std::string& cmdline)
 			v->dump_current_form();
 		} else if (cmd == "exec") {
 			if (tokens.size() != 1) {
-				v->show_error(_("usage: exec <cmd>"));
+				v->show_error(_("usage: exec <operation>"));
 			} else {
 				const auto op = v->get_keymap()->get_opcode(tokens[0]);
-				if (op != OP_NIL) {
+				if (op == OP_NIL) {
+					v->show_error(_("Operation not found"));
+				} else {
 					process_op(op);
 				}
 			}


### PR DESCRIPTION
My personal use case is I want to do `:exec open-all-unread-in-browser-and-mark-read`, I don't use this command enough to bind but still need to use it once in a while

See: #892 