### PR TITLE
Add Rust implementations of FilterParser and Matcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-rs 0.1.0",
  "section_testing 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "strprintf 0.1.0",

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -773,7 +773,7 @@ Operator:Meaning
 +!~+:logical negation of the +=~+ operator
 +<+:less than
 +>+:greater than
-+\<=+:less than or equal
++<=+:less than or equal
 +>=+:greater than or equal
 +between+:within a range of integer values, where the two integer values are separated by a colon (see above for an example)
 +#+:contains; this operator matches if a word is contained in a list of space-separated words (useful for matching tags, see below)

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Alexander Batischev <eual.jp@gmail.com>"]
 
 [dependencies]
 strprintf = { path="../strprintf" }
+regex-rs = { path="../regex-rs" }
 
 chrono = "0.4"
 rand = "0.5"

--- a/rust/libnewsboat/src/filterparser.rs
+++ b/rust/libnewsboat/src/filterparser.rs
@@ -1,0 +1,55 @@
+//! Parses filter expressions.
+
+/// Operators that can be used in comparisons.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operator {
+    Equals,
+    NotEquals,
+    RegexMatches,
+    NotRegexMatches,
+    LessThan,
+    GreaterThan,
+    LessThanOrEquals,
+    GreaterThanOrEquals,
+    Between,
+    Contains,
+    NotContains,
+}
+
+/// Values that can be used on the right-hand side of comparisons.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Str(String),
+    Int(i32),
+    Range(i32, i32),
+}
+
+/// Parsed filter expression.
+///
+/// This is a tree, where nodes are logical operators (`and`, `or`), and leaves are simple
+/// comparisons (`title = "hello"`, `age > 14` etc.)
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expression {
+    And(Box<Expression>, Box<Expression>),
+    Or(Box<Expression>, Box<Expression>),
+    Comparison {
+        attribute: String,
+        op: Operator,
+        value: Value,
+    },
+}
+
+/// Errors that may come up during parsing.
+#[derive(PartialEq, Debug)]
+pub enum Error<'a> {
+    /// Parser finished the work, but the input string still contains some characters.
+    TrailingCharacters(&'a str),
+
+    /// Parsing error at given position.
+    AtPos(usize),
+}
+
+/// Parse a string `expr` as a filter expression.
+pub fn parse(expr: &str) -> Result<Expression, Error> {
+    unimplemented!()
+}

--- a/rust/libnewsboat/src/filterparser.rs
+++ b/rust/libnewsboat/src/filterparser.rs
@@ -1,5 +1,15 @@
 //! Parses filter expressions.
 
+use nom::{
+    branch::alt,
+    bytes::complete::{escaped, is_not, tag, take, take_while, take_while1},
+    character::{is_alphanumeric, is_digit},
+    combinator::{complete, map, opt, peek, recognize, value},
+    error::{make_error, ErrorKind, ParseError, VerboseError},
+    sequence::{delimited, separated_pair, terminated, tuple},
+    IResult, Offset,
+};
+
 /// Operators that can be used in comparisons.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Operator {
@@ -49,7 +59,397 @@ pub enum Error<'a> {
     AtPos(usize),
 }
 
