### PR TITLE
Fix all i18nspector info messages

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -1,5 +1,3 @@
-# OmeGa <omega@mailoo.org>, 2013.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
@@ -7,7 +5,7 @@ msgstr ""
 "POT-Creation-Date: 2020-04-22 13:36+0300\n"
 "PO-Revision-Date: 2017-07-19 20:19+0300\n"
 "Last-Translator: Alejandro Gallo <aamsgallo@gmail.com>\n"
-"Language-Team: Alejandro Gallo <aamsgallo@gmail.com>\n"
+"Language-Team: Alejandro Gallo <aamsgallo@gmail.com>, OmeGa <omega@mailoo.org>\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,5 +1,3 @@
-# Grady Martin <GradyMartin@gmail.com>, 2015
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.9\n"
@@ -7,7 +5,7 @@ msgstr ""
 "POT-Creation-Date: 2020-04-22 13:36+0300\n"
 "PO-Revision-Date: 2015-04-26 05:55+0900\n"
 "Last-Translator: Grady Martin <GradyMartin@gmail.com>\n"
-"Language-Team: Japanese <GradyMartin@gmail.com>\n"
+"Language-Team: \n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/sk.po
+++ b/po/sk.po
@@ -1,7 +1,3 @@
-# Copyright (C) 2017
-# This file is distributed under the same license as the newsboat package.
-# František Hájik <ferko.hajik@gmail.com>, 2017
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.10.1\n"
@@ -9,7 +5,7 @@ msgstr ""
 "POT-Creation-Date: 2020-04-22 13:36+0300\n"
 "PO-Revision-Date: 2017-12-25 00:38+0100\n"
 "Last-Translator: František Hájik <ferko.hajik@gmail.com>\n"
-"Language-Team: František Hájik <ferko.hajik@gmail.com>\n"
+"Language-Team: \n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/zh.po
+++ b/po/zh.po
@@ -1,5 +1,3 @@
-# joshyu  <joshyupeng@gmail.com>, 2007.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
@@ -7,7 +5,7 @@ msgstr ""
 "POT-Creation-Date: 2020-04-22 13:36+0300\n"
 "PO-Revision-Date: 2007-11-21 22:51+0100\n"
 "Last-Translator: josh yu <joshyupeng@gmail.com>\n"
-"Language-Team: Chinese <joshyupeng@gmail.com>\n"
+"Language-Team: \n"
 "Language: zh\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,5 +1,3 @@
-# aeglos  <aeglos.lin@gmail.com>, 2008.
-#
 msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.0\n"
@@ -7,7 +5,7 @@ msgstr ""
 "POT-Creation-Date: 2020-04-22 13:36+0300\n"
 "PO-Revision-Date: 2010-03-03 16:55+0800\n"
 "Last-Translator: Aeglos <aeglos.lin@gmail.com>\n"
-"Language-Team: Traditional Chinese <aeglos.lin@gmail.com>\n"
+"Language-Team: \n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"


### PR DESCRIPTION
> I: po/ja.po: language-team-equal-to-last-translator 'Japanese <GradyMartin@gmail.com>' 'Grady Martin <GradyMartin@gmail.com>'
> I: po/ca.po: language-team-equal-to-last-translator 'Alejandro Gallo <aamsgallo@gmail.com>' 'Alejandro Gallo <aamsgallo@gmail.com>'
> I: po/zh.po: language-team-equal-to-last-translator 'Chinese <joshyupeng@gmail.com>' 'josh yu <joshyupeng@gmail.com>'
> I: po/sk.po: language-team-equal-to-last-translator 'František Hájik <ferko.hajik@gmail.com>' 'František Hájik <ferko.hajik@gmail.com>'
> I: po/zh_TW.po: language-team-equal-to-last-translator 'Traditional Chinese <aeglos.lin@gmail.com>' 'Aeglos <aeglos.lin@gmail.com>'

These make it harder to notice warnings and errors, so let's fix them by
making the translation team empty if there is only one translator.

I also removed copyright headers, since that info is available in the
Git log already and is not presented to end users anyway.

Reviews from everyone are welcome. Will merge in three days.