+fn operators<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Operator, E> {
+    alt((
+        value(Operator::RegexMatches, tag("=~")),
+        value(Operator::Equals, alt((tag("=="), tag("=")))),
+        value(Operator::NotRegexMatches, tag("!~")),
+        value(Operator::NotEquals, tag("!=")),
+        value(Operator::LessThanOrEquals, tag("<=")),
+        value(Operator::GreaterThanOrEquals, tag(">=")),
+        value(Operator::LessThan, tag("<")),
+        value(Operator::GreaterThan, tag(">")),
+        value(Operator::Between, tag("between")),
+        value(Operator::Contains, tag("#")),
+        value(Operator::NotContains, tag("!#")),
+    ))(input)
+}
+
+fn quoted_string<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Value, E> {
+    let empty_string = value(String::new(), tag("\"\""));
+    let nonempty_string = |input| {
+        let (leftovers, chr) = delimited(
+            tag("\""),
+            escaped(is_not("\\\""), '\\', take(1usize)),
+            tag("\""),
+        )(input)?;
+        Ok((leftovers, String::from(chr)))
+    };
+
+    map(alt((nonempty_string, empty_string)), Value::Str)(input)
+}
+
+fn number<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, i32, E> {
+    recognize(tuple((opt(tag("-")), take_while1(|c| is_digit(c as u8)))))(input).and_then(
+        |(leftovers, num)| {
+            match num.parse() {
+                Ok(number) => Ok((leftovers, number)),
+                // It shouldn't matter what ErrorKind we use here: we don't examine it anyway, and
+                // only use the `input` part to figure out the location of the error.
+                Err(_) => Err(nom::Err::Error(make_error(input, ErrorKind::TakeWhile1))),
+            }
+        },
+    )
+}
+
+fn range<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Value, E> {
+    separated_pair(number, tag(":"), number)(input)
+        .map(|(leftovers, (a, b))| (leftovers, Value::Range(a, b)))
+}
+
+/// Skips zero or more space characters.
+///
+/// This is different from `nom::character::complete::space0` in that this function only skips
+/// spaces (ASCII 0x20), whereas Nom's function also skips tabs.
+fn space0<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &'a str, E> {
+    take_while(|c| c == ' ')(input)
+}
+
+/// Skips one or more space characters.
+///
+/// This is different from `nom::character::complete::space1` in that this function only skips
+/// spaces (ASCII 0x20), whereas Nom's function also skips tabs.
+fn space1<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &'a str, E> {
+    take_while1(|c| c == ' ')(input)
+}
+
+fn comparison<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Expression, E> {
+    let attribute_name =
+        take_while1(|c| is_alphanumeric(c as u8) || c == '_' || c == '-' || c == '.');
+
+    let (input, attr) = attribute_name(input)?;
+    let attribute = attr.to_string();
+    let (input, _) = space0(input)?;
+    let (input, op) = operators(input)?;
+    let (input, _) = space0(input)?;
+    let (leftovers, value) = alt((quoted_string, range, map(number, Value::Int)))(input)?;
+
+    Ok((
+        leftovers,
+        Expression::Comparison {
+            attribute,
+            op,
+            value,
+        },
+    ))
+}
+
+fn parens<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Expression, E> {
+    let (input, _) = tag("(")(input)?;
+    let (input, _) = space0(input)?;
+    let (input, result) = alt((expression, parens, comparison))(input)?;
+    let (input, _) = space0(input)?;
+    let (leftovers, _) = tag(")")(input)?;
+
+    Ok((leftovers, result))
+}
+
+/// Peeks to see if input is either:
+/// - zero or more spaces followed by opening paren
+/// - one or more spaces
+///
+/// This is meant to be applied after matching "and" or "or" in the input. These logical operators
+/// require a space after them iff they're followed by something other than parenthesized
+/// expression. For example, these are all valid expressions:
+/// - "x=1and y=0"
+/// - "x=1and(y=0)"
+///
+/// While this one is invalid:
+/// - "x=1andy=0": no space between operator `and` and attribute name `y`
+fn space_after_logop<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &'a str, E> {
+    let opt_space_and_paren = recognize(tuple((space0, tag("("))));
+    let parser = alt((opt_space_and_paren, space1));
+    peek(parser)(input)
+}
+
+fn expression<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Expression, E> {
+    // `Expression`s enum variants can't be used as return values without filling in their
+    // arguments, so we have to create another enum, which variants we can return and `match` on.
+    // This is better than matching on bare strings returned by `tag`, as it enables us to write an
+    // exhaustive `match` that the compiler can validate is exhaustive: we won't be able to add
+    // a `tag` to the parser and forget to handle it.
+    #[derive(Clone)]
+    enum Op {
+        And,
+        Or,
+    };
+
+    let (input, left) = alt((parens, comparison))(input)?;
+    let (input, _) = space0(input)?;
+    let (input, op) = terminated(
+        alt((value(Op::And, tag("and")), value(Op::Or, tag("or")))),
+        space_after_logop,
+    )(input)?;
+    let (input, _) = space0(input)?;
+    let (leftovers, right) = alt((expression, parens, comparison))(input)?;
+
+    let op = match op {
+        Op::And => Expression::And(Box::new(left), Box::new(right)),
+        Op::Or => Expression::Or(Box::new(left), Box::new(right)),
+    };
+
+    Ok((leftovers, op))
+}
+
+fn parser<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, Expression, E> {
+    let parsers = alt((expression, parens, comparison));
+    // Ignore leading and trailing whitespace
+    let parsers = delimited(space0, parsers, space0);
+    // Try to parse input. If parser says it needs more data, make that an error, since `input` is
+    // all we got.
+    complete(parsers)(input)
+}
+
 /// Parse a string `expr` as a filter expression.
 pub fn parse(expr: &str) -> Result<Expression, Error> {
-    unimplemented!()
+    match parser::<VerboseError<&str>>(expr) {
+        Ok((leftovers, expression)) => {
+            if leftovers.is_empty() {
+                Ok(expression)
+            } else {
+                Err(Error::TrailingCharacters(&leftovers))
+            }
+        }
+        Err(error) => {
+            let handler = |e: VerboseError<&str>| -> Error {
+                match e.errors.first() {
+                    None => Error::AtPos(0),
+                    Some((s, _kind)) => Error::AtPos(expr.offset(s)),
+                }
+            };
+
+            match error {
+                nom::Err::Incomplete(_) => {
+                    panic!("Got nom::Err::Incomplete despite wrapping the parser into `complete()`")
+                }
+                nom::Err::Error(e) => Err(handler(e)),
+                nom::Err::Failure(e) => Err(handler(e)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Expression::*, *};
+
+    #[test]
+    fn t_error_on_invalid_queries() {
+        assert_eq!(parse("title =¯ \"foo\""), Err(Error::AtPos(7)));
+        assert_eq!(parse("a = \"b"), Err(Error::AtPos(4)));
+        assert_eq!(parse("a = b"), Err(Error::AtPos(4)));
+        assert_eq!(parse("a !! \"b\""), Err(Error::AtPos(2)));
+
+        assert_eq!(parse("((a=\"b\")))"), Err(Error::TrailingCharacters(")")));
+
+        // From C++ Matcher suite
+        assert_eq!(
+            parse("AAAA between 0:15:30"),
+            Err(Error::TrailingCharacters(":30"))
+        );
+        assert_eq!(
+            parse("x = 42andy=0"),
+            Err(Error::TrailingCharacters("andy=0"))
+        );
+        assert_eq!(
+            parse("x = 42 andy=0"),
+            Err(Error::TrailingCharacters("andy=0"))
+        );
+        assert_eq!(parse("=!"), Err(Error::AtPos(0)));
+    }
+
+    #[test]
+    fn t_no_error_on_valid_queries() {
+        assert!(parse("a = \"b\"").is_ok());
+        assert!(parse("(a=\"b\")").is_ok());
+        assert!(parse("((a=\"b\"))").is_ok());
+        assert!(parse("a != \"b\"").is_ok());
+        assert!(parse("a =~ \"b\"").is_ok());
+        assert!(parse("a !~ \"b\"").is_ok());
+        assert!(parse(
+				"( a = \"b\") and ( b = \"c\" ) or ( ( c != \"d\" ) and ( c !~ \"asdf\" )) or c != \"xx\"").is_ok());
+    }
+
+    #[test]
+    fn t_both_equals_and_double_equals_are_accepted() {
+        let expected = Ok(Expression::Comparison {
+            attribute: "a".to_string(),
+            op: Operator::Equals,
+            value: Value::Str("abc".to_string()),
+        });
+
+        assert_eq!(parse("a = \"abc\""), expected);
+        assert_eq!(parse("a == \"abc\""), expected);
+    }
+
+    #[test]
+    fn t_filterparser_disallows_nul_byte() {
+        assert!(parse("attri\0bute = 0").is_err());
+        assert!(parse("attribute\0= 0").is_err());
+        assert!(parse("attribute = \0").is_err());
+        assert!(parse("attribute = \\\"\0\\\"").is_err());
+
+        // Unlike the C++ implementation, Rust is OK with having NUL inside a string literal. In
+        // C++, it terminates the whole expression and implicitly closes the string literal
+        assert_eq!(
+            parse("attribute = \"hello\0world\""),
+            Ok(Expression::Comparison {
+                attribute: "attribute".to_string(),
+                op: Operator::Equals,
+                value: Value::Str("hello\0world".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn t_parses_empty_string_literals() {
+        let expected = Ok(Expression::Comparison {
+            attribute: "title".to_string(),
+            op: Operator::Equals,
+            value: Value::Str(String::new()),
+        });
+
+        assert_eq!(parse("title==\"\""), expected);
+    }
+
+    #[test]
+    fn t_and_operator_requires_space_or_paren_after_it() {
+        assert!(parse("a=42andy=0").is_err());
+        assert!(parse("(a=42)andy=0").is_err());
+        assert!(parse("a=42 andy=0").is_err());
+
+        let expected_tree = And(
+            Box::new(Comparison {
+                attribute: "a".to_string(),
+                op: Operator::Equals,
+                value: Value::Int(42),
+            }),
+            Box::new(Comparison {
+                attribute: "y".to_string(),
+                op: Operator::Equals,
+                value: Value::Int(0),
+            }),
+        );
+
+        assert_eq!(parse("a=42and(y=0)"), Ok(expected_tree.clone()));
+        assert_eq!(parse("(a=42)and(y=0)"), Ok(expected_tree.clone()));
+        assert_eq!(parse("a=42and y=0"), Ok(expected_tree));
+    }
+
+    #[test]
+    fn t_or_operator_requires_space_or_paren_after_it() {
+        assert!(parse("a=42ory=0").is_err());
+        assert!(parse("(a=42)ory=0").is_err());
+        assert!(parse("a=42 ory=0").is_err());
+
+        let expected_tree = Or(
+            Box::new(Comparison {
+                attribute: "a".to_string(),
+                op: Operator::Equals,
+                value: Value::Int(42),
+            }),
+            Box::new(Comparison {
+                attribute: "y".to_string(),
+                op: Operator::Equals,
+                value: Value::Int(0),
+            }),
+        );
+
+        assert_eq!(parse("a=42or(y=0)"), Ok(expected_tree.clone()));
+        assert_eq!(parse("(a=42)or(y=0)"), Ok(expected_tree.clone()));
+        assert_eq!(parse("a=42or y=0"), Ok(expected_tree));
+    }
+
+    #[test]
+    fn t_space_chars_in_filter_expr_dont_affect_parsing() {
+        let expected = Comparison {
+            attribute: "array".to_string(),
+            op: Operator::Contains,
+            value: Value::Str("bar".to_string()),
+        };
+
+        assert_eq!(parse("array # \"bar\""), Ok(expected.clone()));
+        assert_eq!(parse("   array # \"bar\""), Ok(expected.clone()));
+        assert_eq!(parse("array   # \"bar\""), Ok(expected.clone()));
+        assert_eq!(parse("array #   \"bar\""), Ok(expected.clone()));
+        assert_eq!(parse("array # \"bar\"     "), Ok(expected.clone()));
+        assert_eq!(parse("array#  \"bar\"  "), Ok(expected.clone()));
+        assert_eq!(
+            parse("     array         #         \"bar\"      "),
+            Ok(expected)
+        );
+    }
+
+    #[test]
+    fn t_only_space_characters_are_considered_whitespace_by_filter_parser() {
+        assert_eq!(parse("attr\t= \"value\""), Err(Error::AtPos(4)));
+        assert_eq!(parse("attr =\t\"value\""), Err(Error::AtPos(6)));
+        assert_eq!(parse("attr\n=\t\"value\""), Err(Error::AtPos(4)));
+        assert_eq!(parse("attr\u{b}=\"value\""), Err(Error::AtPos(4)));
+        assert_eq!(
+            parse("attr=\"value\"\r\n"),
+            Err(Error::TrailingCharacters("\r\n"))
+        );
+    }
+
+    #[test]
+    fn t_whitespace_before_and_or_operators_is_not_required() {
+        assert_eq!(
+            parse("x = 42and y=0"),
+            Ok(And(
+                Box::new(Comparison {
+                    attribute: "x".to_string(),
+                    op: Operator::Equals,
+                    value: Value::Int(42)
+                }),
+                Box::new(Comparison {
+                    attribute: "y".to_string(),
+                    op: Operator::Equals,
+                    value: Value::Int(0)
+                })
+            ))
+        );
+
+        assert_eq!(
+            parse("x = \"42\"and y=0"),
+            Ok(And(
+                Box::new(Comparison {
+                    attribute: "x".to_string(),
+                    op: Operator::Equals,
+                    value: Value::Str("42".to_string())
+                }),
+                Box::new(Comparison {
+                    attribute: "y".to_string(),
+                    op: Operator::Equals,
+                    value: Value::Int(0)
+                })
+            ))
+        );
+
+        assert_eq!(
+            parse("x = \"42\"or y=42"),
+            Ok(Or(
+                Box::new(Comparison {
+                    attribute: "x".to_string(),
+                    op: Operator::Equals,
+                    value: Value::Str("42".to_string())
+                }),
+                Box::new(Comparison {
+                    attribute: "y".to_string(),
+                    op: Operator::Equals,
+                    value: Value::Int(42)
+                })
+            ))
+        );
+    }
 }

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -23,6 +23,7 @@ pub mod utils;
 
 pub mod cliargsparser;
 pub mod configpaths;
+pub mod filterparser;
 pub mod fmtstrformatter;
 pub mod history;
 pub mod htmlrenderer;

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -27,4 +27,6 @@ pub mod filterparser;
 pub mod fmtstrformatter;
 pub mod history;
 pub mod htmlrenderer;
+pub mod matchable;
+pub mod matcher;
 pub mod matchererror;

--- a/rust/libnewsboat/src/matchable.rs
+++ b/rust/libnewsboat/src/matchable.rs
@@ -1,0 +1,10 @@
+/// An entity that can be matched against a filter expression using `Matcher`.
+pub trait Matchable {
+    /// Returns `true` if the entity has an attribute named `attr`.
+    fn has_attribute(&self, attr: &str) -> bool;
+
+    /// Returns the value of the attribute named `attr`.
+    ///
+    /// Value undefined if `has_attribute(attr) == false`.
+    fn get_attribute(&self, attr: &str) -> String;
+}

--- a/rust/libnewsboat/src/matchable.rs
+++ b/rust/libnewsboat/src/matchable.rs
@@ -1,10 +1,5 @@
 /// An entity that can be matched against a filter expression using `Matcher`.
 pub trait Matchable {
-    /// Returns `true` if the entity has an attribute named `attr`.
-    fn has_attribute(&self, attr: &str) -> bool;
-
-    /// Returns the value of the attribute named `attr`.
-    ///
-    /// Value undefined if `has_attribute(attr) == false`.
-    fn get_attribute(&self, attr: &str) -> String;
+    /// Returns the value of the attribute named `attr`, or `None` if there is no such attribute.
+    fn attribute_value(&self, attr: &str) -> Option<String>;
 }

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -1,0 +1,36 @@
+//! Checks if given filter expression is true for a given feed or article.
+
+use filterparser::Expression;
+use matchable::Matchable;
+use matchererror::MatcherError;
+
+/// Checks if given filter expression is true for a given feed or article.
+///
+/// This is used for filters, query feeds, `ignore-article` commands, and even for hiding
+/// already-read feeds and items.
+pub struct Matcher {
+    expr: Expression,
+
+    /// Input string from which `expr` was created
+    text: String,
+}
+
+impl Matcher {
+    /// Prepare a `Matcher` that will check items against the filter expression provided in
+    /// `input`.
+    ///
+    /// If `input` can't be parsed, returns a user-readable error.
+    pub fn parse(input: &str) -> Result<Matcher, String> {
+        unimplemented!()
+    }
+
+    /// Check if given matchable `item` matches the filter.
+    pub fn matches(&self, item: &impl Matchable) -> Result<bool, MatcherError> {
+        unimplemented!()
+    }
+
+    /// The filter expression from which this `Matcher` was constructed.
+    pub fn get_expression(&self) -> &str {
+        &self.text
+    }
+}

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -1,6 +1,10 @@
 //! Checks if given filter expression is true for a given feed or article.
 
-use filterparser::Expression;
+extern crate regex_rs;
+extern crate std;
+
+use self::regex_rs::{CompFlags, MatchFlags, Regex};
+use filterparser::{self, Expression, Expression::*, Operator, Value};
 use matchable::Matchable;
 use matchererror::MatcherError;
 
@@ -21,16 +25,960 @@ impl Matcher {
     ///
     /// If `input` can't be parsed, returns a user-readable error.
     pub fn parse(input: &str) -> Result<Matcher, String> {
-        unimplemented!()
+        let expr = filterparser::parse(input).map_err(|e| match e {
+            filterparser::Error::TrailingCharacters(tail) => {
+                format!("Parse error: trailing characters: {}", tail)
+            }
+            filterparser::Error::AtPos(pos) => format!("Parse error at position {}", pos),
+        })?;
+
+        Ok(Matcher {
+            expr,
+            text: input.to_string(),
+        })
     }
 
     /// Check if given matchable `item` matches the filter.
     pub fn matches(&self, item: &impl Matchable) -> Result<bool, MatcherError> {
-        unimplemented!()
+        evaluate_expression(&self.expr, item)
     }
 
     /// The filter expression from which this `Matcher` was constructed.
     pub fn get_expression(&self) -> &str {
         &self.text
+    }
+}
+
+impl Operator {
+    fn apply(&self, attr: &str, value: &Value) -> Result<bool, MatcherError> {
+        match self {
+            Operator::Equals => match value {
+                Value::Str(ref s) => Ok(attr == s),
+                Value::Int(i) => match attr.parse::<i32>() {
+                    Ok(attr) => Ok(attr == *i),
+                    _ => Ok(false),
+                },
+                _ => Ok(false),
+            },
+            Operator::NotEquals => Operator::Equals
+                .apply(attr, value)
+                .and_then(|result| Ok(!result)),
+            Operator::RegexMatches => match value {
+                Value::Str(ref pattern) => {
+                    match Regex::new(
+                        pattern,
+                        CompFlags::EXTENDED | CompFlags::IGNORE_CASE | CompFlags::NO_SUB,
+                    ) {
+                        Ok(regex) => {
+                            let mut result = false;
+                            let max_matches = 1;
+                            if let Ok(matches) =
+                                regex.matches(attr, max_matches, MatchFlags::empty())
+                            {
+                                // Ok with non-empty Vec inside means a match was found
+                                result = !matches.is_empty();
+                            }
+                            Ok(result)
+                        }
+
+                        Err(errmsg) => Err(MatcherError::InvalidRegex {
+                            regex: pattern.clone(),
+                            errmsg,
+                        }),
+                    }
+                }
+                _ => Ok(false),
+            },
+            Operator::NotRegexMatches => Operator::RegexMatches
+                .apply(attr, value)
+                .and_then(|result| Ok(!result)),
+            Operator::LessThan => match value {
+                Value::Int(i) => Ok(attr.parse::<i32>().unwrap() < *i),
+                _ => Ok(false),
+            },
+            Operator::GreaterThan => match value {
+                Value::Int(i) => Ok(attr.parse::<i32>().unwrap() > *i),
+                _ => Ok(true),
+            },
+            Operator::LessThanOrEquals => match value {
+                Value::Int(i) => Ok(attr.parse::<i32>().unwrap() <= *i),
+                _ => Ok(false),
+            },
+            Operator::GreaterThanOrEquals => match value {
+                Value::Int(i) => Ok(attr.parse::<i32>().unwrap() >= *i),
+                _ => Ok(true),
+            },
+            Operator::Between => match value {
+                Value::Range(a, b) => {
+                    let low = std::cmp::min(*a, *b);
+                    let high = std::cmp::max(*a, *b);
+                    let i = attr.parse::<i32>().unwrap();
+                    Ok(i >= low && i <= high)
+                }
+                _ => Ok(false),
+            },
+            Operator::Contains => match value {
+                Value::Int(i) => self.apply(attr, &Value::Str(format!("{}", i))),
+                Value::Str(ref s) => {
+                    for token in attr.split(" ") {
+                        if token == s {
+                            return Ok(true);
+                        }
+                    }
+                    return Ok(false);
+                }
+                _ => Ok(false),
+            },
+            Operator::NotContains => Operator::Contains
+                .apply(attr, value)
+                .and_then(|result| Ok(!result)),
+        }
+    }
+}
+
+fn evaluate_expression(expr: &Expression, item: &impl Matchable) -> Result<bool, MatcherError> {
+    match expr {
+        Comparison {
+            attribute,
+            op,
+            value,
+        } => {
+            if !item.has_attribute(&attribute) {
+                return Err(MatcherError::AttributeUnavailable {
+                    attr: attribute.clone(),
+                });
+            }
+
+            let ref attr = item.get_attribute(&attribute);
+
+            op.apply(attr, &value)
+        }
+        And(left, right) => evaluate_expression(left, item).and_then(|result| {
+            if result {
+                evaluate_expression(right, item)
+            } else {
+                Ok(false)
+            }
+        }),
+        Or(left, right) => evaluate_expression(left, item).and_then(|result| {
+            if result {
+                Ok(true)
+            } else {
+                evaluate_expression(right, item)
+            }
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::BTreeMap;
+
+    struct MockMatchable {
+        values: BTreeMap<String, String>,
+    }
+
+    impl MockMatchable {
+        pub fn new(values: &[(&str, &str)]) -> MockMatchable {
+            MockMatchable {
+                values: values
+                    .into_iter()
+                    .map(|(a, b)| (String::from(*a), String::from(*b)))
+                    .collect::<BTreeMap<_, _>>(),
+            }
+        }
+    }
+
+    impl Matchable for MockMatchable {
+        fn has_attribute(&self, attr: &str) -> bool {
+            self.values.contains_key(attr)
+        }
+
+        fn get_attribute(&self, attr: &str) -> String {
+            self.values
+                .get(attr)
+                .map(|x| x.clone())
+                .unwrap_or_else(|| String::new())
+        }
+    }
+
+    #[test]
+    fn t_test_equality_works_with_strings() {
+        let mock = MockMatchable::new(&[("abcd", "xyz")]);
+        assert!(Matcher::parse("abcd = \"xyz\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("abcd = \"uiop\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_equality_works_with_numbers() {
+        let mock = MockMatchable::new(&[("answer", "42"), ("agent", "007")]);
+        assert!(Matcher::parse("answer = 42")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("answer = 0042")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("answer = 13")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(Matcher::parse("agent = 7").unwrap().matches(&mock).unwrap());
+        assert!(Matcher::parse("agent = 007")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_equality_doesnt_work_with_ranges() {
+        let mock = MockMatchable::new(&[("answer", "42")]);
+        assert!(!Matcher::parse("answer = 0:100")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("answer = 100:200")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("answer = 42:200")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("answer = 0:42")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_nonequality_works_with_strings() {
+        let mock = MockMatchable::new(&[("abcd", "xyz")]);
+        assert!(Matcher::parse("abcd != \"uiop\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("abcd != \"xyz\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_nonequality_works_with_numbers() {
+        let mock = MockMatchable::new(&[("answer", "42"), ("agent", "007")]);
+        assert!(Matcher::parse("answer != 13")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("answer != 42")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(!Matcher::parse("agent != 7")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("agent != 007")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_nonequality_doesnt_work_with_ranges() {
+        let mock = MockMatchable::new(&[("answer", "42")]);
+        assert!(Matcher::parse("answer != 0:100")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("answer != 100:200")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("answer != 42:200")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("answer != 0:42")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_regex_match_works_with_strings() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(Matcher::parse("AAAA =~ \".\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA =~ \"123\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA =~ \"234\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA =~ \"45\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA =~ \"^12345$\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA =~ \"^123456$\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_regex_match_doesnt_work_with_numbers() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(!Matcher::parse("AAAA =~ 12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA =~ 1").unwrap().matches(&mock).unwrap());
+        assert!(!Matcher::parse("AAAA =~ 45")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA =~ 9").unwrap().matches(&mock).unwrap());
+    }
+
+    #[test]
+    fn t_test_regex_match_doesnt_work_with_ranges() {
+        let mock = MockMatchable::new(&[("AAAA", "12345"), ("range", "0:123")]);
+
+        assert!(!Matcher::parse("AAAA =~ 0:123456")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA =~ 12345:99999")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA =~ 0:12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(!Matcher::parse("range =~ 0:123")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("range =~ 0:12")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("range =~ 0:1234")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_error_on_undefined_fields() {
+        let mock = MockMatchable::new(&[]);
+
+        let check = |expression| {
+            match Matcher::parse(expression).unwrap().matches(&mock) {
+                Err(MatcherError::AttributeUnavailable { .. }) => { /* that's the expected result */
+                }
+                result => panic!(format!("unexpected result: {:?}", result)),
+            }
+        };
+
+        check("BBBB = 1");
+        check("BBBB =~ \"foo\"");
+        check("BBBB # \"foo\"");
+        check("BBBB < 0");
+        check("BBBB > 0");
+        check("BBBB between 1:23");
+    }
+
+    #[test]
+    fn t_error_on_invalid_regex() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        match Matcher::parse("AAAA =~ \"[[\"").unwrap().matches(&mock) {
+            Err(MatcherError::InvalidRegex { .. }) => { /* that's the expected result */ }
+            result => panic!(format!("unexpected result: {:?}", result)),
+        }
+
+        match Matcher::parse("AAAA !~ \"[[\"").unwrap().matches(&mock) {
+            Err(MatcherError::InvalidRegex { .. }) => { /* that's the expected result */ }
+            result => panic!(format!("unexpected result: {:?}", result)),
+        }
+    }
+
+    #[test]
+    fn t_test_not_regex_match_works_with_strings() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(!Matcher::parse("AAAA !~ \".\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA !~ \"123\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA !~ \"234\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA !~ \"45\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA !~ \"^12345$\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(Matcher::parse("AAAA !~ \"567\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA !~ \"number\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_not_regex_match_doesnt_work_with_numbers() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(Matcher::parse("AAAA !~ 12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA !~ 1").unwrap().matches(&mock).unwrap());
+        assert!(Matcher::parse("AAAA !~ 45")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA !~ 9").unwrap().matches(&mock).unwrap());
+    }
+
+    #[test]
+    fn t_test_not_regex_match_doesnt_work_with_ranges() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(Matcher::parse("AAAA !~ 0:123456")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA !~ 12345:99999")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA !~ 0:12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_contains_works_with_strings() {
+        let mock = MockMatchable::new(&[("tags", "foo bar baz quux")]);
+
+        assert!(Matcher::parse("tags # \"foo\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("tags # \"baz\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("tags # \"quux\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("tags # \"uu\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("tags # \"xyz\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("tags # \"foo bar\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("tags # \"foo\" and tags # \"bar\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("tags # \"foo\" and tags # \"xyz\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("tags # \"foo\" or tags # \"xyz\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_contains_works_with_numbers() {
+        let mock = MockMatchable::new(&[("fibonacci", "1 1 2 3 5 8 13 21 34")]);
+
+        assert!(Matcher::parse("fibonacci # 1")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("fibonacci # 3")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("fibonacci # 4")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_contains_converts_numbers_to_strings_to_look_them_up() {
+        let mock = MockMatchable::new(&[("fibonacci", "1 1 2 3 5 8 13 21 34")]);
+
+        assert!(Matcher::parse("fibonacci # \"1\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("fibonacci # \"3\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("fibonacci # \"4\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_contains_doesnt_work_with_ranges() {
+        let mock = MockMatchable::new(&[("fibonacci", "1 1 2 3 5 8 13 21 34")]);
+
+        assert!(!Matcher::parse("fibonacci # 1:5")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("fibonacci # 3:100")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_contains_works_with_single_value_lists() {
+        let mock = MockMatchable::new(&[("values", "one"), ("number", "1")]);
+
+        assert!(Matcher::parse("values # \"one\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("number # 1")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_not_contains_works_with_strings() {
+        let mock = MockMatchable::new(&[("tags", "foo bar baz quux")]);
+
+        assert!(Matcher::parse("tags !# \"nein\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("tags !# \"foo\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_not_contains_works_with_numbers() {
+        let mock = MockMatchable::new(&[("fibonacci", "1 1 2 3 5 8 13 21 34")]);
+
+        assert!(!Matcher::parse("fibonacci !# 1")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("fibonacci !# 9")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("fibonacci !# 4")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_not_contains_converts_numbers_to_strings_to_look_them_up() {
+        let mock = MockMatchable::new(&[("fibonacci", "1 1 2 3 5 8 13 21 34")]);
+
+        assert!(!Matcher::parse("fibonacci !# \"1\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("fibonacci !# \"9\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("fibonacci !# \"4\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_not_contains_doesnt_work_with_ranges() {
+        let mock = MockMatchable::new(&[("fibonacci", "1 1 2 3 5 8 13 21 34")]);
+
+        assert!(Matcher::parse("fibonacci !# 1:5")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("fibonacci !# 7:35")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_not_contains_works_even_on_single_value_lists() {
+        let mock = MockMatchable::new(&[("values", "one"), ("number", "1")]);
+
+        assert!(!Matcher::parse("values !# \"one\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("values !# \"two\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("number !# 1")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("number !# 2")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_comparisons_dont_work_with_strings() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(Matcher::parse("AAAA > \"12344\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(Matcher::parse("AAAA > \"12345\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(Matcher::parse("AAAA > \"123456\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(!Matcher::parse("AAAA < \"12345\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(!Matcher::parse("AAAA < \"12346\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(!Matcher::parse("AAAA < \"123456\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(Matcher::parse("AAAA >= \"12344\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(Matcher::parse("AAAA >= \"12345\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(Matcher::parse("AAAA >= \"12346\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(!Matcher::parse("AAAA <= \"12344\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(!Matcher::parse("AAAA <= \"12345\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+
+        assert!(!Matcher::parse("AAAA <= \"12346\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_comparisons_work_with_numbers() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(Matcher::parse("AAAA > 12344")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA > 12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA >= 12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA < 12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA <= 12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_comparisons_dont_work_with_ranges() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(Matcher::parse("AAAA > 0:99999")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA < 0:99999")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA >= 0:99999")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA <= 0:99999")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_operator_between_doesnt_work_with_strings() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(!Matcher::parse("AAAA between \"123\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA between \"12399\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_operator_between_doesnt_work_with_numbers() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(!Matcher::parse("AAAA between 1")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA between 12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA between 99999")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_operator_between_works_with_ranges() {
+        let mock = MockMatchable::new(&[("AAAA", "12345")]);
+
+        assert!(Matcher::parse("AAAA between 0:12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA between 12345:12345")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA between 23:12344")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA between 12346:12344")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_get_expression_method_returns_parsed_expression_as_string() {
+        let expression = "AAAA between 1:30000";
+        let matcher = Matcher::parse(expression).unwrap();
+        assert_eq!(matcher.get_expression(), expression);
+    }
+
+    #[test]
+    fn t_regexes_matched_case_insensitively() {
+        // Inspired by https://github.com/newsboat/newsboat/issues/642
+
+        let mock = MockMatchable::new(&[("abcd", "xyz")]);
+
+        assert!(Matcher::parse("abcd =~ \"xyz\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("abcd =~ \"xYz\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("abcd =~ \"xYZ\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("abcd =~ \"Xyz\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("abcd =~ \"yZ\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("abcd =~ \"^xYZ\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("abcd =~ \"xYz$\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("abcd =~ \"^Xyz$\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("abcd =~ \"^xY\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("abcd =~ \"yZ$\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    // The following tests check if our regex matching uses POSIX extended regular expression
+    // syntax. That syntax is documented in The Open Group Base Specifications Issue 7,
+    // IEEE Std 1003.1-2008 Section 9, "Regular Expressions":
+    // https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/basedefs/V1_chap09.html
+    //
+    // Since POSIX extended regular expressions are pretty basic, it's hard to
+    // find stuff that they support but other engines don't. So in order to
+    // ensure that we're using EREs, these tests try stuff that's *not*
+    // supported by EREs.
+    //
+    // Ideas gleaned from https://www.regular-expressions.info/refcharacters.html
+
+    #[test]
+    fn t_regex_matching_doesnt_support_escape_sequence() {
+        // Supported by Perl, PCRE, PHP and others, but not POSIX ERE
+
+        let mock = MockMatchable::new(&[("attr", "*]+")]);
+
+        assert!(!Matcher::parse(r#"(attr =~ "\Q*]+\E")"#)
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse(r#"(attr !~ "\Q*]+\E")"#)
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_regex_matching_doesnt_support_hexadecimal_escape() {
+        let mock = MockMatchable::new(&[("attr", "value")]);
+
+        assert!(!Matcher::parse(r#"(attr =~ "^va\x6Cue")"#)
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse(r#"attr !~ "^va\x6Cue""#)
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_regex_matching_doesnt_support_backslash_a_as_alert_control_character() {
+        let mock = MockMatchable::new(&[("attr", "\x07")]);
+
+        assert!(!Matcher::parse(r#"(attr =~ "\a")"#)
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse(r#"(attr !~ "\a")"#)
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_regex_matching_doesnt_support_backslash_b_as_backspace_control_character() {
+        let mock = MockMatchable::new(&[("attr", "\x08")]);
+
+        assert!(!Matcher::parse(r#"(attr =~ "\b")"#)
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse(r#"(attr !~ "\b")"#)
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
     }
 }

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -142,17 +142,15 @@ fn evaluate_expression(expr: &Expression, item: &impl Matchable) -> Result<bool,
             attribute,
             op,
             value,
-        } => {
-            if !item.has_attribute(&attribute) {
+        } => match item.attribute_value(&attribute) {
+            None => {
                 return Err(MatcherError::AttributeUnavailable {
                     attr: attribute.clone(),
-                });
+                })
             }
 
-            let ref attr = item.get_attribute(&attribute);
-
-            op.apply(attr, &value)
-        }
+            Some(ref attr) => op.apply(attr, &value),
+        },
         And(left, right) => evaluate_expression(left, item).and_then(|result| {
             if result {
                 evaluate_expression(right, item)
@@ -192,15 +190,8 @@ mod tests {
     }
 
     impl Matchable for MockMatchable {
-        fn has_attribute(&self, attr: &str) -> bool {
-            self.values.contains_key(attr)
-        }
-
-        fn get_attribute(&self, attr: &str) -> String {
-            self.values
-                .get(attr)
-                .map(|x| x.clone())
-                .unwrap_or_else(|| String::new())
+        fn attribute_value(&self, attr: &str) -> Option<String> {
+            self.values.get(attr).cloned()
         }
     }
 

--- a/rust/libnewsboat/src/matchererror.rs
+++ b/rust/libnewsboat/src/matchererror.rs
@@ -1,6 +1,7 @@
 /// Errors produced by `Matcher::matches`.
 ///
 /// These correspond to `MatcherException` on the C++ side.
+#[derive(Debug)]
 pub enum MatcherError {
     /// Current matchable doesn't have an attribute named `attr`
     AttributeUnavailable { attr: String },

--- a/rust/libnewsboat/src/matchererror.rs
+++ b/rust/libnewsboat/src/matchererror.rs
@@ -1,4 +1,4 @@
-/// Errors produced by `Matcher::matches`
+/// Errors produced by `Matcher::matches`.
 ///
 /// These correspond to `MatcherException` on the C++ side.
 pub enum MatcherError {


### PR DESCRIPTION
These don't replace the C++ implementations because we still have to compare them ­— unit tests alone aren't enough.

Most of this code is by @tsipinakis; he submitted it in #701. I made a lot of small edits on top, and history became an absolutely incomprehensible mess, so I created a new one instead. I still managed to split it in somewhat logically-isolated portions, so it's entirely possible to review commit-by-commit.

See #631.