### PR TITLE
Use optional-lite wherever makes sense

### DIFF
--- a/3rd-party/optional.hpp
+++ b/3rd-party/optional.hpp
@@ -1,0 +1,1698 @@
+//
+// Copyright (c) 2014-2018 Martin Moene
+//
+// https://github.com/martinmoene/optional-lite
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#ifndef NONSTD_OPTIONAL_LITE_HPP
+#define NONSTD_OPTIONAL_LITE_HPP
+
+#define optional_lite_MAJOR  3
+#define optional_lite_MINOR  2
+#define optional_lite_PATCH  0
+
+#define optional_lite_VERSION  optional_STRINGIFY(optional_lite_MAJOR) "." optional_STRINGIFY(optional_lite_MINOR) "." optional_STRINGIFY(optional_lite_PATCH)
+
+#define optional_STRINGIFY(  x )  optional_STRINGIFY_( x )
+#define optional_STRINGIFY_( x )  #x
+
+// optional-lite configuration:
+
+#define optional_OPTIONAL_DEFAULT  0
+#define optional_OPTIONAL_NONSTD   1
+#define optional_OPTIONAL_STD      2
+
+#if !defined( optional_CONFIG_SELECT_OPTIONAL )
+# define optional_CONFIG_SELECT_OPTIONAL  ( optional_HAVE_STD_OPTIONAL ? optional_OPTIONAL_STD : optional_OPTIONAL_NONSTD )
+#endif
+
+// Control presence of exception handling (try and auto discover):
+
+#ifndef optional_CONFIG_NO_EXCEPTIONS
+# if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND)
+#  define optional_CONFIG_NO_EXCEPTIONS  0
+# else
+#  define optional_CONFIG_NO_EXCEPTIONS  1
+# endif
+#endif
+
+// C++ language version detection (C++20 is speculative):
+// Note: VC14.0/1900 (VS2015) lacks too much from C++14.
+
+#ifndef   optional_CPLUSPLUS
+# if defined(_MSVC_LANG ) && !defined(__clang__)
+#  define optional_CPLUSPLUS  (_MSC_VER == 1900 ? 201103L : _MSVC_LANG )
+# else
+#  define optional_CPLUSPLUS  __cplusplus
+# endif
+#endif
+
+#define optional_CPP98_OR_GREATER  ( optional_CPLUSPLUS >= 199711L )
+#define optional_CPP11_OR_GREATER  ( optional_CPLUSPLUS >= 201103L )
+#define optional_CPP11_OR_GREATER_ ( optional_CPLUSPLUS >= 201103L )
+#define optional_CPP14_OR_GREATER  ( optional_CPLUSPLUS >= 201402L )
+#define optional_CPP17_OR_GREATER  ( optional_CPLUSPLUS >= 201703L )
+#define optional_CPP20_OR_GREATER  ( optional_CPLUSPLUS >= 202000L )
+
+// C++ language version (represent 98 as 3):
+
+#define optional_CPLUSPLUS_V  ( optional_CPLUSPLUS / 100 - (optional_CPLUSPLUS > 200000 ? 2000 : 1994) )
+
+// Use C++17 std::optional if available and requested:
+
+#if optional_CPP17_OR_GREATER && defined(__has_include )
+# if __has_include( <optional> )
+#  define optional_HAVE_STD_OPTIONAL  1
+# else
+#  define optional_HAVE_STD_OPTIONAL  0
+# endif
+#else
+# define  optional_HAVE_STD_OPTIONAL  0
+#endif
+
+#define optional_USES_STD_OPTIONAL  ( (optional_CONFIG_SELECT_OPTIONAL == optional_OPTIONAL_STD) || ((optional_CONFIG_SELECT_OPTIONAL == optional_OPTIONAL_DEFAULT) && optional_HAVE_STD_OPTIONAL) )
+
+//
+// in_place: code duplicated in any-lite, expected-lite, optional-lite, value-ptr-lite, variant-lite:
+//
+
+#ifndef nonstd_lite_HAVE_IN_PLACE_TYPES
+#define nonstd_lite_HAVE_IN_PLACE_TYPES  1
+
+// C++17 std::in_place in <utility>:
+
+#if optional_CPP17_OR_GREATER
+
+#include <utility>
+
+namespace nonstd {
+
+using std::in_place;
+using std::in_place_type;
+using std::in_place_index;
+using std::in_place_t;
+using std::in_place_type_t;
+using std::in_place_index_t;
+
+#define nonstd_lite_in_place_t(      T)  std::in_place_t
+#define nonstd_lite_in_place_type_t( T)  std::in_place_type_t<T>
+#define nonstd_lite_in_place_index_t(K)  std::in_place_index_t<K>
+
+#define nonstd_lite_in_place(      T)    std::in_place_t{}
+#define nonstd_lite_in_place_type( T)    std::in_place_type_t<T>{}
+#define nonstd_lite_in_place_index(K)    std::in_place_index_t<K>{}
+
+} // namespace nonstd
+
+#else // optional_CPP17_OR_GREATER
+
+#include <cstddef>
+
+namespace nonstd {
+namespace detail {
+
+template< class T >
+struct in_place_type_tag {};
+
+template< std::size_t K >
+struct in_place_index_tag {};
+
+} // namespace detail
+
+struct in_place_t {};
+
+template< class T >
+inline in_place_t in_place( detail::in_place_type_tag<T> /*unused*/ = detail::in_place_type_tag<T>() )
+{
+    return in_place_t();
+}
+
+template< std::size_t K >
+inline in_place_t in_place( detail::in_place_index_tag<K> /*unused*/ = detail::in_place_index_tag<K>() )
+{
+    return in_place_t();
+}
+
+template< class T >
+inline in_place_t in_place_type( detail::in_place_type_tag<T> /*unused*/ = detail::in_place_type_tag<T>() )
+{
+    return in_place_t();
+}
+
+template< std::size_t K >
+inline in_place_t in_place_index( detail::in_place_index_tag<K> /*unused*/ = detail::in_place_index_tag<K>() )
+{
+    return in_place_t();
+}
+
+// mimic templated typedef:
+
+#define nonstd_lite_in_place_t(      T)  nonstd::in_place_t(&)( nonstd::detail::in_place_type_tag<T>  )
+#define nonstd_lite_in_place_type_t( T)  nonstd::in_place_t(&)( nonstd::detail::in_place_type_tag<T>  )
+#define nonstd_lite_in_place_index_t(K)  nonstd::in_place_t(&)( nonstd::detail::in_place_index_tag<K> )
+
+#define nonstd_lite_in_place(      T)    nonstd::in_place_type<T>
+#define nonstd_lite_in_place_type( T)    nonstd::in_place_type<T>
+#define nonstd_lite_in_place_index(K)    nonstd::in_place_index<K>
+
+} // namespace nonstd
+
+#endif // optional_CPP17_OR_GREATER
+#endif // nonstd_lite_HAVE_IN_PLACE_TYPES
+
+//
+// Using std::optional:
+//
+
+#if optional_USES_STD_OPTIONAL
+
+#include <optional>
+
+namespace nonstd {
+
+    using std::optional;
+    using std::bad_optional_access;
+    using std::hash;
+
+    using std::nullopt;
+    using std::nullopt_t;
+
+    using std::operator==;
+    using std::operator!=;
+    using std::operator<;
+    using std::operator<=;
+    using std::operator>;
+    using std::operator>=;
+    using std::make_optional;
+    using std::swap;
+}
+
+#else // optional_USES_STD_OPTIONAL
+
+#include <cassert>
+#include <utility>
+
+// optional-lite alignment configuration:
+
+#ifndef  optional_CONFIG_MAX_ALIGN_HACK
+# define optional_CONFIG_MAX_ALIGN_HACK  0
+#endif
+
+#ifndef  optional_CONFIG_ALIGN_AS
+// no default, used in #if defined()
+#endif
+
+#ifndef  optional_CONFIG_ALIGN_AS_FALLBACK
+# define optional_CONFIG_ALIGN_AS_FALLBACK  double
+#endif
+
+// Compiler warning suppression:
+
+#if defined(__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wundef"
+#elif defined(__GNUC__)
+# pragma GCC   diagnostic push
+# pragma GCC   diagnostic ignored "-Wundef"
+#elif defined(_MSC_VER )
+# pragma warning( push )
+#endif
+
+// half-open range [lo..hi):
+#define optional_BETWEEN( v, lo, hi ) ( (lo) <= (v) && (v) < (hi) )
+
+// Compiler versions:
+//
+// MSVC++ 6.0  _MSC_VER == 1200 (Visual Studio 6.0)
+// MSVC++ 7.0  _MSC_VER == 1300 (Visual Studio .NET 2002)
+// MSVC++ 7.1  _MSC_VER == 1310 (Visual Studio .NET 2003)
+// MSVC++ 8.0  _MSC_VER == 1400 (Visual Studio 2005)
+// MSVC++ 9.0  _MSC_VER == 1500 (Visual Studio 2008)
+// MSVC++ 10.0 _MSC_VER == 1600 (Visual Studio 2010)
+// MSVC++ 11.0 _MSC_VER == 1700 (Visual Studio 2012)
+// MSVC++ 12.0 _MSC_VER == 1800 (Visual Studio 2013)
+// MSVC++ 14.0 _MSC_VER == 1900 (Visual Studio 2015)
+// MSVC++ 14.1 _MSC_VER >= 1910 (Visual Studio 2017)
+
+#if defined(_MSC_VER ) && !defined(__clang__)
+# define optional_COMPILER_MSVC_VER      (_MSC_VER )
+# define optional_COMPILER_MSVC_VERSION  (_MSC_VER / 10 - 10 * ( 5 + (_MSC_VER < 1900 ) ) )
+#else
+# define optional_COMPILER_MSVC_VER      0
+# define optional_COMPILER_MSVC_VERSION  0
+#endif
+
+#define optional_COMPILER_VERSION( major, minor, patch )  ( 10 * (10 * (major) + (minor) ) + (patch) )
+
+#if defined(__GNUC__) && !defined(__clang__)
+# define optional_COMPILER_GNUC_VERSION   optional_COMPILER_VERSION(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#else
+# define optional_COMPILER_GNUC_VERSION   0
+#endif
+
+#if defined(__clang__)
+# define optional_COMPILER_CLANG_VERSION  optional_COMPILER_VERSION(__clang_major__, __clang_minor__, __clang_patchlevel__)
+#else
+# define optional_COMPILER_CLANG_VERSION  0
+#endif
+
+#if optional_BETWEEN(optional_COMPILER_MSVC_VERSION, 70, 140 )
+# pragma warning( disable: 4345 )   // initialization behavior changed
+#endif
+
+#if optional_BETWEEN(optional_COMPILER_MSVC_VERSION, 70, 150 )
+# pragma warning( disable: 4814 )   // in C++14 'constexpr' will not imply 'const'
+#endif
+
+// Presence of language and library features:
+
+#define optional_HAVE(FEATURE) ( optional_HAVE_##FEATURE )
+
+#ifdef _HAS_CPP0X
+# define optional_HAS_CPP0X  _HAS_CPP0X
+#else
+# define optional_HAS_CPP0X  0
+#endif
+
+// Unless defined otherwise below, consider VC14 as C++11 for optional-lite:
+
+#if optional_COMPILER_MSVC_VER >= 1900
+# undef  optional_CPP11_OR_GREATER
+# define optional_CPP11_OR_GREATER  1
+#endif
+
+#define optional_CPP11_90   (optional_CPP11_OR_GREATER_ || optional_COMPILER_MSVC_VER >= 1500)
+#define optional_CPP11_100  (optional_CPP11_OR_GREATER_ || optional_COMPILER_MSVC_VER >= 1600)
+#define optional_CPP11_110  (optional_CPP11_OR_GREATER_ || optional_COMPILER_MSVC_VER >= 1700)
+#define optional_CPP11_120  (optional_CPP11_OR_GREATER_ || optional_COMPILER_MSVC_VER >= 1800)
+#define optional_CPP11_140  (optional_CPP11_OR_GREATER_ || optional_COMPILER_MSVC_VER >= 1900)
+#define optional_CPP11_141  (optional_CPP11_OR_GREATER_ || optional_COMPILER_MSVC_VER >= 1910)
+
+#define optional_CPP14_000  (optional_CPP14_OR_GREATER)
+#define optional_CPP17_000  (optional_CPP17_OR_GREATER)
+
+// Presence of C++11 language features:
+
+#define optional_HAVE_CONSTEXPR_11      optional_CPP11_140
+#define optional_HAVE_IS_DEFAULT        optional_CPP11_140
+#define optional_HAVE_NOEXCEPT          optional_CPP11_140
+#define optional_HAVE_NULLPTR           optional_CPP11_100
+#define optional_HAVE_REF_QUALIFIER     optional_CPP11_140
+
+// Presence of C++14 language features:
+
+#define optional_HAVE_CONSTEXPR_14      optional_CPP14_000
+
+// Presence of C++17 language features:
+
+#define optional_HAVE_NODISCARD         optional_CPP17_000
+
+// Presence of C++ library features:
+
+#define optional_HAVE_CONDITIONAL       optional_CPP11_120
+#define optional_HAVE_REMOVE_CV         optional_CPP11_120
+#define optional_HAVE_TYPE_TRAITS       optional_CPP11_90
+
+#define optional_HAVE_TR1_TYPE_TRAITS   (!! optional_COMPILER_GNUC_VERSION )
+#define optional_HAVE_TR1_ADD_POINTER   (!! optional_COMPILER_GNUC_VERSION )
+
+// C++ feature usage:
+
+#if optional_HAVE( CONSTEXPR_11 )
+# define optional_constexpr  constexpr
+#else
+# define optional_constexpr  /*constexpr*/
+#endif
+
+#if optional_HAVE( IS_DEFAULT )
+# define optional_is_default  = default;
+#else
+# define optional_is_default  {}
+#endif
+
+#if optional_HAVE( CONSTEXPR_14 )
+# define optional_constexpr14  constexpr
+#else
+# define optional_constexpr14  /*constexpr*/
+#endif
+
+#if optional_HAVE( NODISCARD )
+# define optional_nodiscard  [[nodiscard]]
+#else
+# define optional_nodiscard  /*[[nodiscard]]*/
+#endif
+
+#if optional_HAVE( NOEXCEPT )
+# define optional_noexcept  noexcept
+#else
+# define optional_noexcept  /*noexcept*/
+#endif
+
+#if optional_HAVE( NULLPTR )
+# define optional_nullptr  nullptr
+#else
+# define optional_nullptr  NULL
+#endif
+
+#if optional_HAVE( REF_QUALIFIER )
+// NOLINTNEXTLINE( bugprone-macro-parentheses )
+# define optional_ref_qual  &
+# define optional_refref_qual  &&
+#else
+# define optional_ref_qual  /*&*/
+# define optional_refref_qual  /*&&*/
+#endif
+
+// additional includes:
+
+#if optional_CONFIG_NO_EXCEPTIONS
+// already included: <cassert>
+#else
+# include <stdexcept>
+#endif
+
+#if optional_CPP11_OR_GREATER
+# include <functional>
+#endif
+
+#if optional_HAVE( INITIALIZER_LIST )
+# include <initializer_list>
+#endif
+
+#if optional_HAVE( TYPE_TRAITS )
+# include <type_traits>
+#elif optional_HAVE( TR1_TYPE_TRAITS )
+# include <tr1/type_traits>
+#endif
+
+// Method enabling
+
+#if optional_CPP11_OR_GREATER
+
+#define optional_REQUIRES_0(...) \
+    template< bool B = (__VA_ARGS__), typename std::enable_if<B, int>::type = 0 >
+
+#define optional_REQUIRES_T(...) \
+    , typename = typename std::enable_if< (__VA_ARGS__), nonstd::optional_lite::detail::enabler >::type
+
+#define optional_REQUIRES_R(R, ...) \
+    typename std::enable_if< (__VA_ARGS__), R>::type
+
+#define optional_REQUIRES_A(...) \
+    , typename std::enable_if< (__VA_ARGS__), void*>::type = nullptr
+
+#endif
+
+//
+// optional:
+//
+
+namespace nonstd { namespace optional_lite {
+
+namespace std11 {
+
+#if optional_CPP11_OR_GREATER
+    using std::move;
+#else
+    template< typename T > T & move( T & t ) { return t; }
+#endif
+
+#if optional_HAVE( CONDITIONAL )
+    using std::conditional;
+#else
+    template< bool B, typename T, typename F > struct conditional              { typedef T type; };
+    template<         typename T, typename F > struct conditional<false, T, F> { typedef F type; };
+#endif // optional_HAVE_CONDITIONAL
+
+} // namespace std11
+
+#if optional_CPP11_OR_GREATER
+
+/// type traits C++17:
+
+namespace std17 {
+
+#if optional_CPP17_OR_GREATER
+
+using std::is_swappable;
+using std::is_nothrow_swappable;
+
+#elif optional_CPP11_OR_GREATER
+
+namespace detail {
+
+using std::swap;
+
+struct is_swappable
+{
+    template< typename T, typename = decltype( swap( std::declval<T&>(), std::declval<T&>() ) ) >
+    static std::true_type test( int /*unused*/ );
+
+    template< typename >
+    static std::false_type test(...);
+};
+
+struct is_nothrow_swappable
+{
+    // wrap noexcept(expr) in separate function as work-around for VC140 (VS2015):
+
+    template< typename T >
+    static constexpr bool satisfies()
+    {
+        return noexcept( swap( std::declval<T&>(), std::declval<T&>() ) );
+    }
+
+    template< typename T >
+    static auto test( int /*unused*/ ) -> std::integral_constant<bool, satisfies<T>()>{}
+
+    template< typename >
+    static auto test(...) -> std::false_type;
+};
+
+} // namespace detail
+
+// is [nothow] swappable:
+
+template< typename T >
+struct is_swappable : decltype( detail::is_swappable::test<T>(0) ){};
+
+template< typename T >
+struct is_nothrow_swappable : decltype( detail::is_nothrow_swappable::test<T>(0) ){};
+
+#endif // optional_CPP17_OR_GREATER
+
+} // namespace std17
+
+/// type traits C++20:
+
+namespace std20 {
+
+template< typename T >
+struct remove_cvref
+{
+    typedef typename std::remove_cv< typename std::remove_reference<T>::type >::type type;
+};
+
+} // namespace std20
+
+#endif // optional_CPP11_OR_GREATER
+
+/// class optional
+
+template< typename T >
+class optional;
+
+namespace detail {
+
+// for optional_REQUIRES_T
+
+#if optional_CPP11_OR_GREATER
+enum class enabler{};
+#endif
+
+// C++11 emulation:
+
+struct nulltype{};
+
+template< typename Head, typename Tail >
+struct typelist
+{
+    typedef Head head;
+    typedef Tail tail;
+};
+
+#if optional_CONFIG_MAX_ALIGN_HACK
+
+// Max align, use most restricted type for alignment:
+
+#define optional_UNIQUE(  name )       optional_UNIQUE2( name, __LINE__ )
+#define optional_UNIQUE2( name, line ) optional_UNIQUE3( name, line )
+#define optional_UNIQUE3( name, line ) name ## line
+
+#define optional_ALIGN_TYPE( type ) \
+    type optional_UNIQUE( _t ); struct_t< type > optional_UNIQUE( _st )
+
+template< typename T >
+struct struct_t { T _; };
+
+union max_align_t
+{
+    optional_ALIGN_TYPE( char );
+    optional_ALIGN_TYPE( short int );
+    optional_ALIGN_TYPE( int );
+    optional_ALIGN_TYPE( long int  );
+    optional_ALIGN_TYPE( float  );
+    optional_ALIGN_TYPE( double );
+    optional_ALIGN_TYPE( long double );
+    optional_ALIGN_TYPE( char * );
+    optional_ALIGN_TYPE( short int * );
+    optional_ALIGN_TYPE( int *  );
+    optional_ALIGN_TYPE( long int * );
+    optional_ALIGN_TYPE( float * );
+    optional_ALIGN_TYPE( double * );
+    optional_ALIGN_TYPE( long double * );
+    optional_ALIGN_TYPE( void * );
+
+#ifdef HAVE_LONG_LONG
+    optional_ALIGN_TYPE( long long );
+#endif
+
+    struct Unknown;
+
+    Unknown ( * optional_UNIQUE(_) )( Unknown );
+    Unknown * Unknown::* optional_UNIQUE(_);
+    Unknown ( Unknown::* optional_UNIQUE(_) )( Unknown );
+
+    struct_t< Unknown ( * )( Unknown)         > optional_UNIQUE(_);
+    struct_t< Unknown * Unknown::*            > optional_UNIQUE(_);
+    struct_t< Unknown ( Unknown::* )(Unknown) > optional_UNIQUE(_);
+};
+
+#undef optional_UNIQUE
+#undef optional_UNIQUE2
+#undef optional_UNIQUE3
+
+#undef optional_ALIGN_TYPE
+
+#elif defined( optional_CONFIG_ALIGN_AS ) // optional_CONFIG_MAX_ALIGN_HACK
+
+// Use user-specified type for alignment:
+
+#define optional_ALIGN_AS( unused ) \
+    optional_CONFIG_ALIGN_AS
+
+#else // optional_CONFIG_MAX_ALIGN_HACK
+
+// Determine POD type to use for alignment:
+
+#define optional_ALIGN_AS( to_align ) \
+    typename type_of_size< alignment_types, alignment_of< to_align >::value >::type
+
+template< typename T >
+struct alignment_of;
+
+template< typename T >
+struct alignment_of_hack
+{
+    char c;
+    T t;
+    alignment_of_hack();
+};
+
+template< size_t A, size_t S >
+struct alignment_logic
+{
+    enum { value = A < S ? A : S };
+};
+
+template< typename T >
+struct alignment_of
+{
+    enum { value = alignment_logic<
+        sizeof( alignment_of_hack<T> ) - sizeof(T), sizeof(T) >::value };
+};
+
+template< typename List, size_t N >
+struct type_of_size
+{
+    typedef typename std11::conditional<
+        N == sizeof( typename List::head ),
+            typename List::head,
+            typename type_of_size<typename List::tail, N >::type >::type type;
+};
+
+template< size_t N >
+struct type_of_size< nulltype, N >
+{
+    typedef optional_CONFIG_ALIGN_AS_FALLBACK type;
+};
+
+template< typename T>
+struct struct_t { T _; };
+
+#define optional_ALIGN_TYPE( type ) \
+    typelist< type , typelist< struct_t< type >
+
+struct Unknown;
+
+typedef
+    optional_ALIGN_TYPE( char ),
+    optional_ALIGN_TYPE( short ),
+    optional_ALIGN_TYPE( int ),
+    optional_ALIGN_TYPE( long ),
+    optional_ALIGN_TYPE( float ),
+    optional_ALIGN_TYPE( double ),
+    optional_ALIGN_TYPE( long double ),
+
+    optional_ALIGN_TYPE( char *),
+    optional_ALIGN_TYPE( short * ),
+    optional_ALIGN_TYPE( int * ),
+    optional_ALIGN_TYPE( long * ),
+    optional_ALIGN_TYPE( float * ),
+    optional_ALIGN_TYPE( double * ),
+    optional_ALIGN_TYPE( long double * ),
+
+    optional_ALIGN_TYPE( Unknown ( * )( Unknown ) ),
+    optional_ALIGN_TYPE( Unknown * Unknown::*     ),
+    optional_ALIGN_TYPE( Unknown ( Unknown::* )( Unknown ) ),
+
+    nulltype
+    > > > > > > >    > > > > > > >
+    > > > > > > >    > > > > > > >
+    > > > > > >
+    alignment_types;
+
+#undef optional_ALIGN_TYPE
+
+#endif // optional_CONFIG_MAX_ALIGN_HACK
+
+/// C++03 constructed union to hold value.
+
+template< typename T >
+union storage_t
+{
+//private:
+//    template< typename > friend class optional;
+
+    typedef T value_type;
+
+    storage_t() optional_is_default
+
+    explicit storage_t( value_type const & v )
+    {
+        construct_value( v );
+    }
+
+    void construct_value( value_type const & v )
+    {
+        ::new( value_ptr() ) value_type( v );
+    }
+
+#if optional_CPP11_OR_GREATER
+
+    explicit storage_t( value_type && v )
+    {
+        construct_value( std::move( v ) );
+    }
+
+    void construct_value( value_type && v )
+    {
+        ::new( value_ptr() ) value_type( std::move( v ) );
+    }
+
+    template< class... Args >
+    void emplace( Args&&... args )
+    {
+        ::new( value_ptr() ) value_type( std::forward<Args>(args)... );
+    }
+
+    template< class U, class... Args >
+    void emplace( std::initializer_list<U> il, Args&&... args )
+    {
+        ::new( value_ptr() ) value_type( il, std::forward<Args>(args)... );
+    }
+
+#endif
+
+    void destruct_value()
+    {
+        value_ptr()->~T();
+    }
+
+    optional_nodiscard value_type const * value_ptr() const
+    {
+        return as<value_type>();
+    }
+
+    value_type * value_ptr()
+    {
+        return as<value_type>();
+    }
+
+    optional_nodiscard value_type const & value() const optional_ref_qual
+    {
+        return * value_ptr();
+    }
+
+    value_type & value() optional_ref_qual
+    {
+        return * value_ptr();
+    }
+
+#if optional_CPP11_OR_GREATER
+
+    optional_nodiscard value_type const && value() const optional_refref_qual
+    {
+        return std::move( value() );
+    }
+
+    value_type && value() optional_refref_qual
+    {
+        return std::move( value() );
+    }
+
+#endif
+
+#if optional_CPP11_OR_GREATER
+
+    using aligned_storage_t = typename std::aligned_storage< sizeof(value_type), alignof(value_type) >::type;
+    aligned_storage_t data;
+
+#elif optional_CONFIG_MAX_ALIGN_HACK
+
+    typedef struct { unsigned char data[ sizeof(value_type) ]; } aligned_storage_t;
+
+    max_align_t hack;
+    aligned_storage_t data;
+
+#else
+    typedef optional_ALIGN_AS(value_type) align_as_type;
+
+    typedef struct { align_as_type data[ 1 + ( sizeof(value_type) - 1 ) / sizeof(align_as_type) ]; } aligned_storage_t;
+    aligned_storage_t data;
+
+#   undef optional_ALIGN_AS
+
+#endif // optional_CONFIG_MAX_ALIGN_HACK
+
+    optional_nodiscard void * ptr() optional_noexcept
+    {
+        return &data;
+    }
+
+    optional_nodiscard void const * ptr() const optional_noexcept
+    {
+        return &data;
+    }
+
+    template <typename U>
+    optional_nodiscard U * as()
+    {
+        return reinterpret_cast<U*>( ptr() );
+    }
+
+    template <typename U>
+    optional_nodiscard U const * as() const
+    {
+        return reinterpret_cast<U const *>( ptr() );
+    }
+};
+
+} // namespace detail
+
+/// disengaged state tag
+
+struct nullopt_t
+{
+    struct init{};
+    explicit optional_constexpr nullopt_t( init /*unused*/ ) optional_noexcept {}
+};
+
+#if optional_HAVE( CONSTEXPR_11 )
+constexpr nullopt_t nullopt{ nullopt_t::init{} };
+#else
+// extra parenthesis to prevent the most vexing parse:
+const nullopt_t nullopt(( nullopt_t::init() ));
+#endif
+
+/// optional access error
+
+#if ! optional_CONFIG_NO_EXCEPTIONS
+
+class bad_optional_access : public std::logic_error
+{
+public:
+  explicit bad_optional_access()
+  : logic_error( "bad optional access" ) {}
+};
+
+#endif //optional_CONFIG_NO_EXCEPTIONS
+
+/// optional
+
+template< typename T>
+class optional
+{
+private:
+    template< typename > friend class optional;
+
+    typedef void (optional::*safe_bool)() const;
+
+public:
+    typedef T value_type;
+
+    // x.x.3.1, constructors
+
+    // 1a - default construct
+    optional_constexpr optional() optional_noexcept
+    : has_value_( false )
+    , contained()
+    {}
+
+    // 1b - construct explicitly empty
+    // NOLINTNEXTLINE( google-explicit-constructor, hicpp-explicit-conversions )
+    optional_constexpr optional( nullopt_t /*unused*/ ) optional_noexcept
+    : has_value_( false )
+    , contained()
+    {}
+
+    // 2 - copy-construct
+    optional_constexpr14 optional( optional const & other
+#if optional_CPP11_OR_GREATER
+        optional_REQUIRES_A(
+            true || std::is_copy_constructible<T>::value
+        )
+#endif
+    )
+    : has_value_( other.has_value() )
+    {
+        if ( other.has_value() )
+        {
+            contained.construct_value( other.contained.value() );
+        }
+    }
+
+#if optional_CPP11_OR_GREATER
+
+    // 3 (C++11) - move-construct from optional
+    optional_constexpr14 optional( optional && other
+        optional_REQUIRES_A(
+            true || std::is_move_constructible<T>::value
+        )
+        // NOLINTNEXTLINE( performance-noexcept-move-constructor )
+    ) noexcept( std::is_nothrow_move_constructible<T>::value )
+    : has_value_( other.has_value() )
+    {
+        if ( other.has_value() )
+        {
+            contained.construct_value( std::move( other.contained.value() ) );
+        }
+    }
+
+    // 4a (C++11) - explicit converting copy-construct from optional
+    template< typename U >
+    explicit optional( optional<U> const & other
+        optional_REQUIRES_A(
+            std::is_constructible<T, U const &>::value
+            && !std::is_constructible<T, optional<U> &          >::value
+            && !std::is_constructible<T, optional<U> &&         >::value
+            && !std::is_constructible<T, optional<U> const &    >::value
+            && !std::is_constructible<T, optional<U> const &&   >::value
+            && !std::is_convertible<     optional<U> &       , T>::value
+            && !std::is_convertible<     optional<U> &&      , T>::value
+            && !std::is_convertible<     optional<U> const & , T>::value
+            && !std::is_convertible<     optional<U> const &&, T>::value
+            && !std::is_convertible<               U const & , T>::value /*=> explicit */
+        )
+    )
+    : has_value_( other.has_value() )
+    {
+        if ( other.has_value() )
+        {
+            contained.construct_value( T{ other.contained.value() } );
+        }
+    }
+#endif // optional_CPP11_OR_GREATER
+
+    // 4b (C++98 and later) - non-explicit converting copy-construct from optional
+    template< typename U >
+    // NOLINTNEXTLINE( google-explicit-constructor, hicpp-explicit-conversions )
+    optional( optional<U> const & other
+#if optional_CPP11_OR_GREATER
+        optional_REQUIRES_A(
+            std::is_constructible<T, U const &>::value
+            && !std::is_constructible<T, optional<U> &          >::value
+            && !std::is_constructible<T, optional<U> &&         >::value
+            && !std::is_constructible<T, optional<U> const &    >::value
+            && !std::is_constructible<T, optional<U> const &&   >::value
+            && !std::is_convertible<     optional<U> &       , T>::value
+            && !std::is_convertible<     optional<U> &&      , T>::value
+            && !std::is_convertible<     optional<U> const & , T>::value
+            && !std::is_convertible<     optional<U> const &&, T>::value
+            &&  std::is_convertible<               U const & , T>::value /*=> non-explicit */
+        )
+#endif // optional_CPP11_OR_GREATER
+    )
+    : has_value_( other.has_value() )
+    {
+        if ( other.has_value() )
+        {
+            contained.construct_value( other.contained.value() );
+        }
+    }
+
+#if optional_CPP11_OR_GREATER
+
+    // 5a (C++11) - explicit converting move-construct from optional
+    template< typename U >
+    explicit optional( optional<U> && other
+        optional_REQUIRES_A(
+            std::is_constructible<T, U &&>::value
+            && !std::is_constructible<T, optional<U> &          >::value
+            && !std::is_constructible<T, optional<U> &&         >::value
+            && !std::is_constructible<T, optional<U> const &    >::value
+            && !std::is_constructible<T, optional<U> const &&   >::value
+            && !std::is_convertible<     optional<U> &       , T>::value
+            && !std::is_convertible<     optional<U> &&      , T>::value
+            && !std::is_convertible<     optional<U> const & , T>::value
+            && !std::is_convertible<     optional<U> const &&, T>::value
+            && !std::is_convertible<                     U &&, T>::value /*=> explicit */
+        )
+    )
+    : has_value_( other.has_value() )
+    {
+        if ( other.has_value() )
+        {
+            contained.construct_value( T{ std::move( other.contained.value() ) } );
+        }
+    }
+
+    // 5a (C++11) - non-explicit converting move-construct from optional
+    template< typename U >
+    // NOLINTNEXTLINE( google-explicit-constructor, hicpp-explicit-conversions )
+    optional( optional<U> && other
+        optional_REQUIRES_A(
+            std::is_constructible<T, U &&>::value
+            && !std::is_constructible<T, optional<U> &          >::value
+            && !std::is_constructible<T, optional<U> &&         >::value
+            && !std::is_constructible<T, optional<U> const &    >::value
+            && !std::is_constructible<T, optional<U> const &&   >::value
+            && !std::is_convertible<     optional<U> &       , T>::value
+            && !std::is_convertible<     optional<U> &&      , T>::value
+            && !std::is_convertible<     optional<U> const & , T>::value
+            && !std::is_convertible<     optional<U> const &&, T>::value
+            &&  std::is_convertible<                     U &&, T>::value /*=> non-explicit */
+        )
+    )
+    : has_value_( other.has_value() )
+    {
+        if ( other.has_value() )
+        {
+            contained.construct_value( std::move( other.contained.value() ) );
+        }
+    }
+
+    // 6 (C++11) - in-place construct
+    template< typename... Args
+        optional_REQUIRES_T(
+            std::is_constructible<T, Args&&...>::value
+        )
+    >
+    optional_constexpr explicit optional( nonstd_lite_in_place_t(T), Args&&... args )
+    : has_value_( true )
+    , contained( T( std::forward<Args>(args)...) )
+    {}
+
+    // 7 (C++11) - in-place construct,  initializer-list
+    template< typename U, typename... Args
+        optional_REQUIRES_T(
+            std::is_constructible<T, std::initializer_list<U>&, Args&&...>::value
+        )
+    >
+    optional_constexpr explicit optional( nonstd_lite_in_place_t(T), std::initializer_list<U> il, Args&&... args )
+    : has_value_( true )
+    , contained( T( il, std::forward<Args>(args)...) )
+    {}
+
+    // 8a (C++11) - explicit move construct from value
+    template< typename U = value_type >
+    optional_constexpr explicit optional( U && value
+        optional_REQUIRES_A(
+            std::is_constructible<T, U&&>::value
+            && !std::is_same<typename std20::remove_cvref<U>::type, nonstd_lite_in_place_t(U)>::value
+            && !std::is_same<typename std20::remove_cvref<U>::type, optional<T>>::value
+            && !std::is_convertible<U&&, T>::value /*=> explicit */
+        )
+    )
+    : has_value_( true )
+    , contained( T{ std::forward<U>( value ) } )
+    {}
+
+    // 8b (C++11) - non-explicit move construct from value
+    template< typename U = value_type >
+    // NOLINTNEXTLINE( google-explicit-constructor, hicpp-explicit-conversions )
+    optional_constexpr optional( U && value
+        optional_REQUIRES_A(
+            std::is_constructible<T, U&&>::value
+            && !std::is_same<typename std20::remove_cvref<U>::type, nonstd_lite_in_place_t(U)>::value
+            && !std::is_same<typename std20::remove_cvref<U>::type, optional<T>>::value
+            && std::is_convertible<U&&, T>::value /*=> non-explicit */
+        )
+    )
+    : has_value_( true )
+    , contained( std::forward<U>( value ) )
+    {}
+
+#else // optional_CPP11_OR_GREATER
+
+    // 8 (C++98)
+    optional( value_type const & value )
+    : has_value_( true )
+    , contained( value )
+    {}
+
+#endif // optional_CPP11_OR_GREATER
+
+    // x.x.3.2, destructor
+
+    ~optional()
+    {
+        if ( has_value() )
+        {
+            contained.destruct_value();
+        }
+    }
+
+    // x.x.3.3, assignment
+
+    // 1 (C++98and later) -  assign explicitly empty
+    optional & operator=( nullopt_t /*unused*/) optional_noexcept
+    {
+        reset();
+        return *this;
+    }
+
+    // 2 (C++98and later) - copy-assign from optional
+#if optional_CPP11_OR_GREATER
+    // NOLINTNEXTLINE( cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator )
+    optional_REQUIRES_R(
+        optional &,
+        true
+//      std::is_copy_constructible<T>::value
+//      && std::is_copy_assignable<T>::value
+    )
+    operator=( optional const & other )
+        noexcept(
+            std::is_nothrow_move_assignable<T>::value
+            && std::is_nothrow_move_constructible<T>::value
+        )
+#else
+    optional & operator=( optional const & other )
+#endif
+    {
+        if      ( (has_value() == true ) && (other.has_value() == false) ) { reset(); }
+        else if ( (has_value() == false) && (other.has_value() == true ) ) { initialize( *other ); }
+        else if ( (has_value() == true ) && (other.has_value() == true ) ) { contained.value() = *other; }
+        return *this;
+    }
+
+#if optional_CPP11_OR_GREATER
+
+    // 3 (C++11) - move-assign from optional
+    // NOLINTNEXTLINE( cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator )
+    optional_REQUIRES_R(
+        optional &,
+        true
+//      std::is_move_constructible<T>::value
+//      && std::is_move_assignable<T>::value
+    )
+    operator=( optional && other ) noexcept
+    {
+        if      ( (has_value() == true ) && (other.has_value() == false) ) { reset(); }
+        else if ( (has_value() == false) && (other.has_value() == true ) ) { initialize( std::move( *other ) ); }
+        else if ( (has_value() == true ) && (other.has_value() == true ) ) { contained.value() = std::move( *other ); }
+        return *this;
+    }
+
+    // 4 (C++11) - move-assign from value
+    template< typename U = T >
+        // NOLINTNEXTLINE( cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator )
+        optional_REQUIRES_R(
+            optional &,
+            std::is_constructible<T , U>::value
+            && std::is_assignable<T&, U>::value
+            && !std::is_same<typename std20::remove_cvref<U>::type, nonstd_lite_in_place_t(U)>::value
+            && !std::is_same<typename std20::remove_cvref<U>::type, optional<T>>::value
+            && !(std::is_scalar<T>::value && std::is_same<T, typename std::decay<U>::type>::value)
+        )
+    operator=( U && value )
+    {
+        if ( has_value() )
+        {
+            contained.value() = std::forward<U>( value );
+        }
+        else
+        {
+            initialize( T( std::forward<U>( value ) ) );
+        }
+        return *this;
+    }
+
+#else // optional_CPP11_OR_GREATER
+
+    // 4 (C++98) - copy-assign from value
+    template< typename U /*= T*/ >
+    optional & operator=( U const & value )
+    {
+        if ( has_value() ) contained.value() = value;
+        else               initialize( T( value ) );
+        return *this;
+    }
+
+#endif // optional_CPP11_OR_GREATER
+
+    // 5 (C++98 and later) - converting copy-assign from optional
+    template< typename U >
+#if optional_CPP11_OR_GREATER
+        // NOLINTNEXTLINE( cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator )
+        optional_REQUIRES_R(
+            optional&,
+            std::is_constructible<  T , U const &>::value
+            &&  std::is_assignable< T&, U const &>::value
+            && !std::is_constructible<T, optional<U> &          >::value
+            && !std::is_constructible<T, optional<U> &&         >::value
+            && !std::is_constructible<T, optional<U> const &    >::value
+            && !std::is_constructible<T, optional<U> const &&   >::value
+            && !std::is_convertible<     optional<U> &       , T>::value
+            && !std::is_convertible<     optional<U> &&      , T>::value
+            && !std::is_convertible<     optional<U> const & , T>::value
+            && !std::is_convertible<     optional<U> const &&, T>::value
+            && !std::is_assignable<  T&, optional<U> &          >::value
+            && !std::is_assignable<  T&, optional<U> &&         >::value
+            && !std::is_assignable<  T&, optional<U> const &    >::value
+            && !std::is_assignable<  T&, optional<U> const &&   >::value
+        )
+#else
+    optional&
+#endif // optional_CPP11_OR_GREATER
+    operator=( optional<U> const & other )
+    {
+        return *this = optional( other );
+    }
+
+#if optional_CPP11_OR_GREATER
+
+    // 6 (C++11) -  converting move-assign from optional
+    template< typename U >
+        // NOLINTNEXTLINE( cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator )
+        optional_REQUIRES_R(
+            optional&,
+            std::is_constructible<  T , U>::value
+            &&  std::is_assignable< T&, U>::value
+            && !std::is_constructible<T, optional<U> &          >::value
+            && !std::is_constructible<T, optional<U> &&         >::value
+            && !std::is_constructible<T, optional<U> const &    >::value
+            && !std::is_constructible<T, optional<U> const &&   >::value
+            && !std::is_convertible<     optional<U> &       , T>::value
+            && !std::is_convertible<     optional<U> &&      , T>::value
+            && !std::is_convertible<     optional<U> const & , T>::value
+            && !std::is_convertible<     optional<U> const &&, T>::value
+            && !std::is_assignable<  T&, optional<U> &          >::value
+            && !std::is_assignable<  T&, optional<U> &&         >::value
+            && !std::is_assignable<  T&, optional<U> const &    >::value
+            && !std::is_assignable<  T&, optional<U> const &&   >::value
+        )
+    operator=( optional<U> && other )
+    {
+        return *this = optional( std::move( other ) );
+    }
+
+    // 7 (C++11) - emplace
+    template< typename... Args
+        optional_REQUIRES_T(
+            std::is_constructible<T, Args&&...>::value
+        )
+    >
+    T& emplace( Args&&... args )
+    {
+        *this = nullopt;
+        contained.emplace( std::forward<Args>(args)...  );
+        has_value_ = true;
+        return contained.value();
+    }
+
+    // 8 (C++11) - emplace, initializer-list
+    template< typename U, typename... Args
+        optional_REQUIRES_T(
+            std::is_constructible<T, std::initializer_list<U>&, Args&&...>::value
+        )
+    >
+    T& emplace( std::initializer_list<U> il, Args&&... args )
+    {
+        *this = nullopt;
+        contained.emplace( il, std::forward<Args>(args)...  );
+        has_value_ = true;
+        return contained.value();
+    }
+
+#endif // optional_CPP11_OR_GREATER
+
+    // x.x.3.4, swap
+
+    void swap( optional & other )
+#if optional_CPP11_OR_GREATER
+        noexcept(
+            std::is_nothrow_move_constructible<T>::value
+            && std17::is_nothrow_swappable<T>::value
+        )
+#endif
+    {
+        using std::swap;
+        if      ( (has_value() == true ) && (other.has_value() == true ) ) { swap( **this, *other ); }
+        else if ( (has_value() == false) && (other.has_value() == true ) ) { initialize( std11::move(*other) ); other.reset(); }
+        else if ( (has_value() == true ) && (other.has_value() == false) ) { other.initialize( std11::move(**this) ); reset(); }
+    }
+
+    // x.x.3.5, observers
+
+    optional_constexpr value_type const * operator ->() const
+    {
+        return assert( has_value() ),
+            contained.value_ptr();
+    }
+
+    optional_constexpr14 value_type * operator ->()
+    {
+        return assert( has_value() ),
+            contained.value_ptr();
+    }
+
+    optional_constexpr value_type const & operator *() const optional_ref_qual
+    {
+        return assert( has_value() ),
+            contained.value();
+    }
+
+    optional_constexpr14 value_type & operator *() optional_ref_qual
+    {
+        return assert( has_value() ),
+            contained.value();
+    }
+
+#if optional_HAVE( REF_QUALIFIER )  &&  ( !optional_COMPILER_GNUC_VERSION || optional_COMPILER_GNUC_VERSION >= 490 )
+
+    optional_constexpr value_type const && operator *() const optional_refref_qual
+    {
+        return std::move( **this );
+    }
+
+    optional_constexpr14 value_type && operator *() optional_refref_qual
+    {
+        return std::move( **this );
+    }
+
+#endif
+
+#if optional_CPP11_OR_GREATER
+    optional_constexpr explicit operator bool() const optional_noexcept
+    {
+        return has_value();
+    }
+#else
+    optional_constexpr operator safe_bool() const optional_noexcept
+    {
+        return has_value() ? &optional::this_type_does_not_support_comparisons : 0;
+    }
+#endif
+
+    // NOLINTNEXTLINE( modernize-use-nodiscard )
+    /*optional_nodiscard*/ optional_constexpr bool has_value() const optional_noexcept
+    {
+        return has_value_;
+    }
+
+    // NOLINTNEXTLINE( modernize-use-nodiscard )
+    /*optional_nodiscard*/ optional_constexpr14 value_type const & value() const optional_ref_qual
+    {
+#if optional_CONFIG_NO_EXCEPTIONS
+        assert( has_value() );
+#else
+        if ( ! has_value() )
+        {
+            throw bad_optional_access();
+        }
+#endif
+        return contained.value();
+    }
+
+    optional_constexpr14 value_type & value() optional_ref_qual
+    {
+#if optional_CONFIG_NO_EXCEPTIONS
+        assert( has_value() );
+#else
+        if ( ! has_value() )
+        {
+            throw bad_optional_access();
+        }
+#endif
+        return contained.value();
+    }
+
+#if optional_HAVE( REF_QUALIFIER )  &&  ( !optional_COMPILER_GNUC_VERSION || optional_COMPILER_GNUC_VERSION >= 490 )
+
+    // NOLINTNEXTLINE( modernize-use-nodiscard )
+    /*optional_nodiscard*/ optional_constexpr value_type const && value() const optional_refref_qual
+    {
+        return std::move( value() );
+    }
+
+    optional_constexpr14 value_type && value() optional_refref_qual
+    {
+        return std::move( value() );
+    }
+
+#endif
+
+#if optional_CPP11_OR_GREATER
+
+    template< typename U >
+    optional_constexpr value_type value_or( U && v ) const optional_ref_qual
+    {
+        return has_value() ? contained.value() : static_cast<T>(std::forward<U>( v ) );
+    }
+
+    template< typename U >
+    optional_constexpr14 value_type value_or( U && v ) optional_refref_qual
+    {
+        return has_value() ? std::move( contained.value() ) : static_cast<T>(std::forward<U>( v ) );
+    }
+
+#else
+
+    template< typename U >
+    optional_constexpr value_type value_or( U const & v ) const
+    {
+        return has_value() ? contained.value() : static_cast<value_type>( v );
+    }
+
+#endif // optional_CPP11_OR_GREATER
+
+    // x.x.3.6, modifiers
+
+    void reset() optional_noexcept
+    {
+        if ( has_value() )
+        {
+            contained.destruct_value();
+        }
+
+        has_value_ = false;
+    }
+
+private:
+    void this_type_does_not_support_comparisons() const {}
+
+    template< typename V >
+    void initialize( V const & value )
+    {
+        assert( ! has_value()  );
+        contained.construct_value( value );
+        has_value_ = true;
+    }
+
+#if optional_CPP11_OR_GREATER
+    template< typename V >
+    void initialize( V && value )
+    {
+        assert( ! has_value()  );
+        contained.construct_value( std::move( value ) );
+        has_value_ = true;
+    }
+
+#endif
+
+private:
+    bool has_value_;
+    detail::storage_t< value_type > contained;
+
+};
+
+// Relational operators
+
+template< typename T, typename U >
+inline optional_constexpr bool operator==( optional<T> const & x, optional<U> const & y )
+{
+    return bool(x) != bool(y) ? false : !bool( x ) ? true : *x == *y;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator!=( optional<T> const & x, optional<U> const & y )
+{
+    return !(x == y);
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator<( optional<T> const & x, optional<U> const & y )
+{
+    return (!y) ? false : (!x) ? true : *x < *y;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator>( optional<T> const & x, optional<U> const & y )
+{
+    return (y < x);
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator<=( optional<T> const & x, optional<U> const & y )
+{
+    return !(y < x);
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator>=( optional<T> const & x, optional<U> const & y )
+{
+    return !(x < y);
+}
+
+// Comparison with nullopt
+
+template< typename T >
+inline optional_constexpr bool operator==( optional<T> const & x, nullopt_t /*unused*/ ) optional_noexcept
+{
+    return (!x);
+}
+
+template< typename T >
+inline optional_constexpr bool operator==( nullopt_t /*unused*/, optional<T> const & x ) optional_noexcept
+{
+    return (!x);
+}
+
+template< typename T >
+inline optional_constexpr bool operator!=( optional<T> const & x, nullopt_t /*unused*/ ) optional_noexcept
+{
+    return bool(x);
+}
+
+template< typename T >
+inline optional_constexpr bool operator!=( nullopt_t /*unused*/, optional<T> const & x ) optional_noexcept
+{
+    return bool(x);
+}
+
+template< typename T >
+inline optional_constexpr bool operator<( optional<T> const & /*unused*/, nullopt_t /*unused*/ ) optional_noexcept
+{
+    return false;
+}
+
+template< typename T >
+inline optional_constexpr bool operator<( nullopt_t /*unused*/, optional<T> const & x ) optional_noexcept
+{
+    return bool(x);
+}
+
+template< typename T >
+inline optional_constexpr bool operator<=( optional<T> const & x, nullopt_t /*unused*/ ) optional_noexcept
+{
+    return (!x);
+}
+
+template< typename T >
+inline optional_constexpr bool operator<=( nullopt_t /*unused*/, optional<T> const & /*unused*/ ) optional_noexcept
+{
+    return true;
+}
+
+template< typename T >
+inline optional_constexpr bool operator>( optional<T> const & x, nullopt_t /*unused*/ ) optional_noexcept
+{
+    return bool(x);
+}
+
+template< typename T >
+inline optional_constexpr bool operator>( nullopt_t /*unused*/, optional<T> const & /*unused*/ ) optional_noexcept
+{
+    return false;
+}
+
+template< typename T >
+inline optional_constexpr bool operator>=( optional<T> const & /*unused*/, nullopt_t /*unused*/ ) optional_noexcept
+{
+    return true;
+}
+
+template< typename T >
+inline optional_constexpr bool operator>=( nullopt_t /*unused*/, optional<T> const & x ) optional_noexcept
+{
+    return (!x);
+}
+
+// Comparison with T
+
+template< typename T, typename U >
+inline optional_constexpr bool operator==( optional<T> const & x, U const & v )
+{
+    return bool(x) ? *x == v : false;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator==( U const & v, optional<T> const & x )
+{
+    return bool(x) ? v == *x : false;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator!=( optional<T> const & x, U const & v )
+{
+    return bool(x) ? *x != v : true;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator!=( U const & v, optional<T> const & x )
+{
+    return bool(x) ? v != *x : true;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator<( optional<T> const & x, U const & v )
+{
+    return bool(x) ? *x < v : true;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator<( U const & v, optional<T> const & x )
+{
+    return bool(x) ? v < *x : false;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator<=( optional<T> const & x, U const & v )
+{
+    return bool(x) ? *x <= v : true;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator<=( U const & v, optional<T> const & x )
+{
+    return bool(x) ? v <= *x : false;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator>( optional<T> const & x, U const & v )
+{
+    return bool(x) ? *x > v : false;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator>( U const & v, optional<T> const & x )
+{
+    return bool(x) ? v > *x : true;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator>=( optional<T> const & x, U const & v )
+{
+    return bool(x) ? *x >= v : false;
+}
+
+template< typename T, typename U >
+inline optional_constexpr bool operator>=( U const & v, optional<T> const & x )
+{
+    return bool(x) ? v >= *x : true;
+}
+
+// Specialized algorithms
+
+template< typename T
+#if optional_CPP11_OR_GREATER
+    optional_REQUIRES_T(
+        std::is_move_constructible<T>::value
+        && std17::is_swappable<T>::value )
+#endif
+>
+void swap( optional<T> & x, optional<T> & y )
+#if optional_CPP11_OR_GREATER
+    noexcept( noexcept( x.swap(y) ) )
+#endif
+{
+    x.swap( y );
+}
+
+#if optional_CPP11_OR_GREATER
+
+template< typename T >
+optional_constexpr optional< typename std::decay<T>::type > make_optional( T && value )
+{
+    return optional< typename std::decay<T>::type >( std::forward<T>( value ) );
+}
+
+template< typename T, typename...Args >
+optional_constexpr optional<T> make_optional( Args&&... args )
+{
+    return optional<T>( nonstd_lite_in_place(T), std::forward<Args>(args)...);
+}
+
+template< typename T, typename U, typename... Args >
+optional_constexpr optional<T> make_optional( std::initializer_list<U> il, Args&&... args )
+{
+    return optional<T>( nonstd_lite_in_place(T), il, std::forward<Args>(args)...);
+}
+
+#else
+
+template< typename T >
+optional<T> make_optional( T const & value )
+{
+    return optional<T>( value );
+}
+
+#endif // optional_CPP11_OR_GREATER
+
+} // namespace optional_lite
+
+using optional_lite::optional;
+using optional_lite::nullopt_t;
+using optional_lite::nullopt;
+using optional_lite::bad_optional_access;
+
+using optional_lite::make_optional;
+
+} // namespace nonstd
+
+#if optional_CPP11_OR_GREATER
+
+// specialize the std::hash algorithm:
+
+namespace std {
+
+template< class T >
+struct hash< nonstd::optional<T> >
+{
+public:
+    std::size_t operator()( nonstd::optional<T> const & v ) const optional_noexcept
+    {
+        return bool( v ) ? std::hash<T>{}( *v ) : 0;
+    }
+};
+
+} //namespace std
+
+#endif // optional_CPP11_OR_GREATER
+
+#if defined(__clang__)
+# pragma clang diagnostic pop
+#elif defined(__GNUC__)
+# pragma GCC   diagnostic pop
+#elif defined(_MSC_VER )
+# pragma warning( pop )
+#endif
+
+#endif // optional_USES_STD_OPTIONAL
+
+#endif // NONSTD_OPTIONAL_LITE_HPP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ acknowledge contributions from the following people:
   van der Schagt)
 - "feedlink" attribute containing feed title instead of feed URL (Alexander
     Batischev)
+- "date" attribute containing fixed string instead of item's publication date
+    and time (Alexander Batischev)
 ### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ acknowledge contributions from the following people:
 - New format specifiers (%n, %d, and %F) for articlelist-format which
   correspond respectively to article fields "unread", "deleted", and article
   flags (#869) (Dennis van der Schagt)
+- Dependency on martinmoene/optional-lite library, which we vendor
 ### Changed
 - Allow binding multiple keys to general operations: up, down, pageup, pagedown,
   home, end (#847) (Dennis van der Schagt)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ acknowledge contributions from the following people:
   libstfl. A patch for that library is available at
   https://github.com/dennisschagt/stfl/pull/4#issuecomment-613640246 (Dennis
   van der Schagt)
+- "feedlink" attribute containing feed title instead of feed URL (Alexander
+    Batischev)
 ### Security
 
 

--- a/include/cliargsparser.h
+++ b/include/cliargsparser.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#include "3rd-party/optional.hpp"
+
 #include "logger.h"
 
 namespace newsboat {
@@ -22,15 +24,13 @@ public:
 
 	std::string importfile() const;
 
-	/// If `do_read_import()` is `true`, Newsboat should import read articles
-	/// info from  `readinfo_import_file()`.
-	bool do_read_import() const;
-	std::string readinfo_import_file() const;
+	/// If non-null, Newsboat should import read articles info from this
+	/// filepath.
+	nonstd::optional<std::string> readinfo_import_file() const;
 
-	/// If `do_read_export()` is `true`, Newsboat should export read articles
-	/// info to `readinfo_export_file()`.
-	bool do_read_export() const;
-	std::string readinfo_export_file() const;
+	/// If non-null, Newsboat should export read articles info to this
+	/// filepath.
+	nonstd::optional<std::string> readinfo_export_file() const;
 
 	std::string program_name() const;
 
@@ -40,16 +40,15 @@ public:
 
 	bool using_nonstandard_configs() const;
 
-	/// If `should_return()` is `true`, the creator of `CliArgsParser` object
-	/// should call `exit(return_code())`.
-	bool should_return() const;
-	int return_code() const;
+	/// If non-null, the creator of `CliArgsParser` object should call `exit()`
+	/// with this code.
+	nonstd::optional<int> return_code() const;
 
 	/// If `display_msg()` is not empty, the creator of `CliArgsParser` should
 	/// print its contents to stderr.
 	///
 	/// \note The contents of this string should be checked before processing
-	/// `should_return`.
+	/// `return_code()`.
 	std::string display_msg() const;
 
 	/// If `should_print_usage()` is `true`, the creator of `CliArgsParser`
@@ -61,39 +60,22 @@ public:
 
 	bool refresh_on_start() const;
 
-	/// `url_file()` should only be called if `set_url_file()` returned `true`.
-	bool set_url_file() const;
-	std::string url_file() const;
+	nonstd::optional<std::string> url_file() const;
 
-	/// `lock_file()` should only be called if `set_lock_file()` returned
-	/// `true`.
-	bool set_lock_file() const;
-	std::string lock_file() const;
+	nonstd::optional<std::string> lock_file() const;
 
-	/// `cache_file()` should only be called if `set_cache_file()` returned
-	/// `true`.
-	bool set_cache_file() const;
-	std::string cache_file() const;
+	nonstd::optional<std::string> cache_file() const;
 
-	/// `config_file()` should only be called if `set_config_file` returned
-	/// `true`.
-	bool set_config_file() const;
-	std::string config_file() const;
+	nonstd::optional<std::string> config_file() const;
 
-	/// If 'execute_cmds()' is true, Newsboat should execute commands from
-	/// `cmds_to_execute()`.
+	/// If non-null, Newsboat should execute these commands.
 	///
 	/// \note The parser does not check if the passed commands are valid.
-	bool execute_cmds() const;
-	std::vector<std::string> cmds_to_execute() const;
+	nonstd::optional<std::vector<std::string>> cmds_to_execute() const;
 
-	/// `log_file()` should only be called if `set_log_file()` returned `true`.
-	bool set_log_file() const;
-	std::string log_file() const;
+	nonstd::optional<std::string> log_file() const;
 
-	/// `log_level()` should only be called if `set_log_level` returned `true`.
-	bool set_log_level() const;
-	Level log_level() const;
+	nonstd::optional<Level> log_level() const;
 
 	/// Returns the pointer to the Rust object.
 	///

--- a/include/matchable.h
+++ b/include/matchable.h
@@ -3,14 +3,16 @@
 
 #include <string>
 
+#include "3rd-party/optional.hpp"
+
 namespace newsboat {
 
 class Matchable {
 public:
 	Matchable() = default;
 	virtual ~Matchable() = default;
-	virtual bool has_attribute(const std::string& attribname) = 0;
-	virtual std::string get_attribute(const std::string& attribname) = 0;
+	virtual nonstd::optional<std::string> attribute_value(const std::string& attr) =
+		0;
 };
 
 } // namespace newsboat

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -53,7 +53,7 @@ public:
 
 	std::string pubDate() const
 	{
-		return "TODO";
+		return utils::mt_strf_localtime(_("%a, %d %b %Y %T %z"), pubDate_);
 	}
 	void set_pubDate(time_t t)
 	{

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -128,8 +128,7 @@ public:
 	std::string get_tags();
 	std::string get_firsttag();
 
-	bool has_attribute(const std::string& attribname) override;
-	std::string get_attribute(const std::string& attribname) override;
+	nonstd::optional<std::string> attribute_value(const std::string& attr) override;
 
 	void update_items(std::vector<std::shared_ptr<RssFeed>> feeds);
 

--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -123,8 +123,7 @@ public:
 	void update_flags();
 	void sort_flags();
 
-	bool has_attribute(const std::string& attribname) override;
-	std::string get_attribute(const std::string& attribname) override;
+	nonstd::optional<std::string> attribute_value(const std::string& attr) override;
 
 	void set_feedptr(std::shared_ptr<RssFeed> ptr);
 	void set_feedptr(const std::weak_ptr<RssFeed>& ptr);

--- a/include/utils.h
+++ b/include/utils.h
@@ -8,6 +8,8 @@
 #include <string>
 #include <vector>
 
+#include "3rd-party/optional.hpp"
+
 #include "configcontainer.h"
 #include "logger.h"
 
@@ -144,7 +146,8 @@ void remove_soft_hyphens(std::string& text);
 
 bool is_valid_podcast_type(const std::string& mimetype);
 
-LinkType podcast_mime_to_link_type(const std::string& mimetype, bool& ok);
+nonstd::optional<LinkType> podcast_mime_to_link_type(const std::string&
+	mimetype);
 
 std::string get_default_browser();
 

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -1,37 +1,39 @@
 filter/FilterParser.o: filter/FilterParser.cpp filter/FilterParser.h \
  include/logger.h config.h include/strprintf.h filter/Parser.h \
- filter/Scanner.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h
+ filter/Scanner.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h
 filter/Parser.o: filter/Parser.cpp filter/Parser.h filter/FilterParser.h \
  filter/Scanner.h
 filter/Scanner.o: filter/Scanner.cpp filter/Scanner.h
 rss/atomparser.o: rss/atomparser.cpp rss/atomparser.h rss/rssparser.h \
  config.h rss/exception.h rss/feed.h rss/item.h rss/rsspp_uris.h \
- include/utils.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h include/strprintf.h
+ include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h include/logger.h \
+ include/strprintf.h
 rss/exception.o: rss/exception.cpp rss/exception.h
 rss/parser.o: rss/parser.cpp rss/parser.h include/remoteapi.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h rss/feed.h rss/item.h config.h \
  rss/exception.h include/logger.h include/strprintf.h rss/rssparser.h \
  rss/rssparserfactory.h rss/rsspp_uris.h include/strprintf.h \
- include/utils.h include/logger.h
+ include/utils.h 3rd-party/optional.hpp include/logger.h
 rss/rss09xparser.o: rss/rss09xparser.cpp rss/rss09xparser.h \
  rss/rssparser.h config.h rss/exception.h rss/feed.h rss/item.h \
- rss/rsspp_uris.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- include/strprintf.h
+ rss/rsspp_uris.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h include/strprintf.h
 rss/rss10parser.o: rss/rss10parser.cpp rss/rss10parser.h rss/rssparser.h \
  config.h rss/exception.h rss/feed.h rss/item.h rss/rsspp_uris.h
 rss/rss20parser.o: rss/rss20parser.cpp rss/rss20parser.h \
  rss/rss09xparser.h rss/rssparser.h config.h rss/exception.h rss/feed.h \
- rss/item.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- include/strprintf.h
+ rss/item.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h include/strprintf.h
 rss/rssparser.o: rss/rssparser.cpp rss/rssparser.h rss/exception.h \
- include/utils.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h
+ include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h include/logger.h \
+ config.h include/strprintf.h
 rss/rssparserfactory.o: rss/rssparserfactory.cpp rss/rssparserfactory.h \
  rss/rssparser.h rss/atomparser.h config.h rss/exception.h rss/feed.h \
  rss/item.h rss/rss09xparser.h rss/rss10parser.h rss/rss20parser.h
@@ -43,13 +45,13 @@ src/cache.o: src/cache.cpp include/cache.h include/configcontainer.h \
  include/urlreader.h include/queuemanager.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/reloader.h \
  include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/dbexception.h include/logger.h \
- include/strprintf.h include/matcherexception.h include/rssfeed.h \
- include/utils.h include/logger.h include/scopemeasure.h \
- include/strprintf.h include/utils.h
+ include/matchable.h 3rd-party/optional.hpp include/dbexception.h \
+ include/logger.h include/strprintf.h include/matcherexception.h \
+ include/rssfeed.h include/utils.h include/logger.h \
+ include/scopemeasure.h include/strprintf.h include/utils.h
 src/cliargsparser.o: src/cliargsparser.cpp include/cliargsparser.h \
- include/logger.h config.h include/strprintf.h include/globals.h \
- include/ruststring.h include/strprintf.h
+ 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
+ include/globals.h include/ruststring.h include/strprintf.h
 src/colormanager.o: src/colormanager.cpp include/colormanager.h \
  include/configparser.h include/configactionhandler.h config.h \
  include/confighandlerexception.h include/feedlistformaction.h \
@@ -61,19 +63,20 @@ src/colormanager.o: src/colormanager.cpp include/colormanager.h \
  include/fslock.h include/opml.h include/fileurlreader.h \
  include/urlreader.h include/queuemanager.h include/reloader.h \
  include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h include/filebrowserformaction.h \
- include/helpformaction.h include/itemlistformaction.h \
- include/listformatter.h include/itemviewformaction.h include/logger.h \
- include/strprintf.h include/matcherexception.h include/pbview.h \
- include/selectformaction.h include/strprintf.h \
- include/urlviewformaction.h include/utils.h include/logger.h
+ include/matchable.h 3rd-party/optional.hpp \
+ include/filebrowserformaction.h include/dirbrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h \
+ include/filebrowserformaction.h include/helpformaction.h \
+ include/itemlistformaction.h include/listformatter.h \
+ include/itemviewformaction.h include/logger.h include/strprintf.h \
+ include/matcherexception.h include/pbview.h include/selectformaction.h \
+ include/strprintf.h include/urlviewformaction.h include/utils.h \
+ include/logger.h
 src/configcontainer.o: src/configcontainer.cpp include/configcontainer.h \
  include/configparser.h include/configactionhandler.h config.h \
  include/configparser.h include/confighandlerexception.h include/logger.h \
  include/strprintf.h include/strprintf.h include/utils.h \
- include/configcontainer.h include/logger.h
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h
 src/confighandlerexception.o: src/confighandlerexception.cpp \
  include/confighandlerexception.h include/configparser.h \
  include/configactionhandler.h config.h
@@ -81,10 +84,12 @@ src/configparser.o: src/configparser.cpp include/configparser.h \
  include/configactionhandler.h config.h include/configexception.h \
  include/confighandlerexception.h include/configparser.h include/logger.h \
  include/strprintf.h include/strprintf.h include/tagsouppullparser.h \
- include/utils.h include/configcontainer.h include/logger.h
+ include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h
 src/configpaths.o: src/configpaths.cpp include/configpaths.h \
- include/cliargsparser.h include/logger.h config.h include/strprintf.h \
- include/globals.h include/ruststring.h include/strprintf.h
+ include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h include/globals.h include/ruststring.h \
+ include/strprintf.h
 src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/colormanager.h \
@@ -93,8 +98,8 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/queuemanager.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/reloader.h include/remoteapi.h \
  include/rssignores.h include/rssitem.h include/matchable.h \
- include/cliargsparser.h include/logger.h config.h include/strprintf.h \
- include/colormanager.h include/configcontainer.h \
+ 3rd-party/optional.hpp include/cliargsparser.h include/logger.h config.h \
+ include/strprintf.h include/colormanager.h include/configcontainer.h \
  include/configexception.h include/configparser.h include/configpaths.h \
  include/cliargsparser.h include/dbexception.h include/downloadthread.h \
  include/exception.h include/feedhqapi.h include/feedhqurlreader.h \
@@ -117,13 +122,13 @@ src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/stflpp.h config.h include/fmtstrformatter.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/strprintf.h include/utils.h \
- include/configcontainer.h include/logger.h include/strprintf.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/filebrowserformaction.h \
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ include/strprintf.h include/view.h include/colormanager.h \
+ include/controller.h include/cache.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/filebrowserformaction.h \
  include/dirbrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h
 src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
@@ -131,15 +136,16 @@ src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/configparser.h include/configactionhandler.h \
  include/formaction.h include/history.h include/keymap.h include/stflpp.h \
  config.h include/fmtstrformatter.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h include/logger.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h include/view.h include/colormanager.h \
+ include/controller.h include/cache.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
  include/pbcontroller.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h include/fslock.h \
@@ -152,18 +158,20 @@ src/exception.o: src/exception.cpp include/exception.h config.h
 src/feedcontainer.o: src/feedcontainer.cpp include/feedcontainer.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/rssfeed.h include/matchable.h \
- include/rssitem.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/logger.h config.h include/strprintf.h \
- include/utils.h
+ 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h include/utils.h
 src/feedhqapi.o: src/feedhqapi.cpp include/feedhqapi.h include/cache.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/remoteapi.h config.h \
- include/strprintf.h include/utils.h include/logger.h include/strprintf.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h include/strprintf.h
 src/feedhqurlreader.o: src/feedhqurlreader.cpp include/feedhqurlreader.h \
  include/urlreader.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/fileurlreader.h include/logger.h \
  config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h include/logger.h
+ include/configcontainer.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h
 src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/feedlistformaction.h include/history.h include/listformaction.h \
  include/formaction.h include/keymap.h include/configparser.h \
@@ -174,10 +182,10 @@ src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/fslock.h include/opml.h include/fileurlreader.h \
  include/urlreader.h include/queuemanager.h include/reloader.h \
  include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h config.h include/dbexception.h \
- include/feedcontainer.h include/fmtstrformatter.h \
+ include/matchable.h 3rd-party/optional.hpp \
+ include/filebrowserformaction.h include/dirbrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h config.h \
+ include/dbexception.h include/feedcontainer.h include/fmtstrformatter.h \
  include/listformatter.h include/logger.h include/strprintf.h \
  include/reloader.h include/rssfeed.h include/utils.h include/logger.h \
  include/scopemeasure.h include/strprintf.h include/utils.h \
@@ -187,24 +195,26 @@ src/filebrowserformaction.o: src/filebrowserformaction.cpp \
  include/configparser.h include/configactionhandler.h \
  include/formaction.h include/history.h include/keymap.h include/stflpp.h \
  config.h include/fmtstrformatter.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h include/logger.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h include/view.h include/colormanager.h \
+ include/controller.h include/cache.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/fileurlreader.o: src/fileurlreader.cpp include/fileurlreader.h \
- include/urlreader.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h
+ include/urlreader.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h config.h \
+ include/strprintf.h
 src/filtercontainer.o: src/filtercontainer.cpp include/filtercontainer.h \
  include/configparser.h include/configactionhandler.h config.h \
  include/confighandlerexception.h include/matcher.h filter/FilterParser.h \
- include/strprintf.h include/utils.h include/configcontainer.h \
- include/logger.h include/strprintf.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h include/strprintf.h
 src/fmtstrformatter.o: src/fmtstrformatter.cpp include/fmtstrformatter.h \
  include/logger.h config.h include/strprintf.h include/ruststring.h
 src/formaction.o: src/formaction.cpp include/formaction.h \
@@ -212,14 +222,14 @@ src/formaction.o: src/formaction.cpp include/formaction.h \
  include/configactionhandler.h include/stflpp.h config.h \
  include/configexception.h include/logger.h include/strprintf.h \
  include/matcherexception.h include/strprintf.h include/utils.h \
- include/configcontainer.h include/logger.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/filebrowserformaction.h include/formaction.h \
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ include/view.h include/colormanager.h include/controller.h \
+ include/cache.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/filebrowserformaction.h include/formaction.h \
  include/dirbrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h
 src/fslock.o: src/fslock.cpp include/fslock.h include/logger.h config.h \
@@ -230,13 +240,13 @@ src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
  config.h include/fmtstrformatter.h include/keymap.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/strprintf.h include/utils.h \
- include/configcontainer.h include/logger.h include/strprintf.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/filebrowserformaction.h \
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ include/strprintf.h include/view.h include/colormanager.h \
+ include/controller.h include/cache.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/filebrowserformaction.h \
  include/dirbrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h
 src/history.o: src/history.cpp include/history.h include/ruststring.h
@@ -244,19 +254,20 @@ src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
  include/textformatter.h include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  config.h include/logger.h include/strprintf.h include/strprintf.h \
- include/tagsouppullparser.h include/utils.h include/configcontainer.h \
- include/logger.h
+ include/tagsouppullparser.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h
 src/inoreaderapi.o: src/inoreaderapi.cpp include/inoreaderapi.h \
  include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/remoteapi.h include/urlreader.h \
- config.h include/strprintf.h include/utils.h include/logger.h \
- include/strprintf.h
+ config.h include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h include/strprintf.h
 src/inoreaderurlreader.o: src/inoreaderurlreader.cpp \
  include/inoreaderurlreader.h include/urlreader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/fileurlreader.h include/logger.h \
  config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h include/logger.h
+ include/configcontainer.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h
 src/itemlistformaction.o: src/itemlistformaction.cpp \
  include/itemlistformaction.h include/history.h include/listformaction.h \
  include/formaction.h include/keymap.h include/configparser.h \
@@ -267,20 +278,21 @@ src/itemlistformaction.o: src/itemlistformaction.cpp \
  include/filtercontainer.h include/fslock.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h config.h include/controller.h \
- include/dbexception.h include/fmtstrformatter.h include/logger.h \
- include/strprintf.h include/matcherexception.h include/rssfeed.h \
- include/utils.h include/logger.h include/scopemeasure.h \
- include/strprintf.h include/utils.h include/view.h
+ include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
+ include/filebrowserformaction.h include/dirbrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h config.h \
+ include/controller.h include/dbexception.h include/fmtstrformatter.h \
+ include/logger.h include/strprintf.h include/matcherexception.h \
+ include/rssfeed.h include/utils.h include/logger.h \
+ include/scopemeasure.h include/strprintf.h include/utils.h \
+ include/view.h
 src/itemrenderer.o: src/itemrenderer.cpp include/itemrenderer.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
  include/configparser.h include/configactionhandler.h include/matcher.h \
  filter/FilterParser.h include/configcontainer.h include/htmlrenderer.h \
- include/rssfeed.h include/matchable.h include/rssitem.h include/utils.h \
- include/configcontainer.h include/logger.h config.h include/strprintf.h \
- include/textformatter.h
+ include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
+ include/rssitem.h include/utils.h include/configcontainer.h \
+ include/logger.h config.h include/strprintf.h include/textformatter.h
 src/itemviewformaction.o: src/itemviewformaction.cpp \
  include/itemviewformaction.h include/formaction.h include/history.h \
  include/keymap.h include/configparser.h include/configactionhandler.h \
@@ -289,86 +301,92 @@ src/itemviewformaction.o: src/itemviewformaction.cpp \
  include/confighandlerexception.h include/dbexception.h \
  include/fmtstrformatter.h include/itemrenderer.h include/htmlrenderer.h \
  include/logger.h include/strprintf.h include/rssfeed.h \
- include/matchable.h include/rssitem.h include/utils.h \
- include/configcontainer.h include/logger.h include/scopemeasure.h \
- include/strprintf.h include/textformatter.h include/utils.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h
+ include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
+ include/utils.h include/configcontainer.h include/logger.h \
+ include/scopemeasure.h include/strprintf.h include/textformatter.h \
+ include/utils.h include/view.h include/colormanager.h \
+ include/controller.h include/cache.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/filebrowserformaction.h include/dirbrowserformaction.h
 src/keymap.o: src/keymap.cpp include/keymap.h include/configparser.h \
  include/configactionhandler.h config.h include/confighandlerexception.h \
  include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
- include/configcontainer.h include/logger.h
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h
 src/listformaction.o: src/listformaction.cpp include/listformaction.h \
  include/formaction.h include/history.h include/keymap.h \
  include/configparser.h include/configactionhandler.h include/stflpp.h \
- include/rssfeed.h include/matchable.h include/rssitem.h \
- include/matcher.h filter/FilterParser.h include/utils.h \
- include/configcontainer.h include/logger.h config.h include/strprintf.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/regexmanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
+ include/rssitem.h include/matcher.h filter/FilterParser.h \
+ include/utils.h include/configcontainer.h include/logger.h config.h \
+ include/strprintf.h include/view.h include/colormanager.h \
+ include/controller.h include/cache.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/regexmanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/listformatter.o: src/listformatter.cpp include/listformatter.h \
  include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/stflpp.h include/strprintf.h include/utils.h \
- include/configcontainer.h include/logger.h config.h include/strprintf.h
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ config.h include/strprintf.h
 src/logger.o: src/logger.cpp include/logger.h config.h \
  include/strprintf.h
 src/matcher.o: src/matcher.cpp include/matcher.h filter/FilterParser.h \
  include/logger.h config.h include/strprintf.h include/matchable.h \
- include/matcherexception.h include/scopemeasure.h include/logger.h \
- include/utils.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h
+ 3rd-party/optional.hpp include/matcherexception.h include/scopemeasure.h \
+ include/logger.h include/utils.h include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h
 src/matcherexception.o: src/matcherexception.cpp \
  include/matcherexception.h config.h include/ruststring.h \
  include/strprintf.h
 src/newsblurapi.o: src/newsblurapi.cpp include/newsblurapi.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h rss/feed.h rss/item.h include/remoteapi.h \
- include/strprintf.h include/utils.h include/logger.h config.h \
- include/strprintf.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h config.h include/strprintf.h
 src/newsblururlreader.o: src/newsblururlreader.cpp \
  include/newsblururlreader.h rss/feed.h rss/item.h include/urlreader.h \
  include/fileurlreader.h include/logger.h config.h include/strprintf.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h include/logger.h
+ include/configactionhandler.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h
 src/ocnewsapi.o: src/ocnewsapi.cpp include/ocnewsapi.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
- include/logger.h config.h include/strprintf.h
+ 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h
 src/ocnewsurlreader.o: src/ocnewsurlreader.cpp include/ocnewsurlreader.h \
  include/urlreader.h include/fileurlreader.h include/logger.h config.h \
  include/strprintf.h include/remoteapi.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h include/utils.h \
- include/logger.h
+ 3rd-party/optional.hpp include/logger.h
 src/oldreaderapi.o: src/oldreaderapi.cpp include/oldreaderapi.h \
  include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/remoteapi.h config.h \
- include/strprintf.h include/utils.h include/logger.h include/strprintf.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h include/strprintf.h
 src/oldreaderurlreader.o: src/oldreaderurlreader.cpp \
  include/oldreaderurlreader.h include/urlreader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/fileurlreader.h include/logger.h \
  config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h include/logger.h
+ include/configcontainer.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h
 src/opml.o: src/opml.cpp include/opml.h include/feedcontainer.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/fileurlreader.h \
  include/urlreader.h include/rssfeed.h include/matchable.h \
- include/rssitem.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/logger.h config.h include/strprintf.h
+ 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h
 src/opmlurlreader.o: src/opmlurlreader.cpp include/opmlurlreader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/urlreader.h include/utils.h \
- include/logger.h config.h include/strprintf.h
+ 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h
 src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h include/fslock.h \
@@ -378,7 +396,8 @@ src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
  include/matcherexception.h include/nullconfigactionhandler.h \
  include/pbview.h include/colormanager.h include/keymap.h \
  include/stflpp.h include/poddlthread.h include/queueloader.h \
- include/strprintf.h include/utils.h include/logger.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h
 src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
  include/configparser.h include/configactionhandler.h include/keymap.h \
  include/stflpp.h config.h include/configcontainer.h stfl/dllist.h \
@@ -386,28 +405,30 @@ src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
  include/logger.h include/strprintf.h include/pbcontroller.h \
  include/configcontainer.h include/download.h include/fslock.h \
  include/queueloader.h include/poddlthread.h include/strprintf.h \
- include/utils.h include/logger.h
+ include/utils.h 3rd-party/optional.hpp include/logger.h
 src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h config.h \
- include/logger.h include/strprintf.h include/utils.h include/logger.h
+ include/logger.h include/strprintf.h include/utils.h \
+ 3rd-party/optional.hpp include/logger.h
 src/queueloader.o: src/queueloader.cpp include/queueloader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h config.h \
  include/configcontainer.h include/logger.h include/strprintf.h \
- include/stflpp.h include/strprintf.h include/utils.h include/logger.h
+ include/stflpp.h include/strprintf.h include/utils.h \
+ 3rd-party/optional.hpp include/logger.h
 src/queuemanager.o: src/queuemanager.cpp include/queuemanager.h \
- include/configpaths.h include/cliargsparser.h include/logger.h config.h \
- include/strprintf.h include/fmtstrformatter.h include/rssfeed.h \
- include/matchable.h include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- include/utils.h
+ include/configpaths.h include/cliargsparser.h 3rd-party/optional.hpp \
+ include/logger.h config.h include/strprintf.h include/fmtstrformatter.h \
+ include/rssfeed.h include/matchable.h include/rssitem.h \
+ include/matcher.h filter/FilterParser.h include/utils.h \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/stflpp.h include/utils.h
 src/regexmanager.o: src/regexmanager.cpp include/regexmanager.h \
  include/configparser.h include/configactionhandler.h include/matcher.h \
  filter/FilterParser.h config.h include/confighandlerexception.h \
  include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
- include/configcontainer.h include/logger.h
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h
 src/reloader.o: src/reloader.cpp include/reloader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/controller.h include/cache.h \
@@ -416,8 +437,8 @@ src/reloader.o: src/reloader.cpp include/reloader.h \
  include/urlreader.h include/queuemanager.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/reloader.h \
  include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/curlhandle.h include/dbexception.h \
- include/downloadthread.h include/fmtstrformatter.h \
+ include/matchable.h 3rd-party/optional.hpp include/curlhandle.h \
+ include/dbexception.h include/downloadthread.h include/fmtstrformatter.h \
  include/reloadrangethread.h include/reloadthread.h include/controller.h \
  rss/exception.h include/rssfeed.h include/utils.h include/logger.h \
  config.h include/strprintf.h include/rssparser.h rss/feed.h rss/item.h \
@@ -436,32 +457,33 @@ src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
  include/urlreader.h include/queuemanager.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/reloader.h \
  include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/logger.h config.h include/strprintf.h
+ include/matchable.h 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h
 src/remoteapi.o: src/remoteapi.cpp include/remoteapi.h \
  include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h include/logger.h config.h \
- include/strprintf.h
+ include/configactionhandler.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h config.h include/strprintf.h
 src/rssfeed.o: src/rssfeed.cpp include/rssfeed.h include/matchable.h \
- include/rssitem.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h include/cache.h include/configcontainer.h \
+ 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h include/logger.h \
+ config.h include/strprintf.h include/cache.h include/configcontainer.h \
  include/confighandlerexception.h include/dbexception.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
  include/logger.h include/scopemeasure.h include/strprintf.h \
  include/tagsouppullparser.h include/utils.h
 src/rssignores.o: src/rssignores.cpp include/rssignores.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/rssitem.h include/matchable.h include/cache.h \
- include/configcontainer.h include/configparser.h config.h \
- include/configcontainer.h include/confighandlerexception.h \
+ include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
+ include/cache.h include/configcontainer.h include/configparser.h \
+ config.h include/configcontainer.h include/confighandlerexception.h \
  include/dbexception.h include/htmlrenderer.h include/textformatter.h \
  include/regexmanager.h include/logger.h include/strprintf.h \
  include/rssfeed.h include/utils.h include/logger.h include/strprintf.h \
  include/tagsouppullparser.h include/utils.h
 src/rssitem.o: src/rssitem.cpp include/rssitem.h include/matchable.h \
- include/matcher.h filter/FilterParser.h include/cache.h \
- include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
+ include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/dbexception.h include/rssfeed.h \
  include/rssitem.h include/utils.h include/logger.h config.h \
  include/strprintf.h include/strprintf.h include/utils.h
@@ -473,10 +495,10 @@ src/rssparser.o: src/rssparser.cpp include/rssparser.h \
  include/matcher.h filter/FilterParser.h include/logger.h \
  include/strprintf.h include/newsblurapi.h include/ocnewsapi.h \
  rss/exception.h rss/parser.h include/remoteapi.h rss/feed.h \
- rss/rssparser.h include/rssfeed.h include/matchable.h include/rssitem.h \
- include/utils.h include/logger.h include/rssignores.h \
- include/strprintf.h include/ttrssapi.h 3rd-party/json.hpp \
- include/cache.h include/utils.h
+ rss/rssparser.h include/rssfeed.h include/matchable.h \
+ 3rd-party/optional.hpp include/rssitem.h include/utils.h \
+ include/logger.h include/rssignores.h include/strprintf.h \
+ include/ttrssapi.h 3rd-party/json.hpp include/cache.h include/utils.h
 src/ruststring.o: src/ruststring.cpp include/ruststring.h
 src/scopemeasure.o: src/scopemeasure.cpp include/scopemeasure.h \
  include/logger.h config.h include/strprintf.h
@@ -486,10 +508,10 @@ src/selectformaction.o: src/selectformaction.cpp \
  include/formaction.h include/history.h include/keymap.h include/stflpp.h \
  config.h include/fmtstrformatter.h include/listformatter.h \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/strprintf.h include/utils.h include/configcontainer.h \
- include/logger.h include/strprintf.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/fslock.h include/opml.h \
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h include/strprintf.h \
+ include/view.h include/colormanager.h include/controller.h \
+ include/cache.h include/feedcontainer.h include/fslock.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
  include/rssitem.h include/matchable.h include/filebrowserformaction.h \
@@ -497,30 +519,31 @@ src/selectformaction.o: src/selectformaction.cpp \
  include/textformatter.h
 src/stflpp.o: src/stflpp.cpp include/stflpp.h include/exception.h \
  include/logger.h config.h include/strprintf.h include/utils.h \
- include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h
 src/strprintf.o: src/strprintf.cpp include/strprintf.h
 src/tagsouppullparser.o: src/tagsouppullparser.cpp \
  include/tagsouppullparser.h config.h include/logger.h \
- include/strprintf.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- include/xmlexception.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h include/xmlexception.h
 src/textformatter.o: src/textformatter.cpp include/textformatter.h \
  include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/htmlrenderer.h include/textformatter.h include/stflpp.h \
- include/strprintf.h include/utils.h include/configcontainer.h \
- include/logger.h config.h include/strprintf.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h config.h include/strprintf.h
 src/ttrssapi.o: src/ttrssapi.cpp include/ttrssapi.h 3rd-party/json.hpp \
  include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/remoteapi.h include/logger.h \
  config.h include/strprintf.h include/remoteapi.h rss/feed.h rss/item.h \
- include/strprintf.h include/utils.h include/logger.h
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h
 src/ttrssurlreader.o: src/ttrssurlreader.cpp include/ttrssurlreader.h \
  include/urlreader.h include/fileurlreader.h include/logger.h config.h \
  include/strprintf.h include/remoteapi.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h include/utils.h \
- include/logger.h
+ 3rd-party/optional.hpp include/logger.h
 src/urlreader.o: src/urlreader.cpp include/urlreader.h
 src/urlviewformaction.o: src/urlviewformaction.cpp \
  include/urlviewformaction.h include/formaction.h include/history.h \
@@ -528,21 +551,22 @@ src/urlviewformaction.o: src/urlviewformaction.cpp \
  include/stflpp.h include/htmlrenderer.h include/textformatter.h \
  include/regexmanager.h include/matcher.h filter/FilterParser.h config.h \
  include/fmtstrformatter.h include/listformatter.h include/rssfeed.h \
- include/matchable.h include/rssitem.h include/utils.h \
- include/configcontainer.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h include/view.h \
+ include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
+ include/utils.h include/configcontainer.h include/logger.h \
+ include/strprintf.h include/strprintf.h include/utils.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
  include/opml.h include/fileurlreader.h include/urlreader.h \
  include/queuemanager.h include/reloader.h include/remoteapi.h \
  include/rssignores.h include/filebrowserformaction.h \
  include/dirbrowserformaction.h
-src/utils.o: src/utils.cpp include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h include/htmlrenderer.h \
- include/textformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/logger.h include/ruststring.h \
- include/strprintf.h include/rs_utils.h
+src/utils.o: src/utils.cpp include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h config.h \
+ include/strprintf.h include/htmlrenderer.h include/textformatter.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/logger.h include/ruststring.h include/strprintf.h \
+ include/rs_utils.h
 src/view.o: src/view.cpp include/view.h include/colormanager.h \
  include/configparser.h include/configactionhandler.h \
  include/configcontainer.h include/controller.h include/cache.h \
@@ -551,32 +575,34 @@ src/view.o: src/view.cpp include/view.h include/colormanager.h \
  include/queuemanager.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/reloader.h include/remoteapi.h \
  include/rssignores.h include/rssitem.h include/matchable.h \
- include/filebrowserformaction.h include/formaction.h include/history.h \
- include/keymap.h include/stflpp.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h config.h \
- include/dbexception.h stfl/dialogs.h include/dialogsformaction.h \
- include/exception.h stfl/feedlist.h include/feedlistformaction.h \
- include/listformaction.h include/view.h stfl/filebrowser.h \
- include/fmtstrformatter.h include/formaction.h stfl/help.h \
- include/helpformaction.h include/htmlrenderer.h stfl/itemlist.h \
- include/itemlistformaction.h include/listformatter.h stfl/itemview.h \
- include/itemviewformaction.h include/keymap.h include/logger.h \
- include/strprintf.h include/matcherexception.h include/regexmanager.h \
- include/reloadthread.h include/rssfeed.h include/utils.h \
- include/logger.h include/selectformaction.h stfl/selecttag.h \
- include/strprintf.h stfl/urlview.h include/urlviewformaction.h \
- include/utils.h
+ 3rd-party/optional.hpp include/filebrowserformaction.h \
+ include/formaction.h include/history.h include/keymap.h include/stflpp.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h config.h include/dbexception.h stfl/dialogs.h \
+ include/dialogsformaction.h include/exception.h stfl/feedlist.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ stfl/filebrowser.h include/fmtstrformatter.h include/formaction.h \
+ stfl/help.h include/helpformaction.h include/htmlrenderer.h \
+ stfl/itemlist.h include/itemlistformaction.h include/listformatter.h \
+ stfl/itemview.h include/itemviewformaction.h include/keymap.h \
+ include/logger.h include/strprintf.h include/matcherexception.h \
+ include/regexmanager.h include/reloadthread.h include/rssfeed.h \
+ include/utils.h include/logger.h include/selectformaction.h \
+ stfl/selecttag.h include/strprintf.h stfl/urlview.h \
+ include/urlviewformaction.h include/utils.h
 test/cache.o: test/cache.cpp include/cache.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h 3rd-party/catch.hpp \
  include/configcontainer.h include/rssfeed.h include/matchable.h \
- include/rssitem.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/logger.h config.h include/strprintf.h \
- include/rssignores.h include/rssparser.h include/remoteapi.h rss/feed.h \
- rss/item.h test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+ 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h include/rssignores.h include/rssparser.h \
+ include/remoteapi.h rss/feed.h rss/item.h test/test-helpers/tempfile.h \
+ test/test-helpers/maintempdir.h
 test/cliargsparser.o: test/cliargsparser.cpp 3rd-party/catch.hpp \
- include/cliargsparser.h include/logger.h config.h include/strprintf.h \
- test/test-helpers/envvar.h test/test-helpers/opts.h \
- test/test-helpers/tempdir.h test/test-helpers/maintempdir.h
+ include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h test/test-helpers/envvar.h test/test-helpers/opts.h \
+ test/test-helpers/stringmaker/optional.h test/test-helpers/tempdir.h \
+ test/test-helpers/maintempdir.h
 test/colormanager.o: test/colormanager.cpp include/colormanager.h \
  include/configparser.h include/configactionhandler.h 3rd-party/catch.hpp \
  include/confighandlerexception.h
@@ -586,22 +612,23 @@ test/configcontainer.o: test/configcontainer.cpp \
  include/confighandlerexception.h include/configparser.h include/keymap.h
 test/configparser.o: test/configparser.cpp include/configparser.h \
  include/configactionhandler.h 3rd-party/catch.hpp include/keymap.h \
- include/configparser.h test/test-helpers/envvar.h \
+ include/configparser.h test/test-helpers/envvar.h 3rd-party/optional.hpp \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/configpaths.o: test/configpaths.cpp include/configpaths.h \
- include/cliargsparser.h include/logger.h config.h include/strprintf.h \
- 3rd-party/catch.hpp test/test-helpers/chmod.h test/test-helpers/envvar.h \
- test/test-helpers/opts.h test/test-helpers/tempdir.h \
- test/test-helpers/maintempdir.h include/utils.h \
- include/configcontainer.h include/configparser.h \
+ include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h 3rd-party/catch.hpp test/test-helpers/chmod.h \
+ test/test-helpers/envvar.h test/test-helpers/opts.h \
+ test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
+ include/utils.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h
 test/download.o: test/download.cpp include/download.h 3rd-party/catch.hpp
 test/feedcontainer.o: test/feedcontainer.cpp 3rd-party/catch.hpp \
  include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/configcontainer.h \
  include/feedcontainer.h include/rssfeed.h include/matchable.h \
- include/rssitem.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/logger.h config.h include/strprintf.h
+ 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h
 test/fileurlreader.o: test/fileurlreader.cpp include/fileurlreader.h \
  include/urlreader.h 3rd-party/catch.hpp test/test-helpers/misc.h \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
@@ -622,7 +649,8 @@ test/htmlrenderer.o: test/htmlrenderer.cpp include/htmlrenderer.h \
  include/textformatter.h include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  3rd-party/catch.hpp include/strprintf.h include/utils.h \
- include/configcontainer.h include/logger.h config.h include/strprintf.h
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ config.h include/strprintf.h
 test/itemlistformaction.o: test/itemlistformaction.cpp \
  include/itemlistformaction.h include/history.h include/listformaction.h \
  include/formaction.h include/keymap.h include/configparser.h \
@@ -633,13 +661,14 @@ test/itemlistformaction.o: test/itemlistformaction.cpp \
  include/filtercontainer.h include/fslock.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h 3rd-party/catch.hpp include/cache.h \
- include/configpaths.h include/cliargsparser.h include/logger.h config.h \
- include/strprintf.h include/feedlistformaction.h stfl/itemlist.h \
- include/keymap.h include/regexmanager.h include/rssfeed.h \
- include/utils.h test/test-helpers/misc.h test/test-helpers/tempfile.h \
+ include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
+ include/filebrowserformaction.h include/dirbrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h 3rd-party/catch.hpp \
+ include/cache.h include/configpaths.h include/cliargsparser.h \
+ include/logger.h config.h include/strprintf.h \
+ include/feedlistformaction.h stfl/itemlist.h include/keymap.h \
+ include/regexmanager.h include/rssfeed.h include/utils.h \
+ test/test-helpers/misc.h test/test-helpers/tempfile.h \
  test/test-helpers/maintempdir.h
 test/itemrenderer.o: test/itemrenderer.cpp include/itemrenderer.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
@@ -647,8 +676,8 @@ test/itemrenderer.o: test/itemrenderer.cpp include/itemrenderer.h \
  filter/FilterParser.h 3rd-party/catch.hpp include/cache.h \
  include/configcontainer.h include/configcontainer.h \
  include/regexmanager.h include/rssfeed.h include/matchable.h \
- include/rssitem.h include/utils.h include/logger.h config.h \
- include/strprintf.h test/test-helpers/envvar.h
+ 3rd-party/optional.hpp include/rssitem.h include/utils.h \
+ include/logger.h config.h include/strprintf.h test/test-helpers/envvar.h
 test/keymap.o: test/keymap.cpp include/keymap.h include/configparser.h \
  include/configactionhandler.h 3rd-party/catch.hpp \
  include/confighandlerexception.h
@@ -657,7 +686,8 @@ test/listformatter.o: test/listformatter.cpp include/listformatter.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  3rd-party/catch.hpp
 test/matcher.o: test/matcher.cpp include/matcher.h filter/FilterParser.h \
- 3rd-party/catch.hpp include/matchable.h include/matcherexception.h
+ 3rd-party/catch.hpp include/matchable.h 3rd-party/optional.hpp \
+ include/matcherexception.h test/test-helpers/stringmaker/optional.h
 test/matcherexception.o: test/matcherexception.cpp \
  include/matcherexception.h 3rd-party/catch.hpp
 test/opml.o: test/opml.cpp include/opml.h include/feedcontainer.h \
@@ -665,16 +695,16 @@ test/opml.o: test/opml.cpp include/opml.h include/feedcontainer.h \
  include/configactionhandler.h include/fileurlreader.h \
  include/urlreader.h 3rd-party/catch.hpp include/cache.h \
  include/fileurlreader.h include/rssfeed.h include/matchable.h \
- include/rssitem.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/logger.h config.h include/strprintf.h \
- test/test-helpers/misc.h test/test-helpers/tempfile.h \
- test/test-helpers/maintempdir.h
+ 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/logger.h config.h \
+ include/strprintf.h test/test-helpers/misc.h \
+ test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/opmlurlreader.o: test/opmlurlreader.cpp include/opmlurlreader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/urlreader.h 3rd-party/catch.hpp \
  test/test-helpers/misc.h test/test-helpers/tempfile.h \
- test/test-helpers/maintempdir.h include/utils.h include/logger.h \
- config.h include/strprintf.h
+ test/test-helpers/maintempdir.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h config.h include/strprintf.h
 test/queueloader.o: test/queueloader.cpp include/queueloader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h 3rd-party/catch.hpp \
@@ -683,32 +713,38 @@ test/queueloader.o: test/queueloader.cpp include/queueloader.h \
 test/regexmanager.o: test/regexmanager.cpp include/regexmanager.h \
  include/configparser.h include/configactionhandler.h include/matcher.h \
  filter/FilterParser.h 3rd-party/catch.hpp \
- include/confighandlerexception.h include/matchable.h
+ include/confighandlerexception.h include/matchable.h \
+ 3rd-party/optional.hpp
 test/remoteapi.o: test/remoteapi.cpp include/remoteapi.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h 3rd-party/catch.hpp
 test/rssfeed.o: test/rssfeed.cpp include/rssfeed.h include/matchable.h \
- include/rssitem.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h 3rd-party/catch.hpp include/cache.h \
+ 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+ filter/FilterParser.h include/utils.h include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h include/logger.h \
+ config.h include/strprintf.h 3rd-party/catch.hpp include/cache.h \
  include/configcontainer.h include/rssparser.h include/remoteapi.h \
- rss/feed.h rss/item.h
+ rss/feed.h rss/item.h test/test-helpers/envvar.h \
+ test/test-helpers/stringmaker/optional.h
 test/rssignores.o: test/rssignores.cpp include/rssignores.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/rssitem.h include/matchable.h 3rd-party/catch.hpp \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/confighandlerexception.h include/rssitem.h
+ include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
+ 3rd-party/catch.hpp include/cache.h include/configcontainer.h \
+ include/configparser.h include/confighandlerexception.h \
+ include/rssitem.h
 test/rssitem.o: test/rssitem.cpp include/rssitem.h include/matchable.h \
- include/matcher.h filter/FilterParser.h 3rd-party/catch.hpp \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/configcontainer.h
+ 3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
+ 3rd-party/catch.hpp include/cache.h include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h \
+ include/configcontainer.h include/rssfeed.h include/rssitem.h \
+ include/utils.h include/logger.h config.h include/strprintf.h \
+ test/test-helpers/envvar.h test/test-helpers/stringmaker/optional.h
 test/rsspp_parser.o: test/rsspp_parser.cpp rss/parser.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h rss/feed.h rss/item.h 3rd-party/catch.hpp \
  rss/exception.h test/test-helpers/exceptionwithmsg.h
 test/rsspp_rssparser.o: test/rsspp_rssparser.cpp rss/rssparser.h \
- 3rd-party/catch.hpp test/test-helpers/envvar.h
+ 3rd-party/catch.hpp test/test-helpers/envvar.h 3rd-party/optional.hpp
 test/ruststring.o: test/ruststring.cpp include/ruststring.h \
  3rd-party/catch.hpp
 test/strprintf.o: test/strprintf.cpp include/strprintf.h \
@@ -718,13 +754,14 @@ test/tagsouppullparser.o: test/tagsouppullparser.cpp \
 test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
  include/strprintf.h
 test/test-helpers/chdir.o: test/test-helpers/chdir.cpp \
- test/test-helpers/chdir.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h
+ test/test-helpers/chdir.h include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h config.h \
+ include/strprintf.h
 test/test-helpers/chmod.o: test/test-helpers/chmod.cpp \
  test/test-helpers/chmod.h
 test/test-helpers/envvar.o: test/test-helpers/envvar.cpp \
- test/test-helpers/envvar.h 3rd-party/catch.hpp
+ test/test-helpers/envvar.h 3rd-party/optional.hpp 3rd-party/catch.hpp
 test/test-helpers/maintempdir.o: test/test-helpers/maintempdir.cpp \
  test/test-helpers/maintempdir.h
 test/test-helpers/misc.o: test/test-helpers/misc.cpp \
@@ -739,10 +776,12 @@ test/textformatter.o: test/textformatter.cpp include/textformatter.h \
  include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  3rd-party/catch.hpp
-test/utils.o: test/utils.cpp include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h 3rd-party/catch.hpp include/htmlrenderer.h \
+test/utils.o: test/utils.cpp include/utils.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h config.h \
+ include/strprintf.h 3rd-party/catch.hpp include/htmlrenderer.h \
  include/textformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/rs_utils.h test/test-helpers/chdir.h \
- test/test-helpers/envvar.h test/test-helpers/tempdir.h \
- test/test-helpers/maintempdir.h test/test-helpers/tempfile.h
+ test/test-helpers/envvar.h test/test-helpers/stringmaker/optional.h \
+ test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
+ test/test-helpers/tempfile.h

--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -160,9 +160,12 @@ void print_version(const std::string& argv0, unsigned int level)
 					"to see the full text.)"),
 				argv0)
 			<< std::endl;
-		ss << _("It bundles JSON for Modern C++ library, "
-				"licensed under the MIT License: "
+		ss << _("It bundles:") << std::endl;
+		ss << _("- JSON for Modern C++ library, licensed under the MIT License: "
 				"https://github.com/nlohmann/json")
+			<< std::endl;
+		ss << _("- optional-lite library, licensed under the Boost Software "
+				"License: https://github.com/martinmoene/optional-lite")
 			<< std::endl;
 		ss << std::endl;
 

--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -221,8 +221,8 @@ int main(int argc, char* argv[])
 	if (args.should_print_usage()) {
 		print_usage(args.program_name(), configpaths.config_file(),
 			configpaths.url_file(), configpaths.cache_file());
-		if (args.should_return()) {
-			return args.return_code();
+		if (args.return_code().has_value()) {
+			return args.return_code().value();
 		}
 	} else if (args.show_version()) {
 		print_version(args.program_name(), args.show_version());

--- a/po/ca.po
+++ b/po/ca.po
@@ -2,10 +2,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2017-07-19 20:19+0300\n"
 "Last-Translator: Alejandro Gallo <aamsgallo@gmail.com>\n"
-"Language-Team: Alejandro Gallo <aamsgallo@gmail.com>, OmeGa <omega@mailoo.org>\n"
+"Language-Team: Alejandro Gallo <aamsgallo@gmail.com>, OmeGa <omega@mailoo."
+"org>\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -144,22 +145,32 @@ msgstr ""
 "newsboat és software lliure, y llicenciat sota la MIT/X Consortium License."
 
 #: newsboat.cpp:163
-msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+msgid "It bundles:"
 msgstr ""
 
-#: newsboat.cpp:237
+#: newsboat.cpp:164
+msgid ""
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
+msgstr ""
+
+#: newsboat.cpp:167
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -285,51 +296,51 @@ msgstr "comando invàlid `%s'"
 msgid "Starting %s %s..."
 msgstr "Iniciant %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Error: una instància de %s ja s'està executant (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Carregant configuració..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "fet."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Obrint caché..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Error: l'apertura de l'arxiu de caché `%s' va fallar: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Carregant URLs desde %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -338,7 +349,7 @@ msgstr ""
 "Error: no hi ha URLs configurades. Per favor omple l'arxiu %s amb URLs de "
 "fonts RSS, o importa un arxiu OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -346,7 +357,7 @@ msgstr ""
 "Sembla que la font OPML a la cual et vas subscriure no conté fonts. Por "
 "favor llénala amb fonts, e intenta-ho de nou."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -355,7 +366,7 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de The Old Reader. Si "
 "us plau fes-ho i intenta-ho de nou."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -364,7 +375,7 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de Tiny Tiny RSS. Si "
 "us plau fes-ho e intenta-ho de nou."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -373,7 +384,7 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de NewsBlur Reader. "
 "Si us plau fes-ho e intenta-ho de nou."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -382,69 +393,69 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de The Old Reader. Si "
 "us plau fes-ho i intenta-ho de nou."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Carregant articles des del caché..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Netejant el caché totalment..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Error al carregar les fonts desde la base de dades: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Error al carregar la font «%s»: %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Omplint les fonts de consulta..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Important la llista d'articles llegits..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Exportant la llista d'articles llegits..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Netejant el caché..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "va fallar: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Error: no es van poder marcar com llegides totes les fonts: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, fuzzy, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ocurrió un error al processar %s."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importació de %s finalitzada."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u articles no llegits"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "comando invàlid `%s'"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: no es va poder obrir l'arxiu de configuració `%s'!"
@@ -489,7 +500,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Guardar"
 
@@ -591,7 +602,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -636,7 +647,7 @@ msgid "No filters defined."
 msgstr "No hi ha filtres definits."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Buscar: "
 
@@ -658,7 +669,7 @@ msgid "y"
 msgstr "s"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Sortir"
@@ -668,7 +679,7 @@ msgid "Open"
 msgstr "Obrir"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Següent no llegit"
 
@@ -694,7 +705,7 @@ msgid "Search"
 msgstr "Buscar"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Ajuda"
@@ -870,7 +881,7 @@ msgstr "Elements compartits"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Cambiant l'estat de lectura per l'article..."
 
@@ -879,12 +890,12 @@ msgstr "Cambiant l'estat de lectura per l'article..."
 msgid "Error while toggling read flag: %s"
 msgstr "Error al cambiar l'estat de lectura: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "llista de URLs vacía."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Indicadors: "
 
@@ -897,18 +908,18 @@ msgid "Error: you can't reload search results."
 msgstr "Error: no es pot recarregar resultats de búsqueda."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "No hi ha elements no llegits."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Ja estàs en el último element."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Ja estàs en el primer element."
@@ -922,7 +933,7 @@ msgstr "No hi ha fonts no llegides."
 msgid "Marking all above as read..."
 msgstr "Marcant totes les fonts com llegides..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Encadenar article al comando: "
 
@@ -946,7 +957,7 @@ msgstr ""
 "¿Ordenar inversament per (f)echa/(t)ítulo/(i)ndicadors/(a)utor/(e)nlace/"
 "(g)uid?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Indicadors actualizats."
 
@@ -955,17 +966,17 @@ msgstr "Indicadors actualizats."
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: va fallar aplicar el filtre: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Guardat abortat."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Guardar article com %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: no es va poder guardar l'article com %s"
@@ -1032,68 +1043,68 @@ msgstr "URL de descàrrega del podcast: "
 msgid "type: "
 msgstr "tipus: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Adalt"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Desota"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar l'article com llegit: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Se añadió %s a la cua de descàrregues."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "URL invàlida: «%s»"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Article guardat com %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no es va poder escriure l'article en l'arxiu %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Iniciant el navegador..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar l'article com no llegit: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Anar a URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Obrir en el navegador"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Agregar a la cua"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Article - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Error: expressió regular invàlida!"
 
@@ -1581,11 +1592,11 @@ msgstr "Error al obtenir %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Error: font invàlida!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "insuficients arguments"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' no és una expressió regular vàlida: %s"

--- a/po/de.po
+++ b/po/de.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2019-12-22 10:40+0100\n"
 "Last-Translator: Lysander Trischler <github@lyse.isobeef.org>\n"
 "Language-Team: Andreas Krennmair <ak@newsbeuter.org>, Simon Nagl "
@@ -147,24 +147,38 @@ msgstr ""
 "den vollständigen Lizenztext an.) "
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Es wird die unter der MIT-Lizenz stehende Bibliothek JSON für Modernes C++ "
 "verwendet: https://github.com/nlohmann/json"
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Es wird die unter der MIT-Lizenz stehende Bibliothek JSON für Modernes C++ "
+"verwendet: https://github.com/nlohmann/json"
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr "newsboat::DbException gefangen mit Nachricht: %s"
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "newsboat::MatcherException gefangen mit Nachricht: %s"
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "newsboat::Exception gefangen mit Nachricht: %s"
@@ -286,52 +300,52 @@ msgstr "unbekannter Befehl `%s'"
 msgid "Starting %s %s..."
 msgstr "Starte %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Fehler: Eine Instanz von %s läuft bereits (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Lade Konfiguration..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "Fertig."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Öffne Zwischenspeicher..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Fehler: Das Öffnen der Zwischenspeicherdatei `%s' schlug fehl: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 "Fehler: Sie müssen „cookie-cache“ setzen, um NewsBlur verwenden zu können.\n"
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "Die Datei %s kann weder gelesen noch erstellt werden\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Lade URLs von %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -340,7 +354,7 @@ msgstr ""
 "Fehler: keine URLs konfiguriert. Bitte füllen Sie die Datei %s mit RSS-Feed-"
 "URLs oder importieren Sie eine OPML-Datei."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -348,7 +362,7 @@ msgstr ""
 "Es sieht so aus als würde die konfigurierte OPML-Datei keine Feeds "
 "enthalten. Bitte füllen Sie diese mit Feeds, und probieren Sie es erneut."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -356,7 +370,7 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem The-Old-Reader-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -364,7 +378,7 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem Tiny-Tiny-RSS-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -372,7 +386,7 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem NewsBlur-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -380,69 +394,69 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem Inoreader-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Lade Artikel aus dem Zwischenspeicher..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Bereinige Zwischenspeicher gründlich..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Fehler beim Laden der Feeds aus der Datenbank: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Fehler beim Laden von Feed `%s': %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Query-Feed vorbefüllen..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Importiere Liste von gelesenen Artikeln..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Exportierte Liste von gelesenen Artikeln..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Bereinige Zwischenspeicher..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "Fehlgeschlagen: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Fehler: Konnte nicht alle Feeds als gelesen markieren: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ein Fehler ist beim Parsen von %s aufgetreten."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Import von %s fertig."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u ungelesene Artikel"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: unbekannter Befehl"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fehler: Konnte Konfigurationsdatei `%s' nicht öffnen!"
@@ -487,7 +501,7 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Speichern"
 
@@ -586,7 +600,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "Browser brach mit Rückgabestatus %i ab"
@@ -631,7 +645,7 @@ msgid "No filters defined."
 msgstr "Keine Filter definiert."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Suche nach: "
 
@@ -653,7 +667,7 @@ msgid "y"
 msgstr "j"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Beenden"
@@ -663,7 +677,7 @@ msgid "Open"
 msgstr "Öffnen"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "nächster Ungelesener"
 
@@ -689,7 +703,7 @@ msgid "Search"
 msgstr "Suchen"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Hilfe"
@@ -861,7 +875,7 @@ msgstr "für gut befundene Artikel"
 msgid "Saved web pages"
 msgstr "gespeicherte Webseiten"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Schalte Gelesen-Flag für Artikel um..."
 
@@ -870,12 +884,12 @@ msgstr "Schalte Gelesen-Flag für Artikel um..."
 msgid "Error while toggling read flag: %s"
 msgstr "Fehler beim Umschalten des Gelesen-Flags: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "URL-Liste leer."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Flags: "
 
@@ -888,18 +902,18 @@ msgid "Error: you can't reload search results."
 msgstr "Fehler: Sie können Suchergebnisse nicht neu laden."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Keine ungelesenen Artikel."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Bereits beim letzten Artikel."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Bereits beim ersten Artikel."
@@ -912,7 +926,7 @@ msgstr "Keine ungelesenen Feeds."
 msgid "Marking all above as read..."
 msgstr "Markiere alle obenstehenden Artikel als gelesen..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Artikel zu Befehl umleiten: "
 
@@ -934,7 +948,7 @@ msgstr ""
 "Umgekehrt sortieren nach (d)atum/(t)itel/(f)lags/(a)utor/(l)ink/(g)uid/"
 "(z)ufällig?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Flags aktualisiert."
 
@@ -943,17 +957,17 @@ msgstr "Flags aktualisiert."
 msgid "Error: applying the filter failed: %s"
 msgstr "Fehler: Anwenden des Filters fehlgeschlagen: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Speichern abgebrochen."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artikel nach %s gespeichert"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fehler: Konnte Artikel nicht nach %s speichern"
@@ -1024,68 +1038,68 @@ msgstr "Podcast-Download-URL: "
 msgid "type: "
 msgstr "Typ: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Anfang"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Ende"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fehler beim Markieren des Artikels als gelesen: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s zur Download-Warteschlange hinzugefügt."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Ungültige URL: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Artikel nach %s gespeichert."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Fehler: Konnte Artikel nicht nach %s speichern"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Starte Browser..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Fehler beim Markieren des Artikels als ungelesen: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Gehe zu URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "im Browser öffnen"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "in Warteschlange"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Fehler: Ungültiger regulärer Ausdruck!"
 
@@ -1574,11 +1588,11 @@ msgstr "Fehler beim Abholen von %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Fehler: Ungültiger Feed!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "zu wenige Parameter"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' ist kein gültiger Filterausdruck"

--- a/po/es.po
+++ b/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2020-04-21 23:43+0200\n"
 "Last-Translator: Marcos Cruz <github@programandala.net>\n"
 "Language-Team: ROOT <epsilon@correoe.no-ip.org>, OmeGa <omega@mailoo.org>, "
@@ -143,24 +143,38 @@ msgstr ""
 "el texto completo)."
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Incluye la librería JSON for Modern C++, con la licencia MIT: https://github."
 "com/nlohmann/json."
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Incluye la librería JSON for Modern C++, con la licencia MIT: https://github."
+"com/nlohmann/json."
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr "Se atrapó newsboat::DbException con el mensaje: %s"
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Se atrapó newsboat::MatcherException con el mensaje: %s"
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Se atrapó newsboat::Exception con el mensaje: %s"
@@ -283,51 +297,51 @@ msgstr "comando desconocido `%s'"
 msgid "Starting %s %s..."
 msgstr "Iniciando %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Error: una instancia de %s ya está ejecutándose (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Cargando la configuración..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "hecho."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Abriendo la caché..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Error: la apertura del archivo de caché `%s' falló: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "ERROR: debe definir `cookie-cache` para usar NewsBlur.\n"
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s es inaccesible y no se puede crear\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Cargando las URL desde %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -336,7 +350,7 @@ msgstr ""
 "Error: no hay URL configuradas. Por favor, añade URL de fuentes RSS al "
 "archivo %s,o importa un archivo OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -344,7 +358,7 @@ msgstr ""
 "Parece que la fuente OPML a la que estás suscrito no contiene fuentes. Por "
 "favor, añádelas e inténtalo de nuevo."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -352,7 +366,7 @@ msgstr ""
 "Parece que no has configurado fuentes en tu cuenta de The Old Reader. Por "
 "favor, hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -360,7 +374,7 @@ msgstr ""
 "Parece que no has configurado fuentes en tu cuenta de Tiny Tiny RSS. Por "
 "favor, hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -368,7 +382,7 @@ msgstr ""
 "Parece que no has configurado fuentes en tu cuenta de NewsBlur. Por favor, "
 "hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -376,69 +390,69 @@ msgstr ""
 "Parece que no has configurado fuentes en tu cuenta de Inoreader. Por favor, "
 "hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Cargando artículos desde la caché..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Limpiando completamente la caché..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Error al cargar las fuentes desde la base de datos: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Error al cargar la fuente «%s»: %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Prerrellenando las fuentes de consulta..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Importando la lista de artículos leídos..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Exportando la lista de artículos leídos..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Limpiando la caché..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "falló: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Error: no se pudo marcar todas las fuentes como leídas: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ocurrió un error al procesar %s."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importación de %s finalizada."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u artículos no leídos"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: comando desconocido"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: no se pudo abrir el archivo de configuración `%s'."
@@ -483,7 +497,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Guardar"
 
@@ -582,7 +596,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "El navegador devolvió el código de error %i"
@@ -627,7 +641,7 @@ msgid "No filters defined."
 msgstr "No hay filtros creados."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Buscar: "
 
@@ -649,7 +663,7 @@ msgid "y"
 msgstr "s"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Salir"
@@ -659,7 +673,7 @@ msgid "Open"
 msgstr "Abrir"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Siguiente no leído"
 
@@ -685,7 +699,7 @@ msgid "Search"
 msgstr "Buscar"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Ayuda"
@@ -858,7 +872,7 @@ msgstr "Elementos favoritos"
 msgid "Saved web pages"
 msgstr "Páginas web guardadas"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Cambiando la marca de lectura del artículo..."
 
@@ -867,12 +881,12 @@ msgstr "Cambiando la marca de lectura del artículo..."
 msgid "Error while toggling read flag: %s"
 msgstr "Error cambiando la marca de lectura: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "Lista de las URL vacía."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Marcas: "
 
@@ -885,18 +899,18 @@ msgid "Error: you can't reload search results."
 msgstr "Error: no puedes recargar los resultados de la búsqueda."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "No hay elementos por leer."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Ya estás en el último elemento."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Ya estás en el primer elemento."
@@ -909,7 +923,7 @@ msgstr "No hay fuentes por leer."
 msgid "Marking all above as read..."
 msgstr "Marcando todo lo de arriba como leído..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Enviar artículo a comando: "
 
@@ -930,7 +944,7 @@ msgstr ""
 "¿Ordenar decrecientemente por (f)echa/(t)ítulo/(m)arcas/(a)utor/(e)nlace/"
 "(g)uid?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Marcas actualizadas."
 
@@ -939,17 +953,17 @@ msgstr "Marcas actualizadas."
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: la aplicación del filtro falló: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Abortada la operación de guardar."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artículo guardado en %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: no se pudo guardar el artículo como %s"
@@ -1020,68 +1034,68 @@ msgstr "URL de descarga del pódcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Arriba"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Abajo"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar el artículo como leído: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Se añadió %s a la cola de descargas."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "URL incorrecta: %s"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Artículo guardado como %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no se pudo escribir el artículo en el archivo %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Iniciando el navegador..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar el artículo como no leído: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Ir a URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Abrir en el navegador"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Añadir a la cola"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Artículo - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Error: expresión regular incorrecta."
 
@@ -1569,11 +1583,11 @@ msgstr "Error al descargar %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Error: fuente incorrecta."
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "pocos parámetros"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' no es una expresión de filtrado válida"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2017-07-11 10:22+0200\n"
 "Last-Translator: rugie <fliehen@posteo.net>\n"
 "Language-Team: Nicolas Martyanoff <khaelin@gmail.com>\n"
@@ -150,24 +150,38 @@ msgstr ""
 "(Tapez `%s -vv' pour voir le reste du texte.)"
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Il contient la bibliothèque JSON for Modern C++, publiée sous la licence MIT/"
 "X Consortiumhttps://github.com/nlohmann/json"
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Il contient la bibliothèque JSON for Modern C++, publiée sous la licence MIT/"
+"X Consortiumhttps://github.com/nlohmann/json"
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -289,51 +303,51 @@ msgstr "commande inconnue `%s'"
 msgid "Starting %s %s..."
 msgstr "Démarrage de %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Erreur : %s est déjà en cours d'exécution (PID : %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Chargement de la configuration..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "fait."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Ouverture du cache..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Erreur : l'ouverture du fichier de cache `%s' a échoué : %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s est inaccessible et ne peut être créé\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Chargement des liens depuis %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -342,7 +356,7 @@ msgstr ""
 "Erreur : aucun lien renseigné. Veuillez remplir le fichier %s avec des liens "
 "de fils RSS ou importer un fichier OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -350,7 +364,7 @@ msgstr ""
 "Il semble que le fichier OPML que vous avez ajouté ne contient aucun fil. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -358,7 +372,7 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte The Old Reader. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -366,7 +380,7 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte Tiny Tiny RSS. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -374,7 +388,7 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte NewsBlur. Ajoutez-"
 "en puis réessayez."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -382,69 +396,69 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte Inoreader. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Chargement des articles depuis le cache..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Nettoyage en profondeur du cache..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Erreur lors du chargement des fils depuis la base de données : "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Erreur lors du chargement du fil '%s' : %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Pré-remplissage des fils de requête ..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Importation de la liste d'articles lus..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Exportation de la liste d'articles lus..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Nettoyage du cache..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "échoué : "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Erreur : Tous les fils n'ont pu être marqués comme lus : %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Une erreur est survenue lors de l'analyse de %s."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importation de %s terminée."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u articles à lire"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s : %s : commande inconnue"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Erreur : échec de l'ouverture du fichier de configuration `%s' !"
@@ -489,7 +503,7 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -591,7 +605,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -637,7 +651,7 @@ msgid "No filters defined."
 msgstr "Aucun filtre défini."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Rechercher : "
 
@@ -659,7 +673,7 @@ msgid "y"
 msgstr "o"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Quitter"
@@ -669,7 +683,7 @@ msgid "Open"
 msgstr "Ouvrir"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Suivant"
 
@@ -695,7 +709,7 @@ msgid "Search"
 msgstr "Rechercher"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Aide"
@@ -867,7 +881,7 @@ msgstr "Éléments favoris"
 msgid "Saved web pages"
 msgstr "Pages web sauvegardées"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Basculement de l'état de lecture de l'article..."
 
@@ -876,12 +890,12 @@ msgstr "Basculement de l'état de lecture de l'article..."
 msgid "Error while toggling read flag: %s"
 msgstr "Erreur lors du basculement de l'état de lecture : %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "L'article ne contient aucun lien."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Signaux : "
 
@@ -894,18 +908,18 @@ msgid "Error: you can't reload search results."
 msgstr "Erreur : les résultats de recherche ne peuvent être rechargés."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Aucun élément à lire."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Déjà au dernier élément."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Déjà au premier élément."
@@ -919,7 +933,7 @@ msgstr "Aucun fil ne contient d'éléments à lire."
 msgid "Marking all above as read..."
 msgstr "Tous les fils sont marqués comme lus..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Passer l'article à la commande : "
 
@@ -942,7 +956,7 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Trier en sens inverse par (d)ate/(t)itre/signau(x)/(a)uteur/(l)ien/(g)uid ?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Signaux actualisés."
 
@@ -951,17 +965,17 @@ msgstr "Signaux actualisés."
 msgid "Error: applying the filter failed: %s"
 msgstr "Erreur : l'application du filtre a échoué : %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Enregistrement annulé."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Article enregistré dans %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Erreur : l'article n'a pu être enregistré dans %s"
@@ -1028,68 +1042,68 @@ msgstr "Lien de téléchargement du podcast : "
 msgid "type: "
 msgstr "type : "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Début"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Fin"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Erreur lors du passage de l'article à l'état lu : %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Ajout de %s à la file d'attente."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Lien invalide : '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Article enregistré dans %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Erreur : échec lors de l'enregistrement vers %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Lancement du navigateur..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Erreur en marquant l'article comme lu : %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Aller à l'addresse #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Ouvrir dans le navigateur"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Ajouter à la file d'attente"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Article - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Erreur : expression régulière incorrecte !"
 
@@ -1579,11 +1593,11 @@ msgstr "Erreur lors de la récupération de %s : %s"
 msgid "Error: invalid feed!"
 msgstr "Erreur : fil invalide !"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "paramètres insuffisants"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' n'est pas une expression de filtrage correcte"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2008-01-28 10:00+0100\n"
 "Last-Translator: Zsolt Udvari <udvzsolt@gmail.com>\n"
 "Language-Team: \n"
@@ -144,22 +144,32 @@ msgstr ""
 "newsboat egy ingyenes szoftver és MIT/X Consortium License-szel rendelkezik."
 
 #: newsboat.cpp:163
-msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+msgid "It bundles:"
 msgstr ""
 
-#: newsboat.cpp:237
+#: newsboat.cpp:164
+msgid ""
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
+msgstr ""
+
+#: newsboat.cpp:167
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -282,51 +292,51 @@ msgstr "ismeretlen parancs: `%s'"
 msgid "Starting %s %s..."
 msgstr "%s %s indítása..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Hiba: egy példány már fut %s-ből (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Konfiguráció betöltése..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "kész."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Cache megnyitása..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Hiba `%s' cache-file megnyitása közben: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "URL-ek betöltése %s-ből..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -335,7 +345,7 @@ msgstr ""
 "Hiba: nincs URL beállítva. Kérlek töltsd fel a(z) %s file-t RSS URL-ekkel "
 "vagy importálj egy OPML file-ból."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -343,7 +353,7 @@ msgstr ""
 "Úgy tűnik, az OPML, amit betöltöttél, nem tartalmaz hírforrásokat. Töltsd "
 "fel forrásokkal és próbáld újra!"
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -352,7 +362,7 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -361,7 +371,7 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -370,7 +380,7 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -379,69 +389,69 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Cikkek töltése a cache-bõl..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "A cache teljes ürítése..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Nem sikerült betölteni a forrásokat az adatbázisból: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Hiba a `%s' forrás betöltése közben: %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "A lekérdezési mezők kezdeti feltöltése..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Olvasott cikkek listájának importálása..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Olvasott cikkek listájának exportálása..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "A cache takarítása..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "nem sikerült: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Hiba: nem tudtam olvasottnak megjelölni: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Egy hiba lépett fel, miközben %s-t elemeztem."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s importálása befejeződött."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u olvasatlan hír"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "ismeretlen parancs: `%s'"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Hiba: nem tudtam megnyitni a(z) `%s' konfigurációs fájlt!"
@@ -486,7 +496,7 @@ msgid "Cancel"
 msgstr "Mégsem"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Mentés"
 
@@ -588,7 +598,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -633,7 +643,7 @@ msgid "No filters defined."
 msgstr "Nincs szűrő (filter) definiálva."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Keresés: "
 
@@ -655,7 +665,7 @@ msgid "y"
 msgstr "i"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Kilép"
@@ -665,7 +675,7 @@ msgid "Open"
 msgstr "Megnyit"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Köv. olvasatlan"
 
@@ -691,7 +701,7 @@ msgid "Search"
 msgstr "Keres"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Súgó"
@@ -866,7 +876,7 @@ msgstr "Megosztott elemek"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Az olvasott jelző ki/beállítása a cikkre..."
 
@@ -875,12 +885,12 @@ msgstr "Az olvasott jelző ki/beállítása a cikkre..."
 msgid "Error while toggling read flag: %s"
 msgstr "Hiba az olvasott jelző állítása közben: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "URL lista üres."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Jelzõk: "
 
@@ -893,18 +903,18 @@ msgid "Error: you can't reload search results."
 msgstr "Hiba: nem töltheted újra a keresési eredményt."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Nincs olvasatlan elem."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
@@ -918,7 +928,7 @@ msgstr "Nincs olvasatlan forrás."
 msgid "Marking all above as read..."
 msgstr "Az összes forrás olvasottként jelölése..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "A cikk pipe-olása a parancsnak: "
 
@@ -941,7 +951,7 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Fordított rendezés (d)átum/(c)ím/(j)elzők/(s)zerző/(l)ink/(g)uid alapján?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Jelzők frissítve."
 
@@ -950,17 +960,17 @@ msgstr "Jelzők frissítve."
 msgid "Error: applying the filter failed: %s"
 msgstr "Hiba: szűrő alkalmazása nem sikerült: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Mentés megszakítva."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Cikk mentése %s-be"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Hiba: nem tudtam a cikket %s fájlba menteni"
@@ -1027,68 +1037,68 @@ msgstr "Podcast letöltés URL: "
 msgid "type: "
 msgstr "típus: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Fent"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Lent"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Hiba a cikk olvasottá tétele közben: %s "
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s hozzáadása a letöltési listához."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Érvénytelen URL: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Cikk mentve %s-be."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Hiba: nem tudtam a cikket a(z) %s file-ba menteni"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Böngésző indítása..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Hiba a cikk olvasatlanná tétele közben: %s "
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Ugrás: URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Megnyitás böngészőben"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Lista"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Cikk %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Hiba: érvénytelen reguláris kifejezés!"
 
@@ -1579,11 +1589,11 @@ msgstr "Hiba letöltés közben: %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Hiba: érvénytelen hírforrás!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "túl kevés paraméter"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' nem valódi reguláris kifejezés: %s"

--- a/po/it.po
+++ b/po/it.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2019-08-26 23:02+0200\n"
 "Last-Translator: Leandro Noferini <leandro@noferini.org>\n"
 "Language-Team: Claudio M. Alessi <somppy@gmail.com>\n"
@@ -147,24 +147,38 @@ msgstr ""
 "testo integrale.)"
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Include la libreria JSON for Modern C++, sotto licenza MIT: https://github."
 "com/nlohmann/json"
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Include la libreria JSON for Modern C++, sotto licenza MIT: https://github."
+"com/nlohmann/json"
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr "Ricevuto newsboat::DbException con messaggio: %s"
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Ricevuto newsboat::MatcherException con messaggio: %s"
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Ricevuto newsboat::Exception con messaggio: %s"
@@ -286,51 +300,51 @@ msgstr "comando sconosciuto `%s'"
 msgid "Starting %s %s..."
 msgstr "Sto avviando %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Errore: un'istanza di %s è già in esecuzione (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Sto caricando la configurazione..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "fatto."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Sto aprendo la cache..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Errore: apertura del file cache `%s' fallita: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "ERRORE: Devi impostare `cookie-cache` per usare NewsBlur.\n"
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s è inaccessibile e non può essere creato\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Sto caricando gli URL da %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -339,7 +353,7 @@ msgstr ""
 "Errore: nessun URL configurato. Per favore, inserisci i feed RSS nel file %s "
 "o importa un file OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -347,7 +361,7 @@ msgstr ""
 "Sembra che il feed OPML di cui hai chiesto la sottoscrizione non contenga "
 "feed. Per favore, inserisci i feed e riprova."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -355,7 +369,7 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account The Old "
 "Reader. Per favore, fallo e riprova."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -363,7 +377,7 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account Tiny Tiny "
 "RSS. Per favore, fallo e riprova."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -371,7 +385,7 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account NewsBlur. Per "
 "favore, fallo e riprova."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -379,69 +393,69 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account Inoreader. "
 "Per favore, fallo e riprova."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Sto caricando gli articoli dalla cache..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Sto pulendo accuratamente la cache..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Errore durante il caricamento dei feed dal database: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Errore durante il caricamento del feed `%s': %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Sto precompilando l'interrogazione dei feed..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Sto importando la lista degli articoli letti..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Sto esportando la lista degli articoli letti..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Sto pulendo la cache..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "fallito: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Errore: impossibile contrassegnare tutti i feed letti: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Si è verificato un errore analizzando %s."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importazione di %s finita."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u articoli non letti"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: comando sconosciuto"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Errore: impossibile aprire il file di configurazione `%s'!"
@@ -486,7 +500,7 @@ msgid "Cancel"
 msgstr "Cancella"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Salva"
 
@@ -585,7 +599,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -630,7 +644,7 @@ msgid "No filters defined."
 msgstr "Nessun filtro definito."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Ricerca: "
 
@@ -652,7 +666,7 @@ msgid "y"
 msgstr "s"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Esci"
@@ -662,7 +676,7 @@ msgid "Open"
 msgstr "Apri"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Prossimo non letto"
 
@@ -688,7 +702,7 @@ msgid "Search"
 msgstr "Cerca"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Aiuto"
@@ -860,7 +874,7 @@ msgstr "Elementi preferiti"
 msgid "Saved web pages"
 msgstr "Pagine web salvate"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Cambiando la flag \"letto\" per l'articolo..."
 
@@ -869,12 +883,12 @@ msgstr "Cambiando la flag \"letto\" per l'articolo..."
 msgid "Error while toggling read flag: %s"
 msgstr "Errore cambiando la flag \"letto\": %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "Lista URL vuota."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Flag: "
 
@@ -887,18 +901,18 @@ msgid "Error: you can't reload search results."
 msgstr "Errore: non puoi ricaricare i risultati della ricerca."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Nessuna voce non letta."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Già all'ultimo elemento."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Già al primo elemento."
@@ -911,7 +925,7 @@ msgstr "Nessun feed non letto."
 msgid "Marking all above as read..."
 msgstr "Contrassegno i feed al di sopra come letti..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Metti in pipe l'articolo col comando: "
 
@@ -933,7 +947,7 @@ msgstr ""
 "Ordina al contrario per (d)ata/(t)itolo/(f)lag/(a)utore/(c)ollegamento/"
 "(g)uid/(r)andom?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Flag aggiornate."
 
@@ -942,17 +956,17 @@ msgstr "Flag aggiornate."
 msgid "Error: applying the filter failed: %s"
 msgstr "Errore: applicazione del filtro fallita: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Salvataggio annullato."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Articolo salvato su %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Errore: impossibile salvare l'articolo su %s"
@@ -1023,68 +1037,68 @@ msgstr "URL scaricamento podcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Su"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Giù"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Errore contrassegnando l'articolo come letto: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Aggiunto %s alla coda dei download."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "URL invalido: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Articolo salvato su %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Errore: impossibile scrivere l'articolo sul file %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Sto avviando il browser..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Errore contrassegnando l'articolo come non letto: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Vai a URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Apri nel browser"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Accoda"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Articolo - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Errore: espressione regolare non valida!"
 
@@ -1569,11 +1583,11 @@ msgstr "Errore durante il recupero di %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Errore: feed non valido!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "parametri insufficienti"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' non è un'espressione regolare valida"

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.9\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2015-04-26 05:55+0900\n"
 "Last-Translator: Grady Martin <GradyMartin@gmail.com>\n"
 "Language-Team: \n"
@@ -141,22 +141,32 @@ msgstr ""
 "ます。"
 
 #: newsboat.cpp:163
-msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+msgid "It bundles:"
 msgstr ""
 
-#: newsboat.cpp:237
+#: newsboat.cpp:164
+msgid ""
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
+msgstr ""
+
+#: newsboat.cpp:167
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -276,150 +286,150 @@ msgstr ""
 msgid "Starting %s %s..."
 msgstr "%s%sを起動中…"
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "エラー：%sは既に起動中です（PID: %u）"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "設定を読み込み中…"
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "完了しました。"
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "キャッシュを読み込み中…"
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr ""
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "%sからURLを読み込み中…"
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr ""
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr ""
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "キャッシュから記事を読み込み中…"
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "キャッシュをより細かく整理中…"
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr ""
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr ""
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr ""
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "キャッシュを整理中…"
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr ""
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr ""
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr ""
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr ""
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr ""
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr ""
@@ -464,7 +474,7 @@ msgid "Cancel"
 msgstr ""
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "保存"
 
@@ -559,7 +569,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -604,7 +614,7 @@ msgid "No filters defined."
 msgstr ""
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr ""
 
@@ -626,7 +636,7 @@ msgid "y"
 msgstr ""
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "閉じる"
@@ -636,7 +646,7 @@ msgid "Open"
 msgstr "開く"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "次"
 
@@ -662,7 +672,7 @@ msgid "Search"
 msgstr "検索"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "ヘルプ"
@@ -833,7 +843,7 @@ msgstr ""
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr ""
 
@@ -842,12 +852,12 @@ msgstr ""
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr ""
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr ""
 
@@ -860,18 +870,18 @@ msgid "Error: you can't reload search results."
 msgstr ""
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
@@ -884,7 +894,7 @@ msgstr ""
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -903,7 +913,7 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr ""
 
@@ -912,17 +922,17 @@ msgstr ""
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
@@ -989,68 +999,68 @@ msgstr "コンテンツ："
 msgid "type: "
 msgstr ""
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr ""
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr ""
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%sのダウンロードを予約しました。"
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "%s…無効なURLです。"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr ""
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "ブラウザーを起動中…"
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "ブラウザーで開く"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "コンテンツをダウンロード"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr ""
 
@@ -1530,11 +1540,11 @@ msgstr ""
 msgid "Error: invalid feed!"
 msgstr ""
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr ""
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "「%s」は無効な色です。"

--- a/po/nb.po
+++ b/po/nb.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2012-08-08 20:07+0100\n"
 "Last-Translator: Daniel Aleksandersen <code@daniel.priv.no>\n"
 "Language-Team: \n"
@@ -145,22 +145,32 @@ msgid ""
 msgstr "newsboat er fri programvare lisensiert under MIT/X Consortium License."
 
 #: newsboat.cpp:163
-msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+msgid "It bundles:"
 msgstr ""
 
-#: newsboat.cpp:237
+#: newsboat.cpp:164
+msgid ""
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
+msgstr ""
+
+#: newsboat.cpp:167
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -287,51 +297,51 @@ msgstr "ukjent kommando `%s'"
 msgid "Starting %s %s..."
 msgstr "Starter %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Feil: en annen instans av %s kjører allerede (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Leser oppsett..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "utført."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Åpner mellomlager..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Feil: åpning av mellomlagerfilen `%s' feilet: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Laster inn URLer fra %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -340,7 +350,7 @@ msgstr ""
 "Feil: ingen URLer er satt opp. Vennligst fyll inn filen %s med RSS "
 "nyhetsstrømmer, eller importer fra en OPML-fil."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -349,7 +359,7 @@ msgstr ""
 "nyhetsstrømmer. Vennligst sørg for at den inneholder noen nyhetsstrømmer og "
 "prøv igjen."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -358,7 +368,7 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -367,7 +377,7 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -376,7 +386,7 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -385,69 +395,69 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Leser artikler fra mellomlageret..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Rydder grundig opp i mellomlageret..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Feil under innlesing av nyhetsstrømmer fra databasen: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Feil under innlastning av nyhetsstrømmen '%s': %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Forhåndsutfyller spørringsstrømmer..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Importerer liste over leste artikler..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Eksporterer liste over leste artikler..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Rydder opp i mellomlageret..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "feilet: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Feil: kunne ikke markere alle nyhetsstrømmene som lest: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "En feil oppsto under tolkningen av %s"
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Fullførte importeringen av %s."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u uleste artikler"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "ukjent kommando `%s'"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Feil: kunne ikke åpne oppsettsfilen `%s'!"
@@ -492,7 +502,7 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Lagre"
 
@@ -594,7 +604,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -639,7 +649,7 @@ msgid "No filters defined."
 msgstr "Ingen angitte filtere."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Søk etter: "
 
@@ -661,7 +671,7 @@ msgid "y"
 msgstr "j"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Avslutt"
@@ -671,7 +681,7 @@ msgid "Open"
 msgstr "Åpne"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Neste uleste"
 
@@ -697,7 +707,7 @@ msgid "Search"
 msgstr "Søk"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Hjelp"
@@ -873,7 +883,7 @@ msgstr "Delte innlegg"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Setter lestflagg for artikkelen..."
 
@@ -882,12 +892,12 @@ msgstr "Setter lestflagg for artikkelen..."
 msgid "Error while toggling read flag: %s"
 msgstr "Feil under setting av lestflagg: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "URL-listen er tom."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Flagg: "
 
@@ -900,18 +910,18 @@ msgid "Error: you can't reload search results."
 msgstr "Feil: du kan ikke oppdatere søkeresultater."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Ingen uleste innlegg."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Allerede på siste innlegg."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Allerede på første innlegg."
@@ -925,7 +935,7 @@ msgstr "Ingen uleste nyhetsstrømmer."
 msgid "Marking all above as read..."
 msgstr "Markerer alle nyhetsstrømmer som lest..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Send artikkel til kommando: "
 
@@ -948,7 +958,7 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sorter synkende etter (d)ato)/(t)ittel/(f)lagg/f(o)rfatter/(l)enke/(g)uide?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Flagg oppdatert."
 
@@ -957,17 +967,17 @@ msgstr "Flagg oppdatert."
 msgid "Error: applying the filter failed: %s"
 msgstr "Feil: bruk av filteret feilet: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Avbrøt lagringen."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Lagret artikkelen til %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Feil: kunne ikke lagre artikkelen til %s"
@@ -1034,68 +1044,68 @@ msgstr "Podkastnedlastings-URL: "
 msgid "type: "
 msgstr "slag: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Toppen"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Bunnen"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Feil mens artikkelen ble markert som lest: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "La til %s til nedlastingskøen."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Ugyldig URL: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Lagret artikkel til %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Feil: kunne ikke skrive artikkelen til filen %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Åpner nettleseren..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Feil mens artikkelen ble markert som lest: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Gå til URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Åpne i nettleseren"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Legg til i køen"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Artikkel - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Feil: ugyldig regulært uttrykk!"
 
@@ -1581,11 +1591,11 @@ msgstr "Feil under innhenting av %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Feil: ugyldig nyhetsstrøm!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "for få argumenter"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' er ikke et gyldig regulært utrykk: %s"

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -140,22 +140,32 @@ msgid ""
 msgstr ""
 
 #: newsboat.cpp:163
-msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+msgid "It bundles:"
 msgstr ""
 
-#: newsboat.cpp:237
+#: newsboat.cpp:164
+msgid ""
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
+msgstr ""
+
+#: newsboat.cpp:167
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -275,150 +285,150 @@ msgstr ""
 msgid "Starting %s %s..."
 msgstr ""
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr ""
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr ""
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr ""
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr ""
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr ""
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr ""
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr ""
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr ""
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr ""
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr ""
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr ""
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr ""
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr ""
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr ""
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr ""
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr ""
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr ""
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr ""
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr ""
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr ""
@@ -463,7 +473,7 @@ msgid "Cancel"
 msgstr ""
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr ""
 
@@ -558,7 +568,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -603,7 +613,7 @@ msgid "No filters defined."
 msgstr ""
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr ""
 
@@ -625,7 +635,7 @@ msgid "y"
 msgstr ""
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr ""
@@ -635,7 +645,7 @@ msgid "Open"
 msgstr ""
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr ""
 
@@ -661,7 +671,7 @@ msgid "Search"
 msgstr ""
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr ""
@@ -831,7 +841,7 @@ msgstr ""
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr ""
 
@@ -840,12 +850,12 @@ msgstr ""
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr ""
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr ""
 
@@ -858,18 +868,18 @@ msgid "Error: you can't reload search results."
 msgstr ""
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
@@ -882,7 +892,7 @@ msgstr ""
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -901,7 +911,7 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr ""
 
@@ -910,17 +920,17 @@ msgstr ""
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
@@ -987,68 +997,68 @@ msgstr ""
 msgid "type: "
 msgstr ""
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr ""
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr ""
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr ""
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr ""
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr ""
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr ""
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr ""
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr ""
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr ""
 
@@ -1522,11 +1532,11 @@ msgstr ""
 msgid "Error: invalid feed!"
 msgstr ""
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr ""
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2020-02-08 00:10+0100\n"
 "Last-Translator: Dennis van der Schagt <dennisschagt@gmail.com>\n"
 "Language-Team: Dutch <vertalen@vrijschrift.org>, Erwin Poeze <donnut@outlook."
@@ -146,24 +146,38 @@ msgstr ""
 "`%s -vv' voor de volledige tekst)."
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Het maakt gebruik van \"JSON for Modern C++\" wat ook gelicenseerd is onder "
 "de MIT-licentie: https://github.com/nlohmann/json"
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Het maakt gebruik van \"JSON for Modern C++\" wat ook gelicenseerd is onder "
+"de MIT-licentie: https://github.com/nlohmann/json"
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr "Fout (newsboat::DbException): %s"
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Fout (newsboat::MatcherException): %s"
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Fout (newsboat::Exception): %s"
@@ -285,53 +299,53 @@ msgstr "onbekende opdracht ‘%s’"
 msgid "Starting %s %s..."
 msgstr "Starten van %s %s…"
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Fout: er draait al een instantie van %s (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Laden van de configuratie…"
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "klaar."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Openen van de cache…"
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Fout: openen van het cachebestand ‘%s’ is mislukt: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 "Error: `cookie-cache` moet ingesteld worden om NewsBlur te kunnen "
 "gebruiken.\n"
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s is niet toegangelijk en kan ook niet aangemaakt worden\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "URLs laden uit %s…"
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -340,7 +354,7 @@ msgstr ""
 "Fout: geen URLs geconfigureerd. Plaats RSS-feed URLs in het bestand %s of "
 "importeer een OPML-bestand."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -348,7 +362,7 @@ msgstr ""
 "Blijkbaar bevat de OPML-feed waar uw zich op heeft geabonneerd geen feeds. "
 "Vul het met feeds en probeer het dan opnieuw."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -356,7 +370,7 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw \"The Old Reader\"-"
 "account. Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -364,7 +378,7 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw Tiny Tiny RSS-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -372,7 +386,7 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw NewsBlur-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -380,69 +394,69 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw Inoreader-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Laden van artikelen uit de cache…"
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Grondig opruimen van de cache…"
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Fout bij het laden van feeds uit de database: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Fout tijdens het laden van ‘%s’: %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Feedzoekopdrachten voorinvullen…"
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Importeren van lijst van gelezen artikelen…"
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Exporteren van lijst van gelezen artikelen…"
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Opruimen van de cache…"
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "fout: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Fout: alle feeds als gelezen markeren is mislukt: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Het ontleden van %s is mislukt."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Klaar met importeren van %s."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u ongelezen artikelen"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: onbekende opdracht"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fout: configuratiebestand ‘%s’ openen is mislukt!"
@@ -487,7 +501,7 @@ msgid "Cancel"
 msgstr "Annuleren"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Opslaan"
 
@@ -586,7 +600,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "Browser gaf error code %i terug"
@@ -631,7 +645,7 @@ msgid "No filters defined."
 msgstr "Geen filters gedefinieerd."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Zoeken naar: "
 
@@ -653,7 +667,7 @@ msgid "y"
 msgstr "j"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Afsluiten"
@@ -663,7 +677,7 @@ msgid "Open"
 msgstr "Openen"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Volgende Ongelezen"
 
@@ -689,7 +703,7 @@ msgid "Search"
 msgstr "Zoeken"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Hulp"
@@ -861,7 +875,7 @@ msgstr "Liked items"
 msgid "Saved web pages"
 msgstr "Opgeslagen webpagina's"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Gelezen-vlag van artikel omschakelen…"
 
@@ -870,12 +884,12 @@ msgstr "Gelezen-vlag van artikel omschakelen…"
 msgid "Error while toggling read flag: %s"
 msgstr "Gelezen-vlag omschakelen is mislukt: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "URL-lijst is leeg."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Vlaggen: "
 
@@ -888,18 +902,18 @@ msgid "Error: you can't reload search results."
 msgstr "Fout: zoekresultaten vernieuwen is mislukt."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Er zijn geen ongelezen items."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Dit is reeds het laatste item."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Dit is reeds het eerste item."
@@ -912,7 +926,7 @@ msgstr "Geen ongelezen feeds."
 msgid "Marking all above as read..."
 msgstr "Bezig met alle voorgaande feeds als gelezen te markeren…"
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Pipe artikel naar commando: "
 
@@ -935,7 +949,7 @@ msgstr ""
 "Omgekeerd sorteren op (d)atum/(t)itel/(v)laggen/(a)uteur/(k)oppeling/(g)uid/"
 "(w)illekeurig?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Vlaggen zijn bijgewerkt."
 
@@ -944,17 +958,17 @@ msgstr "Vlaggen zijn bijgewerkt."
 msgid "Error: applying the filter failed: %s"
 msgstr "Fout: toepassen van filter is mislukt: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Opslaan afgebroken."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artikel opgeslagen in %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fout: opslaan artikel in %s is mislukt"
@@ -1025,68 +1039,68 @@ msgstr "Download-URL podcast: "
 msgid "type: "
 msgstr "type: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Boven"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Onder"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fout bij het als gelezen markeren van het artikel: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s toegevoegd aan de downloadwachtrij."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Ongeldige URL: ‘%s’"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Artikel opgeslagen in %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Fout: artikel opslaan in bestand ‘%s’ is mislukt"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Bezig met starten van browser…"
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Het als ongelezen markeren van het artikel ‘%s’ is mislukt"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Ga naar URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Openen in browser"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Aan downloadlijst toevoegen"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Fout: ongeldige reguliere expressie!"
 
@@ -1569,11 +1583,11 @@ msgstr "Ophalen van ‘%s’ is mislukt: %s"
 msgid "Error: invalid feed!"
 msgstr "Fout: ongeldige feed!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "te weinig argumenten"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "‘%s’ is een ongeldige filterexpressie"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2019-01-09 20:42+0100\n"
 "Last-Translator: Michal Siemek <carnophage@dobramama.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -148,24 +148,38 @@ msgstr ""
 "aby zobaczyć pełny tekst licencji.)"
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Zawiera bibliotekę JSON for Modern C++ na licencji MIT License: https://"
 "github.com/nlohmann/json"
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Zawiera bibliotekę JSON for Modern C++ na licencji MIT License: https://"
+"github.com/nlohmann/json"
+
+#: newsboat.cpp:240
 #, fuzzy, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr "Złapano wyjątek newsboat::dbexception o treści: %s"
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, fuzzy, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Złapano wyjątek newsboat::matcherexception o treści: %s"
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, fuzzy, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Złapano wyjątek newsboat::dbexception o treści: %s"
@@ -290,51 +304,51 @@ msgstr "nieznana komenda '%s'"
 msgid "Starting %s %s..."
 msgstr "Uruchamianie %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Błąd: inny proces %s jest już uruchomiony (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Czytanie konfiguracji..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "gotowe."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Otwieranie pamięci podręcznej..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Błąd: otwarcie pliku pamięci podręcznej '%s' nieudane: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "BŁĄD: Musisz ustawić `cookie-cache` aby korzystać z NewsBlur.\n"
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s jest niedostępny i nie może zostać utworzony\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Czytanie odnośników z %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -343,7 +357,7 @@ msgstr ""
 "Błąd: brak skonfigurowanych odnośników. Dodaj do pliku %s kilka odnośników "
 "do kanałów RSS lub zaimportuj plik OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -351,7 +365,7 @@ msgstr ""
 "Wygląda na to, że kanał OPML który subskrybujesz nie posiada żadnych kanałów."
 "Wypełnij go źródłami RSS i spróbuj ponownie."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -359,7 +373,7 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie The "
 "Old Reader. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -367,7 +381,7 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie Tiny "
 "Tiny RSS. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -375,7 +389,7 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie "
 "NewsBlur. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -383,69 +397,69 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie "
 "Inoreader. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Wczytywanie artykułów z pamięci podręcznej..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Dokładne czyszczenie pamięci podręcznej..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Błąd podczas wczytywania kanałów z bazy danych: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Błąd podczas ładowania kanału: '%s': %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Wstępne wypełnianie kanałów zapytań..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Importowanie listy przeczytanych artykułów..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Eksportowanie listy przeczytanych artykułów..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Czyszczenie pamięci podręcznej..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "nieudane: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Błąd: nie można zaznaczyć wszystkich kanałów jako przeczytanych: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Wystąpił błąd podczas przetwarzania %s."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Import z %s zakończony."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u nieprzeczytanych artykułów"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: nieznana komenda"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Błąd: nie można otworzyć pliku konfiguracyjnego `%s'!"
@@ -490,7 +504,7 @@ msgid "Cancel"
 msgstr "Anuluj"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Zapisz"
 
@@ -589,7 +603,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -634,7 +648,7 @@ msgid "No filters defined."
 msgstr "Brak zdefiniowanych filtrów."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Szukaj: "
 
@@ -656,7 +670,7 @@ msgid "y"
 msgstr "t"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Wyjście"
@@ -666,7 +680,7 @@ msgid "Open"
 msgstr "Otwórz"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Następny nieprzeczytany"
 
@@ -692,7 +706,7 @@ msgid "Search"
 msgstr "Szukaj"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Pomoc"
@@ -864,7 +878,7 @@ msgstr "Polubione pozycje"
 msgid "Saved web pages"
 msgstr "Zapisane strony internetowe"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Przełączam znacznik przeczytania dla artykułu..."
 
@@ -873,12 +887,12 @@ msgstr "Przełączam znacznik przeczytania dla artykułu..."
 msgid "Error while toggling read flag: %s"
 msgstr "Błąd podczas przełączania znacznika przeczytania: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "Lista adresów jest pusta."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Flagi: "
 
@@ -891,18 +905,18 @@ msgid "Error: you can't reload search results."
 msgstr "Błąd: nie możesz odświeżyć wyników wyszukiwania."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Brak nieprzeczytanych pozycji."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "To już ostatnia pozycja."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "To już pierwsza pozycja."
@@ -915,7 +929,7 @@ msgstr "Brak nieprzeczytanych kanałów."
 msgid "Marking all above as read..."
 msgstr "Oznaczam powyższe jako przeczytane..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Prześlij artykuł do polecenia: "
 
@@ -938,7 +952,7 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sortuj odwrotnie wg (d)aty/(t)ytułu/(f)lag/(a)utora/(o)dnośnika/(g)uid?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Znaczniki uaktualnione."
 
@@ -947,17 +961,17 @@ msgstr "Znaczniki uaktualnione."
 msgid "Error: applying the filter failed: %s"
 msgstr "Błąd: użycie filtra nie powiodło się: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Zapisywanie przerwane."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Zapisano artykuł do %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Błąd: nie można zapisać artykułu do %s"
@@ -1024,68 +1038,68 @@ msgstr "Adres podcastu: "
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Góra"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Dół"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Błąd podczas oznaczania artykułu jako przeczytanego: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Dodano %s do kolejki pobierania."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Niepoprawny adres URL: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Zapisano artykuł do %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Błąd: nie można zapisać artykułu do pliku %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Uruchamiam przeglądarkę..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Błąd podczas oznaczania artykułu jako nieprzeczytanego: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Idź do adresu URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Otwórz w przeglądarce"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Zakolejkuj"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Artykuł - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Błąd: nieprawidłowe wyrażenie regularne!"
 
@@ -1568,11 +1582,11 @@ msgstr "Błąd podczas pobierania %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Błąd: nieprawidłowy kanał!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "zbyt mało parametrów"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' nie jest poprawnym filtrem"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.8\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2018-03-06 20:35-0300\n"
 "Last-Translator: Alexandre Erwin Ittner <alexandre@ittner.com.br>\n"
 "Language-Team: \n"
@@ -150,24 +150,38 @@ msgstr ""
 "License. (Digite `%s -vv' para ver o texto completo.)"
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Ele inclui a biblioteca JSON for Modern C++, licenciada sob a MIT License: "
 "https://github.com/nlohmann/json"
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Ele inclui a biblioteca JSON for Modern C++, licenciada sob a MIT License: "
+"https://github.com/nlohmann/json"
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -290,51 +304,51 @@ msgstr "comando desconhecido '%s'"
 msgid "Starting %s %s..."
 msgstr "Iniciando o %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Erro: uma instância de %s já está sendo executada (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Carregando configuração..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "pronto."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Abrindo o cache..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Erro: falha ao abrir o arquivo de cache '%s': %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s não está acessível e não pode ser criado\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Carregando URLS a partir de %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -343,7 +357,7 @@ msgstr ""
 "Erro: nenhuma URL configurada. Por favor preencha o arquivo %s com URLs de "
 "fontes RSS ou importe um arquivo OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -351,7 +365,7 @@ msgstr ""
 "Parece que a fonte OPML especificada não tem fontes RSS. Por favor, preencha-"
 "a com fontes RSS e tente novamente."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -359,7 +373,7 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta em The Old Reader. "
 "Faça isso, e tente novamente."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -367,7 +381,7 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta do Tiny Tiny RSS."
 "Faça isso, e tente novamente."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -375,7 +389,7 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta do NewsBlur. Faça "
 "isso, e tente novamente."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -383,69 +397,69 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta em Inoreader. Faça "
 "isso, e tente novamente."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Carregando artigos do cache..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Limpando o cache completamente..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Erro carregando as fontes do banco de dados: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Erro carregando fonte '%s': %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Pré-povoando fontes de consulta..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Importando lista de artigos lidos..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Exportando lista de artigos lidos..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Limpando o cache..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "falha: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Erro: não foi possível marcar todos artigos como lidos: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Um erro ocorreu durante a análise de %s."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importação de %s concluída."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u artigos não lidos"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: comando desconhecido"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Erro: não foi possível abrir o arquivo de configuração '%s'!"
@@ -490,7 +504,7 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Salvar"
 
@@ -592,7 +606,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -637,7 +651,7 @@ msgid "No filters defined."
 msgstr "Nenhum filtro definido."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Procurar por: "
 
@@ -659,7 +673,7 @@ msgid "y"
 msgstr "s"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Sair"
@@ -669,7 +683,7 @@ msgid "Open"
 msgstr "Abrir"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Próxima Não Lida"
 
@@ -695,7 +709,7 @@ msgid "Search"
 msgstr "Procurar"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Ajuda"
@@ -867,7 +881,7 @@ msgstr "Itens gostados"
 msgid "Saved web pages"
 msgstr "Páginas web salvas"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Alternando estado lido/não lido do artigo..."
 
@@ -876,12 +890,12 @@ msgstr "Alternando estado lido/não lido do artigo..."
 msgid "Error while toggling read flag: %s"
 msgstr "Erro ao alternar estado lido/não lido do artigo: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "A lista de URLs está vazia."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Sinalizações: "
 
@@ -894,18 +908,18 @@ msgid "Error: you can't reload search results."
 msgstr "Erro: você não pode recarregar os resultados da busca."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Nenhum artigo não lido."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Já no último item"
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Já no primeiro item"
@@ -919,7 +933,7 @@ msgstr "Nenhuma fonte não lida."
 msgid "Marking all above as read..."
 msgstr "Marcando todas fontes RSS como lidas..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Passar o artigo por pipe ao comando: "
 
@@ -943,7 +957,7 @@ msgstr ""
 "Classificar inversamente por (d)ata/(t)ítulo/(s)inalizações/(a)utor/(l)ink/"
 "(g)uid?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Sinalizações atualizadas."
 
@@ -952,17 +966,17 @@ msgstr "Sinalizações atualizadas."
 msgid "Error: applying the filter failed: %s"
 msgstr "Erro: aplicação do filtro falhou: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Salvamento cancelado."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artigo salvo em %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Erro: não foi possível salvar artigo em %s"
@@ -1029,68 +1043,68 @@ msgstr "URL para baixar Podcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Início"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Fim"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Erro marcando artigo como lido: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s foi adicionado à fila para ser baixado."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "URL inválida: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Artigo salvo em %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Erro: não foi possível gravar o artigo no arquivo %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Iniciando navegador..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Erro marcando artigo como não lido: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Ir para a URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Abrir no Navegador"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Pôr na Fila"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Artigo - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Erro: expressão regular inválida!"
 
@@ -1575,11 +1589,11 @@ msgstr "Erro ao tentar obter %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Erro: fonte RSS inválida!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "poucos parâmetros"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' não é uma expressão de filtro válida"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2020-03-20 17:59+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Konstantin Shakhnov <kastian@mail.ru>, Alexander Batischev "
@@ -147,24 +147,38 @@ msgstr ""
 "просмотра полного текста наберите `%s -vv')."
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Программа включает в себя библиотеку «JSON for Modern C++» под лицензией "
 "MIT: https://github.com/nlohmann/json"
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Программа включает в себя библиотеку «JSON for Modern C++» под лицензией "
+"MIT: https://github.com/nlohmann/json"
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr "Поймали newsboat::DbException с сообщением: %s"
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Поймали newsboat::MatcherException с сообщением: %s"
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Поймали newsboat::Exception с сообщением: %s"
@@ -286,51 +300,51 @@ msgstr "неизвестная команда `%s'"
 msgid "Starting %s %s..."
 msgstr "Запускаю %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Ошибка: уже запущена копия %s (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Загружаю настройки..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "сделано."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Открываю кэш..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Ошибка: попытка открыть файл кэша `%s' завершилась неудачей: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "Ошибка: для пользования NewsBlur нужно задать `cookie-cache`.\n"
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s недоступен и не может быть создан\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Загружаю ссылки из %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -339,7 +353,7 @@ msgstr ""
 "Ошибка: не найдено ни одной ссылки. Пожалуйста, занесите в файл %s ссылки на "
 "RSS ленты или импортируйте файл OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -347,7 +361,7 @@ msgstr ""
 "Похоже что лента OPML, на которую вы подписались, не содержит лент новостей."
 "Пожалуйста заполните её лентами и попробуйте еще раз."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -355,7 +369,7 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "The Old Reader. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -363,7 +377,7 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "Tiny Tiny RSS. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -371,7 +385,7 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "NewsBlur. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -379,69 +393,69 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "Inoreader. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Загружаю заметки из кэша..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Тщательно очищаю кэш..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Ошибка во время загрузки лент новостей из базы: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Ошибка во время загрузки ленты '%s': %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Заполняю динамические ленты..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Импортирую список прочитанных заметок..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Экспортирую список прочитанных заметок..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Очищаю кэш..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "не получилось: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Ошибка: невозможно отметить все ленты как прочитанные: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "При обработке %s возникла ошибка."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Импорт %s завершён."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u непрочитанных заметок"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: неизвестная команда"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Ошибка: невозможно открыть конфигурационный файл `%s'!"
@@ -486,7 +500,7 @@ msgid "Cancel"
 msgstr "Отмена"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Сохранить"
 
@@ -585,7 +599,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "Браузер вернул код ошибки %i"
@@ -630,7 +644,7 @@ msgid "No filters defined."
 msgstr "Не определено ни одного фильтра."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Искать: "
 
@@ -652,7 +666,7 @@ msgid "y"
 msgstr "y"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Выход"
@@ -662,7 +676,7 @@ msgid "Open"
 msgstr "Открыть"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Следующая непрочитанная"
 
@@ -688,7 +702,7 @@ msgid "Search"
 msgstr "Искать"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Помощь"
@@ -860,7 +874,7 @@ msgstr "Понравившиеся статьи"
 msgid "Saved web pages"
 msgstr "Сохранённые веб-страницы"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Переключение флага прочтения у заметки..."
 
@@ -869,12 +883,12 @@ msgstr "Переключение флага прочтения у заметки
 msgid "Error while toggling read flag: %s"
 msgstr "Ошибка во время переключения флага прочтения: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "Список ссылок пуст."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Флаги: "
 
@@ -887,18 +901,18 @@ msgid "Error: you can't reload search results."
 msgstr "Ошибка: вы не можете обновить результаты поиска."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Непрочитанных элементов нет."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Уже на последней записи."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Уже на первой записи."
@@ -911,7 +925,7 @@ msgstr "Непрочитанных лент нет."
 msgid "Marking all above as read..."
 msgstr "Отмечаю все, что выше, как прочитанные..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Обработать заметку командой: "
 
@@ -934,7 +948,7 @@ msgstr ""
 "Сортировать в обратном порядке по дате (d)/заголовку (t)/флагам (f)/автору "
 "(a)/ссылке (l)/(g)uid/(r)случайно?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Флаги обновлены."
 
@@ -943,17 +957,17 @@ msgstr "Флаги обновлены."
 msgid "Error: applying the filter failed: %s"
 msgstr "Ошибка: применение фильтра завершилось неудачей: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Прерванное сохранение."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Заметка сохранена в %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Ошибка: невозможно сохранить заметку в %s"
@@ -1024,68 +1038,68 @@ msgstr "Ссылка загрузки подкаста: "
 msgid "type: "
 msgstr "тип: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Верх"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Низ"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Ошибка во время пометки заметки как прочитанной: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Добавили %s в очередь загрузки."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Неверная ссылка: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Заметка сохранена в %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Ошибка: невозможно записать заметку в файл %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Запускаю браузер..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Ошибка во время пометки заметки как непрочитанной: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Открыть ссылку №"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Открыть в браузере"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Поставить в очередь"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Заметка - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Ошибка: неправильное регулярное выражение!"
 
@@ -1569,11 +1583,11 @@ msgstr "Ошибка во время получения %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Ошибка: некорректная лента!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "слишком мало параметров"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' — неверный фильтр"

--- a/po/sk.po
+++ b/po/sk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.10.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2017-12-25 00:38+0100\n"
 "Last-Translator: František Hájik <ferko.hajik@gmail.com>\n"
 "Language-Team: \n"
@@ -143,22 +143,32 @@ msgid ""
 msgstr "newsboat je slobodný softvér a licencovaný pod licenciou MIT."
 
 #: newsboat.cpp:163
-msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+msgid "It bundles:"
 msgstr ""
 
-#: newsboat.cpp:237
+#: newsboat.cpp:164
+msgid ""
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
+msgstr ""
+
+#: newsboat.cpp:167
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -282,51 +292,51 @@ msgstr "neznámy príkaz `%s'"
 msgid "Starting %s %s..."
 msgstr "Spúšťanie %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Chyba: program %s už beží (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Načítanie konfigurácie..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "hotovo."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Otvorenie vyrovnávacej pamäte..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Chyba: otvorenie \"cache\" súboru `%s' zlyhalo: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s je nedostupný a nemôže byť vytvorený\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Načítanie adries URL z %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -335,7 +345,7 @@ msgstr ""
 "Chyba: nenakonfigurované žiadne URL adresy. Prosím vyplňte súbor% s pomocou "
 "URL adries RSS alebo importujte súbor OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -343,7 +353,7 @@ msgstr ""
 "Vyzerá to tak, že OPML zdroj, neobsahuje žiadne kanály. Vyplňte ho kanálmi a "
 "skúste to znova."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -351,7 +361,7 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte The Old Reader. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -359,7 +369,7 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte Tiny Tiny RSS. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -367,7 +377,7 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte NewsBlur. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -375,69 +385,69 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte Inoreader. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Načítanie článkov zo súboru \"cache\"..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Dokladné vyčistenie \"cahce\"..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Chyba pri načítavaní informačných kanálov z databázy: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Chyba pri načítaní informačného kanálu '%s': %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Predvolené dopyty kanálov..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Importovať zoznam čítaných článkov..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Exportovať zoznam čítaných článkov..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Vyčistenie \"cache\"..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "zlyhalo: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Chyba: nemožno označiť všetky prečítané informačné kanály: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Vyskytla sa chyba počas \"parsingu\" %s."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Import %s ukončený."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u neprečítaných článkov"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: neznámy príkaz"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Chyba: nemožno otvoriť konfiguračný súbor `%s'!"
@@ -482,7 +492,7 @@ msgid "Cancel"
 msgstr "Zrušiť"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Uložiť"
 
@@ -584,7 +594,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -629,7 +639,7 @@ msgid "No filters defined."
 msgstr "Neboli definované žiadne filtre."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Vyhľadať: "
 
@@ -651,7 +661,7 @@ msgid "y"
 msgstr "a"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Ukončiť"
@@ -661,7 +671,7 @@ msgid "Open"
 msgstr "Otvoriť"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Ďalší neprečítaný"
 
@@ -687,7 +697,7 @@ msgid "Search"
 msgstr "Hľadať"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Pomocník"
@@ -859,7 +869,7 @@ msgstr "Obľúbené položky"
 msgid "Saved web pages"
 msgstr "Web stránka uložená"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Prepínanie príznaku čítania článku..."
 
@@ -868,12 +878,12 @@ msgstr "Prepínanie príznaku čítania článku..."
 msgid "Error while toggling read flag: %s"
 msgstr "Chyba pri prepínaní príznaku čítania: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "Zoznam URL je prázdny."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Príznaky (flags): "
 
@@ -886,18 +896,18 @@ msgid "Error: you can't reload search results."
 msgstr "Chyba: nemožno načítať výsledky vyhľadávania."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Všetky položky prečítané."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Celkom posledná položka."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Celkom prvá položka."
@@ -911,7 +921,7 @@ msgstr "Všetko prečítané."
 msgid "Marking all above as read..."
 msgstr "Označenie všetkých kanálov za prečítané..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Odoslať (Pipe) článok do príkazu: "
 
@@ -937,7 +947,7 @@ msgstr ""
 "Zotriediť spätne podľa (d)átumu/(n)ázvu/(p)ríznaku/(a)utora/(o)dkazu/"
 "(i)dentifikátora?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Príznaky aktualizované."
 
@@ -946,17 +956,17 @@ msgstr "Príznaky aktualizované."
 msgid "Error: applying the filter failed: %s"
 msgstr "Chyba: použitie filtra zlyhalo: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Ukladanie bolo prerušené."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Článok bol uložený do %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Chyba: článok nemožno uložiť do %s"
@@ -1023,68 +1033,68 @@ msgstr "Podcast Download URL: "
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Vrch"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Spodok"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Chyba pri označovaní článku za prečítaný: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s pridaný do fronty sťahovania."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Nesprávna URL: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Článok uložený do %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Chyba: nemožno zapísať článok do súboru %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Spustenie prehliadača..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Chyba pri označovaní článku ako neprečítaného: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Choď na URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Otvoriť v prehliadači"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Do fronty"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Článok - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Chyba: neplatný regulárny výraz!"
 
@@ -1571,11 +1581,11 @@ msgstr "Chyba pri načítaní %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Chyba: vadný kanál!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "príliš málo parametrov"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' nie je platný prvok konfigurácie"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat-2.12\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2018-08-08 10:17+0200\n"
 "Last-Translator: Dennis Öberg <contact@dennisoberg.se>\n"
 "Language-Team: Niklas Grahn <terra.unknown@yahoo.com>\n"
@@ -147,24 +147,38 @@ msgstr ""
 "för att se hela texten.)"
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Det inkluderar biblioteket JSON for Modern C++, licensierat under MIT-"
 "licensen: https://github.com/nlohmann/json"
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Det inkluderar biblioteket JSON for Modern C++, licensierat under MIT-"
+"licensen: https://github.com/nlohmann/json"
+
+#: newsboat.cpp:240
 #, fuzzy, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr "Fångade newsboat::dbexception med meddelande: %s"
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, fuzzy, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Fångade newsboat::matcherexception med meddelande: %s"
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, fuzzy, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Fångade newsboat::exception med meddelande: %s"
@@ -286,51 +300,51 @@ msgstr "okänt kommando `%s'"
 msgid "Starting %s %s..."
 msgstr "Startar %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Fel: en instans av %s körs redan (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Läser in konfiguration..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "färdig."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Öppnar cache..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Fel: öppnande av cache-fil `%s' misslyckades: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "FEL: Du måste sätta 'cookie-cache' till att använda NewsBlur.\n"
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s är oåtkomlig och kan inte skapas\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Läser in URL:er från %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -339,7 +353,7 @@ msgstr ""
 "Fel: inga URL:er konfigurerade. Var god fyll filen %s med URL:er till RSS-"
 "kanaler eller importera en OPML-fil."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -347,7 +361,7 @@ msgstr ""
 "Det ser ut som om OPML-flödet som du valde att prenumerera på inte "
 "innehåller några webbflöden. Var god fyll den med webbflöden och prova igen."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -355,7 +369,7 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt The Old "
 "Reader-konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -363,7 +377,7 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt Tiny Tiny "
 "RSS-konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -371,7 +385,7 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt NewsBlur-"
 "konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -379,69 +393,69 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt Inoreader-"
 "konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Läser in artiklar från cache..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Tömmer noggrant cache..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Fel vid inläsning av webbflöden från databasen: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Fel vid inläsning av webbflöde `%s': %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Förbefolkar förfrågansflöden..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Importerar lista över lästa artiklar..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Exporterar lista över lästa artiklar..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Tömmer cache..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "misslyckades: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Fel: kunde inte markera alla webbflödeer som lästa: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ett fel inträffade vid tolkning av %s."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importering av %s färdig."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u olästa artiklar"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: okänt kommando"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fel: kunde inte öppna konfigurationsfil `%s'!"
@@ -486,7 +500,7 @@ msgid "Cancel"
 msgstr "Avbryt"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Spara"
 
@@ -585,7 +599,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -630,7 +644,7 @@ msgid "No filters defined."
 msgstr "Inga filter definierade."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Sök efter: "
 
@@ -652,7 +666,7 @@ msgid "y"
 msgstr "j"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Avsluta"
@@ -662,7 +676,7 @@ msgid "Open"
 msgstr "Öppna"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Nästa olästa"
 
@@ -688,7 +702,7 @@ msgid "Search"
 msgstr "Sök"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Hjälp"
@@ -860,7 +874,7 @@ msgstr "Gillade poster"
 msgid "Saved web pages"
 msgstr "Sparade webbsidor"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Växlar läsflagga för artikel..."
 
@@ -869,12 +883,12 @@ msgstr "Växlar läsflagga för artikel..."
 msgid "Error while toggling read flag: %s"
 msgstr "Fel vid växling av läsflagga: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "URL-lista tom."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Flaggor: "
 
@@ -887,18 +901,18 @@ msgid "Error: you can't reload search results."
 msgstr "Fel: du kan inte läsa om sökresultat."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Inga olästa poster."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Redan på sista posten."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Redan på första posten."
@@ -911,7 +925,7 @@ msgstr "Inga olästa webbflöden."
 msgid "Marking all above as read..."
 msgstr "Markerar allt ovanför som läst..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Skicka artikel genom pipe till kommando: "
 
@@ -934,7 +948,7 @@ msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sortera omvänt utifrån (d)atum/(t)itel/(F)laggor/(f)örfattare/(l)änk/(g)uid?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Flaggor uppdaterade."
 
@@ -943,17 +957,17 @@ msgstr "Flaggor uppdaterade."
 msgid "Error: applying the filter failed: %s"
 msgstr "Fel: verkställande av filtret misslyckades: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Avbröt sparande."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Sparade artikel till %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fel: kunde inte spara artikel till %s"
@@ -1020,68 +1034,68 @@ msgstr "Hämtnings-URL för poddsändning: "
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Överkant"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Nederkant"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fel vid markering av artikel som läst: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Lade till %s i hämtningskö."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Ogiltig URL: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Sparade artikel till %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Fel: kunde inte skriva artikel till fil %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Startar webbläsare..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Fel vid markering av artikel som oläst: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Gå till URL #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Öppna i webbläsare"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Kölägg"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Fel: ogiltigt reguljärt uttryck!"
 
@@ -1563,11 +1577,11 @@ msgstr "Fel vid hämtning av %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Fel: ogiltigt webbflöde!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "för få parametrar"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' är inte ett giltigt filteruttryck"

--- a/po/tr.po
+++ b/po/tr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2020-04-03 19:00+0300\n"
 "Last-Translator: Emir SARI <bitigchi@me.com>, 2020\n"
 "Language-Team: H. Gökhan SARI <hsa2@difuzyon.net>\n"
@@ -143,22 +143,32 @@ msgid ""
 msgstr ""
 
 #: newsboat.cpp:163
-msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+msgid "It bundles:"
 msgstr ""
 
-#: newsboat.cpp:237
+#: newsboat.cpp:164
+msgid ""
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
+msgstr ""
+
+#: newsboat.cpp:167
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -280,51 +290,51 @@ msgstr "bilinmeyen komut `%s'"
 msgid "Starting %s %s..."
 msgstr "%s %s başlatılıyor..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Hata: %s zaten çalışıyor (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Ayarlar yükleniyor..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "tamamlandı."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Önbellek açılıyor..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Hata: `%s' önbellek dosyası açılamadı: %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "%s kaynağından adresler yükleniyor..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -333,7 +343,7 @@ msgstr ""
 "Hata: hiçbir adres ayarlanmamış. Lütfen %s içine RSS besleme kaynakları "
 "ekleyin ya da bir OPML dosyasını içeri aktarın."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -341,7 +351,7 @@ msgstr ""
 "Belirttiğiniz OPML dosyası herhangi bir kaynak içermiyor. Lütfen besleme "
 "kaynaklarını doğru biçimde bu dosyaya ekleyin ve tekrar deneyin."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -349,7 +359,7 @@ msgstr ""
 "Görünüşe göre The Old Reader hesabınızda herhangi bir besleme "
 "ayarlamamışsınız. Lütfen bir tane ayarlayıp yeniden deneyin."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -357,7 +367,7 @@ msgstr ""
 "Görünüşe göre Tiny Tiny RSS hesabınızda herhangi bir besleme "
 "ayarlamamışsınız. Lütfen bir tane ayarlayıp yeniden deneyin."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -365,7 +375,7 @@ msgstr ""
 "Görünüşe göre NewsBlur hesabınızda herhangi bir besleme ayarlamamışsınız. "
 "Lütfen bir tane ayarlayıp yeniden deneyin."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -373,69 +383,69 @@ msgstr ""
 "Görünüşe göre Inoreader hesabınızda herhangi bir besleme ayarlamamışsınız. "
 "Lütfen bir tane ayarlayıp yeniden deneyin."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Yazılar önbellekten yükleniyor..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Önbellek boşaltılıyor..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Veritabanından beslemeler alınırken hata oluştu: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "`%s' beslemesi yüklenirken hata: %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Sorgu beslemesi güncelleniyor..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Okunmuş yazıların listesi içe aktarılıyor..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Okunmuş yazıların listesi dışa aktarılıyor..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Önbellek temizleniyor..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "başarız: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Hata: tüm beslemeler okundu olarak imlenemedi: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s'in içeri aktarımı tamamlandı."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u okunmamış yazı"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: Bilinmeyen komut"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Hata: ayar dosyası `%s' kaydedilemedi!"
@@ -480,7 +490,7 @@ msgid "Cancel"
 msgstr "İptal"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Kaydet"
 
@@ -575,7 +585,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -620,7 +630,7 @@ msgid "No filters defined."
 msgstr "Hiçbir filtre tanımlanmadı."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Ara: "
 
@@ -642,7 +652,7 @@ msgid "y"
 msgstr "e"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Çık"
@@ -652,7 +662,7 @@ msgid "Open"
 msgstr "Aç"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Sonraki Okunmamış"
 
@@ -678,7 +688,7 @@ msgid "Search"
 msgstr "Ara"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Yardım"
@@ -850,7 +860,7 @@ msgstr "Beğenilen ögeler"
 msgid "Saved web pages"
 msgstr "Kayıtlı web sayfaları"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Bayrak okuma açılıyor/kapatılıyor..."
 
@@ -859,12 +869,12 @@ msgstr "Bayrak okuma açılıyor/kapatılıyor..."
 msgid "Error while toggling read flag: %s"
 msgstr "Hata: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "Adres listesi boş."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Bayraklar: "
 
@@ -877,18 +887,18 @@ msgid "Error: you can't reload search results."
 msgstr "Hata: arama sonuçlarını yeniden yükleyemezsiniz."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Okunmamış yok."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
@@ -901,7 +911,7 @@ msgstr "Okunmamış besleme yok."
 msgid "Marking all above as read..."
 msgstr "Yukarıdakilerin tümü okundu olarak imleniyor..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -920,7 +930,7 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Bayraklar güncellendi."
 
@@ -929,17 +939,17 @@ msgstr "Bayraklar güncellendi."
 msgid "Error: applying the filter failed: %s"
 msgstr "Hata: filtre uygulanırken hata oluştu: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Kayıt işlemi iptal edildi."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Yazı %s'e kaydedildi"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Hata: yazı %s'e kaydedilemedi"
@@ -1006,68 +1016,68 @@ msgstr "Podcast İndirme Adresi: "
 msgid "type: "
 msgstr "biçim: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Yukarı"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Aşağı"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Yazı okundu olarak imlenirken hata oluştu: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "%s indirme kuyruğuna eklendi."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr ""
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Yazı %s'e kaydedildi."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Hata: yazı %s'e kaydedilemedi"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Tarayıcı başlatılıyor..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Yazı yeni olarak imlenirken hata oluştu: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Tarayıcıda Görüntüle"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Kuyruktan Çıkar"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Yazı - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Hata: geçersiz düzenli ifade!"
 
@@ -1546,11 +1556,11 @@ msgstr "%s alınırken hata oluştu: %s"
 msgid "Error: invalid feed!"
 msgstr "Hata: geçersiz besleme!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "çok az değişken"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' geçerli bir düzenli ifade değil"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2020-03-20 18:00+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Ivan Kovnatsky <sevenfourk@gmail.com>, Alexander Batischev "
@@ -146,24 +146,38 @@ msgstr ""
 "vv', щоб переглянути повний текст)."
 
 #: newsboat.cpp:163
+msgid "It bundles:"
+msgstr ""
+
+#: newsboat.cpp:164
+#, fuzzy
 msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
 msgstr ""
 "Програма включає в себе бібліотеку «JSON for Modern C++» за ліцензією MIT: "
 "https://github.com/nlohmann/json"
 
-#: newsboat.cpp:237
+#: newsboat.cpp:167
+#, fuzzy
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+"Програма включає в себе бібліотеку «JSON for Modern C++» за ліцензією MIT: "
+"https://github.com/nlohmann/json"
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr "Впіймали newsboat::DbException із повідомленням: %s"
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Впіймали newsboat::MatcherException із повідомленням: %s"
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Впіймали newsboat::Exception із повідомленням: %s"
@@ -285,52 +299,52 @@ msgstr "невідома команда `%s'"
 msgid "Starting %s %s..."
 msgstr "Запускаю %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Помилка: вже працює копія %s (PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "Завантаження налаштувань..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "готово."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "Відкриваю кеш..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Помилка: при відкритті файлу кеша `%s' виникла %s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 "Помилка: для выкористання NewsBlur потрібно налаштувати `cookie-cache`.\n"
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s недоступний і не може бути створеним\n"
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Завантажую URLs з %s..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -339,7 +353,7 @@ msgstr ""
 "Помилка: не вказано URLs. Будь ласка, додайте RSS URLs у файл %s чи "
 "імпортуйте файл OPML."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -347,7 +361,7 @@ msgstr ""
 "Схоже на те, що OPML тема, на яку ви підписалися не містить тем. Будь ласка, "
 "заповніть її темами та спробуйте знову."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -355,7 +369,7 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті The Old Reader."
 "Будь ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -363,7 +377,7 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті Tiny Tiny RSS."
 "Будь ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -371,7 +385,7 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті NewsBlur.Будь "
 "ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -379,69 +393,69 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті Inoreader.Будь "
 "ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "Завантаження статей з кешу..."
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "Ретельне очищення кешу..."
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "Помилка при завантаженні тем з бази даних: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Помилка при завантаженні теми `%s': %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "Підготовлюю динамічні теми..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "Імпортую список прочитаних статей..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "Зберігаю список прочитаних статей..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "Очищення кешу..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "невдало: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Помилка: не вдалось позначити всі теми як прочитані: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Виникла помилка при розборі %s."
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "Імпорт %s завершено."
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u непрочитаних статей"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: невідома команда"
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Помилка: не можу відкрити файл конфігурації `%s'!"
@@ -486,7 +500,7 @@ msgid "Cancel"
 msgstr "Відміна"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "Зберегти"
 
@@ -585,7 +599,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "Браузер повернув код помилки %i"
@@ -630,7 +644,7 @@ msgid "No filters defined."
 msgstr "Не визначено фільтри."
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "Шукати: "
 
@@ -652,7 +666,7 @@ msgid "y"
 msgstr "y"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "Вихід"
@@ -662,7 +676,7 @@ msgid "Open"
 msgstr "Відкрити"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "Наступна непрочитана"
 
@@ -688,7 +702,7 @@ msgid "Search"
 msgstr "Пошук"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "Довідка"
@@ -860,7 +874,7 @@ msgstr "Вподобані статті"
 msgid "Saved web pages"
 msgstr "Збережені веб-сторінки"
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "Переключення флагу прочитано для статей..."
 
@@ -869,12 +883,12 @@ msgstr "Переключення флагу прочитано для стате
 msgid "Error while toggling read flag: %s"
 msgstr "Помилка при переключенні флагу прочитано: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "Список URL пустий."
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "Флаги: "
 
@@ -887,18 +901,18 @@ msgid "Error: you can't reload search results."
 msgstr "Помилка: не можна перезавантажувати результати пошуку."
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "Немає непрочитаних статей."
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr "Вже на останній статті."
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr "Вже на першій статті."
@@ -911,7 +925,7 @@ msgstr "Немає непрочитаних тем."
 msgid "Marking all above as read..."
 msgstr "Позначаю все, що вище, як прочитані..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Пайпувати статтю до каманди: "
 
@@ -934,7 +948,7 @@ msgstr ""
 "Сортувати реверсно за (d)датою/(t)назвою/(f)флагами/(a)автором/(l)посиланням/"
 "(g)uid/(r)випадково?"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "Флаги поновлено."
 
@@ -943,17 +957,17 @@ msgstr "Флаги поновлено."
 msgid "Error: applying the filter failed: %s"
 msgstr "Помилка: примінення фільтру невдале: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "Збереження перервано."
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "Стаття збережена у %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Помилка: не можу зберегти у %s"
@@ -1024,68 +1038,68 @@ msgstr "Посилання на завантаження Podcast: "
 msgid "type: "
 msgstr "тип: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "Вершина"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "Низ"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Помилка при позначенні статті як прочитано: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "Додано %s до черги завантаження."
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "Некоректний URL: '%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "Збережено статтю у %s."
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "Помилка: не можу записати статтю у файл %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "Запускаю браузер..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Помилка при позначенні статті як непрочитано: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "Перейти за посиланням №"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "Відкрити у браузері"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "Поставити у чергу"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "Стаття - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "Помилка: неправильний вираз!"
 
@@ -1569,11 +1583,11 @@ msgstr "Помилка при стягненні %s: %s"
 msgid "Error: invalid feed!"
 msgstr "Помилка: непрацездатна тема!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "замало параметрів"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' не є правильним фільтром"

--- a/po/zh.po
+++ b/po/zh.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2007-11-21 22:51+0100\n"
 "Last-Translator: josh yu <joshyupeng@gmail.com>\n"
 "Language-Team: \n"
@@ -141,22 +141,32 @@ msgid ""
 msgstr ""
 
 #: newsboat.cpp:163
-msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+msgid "It bundles:"
 msgstr ""
 
-#: newsboat.cpp:237
+#: newsboat.cpp:164
+msgid ""
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
+msgstr ""
+
+#: newsboat.cpp:167
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -279,64 +289,64 @@ msgstr "未知的命令 `%s' "
 msgid "Starting %s %s..."
 msgstr "启动 %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "错误：%s的一个进程已经在运行中（PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "加载配置文件..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "完毕."
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "打开缓存..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "错误:打开缓存文件`%s' 失败:%s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "从 %s 文件加载链接..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr "错误：没有配置链接。请用RSS种子的链接替换 %s 或者导入一个OPML文件."
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr "看起来你订阅的OPML种子没有包含任何种子请更正之后再尝试一下。"
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -344,7 +354,7 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -352,7 +362,7 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -360,7 +370,7 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -368,70 +378,70 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "从缓存中加载文章"
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "彻底清除缓存"
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "当从数据库中加载种子的时候出错: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, fuzzy, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "当调用`%s'的时候出错: %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 #, fuzzy
 msgid "Prepopulating query feeds..."
 msgstr "更新查询种子..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "导入阅读文章列表"
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "导出阅读文章列表"
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "清空缓存..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "失败: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "错误:无法将所有种子都标记为已读: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s 导入完毕"
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u 篇未读文章"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "未知的命令 `%s' "
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, fuzzy, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "错误：无法将文章写至 %s"
@@ -477,7 +487,7 @@ msgid "Cancel"
 msgstr "取消"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "保存"
 
@@ -574,7 +584,7 @@ msgstr ""
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -619,7 +629,7 @@ msgid "No filters defined."
 msgstr "没有定义任何过滤器（filter）"
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "查找: "
 
@@ -641,7 +651,7 @@ msgid "y"
 msgstr "y"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "放弃"
@@ -651,7 +661,7 @@ msgid "Open"
 msgstr "打开"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "下一篇未读"
 
@@ -677,7 +687,7 @@ msgid "Search"
 msgstr "查找"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "帮助"
@@ -851,7 +861,7 @@ msgstr "没有未读的文章"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "切换文章阅读标记（已读/未读）"
 
@@ -860,12 +870,12 @@ msgstr "切换文章阅读标记（已读/未读）"
 msgid "Error while toggling read flag: %s"
 msgstr "当切换阅读标记（已读/未读）时出错: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "空空如也的链接列表"
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "标记: "
 
@@ -878,18 +888,18 @@ msgid "Error: you can't reload search results."
 msgstr "错误：你不能重新加载所选项目"
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "没有未读的文章"
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
@@ -903,7 +913,7 @@ msgstr "没有未读的种子"
 msgid "Marking all above as read..."
 msgstr "将所有种子都标记为已读..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr ""
 
@@ -923,7 +933,7 @@ msgstr ""
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "标记已更新"
 
@@ -932,17 +942,17 @@ msgstr "标记已更新"
 msgid "Error: applying the filter failed: %s"
 msgstr "错误: 应用过滤器失败: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "放弃保存"
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "错误：无法保存文章到 %s"
@@ -1009,68 +1019,68 @@ msgstr "播客下载的地址: "
 msgid "type: "
 msgstr "类型: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "顶部"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "底部"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "当标记文章为已读的时候出错: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "将 %s 加入下载队列"
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr ""
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "将文章保存至 %s "
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "错误：无法将文章写至 %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "启动浏览器..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "当标记文章为未读的时候出错: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "在浏览器里打开"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "加入队列"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, fuzzy, c-format
 msgid "Article - %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 #, fuzzy
 msgid "Error: invalid regular expression!"
 msgstr "错误:无效的种子!"
@@ -1571,12 +1581,12 @@ msgstr "当抓取%s的时候出错: %s"
 msgid "Error: invalid feed!"
 msgstr "错误:无效的种子!"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 #, fuzzy
 msgid "too few arguments"
 msgstr "参数太少"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "错误:无效的种子!"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-04-22 13:36+0300\n"
+"POT-Creation-Date: 2020-04-22 18:35+0300\n"
 "PO-Revision-Date: 2010-03-03 16:55+0800\n"
 "Last-Translator: Aeglos <aeglos.lin@gmail.com>\n"
 "Language-Team: \n"
@@ -144,22 +144,32 @@ msgid ""
 msgstr "newsboat是基於MIT/X Consortium License發佈的自由軟體"
 
 #: newsboat.cpp:163
-msgid ""
-"It bundles JSON for Modern C++ library, licensed under the MIT License: "
-"https://github.com/nlohmann/json"
+msgid "It bundles:"
 msgstr ""
 
-#: newsboat.cpp:237
+#: newsboat.cpp:164
+msgid ""
+"- JSON for Modern C++ library, licensed under the MIT License: https://"
+"github.com/nlohmann/json"
+msgstr ""
+
+#: newsboat.cpp:167
+msgid ""
+"- optional-lite library, licensed under the Boost Software License: https://"
+"github.com/martinmoene/optional-lite"
+msgstr ""
+
+#: newsboat.cpp:240
 #, c-format
 msgid "Caught newsboat::DbException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:244
+#: newsboat.cpp:247
 #, c-format
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:250 podboat.cpp:37
+#: newsboat.cpp:253 podboat.cpp:37
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
@@ -281,64 +291,64 @@ msgstr "未知的命令 `%s' "
 msgid "Starting %s %s..."
 msgstr "啟動 %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:216 src/pbcontroller.cpp:255
+#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "錯誤：已有一個%s程序在執行中（PID: %u)"
 
-#: src/controller.cpp:170 src/pbcontroller.cpp:263
+#: src/controller.cpp:168 src/pbcontroller.cpp:263
 msgid "Loading configuration..."
 msgstr "載入設定檔..."
 
-#: src/controller.cpp:205 src/controller.cpp:250 src/controller.cpp:316
-#: src/controller.cpp:369 src/controller.cpp:373 src/controller.cpp:409
-#: src/controller.cpp:423 src/controller.cpp:441 src/controller.cpp:452
-#: src/controller.cpp:496 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:314
+#: src/controller.cpp:367 src/controller.cpp:371 src/controller.cpp:407
+#: src/controller.cpp:421 src/controller.cpp:439 src/controller.cpp:450
+#: src/controller.cpp:494 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
 msgid "done."
 msgstr "完成。"
 
-#: src/controller.cpp:226 src/controller.cpp:364
+#: src/controller.cpp:224 src/controller.cpp:362
 msgid "Opening cache..."
 msgstr "打開快取中..."
 
-#: src/controller.cpp:233 src/controller.cpp:241
+#: src/controller.cpp:231 src/controller.cpp:239
 #, c-format
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "錯誤:打開快取檔案`%s' 失敗:%s"
 
-#: src/controller.cpp:272
+#: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
 
-#: src/controller.cpp:280
+#: src/controller.cpp:278
 #, c-format
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:298
+#: src/controller.cpp:296
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:305
+#: src/controller.cpp:303
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "從 %s 中載入鏈結..."
 
-#: src/controller.cpp:324
+#: src/controller.cpp:322
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr "錯誤：沒有設置鏈結。請用RSS來源的鏈結替換 %s 或者匯入一個OPML檔案"
 
-#: src/controller.cpp:330
+#: src/controller.cpp:328
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr "看起來你訂閱的OPML沒有任何來源。請先加入來源，然後再試一次。"
 
-#: src/controller.cpp:335
+#: src/controller.cpp:333
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -346,7 +356,7 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:340
+#: src/controller.cpp:338
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -354,7 +364,7 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:345
+#: src/controller.cpp:343
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -362,7 +372,7 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:350
+#: src/controller.cpp:348
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -370,69 +380,69 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:361
+#: src/controller.cpp:359
 msgid "Loading articles from cache..."
 msgstr "從快取中載入文章"
 
-#: src/controller.cpp:370
+#: src/controller.cpp:368
 msgid "Cleaning up cache thoroughly..."
 msgstr "徹底清空快取"
 
-#: src/controller.cpp:390
+#: src/controller.cpp:388
 msgid "Error while loading feeds from database: "
 msgstr "從資料庫中載入來源時發生錯誤: "
 
-#: src/controller.cpp:396
+#: src/controller.cpp:394
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "載入 `%s'的時候發生錯誤: %s"
 
-#: src/controller.cpp:416
+#: src/controller.cpp:414
 msgid "Prepopulating query feeds..."
 msgstr "更新查詢來源..."
 
-#: src/controller.cpp:438
+#: src/controller.cpp:436
 msgid "Importing list of read articles..."
 msgstr "匯入已閱讀文章列表..."
 
-#: src/controller.cpp:449
+#: src/controller.cpp:447
 msgid "Exporting list of read articles..."
 msgstr "匯出已閱讀文章列表..."
 
-#: src/controller.cpp:489
+#: src/controller.cpp:487
 msgid "Cleaning up cache..."
 msgstr "清空快取..."
 
-#: src/controller.cpp:501
+#: src/controller.cpp:499
 msgid "failed: "
 msgstr "失敗: "
 
-#: src/controller.cpp:527
+#: src/controller.cpp:525
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "錯誤:無法將所有來源標為已讀: %s"
 
-#: src/controller.cpp:627
+#: src/controller.cpp:625
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "在分析%s時發生錯誤"
 
-#: src/controller.cpp:632
+#: src/controller.cpp:630
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s 匯入完畢"
 
-#: src/controller.cpp:762
+#: src/controller.cpp:760
 #, c-format
 msgid "%u unread articles"
 msgstr "%u篇未讀文章"
 
-#: src/controller.cpp:767
+#: src/controller.cpp:765
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "未知的命令 `%s' "
 
-#: src/controller.cpp:880
+#: src/controller.cpp:878
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "錯誤：無法開啟組態檔案`%s'！"
@@ -477,7 +487,7 @@ msgid "Cancel"
 msgstr "取消"
 
 #: src/dirbrowserformaction.cpp:281 src/filebrowserformaction.cpp:272
-#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:451
+#: src/itemlistformaction.cpp:1243 src/itemviewformaction.cpp:449
 msgid "Save"
 msgstr "儲存"
 
@@ -575,7 +585,7 @@ msgstr "排序依照：(f)第一項Tag/(t)標題/(a)文章數量/(u)未讀文章
 #: src/feedlistformaction.cpp:282 src/feedlistformaction.cpp:305
 #: src/itemlistformaction.cpp:140 src/itemlistformaction.cpp:175
 #: src/itemlistformaction.cpp:193 src/itemlistformaction.cpp:206
-#: src/itemviewformaction.cpp:230 src/itemviewformaction.cpp:412
+#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:410
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
@@ -620,7 +630,7 @@ msgid "No filters defined."
 msgstr "沒有定義任何過濾器(filter)"
 
 #: src/feedlistformaction.cpp:486 src/helpformaction.cpp:41
-#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:258
+#: src/itemlistformaction.cpp:605 src/itemviewformaction.cpp:256
 msgid "Search for: "
 msgstr "搜尋: "
 
@@ -642,7 +652,7 @@ msgid "y"
 msgstr "y"
 
 #: src/feedlistformaction.cpp:623 src/helpformaction.cpp:223
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:450
+#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:448
 #: src/pbview.cpp:362 src/pbview.cpp:369 src/urlviewformaction.cpp:141
 msgid "Quit"
 msgstr "放棄"
@@ -652,7 +662,7 @@ msgid "Open"
 msgstr "打開"
 
 #: src/feedlistformaction.cpp:625 src/itemlistformaction.cpp:1245
-#: src/itemviewformaction.cpp:452
+#: src/itemviewformaction.cpp:450
 msgid "Next Unread"
 msgstr "下一篇未讀"
 
@@ -678,7 +688,7 @@ msgid "Search"
 msgstr "搜尋"
 
 #: src/feedlistformaction.cpp:631 src/helpformaction.cpp:255
-#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:455
+#: src/itemlistformaction.cpp:1248 src/itemviewformaction.cpp:453
 #: src/pbview.cpp:296 src/pbview.cpp:377
 msgid "Help"
 msgstr "說明"
@@ -851,7 +861,7 @@ msgstr "分享的文章"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:369
+#: src/itemlistformaction.cpp:218 src/itemviewformaction.cpp:367
 msgid "Toggling read flag for article..."
 msgstr "切換文章閱讀標記（已讀/未讀）"
 
@@ -860,12 +870,12 @@ msgstr "切換文章閱讀標記（已讀/未讀）"
 msgid "Error while toggling read flag: %s"
 msgstr "當切換閱讀標記（已讀/未讀）時出錯: %s"
 
-#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:300
+#: src/itemlistformaction.cpp:305 src/itemviewformaction.cpp:298
 msgid "URL list empty."
 msgstr "空白的鏈結列表"
 
 #: src/itemlistformaction.cpp:363 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:288
+#: src/itemviewformaction.cpp:286
 msgid "Flags: "
 msgstr "標記: "
 
@@ -878,18 +888,18 @@ msgid "Error: you can't reload search results."
 msgstr "錯誤：你不能重新載入所選項目"
 
 #: src/itemlistformaction.cpp:432 src/itemlistformaction.cpp:441
-#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:322
-#: src/itemviewformaction.cpp:333 src/itemviewformaction.cpp:363
+#: src/itemlistformaction.cpp:465 src/itemviewformaction.cpp:320
+#: src/itemviewformaction.cpp:331 src/itemviewformaction.cpp:361
 #: src/view.cpp:801 src/view.cpp:877
 msgid "No unread items."
 msgstr "沒有未讀的文章"
 
-#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:343
+#: src/itemlistformaction.cpp:449 src/itemviewformaction.cpp:341
 #: src/view.cpp:950
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:353
+#: src/itemlistformaction.cpp:458 src/itemviewformaction.cpp:351
 #: src/view.cpp:915
 msgid "Already on first item."
 msgstr ""
@@ -903,7 +913,7 @@ msgstr "沒有未讀的來源"
 msgid "Marking all above as read..."
 msgstr "將所有來源標為已讀..."
 
-#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:274
+#: src/itemlistformaction.cpp:588 src/itemviewformaction.cpp:272
 msgid "Pipe article to command: "
 msgstr "Pipe article to command: "
 
@@ -925,7 +935,7 @@ msgstr "排序依照：(d)日期/(t)標題/(f)"
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "反向排序依(d)日期/(t)標題/(f)標誌/(a)作者/(l)連結/(g)用戶號碼"
 
-#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:527
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:525
 msgid "Flags updated."
 msgstr "標記已更新"
 
@@ -934,17 +944,17 @@ msgstr "標記已更新"
 msgid "Error: applying the filter failed: %s"
 msgstr "錯誤: 套用過濾器失敗: %s"
 
-#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:211
-#: src/itemviewformaction.cpp:497
+#: src/itemlistformaction.cpp:1334 src/itemviewformaction.cpp:209
+#: src/itemviewformaction.cpp:495
 msgid "Aborted saving."
 msgstr "放棄儲存"
 
-#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:503
+#: src/itemlistformaction.cpp:1339 src/itemviewformaction.cpp:501
 #, c-format
 msgid "Saved article to %s"
 msgstr "把文章儲存到 %s"
 
-#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:507
+#: src/itemlistformaction.cpp:1342 src/itemviewformaction.cpp:505
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "錯誤：無法儲存文章到 %s"
@@ -1011,68 +1021,68 @@ msgstr "Pocast下載網址: "
 msgid "type: "
 msgstr "類型: "
 
-#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:605
+#: src/itemviewformaction.cpp:58 src/itemviewformaction.cpp:603
 msgid "Top"
 msgstr "頂端"
 
-#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:607
+#: src/itemviewformaction.cpp:59 src/itemviewformaction.cpp:605
 msgid "Bottom"
 msgstr "底端"
 
-#: src/itemviewformaction.cpp:176 src/view.cpp:584
+#: src/itemviewformaction.cpp:174 src/view.cpp:584
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "當標記文章為已讀的時候發生錯誤: %s"
 
-#: src/itemviewformaction.cpp:191
+#: src/itemviewformaction.cpp:189
 #, c-format
 msgid "Added %s to download queue."
 msgstr "將 %s 加入下載隊列"
 
-#: src/itemviewformaction.cpp:195
+#: src/itemviewformaction.cpp:193
 #, c-format
 msgid "Invalid URL: '%s'"
 msgstr "無效的網址：'%s'"
 
-#: src/itemviewformaction.cpp:216
+#: src/itemviewformaction.cpp:214
 #, c-format
 msgid "Saved article to %s."
 msgstr "將文章保存至 %s "
 
-#: src/itemviewformaction.cpp:219
+#: src/itemviewformaction.cpp:217
 #, c-format
 msgid "Error: couldn't write article to file %s"
 msgstr "錯誤：無法將文章寫至 %s"
 
-#: src/itemviewformaction.cpp:228 src/itemviewformaction.cpp:409
-#: src/itemviewformaction.cpp:552 src/urlviewformaction.cpp:44
+#: src/itemviewformaction.cpp:226 src/itemviewformaction.cpp:407
+#: src/itemviewformaction.cpp:550 src/urlviewformaction.cpp:44
 #: src/urlviewformaction.cpp:78
 msgid "Starting browser..."
 msgstr "啟動瀏覽器..."
 
-#: src/itemviewformaction.cpp:375
+#: src/itemviewformaction.cpp:373
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "將文章標為未讀時發生錯誤: %s"
 
-#: src/itemviewformaction.cpp:429 src/keymap.cpp:190
+#: src/itemviewformaction.cpp:427 src/keymap.cpp:190
 msgid "Goto URL #"
 msgstr "前往網址 #"
 
-#: src/itemviewformaction.cpp:453 src/urlviewformaction.cpp:142
+#: src/itemviewformaction.cpp:451 src/urlviewformaction.cpp:142
 msgid "Open in Browser"
 msgstr "在瀏覽器裡打開"
 
-#: src/itemviewformaction.cpp:454
+#: src/itemviewformaction.cpp:452
 msgid "Enqueue"
 msgstr "加入隊列"
 
-#: src/itemviewformaction.cpp:618
+#: src/itemviewformaction.cpp:616
 #, c-format
 msgid "Article - %s"
 msgstr "文章 - %s"
 
-#: src/itemviewformaction.cpp:668
+#: src/itemviewformaction.cpp:666
 msgid "Error: invalid regular expression!"
 msgstr "錯誤:無效的正規表示式！"
 
@@ -1561,11 +1571,11 @@ msgstr "在抓取%s的時候發生錯誤: %s"
 msgid "Error: invalid feed!"
 msgstr "錯誤:無效的來源！"
 
-#: src/rssfeed.cpp:221
+#: src/rssfeed.cpp:210
 msgid "too few arguments"
 msgstr "參數過少"
 
-#: src/rssfeed.cpp:236
+#: src/rssfeed.cpp:225
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' 不是一個有效的正規表示式： %s"

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -90,6 +90,28 @@ extern "C" {
 		return {}; \
 	}
 
+#define GET_OPTIONAL_VALUE(CHECKER, GETTER, DEFAULT) \
+	if (rs_cliargsparser) { \
+		if (rs_cliargsparser_ ## CHECKER (rs_cliargsparser)) { \
+			return rs_cliargsparser_ ## GETTER (rs_cliargsparser); \
+		} else { \
+			return nonstd::nullopt; \
+		} \
+	} else { \
+		return DEFAULT; \
+	}
+
+#define GET_OPTIONAL_STRING(CHECKER, GETTER) \
+	if (rs_cliargsparser) { \
+		if (rs_cliargsparser_ ## CHECKER (rs_cliargsparser)) { \
+			return RustString(rs_cliargsparser_ ## GETTER (rs_cliargsparser)); \
+		} else { \
+			return nonstd::nullopt; \
+		} \
+	} else { \
+		return {}; \
+	}
+
 namespace newsboat {
 
 CliArgsParser::CliArgsParser(int argc, char* argv[])
@@ -124,24 +146,14 @@ std::string CliArgsParser::importfile() const
 	GET_STRING(importfile);
 }
 
-bool CliArgsParser::do_read_import() const
+nonstd::optional<std::string> CliArgsParser::readinfo_import_file() const
 {
-	GET_VALUE(do_read_import, false);
+	GET_OPTIONAL_STRING(do_read_import, readinfo_import_file);
 }
 
-std::string CliArgsParser::readinfo_import_file() const
+nonstd::optional<std::string> CliArgsParser::readinfo_export_file() const
 {
-	GET_STRING(readinfo_import_file);
-}
-
-bool CliArgsParser::do_read_export() const
-{
-	GET_VALUE(do_read_export, false);
-}
-
-std::string CliArgsParser::readinfo_export_file() const
-{
-	GET_STRING(readinfo_export_file);
+	GET_OPTIONAL_STRING(do_read_export, readinfo_export_file);
 }
 
 std::string CliArgsParser::program_name() const
@@ -164,14 +176,9 @@ bool CliArgsParser::using_nonstandard_configs() const
 	GET_VALUE(using_nonstandard_configs, false);
 }
 
-bool CliArgsParser::should_return() const
+nonstd::optional<int> CliArgsParser::return_code() const
 {
-	GET_VALUE(should_return, false);
-}
-
-int CliArgsParser::return_code() const
-{
-	GET_VALUE(return_code, 0);
+	GET_OPTIONAL_VALUE(should_return, return_code, 0);
 }
 
 std::string CliArgsParser::display_msg() const
@@ -189,87 +196,61 @@ bool CliArgsParser::refresh_on_start() const
 	GET_VALUE(refresh_on_start, false);
 }
 
-bool CliArgsParser::set_url_file() const
+nonstd::optional<std::string> CliArgsParser::url_file() const
 {
-	GET_VALUE(set_url_file, false);
+	GET_OPTIONAL_STRING(set_url_file, url_file);
 }
 
-std::string CliArgsParser::url_file() const
+nonstd::optional<std::string> CliArgsParser::lock_file() const
 {
-	GET_STRING(url_file);
+	GET_OPTIONAL_STRING(set_lock_file, lock_file);
 }
 
-bool CliArgsParser::set_lock_file() const
+nonstd::optional<std::string> CliArgsParser::cache_file() const
 {
-	GET_VALUE(set_lock_file, false);
+	GET_OPTIONAL_STRING(set_cache_file, cache_file);
 }
 
-std::string CliArgsParser::lock_file() const
+nonstd::optional<std::string> CliArgsParser::config_file() const
 {
-	GET_STRING(lock_file);
+	GET_OPTIONAL_STRING(set_config_file, config_file);
 }
 
-bool CliArgsParser::set_cache_file() const
-{
-	GET_VALUE(set_cache_file, false);
-}
-
-std::string CliArgsParser::cache_file() const
-{
-	GET_STRING(cache_file);
-}
-
-bool CliArgsParser::set_config_file() const
-{
-	GET_VALUE(set_config_file, false);
-}
-
-std::string CliArgsParser::config_file() const
-{
-	GET_STRING(config_file);
-}
-
-bool CliArgsParser::execute_cmds() const
-{
-	GET_VALUE(execute_cmds, false);
-}
-
-std::vector<std::string> CliArgsParser::cmds_to_execute() const
+nonstd::optional<std::vector<std::string>> CliArgsParser::cmds_to_execute()
+	const
 {
 	if (rs_cliargsparser) {
-		std::vector<std::string> result;
+		if (rs_cliargsparser_execute_cmds(rs_cliargsparser)) {
+			std::vector<std::string> result;
 
-		const auto count = rs_cliargsparser_cmds_to_execute_count(rs_cliargsparser);
-		for (unsigned int i = 0; i < count; ++i) {
-			result.push_back(RustString(rs_cliargsparser_cmd_to_execute_n(rs_cliargsparser,
-						i)));
+			const auto count = rs_cliargsparser_cmds_to_execute_count(rs_cliargsparser);
+			for (unsigned int i = 0; i < count; ++i) {
+				result.push_back(RustString(rs_cliargsparser_cmd_to_execute_n(rs_cliargsparser,
+							i)));
+			}
+
+			return result;
+		} else {
+			return nonstd::nullopt;
 		}
-
-		return result;
 	} else {
 		return {};
 	}
 }
 
-bool CliArgsParser::set_log_file() const
+nonstd::optional<std::string> CliArgsParser::log_file() const
 {
-	GET_VALUE(set_log_file, false);
+	GET_OPTIONAL_STRING(set_log_file, log_file);
 }
 
-std::string CliArgsParser::log_file() const
-{
-	GET_STRING(log_file);
-}
-
-bool CliArgsParser::set_log_level() const
-{
-	GET_VALUE(set_log_level, false);
-}
-
-Level CliArgsParser::log_level() const
+nonstd::optional<Level> CliArgsParser::log_level() const
 {
 	if (rs_cliargsparser) {
-		return static_cast<Level>(rs_cliargsparser_log_level(rs_cliargsparser));
+		if (rs_cliargsparser_set_log_level(rs_cliargsparser)) {
+			return static_cast<Level>(rs_cliargsparser_log_level(rs_cliargsparser));
+		} else {
+			return nonstd::nullopt;
+		}
 	} else {
 		return Level::NONE;
 	}

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -119,11 +119,9 @@ void ItemViewFormAction::prepare()
 					"article");
 		} else {
 			if (!item->enclosure_url().empty()) {
-				bool ok = false;
-				const auto link_type = utils::podcast_mime_to_link_type(item->enclosure_type(),
-						ok);
-				if (ok) {
-					links.push_back(LinkPair(item->enclosure_url(), link_type));
+				const auto link_type = utils::podcast_mime_to_link_type(item->enclosure_type());
+				if (link_type.has_value()) {
+					links.push_back(LinkPair(item->enclosure_url(), link_type.value()));
 				}
 			}
 

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -131,19 +131,8 @@ std::shared_ptr<RssItem> RssFeed::get_item_by_guid_unlocked(
 	return std::shared_ptr<RssItem>(new RssItem(ch));
 }
 
-bool RssFeed::has_attribute(const std::string& attribname)
-{
-	if (attribname == "feedtitle" || attribname == "description" ||
-		attribname == "feedlink" || attribname == "feeddate" ||
-		attribname == "rssurl" || attribname == "unread_count" ||
-		attribname == "total_count" || attribname == "tags" ||
-		attribname == "feedindex") {
-		return true;
-	}
-	return false;
-}
-
-std::string RssFeed::get_attribute(const std::string& attribname)
+nonstd::optional<std::string> RssFeed::attribute_value(const std::string&
+	attribname)
 {
 	if (attribname == "feedtitle") {
 		return title();
@@ -164,7 +153,7 @@ std::string RssFeed::get_attribute(const std::string& attribname)
 	} else if (attribname == "feedindex") {
 		return std::to_string(idx);
 	}
-	return "";
+	return nonstd::nullopt;
 }
 
 void RssFeed::update_items(std::vector<std::shared_ptr<RssFeed>> feeds)

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -150,7 +150,7 @@ std::string RssFeed::get_attribute(const std::string& attribname)
 	} else if (attribname == "description") {
 		return utils::utf8_to_locale(description());
 	} else if (attribname == "feedlink") {
-		return title();
+		return link();
 	} else if (attribname == "feeddate") {
 		return pubDate();
 	} else if (attribname == "rssurl") {

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -134,27 +134,8 @@ void RssItem::set_enclosure_type(const std::string& type)
 	enclosure_type_ = type;
 }
 
-bool RssItem::has_attribute(const std::string& attribname)
-{
-	if (attribname == "title" || attribname == "link" ||
-		attribname == "author" || attribname == "content" ||
-		attribname == "date" || attribname == "guid" ||
-		attribname == "unread" || attribname == "enclosure_url" ||
-		attribname == "enclosure_type" || attribname == "flags" ||
-		attribname == "age" || attribname == "articleindex") {
-		return true;
-	}
-
-	// if we have a feed, then forward the request
-	std::shared_ptr<RssFeed> feedptr = feedptr_.lock();
-	if (feedptr) {
-		return feedptr->RssFeed::has_attribute(attribname);
-	}
-
-	return false;
-}
-
-std::string RssItem::get_attribute(const std::string& attribname)
+nonstd::optional<std::string> RssItem::attribute_value(const std::string&
+	attribname)
 {
 	if (attribname == "title") {
 		return utils::utf8_to_locale(title());
@@ -186,10 +167,10 @@ std::string RssItem::get_attribute(const std::string& attribname)
 	// if we have a feed, then forward the request
 	std::shared_ptr<RssFeed> feedptr = feedptr_.lock();
 	if (feedptr) {
-		return feedptr->RssFeed::get_attribute(attribname);
+		return feedptr->RssFeed::attribute_value(attribname);
 	}
 
-	return "";
+	return nonstd::nullopt;
 }
 
 void RssItem::update_flags()

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -935,14 +935,16 @@ bool utils::is_valid_podcast_type(const std::string& mimetype)
 	return rs_is_valid_podcast_type(mimetype.c_str());
 }
 
-LinkType utils::podcast_mime_to_link_type(const std::string& mimetype, bool& ok)
+nonstd::optional<LinkType> utils::podcast_mime_to_link_type(
+	const std::string& mimetype)
 {
+	bool ok = false;
 	const auto result = rs_podcast_mime_to_link_type(mimetype.c_str(), &ok);
 	if (ok) {
 		return static_cast<LinkType>(result);
 	}
 
-	return LinkType::AUDIO;
+	return nonstd::nullopt;
 }
 
 /*

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -5,6 +5,7 @@
 #include "cliargsparser.h"
 #include "test-helpers/envvar.h"
 #include "test-helpers/opts.h"
+#include "test-helpers/stringmaker/optional.h"
 #include "test-helpers/tempdir.h"
 
 using namespace newsboat;
@@ -18,7 +19,6 @@ TEST_CASE(
 		CliArgsParser args(opts.argc(), opts.argv());
 
 		REQUIRE(args.should_print_usage());
-		REQUIRE(args.should_return());
 		REQUIRE(args.return_code() == EXIT_FAILURE);
 	};
 
@@ -101,7 +101,6 @@ TEST_CASE(
 		CliArgsParser args(opts.argc(), opts.argv());
 
 		REQUIRE(args.should_print_usage());
-		REQUIRE(args.should_return());
 		REQUIRE(args.return_code() == EXIT_FAILURE);
 	};
 
@@ -167,7 +166,6 @@ TEST_CASE("Asks to print usage and exit with success if -h/--help is provided",
 		CliArgsParser args(opts.argc(), opts.argv());
 
 		REQUIRE(args.should_print_usage());
-		REQUIRE(args.should_return());
 		REQUIRE(args.return_code() == EXIT_SUCCESS);
 	};
 
@@ -181,8 +179,8 @@ TEST_CASE("Asks to print usage and exit with success if -h/--help is provided",
 }
 
 TEST_CASE(
-	"Sets `url_file`, `set_url_file`, and "
-	"`using_nonstandard_configs` if -u/--url-file is provided",
+	"Sets `url_file` and `using_nonstandard_configs` if -u/--url-file "
+	"is provided",
 	"[CliArgsParser]")
 {
 	const std::string filename("urlfile");
@@ -190,7 +188,6 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_url_file());
 		REQUIRE(args.url_file() == filename);
 		REQUIRE(args.using_nonstandard_configs());
 	};
@@ -217,7 +214,6 @@ TEST_CASE("Resolves tilde to homedir in -u/--url-file", "[CliArgsParser]")
 	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_url_file());
 		REQUIRE(args.url_file() == tmp.get_path() + filename);
 	};
 
@@ -231,9 +227,8 @@ TEST_CASE("Resolves tilde to homedir in -u/--url-file", "[CliArgsParser]")
 }
 
 TEST_CASE(
-	"Sets `cache_file`, `lock_file`, `set_cache_file`, `set_lock_file`, "
-	"and "
-	"`using_nonstandard_configs` if -c/--cache-file is provided",
+	"Sets `cache_file`, `lock_file`, and `using_nonstandard_configs` "
+	"if -c/--cache-file is provided",
 	"[CliArgsParser]")
 {
 	const std::string filename("cache.db");
@@ -241,9 +236,7 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_cache_file());
 		REQUIRE(args.cache_file() == filename);
-		REQUIRE(args.set_lock_file());
 		REQUIRE(args.lock_file() == filename + ".lock");
 		REQUIRE(args.using_nonstandard_configs());
 	};
@@ -270,9 +263,7 @@ TEST_CASE("Resolves tilde to homedir in -c/--cache-file", "[CliArgsParser]")
 	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_cache_file());
 		REQUIRE(args.cache_file() == tmp.get_path() + filename);
-		REQUIRE(args.set_lock_file());
 		REQUIRE(args.lock_file() == tmp.get_path() + filename + ".lock");
 	};
 
@@ -286,8 +277,8 @@ TEST_CASE("Resolves tilde to homedir in -c/--cache-file", "[CliArgsParser]")
 }
 
 TEST_CASE(
-	"Sets `config_file`, `set_config_file`, and "
-	"`using_nonstandard_configs` if -C/--config-file is provided",
+	"Sets `config_file` and `using_nonstandard_configs` if -C/--config-file "
+	"is provided",
 	"[CliArgsParser]")
 {
 	const std::string filename("config file");
@@ -295,7 +286,6 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_config_file());
 		REQUIRE(args.config_file() == filename);
 		REQUIRE(args.using_nonstandard_configs());
 	};
@@ -322,7 +312,6 @@ TEST_CASE("Resolves tilde to homedir in -C/--config-file", "[CliArgsParser]")
 	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_config_file());
 		REQUIRE(args.config_file() == tmp.get_path() + filename);
 		REQUIRE(args.using_nonstandard_configs());
 	};
@@ -413,7 +402,8 @@ TEST_CASE("Sets `execute_cmds` if -x/--execute is provided", "[CliArgsParser]")
 	auto check = [](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.execute_cmds());
+		REQUIRE_FALSE(args.cmds_to_execute() == nonstd::nullopt);
+		REQUIRE_FALSE(args.cmds_to_execute().value().empty());
 	};
 
 	SECTION("-x") {
@@ -476,8 +466,7 @@ TEST_CASE("Requests silent mode if -q/--quiet is provided", "[CliArgsParser]")
 }
 
 TEST_CASE(
-	"Sets `do_read_import` and `readinfofile` if -I/--import-from-file "
-	"is provided",
+	"Sets `readinfofile` if -I/--import-from-file is provided",
 	"[CliArgsParser]")
 {
 	const std::string filename("filename");
@@ -485,7 +474,6 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.do_read_import());
 		REQUIRE(args.readinfo_import_file() == filename);
 	};
 
@@ -512,7 +500,6 @@ TEST_CASE("Resolves tilde to homedir in -I/--import-from-file",
 	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.do_read_import());
 		REQUIRE(args.readinfo_import_file() == tmp.get_path() + filename);
 	};
 
@@ -526,8 +513,7 @@ TEST_CASE("Resolves tilde to homedir in -I/--import-from-file",
 }
 
 TEST_CASE(
-	"Sets `do_read_export` and `readinfofile` if -E/--export-to-file "
-	"is provided",
+	"Sets `readinfofile` if -E/--export-to-file is provided",
 	"[CliArgsParser]")
 {
 	const std::string filename("filename");
@@ -535,7 +521,6 @@ TEST_CASE(
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.do_read_export());
 		REQUIRE(args.readinfo_export_file() == filename);
 	};
 
@@ -561,7 +546,6 @@ TEST_CASE("Resolves tilde to homedir in -E/--export-to-file", "[CliArgsParser]")
 	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.do_read_export());
 		REQUIRE(args.readinfo_export_file() == tmp.get_path() + filename);
 	};
 
@@ -586,7 +570,6 @@ TEST_CASE(
 		CliArgsParser args(opts.argc(), opts.argv());
 
 		REQUIRE(args.should_print_usage());
-		REQUIRE(args.should_return());
 		REQUIRE(args.return_code() == EXIT_FAILURE);
 	};
 
@@ -599,7 +582,7 @@ TEST_CASE(
 	}
 }
 
-TEST_CASE("Sets `set_log_file` and `log_file` if -d/--log-file is provided",
+TEST_CASE("Sets `log_file` if -d/--log-file is provided",
 	"[CliArgsParser]")
 {
 	const std::string filename("log file.txt");
@@ -607,7 +590,6 @@ TEST_CASE("Sets `set_log_file` and `log_file` if -d/--log-file is provided",
 	auto check = [&filename](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_log_file());
 		REQUIRE(args.log_file() == filename);
 	};
 
@@ -633,7 +615,6 @@ TEST_CASE("Resolves tilde to homedir in -d/--log-file", "[CliArgsParser]")
 	auto check = [&filename, &tmp](TestHelpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_log_file());
 		REQUIRE(args.log_file() == tmp.get_path() + filename);
 	};
 
@@ -647,14 +628,12 @@ TEST_CASE("Resolves tilde to homedir in -d/--log-file", "[CliArgsParser]")
 }
 
 TEST_CASE(
-	"Sets `set_log_level` and `log_level` if argument to "
-	"-l/--log-level is in range of [1; 6]",
+	"Sets `log_level` if argument to -l/--log-level is in range of [1; 6]",
 	"[CliArgsParser]")
 {
 	auto check = [](TestHelpers::Opts opts, Level expected) {
 		CliArgsParser args(opts.argc(), opts.argv());
 
-		REQUIRE(args.set_log_level());
 		REQUIRE(args.log_level() == expected);
 	};
 
@@ -692,7 +671,6 @@ TEST_CASE(
 		CliArgsParser args(opts.argc(), opts.argv());
 
 		REQUIRE_FALSE(args.display_msg() == "");
-		REQUIRE(args.should_return());
 		REQUIRE(args.return_code() == EXIT_FAILURE);
 	};
 

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -6,6 +6,7 @@
 
 #include "matchable.h"
 #include "matcherexception.h"
+#include "test-helpers/stringmaker/optional.h"
 
 using namespace newsboat;
 
@@ -19,19 +20,15 @@ public:
 		: m_data(data)
 	{}
 
-	virtual bool has_attribute(const std::string& attribname)
-	{
-		return m_data.find(attribname) != m_data.cend();
-	}
-
-	virtual std::string get_attribute(const std::string& attribname)
+	nonstd::optional<std::string> attribute_value(const std::string& attribname)
+	override
 	{
 		const auto it = m_data.find(attribname);
 		if (it != m_data.cend()) {
 			return it->second;
 		}
 
-		return "";
+		return nonstd::nullopt;
 	}
 
 private:

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -411,17 +411,13 @@ TEST_CASE("RegexManager doesn't throw on valid `highlight-article' definition",
 
 struct RegexManagerMockMatchable : public Matchable {
 public:
-	bool has_attribute(const std::string& attribname) override
-	{
-		return attribname == "attr";
-	}
-
-	std::string get_attribute(const std::string& attribname) override
+	nonstd::optional<std::string> attribute_value(const std::string& attribname)
+	override
 	{
 		if (attribname == "attr") {
 			return "val";
 		}
-		return "";
+		return nonstd::nullopt;
 	}
 };
 

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -8,7 +8,7 @@
 using namespace newsboat;
 
 TEST_CASE("RssFeed::set_rssurl() checks if query feed has a valid query",
-	"[rss]")
+	"[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -26,7 +26,7 @@ TEST_CASE("RssFeed::set_rssurl() checks if query feed has a valid query",
 	}
 }
 
-TEST_CASE("RssFeed::sort() correctly sorts articles", "[rss]")
+TEST_CASE("RssFeed::sort() correctly sorts articles", "[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -206,7 +206,7 @@ TEST_CASE("RssFeed::sort() correctly sorts articles", "[rss]")
 }
 
 TEST_CASE("RssFeed::unread_item_count() returns number of unread articles",
-	"[rss]")
+	"[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -236,7 +236,7 @@ TEST_CASE("RssFeed::unread_item_count() returns number of unread articles",
 }
 
 TEST_CASE("RssFeed::matches_tag() returns true if article has a specified tag",
-	"[rss]")
+	"[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -252,7 +252,7 @@ TEST_CASE("RssFeed::matches_tag() returns true if article has a specified tag",
 	REQUIRE_FALSE(f.matches_tag("Five"));
 }
 
-TEST_CASE("RssFeed::get_firsttag() returns first tag", "[rss]")
+TEST_CASE("RssFeed::get_firsttag() returns first tag", "[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -279,7 +279,7 @@ TEST_CASE("RssFeed::get_firsttag() returns first tag", "[rss]")
 
 TEST_CASE(
 	"RssFeed::hidden() returns true if feed has a tag starting with \"!\"",
-	"[rss]")
+	"[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -302,7 +302,7 @@ TEST_CASE(
 
 TEST_CASE(
 	"RssFeed::mark_all_items_read() marks all items within a feed as read",
-	"[rss]")
+	"[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -320,7 +320,7 @@ TEST_CASE(
 	}
 }
 
-TEST_CASE("RssFeed::set_tags() sets tags for a feed", "[rss]")
+TEST_CASE("RssFeed::set_tags() sets tags for a feed", "[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -337,7 +337,7 @@ TEST_CASE("RssFeed::set_tags() sets tags for a feed", "[rss]")
 TEST_CASE(
 	"RssFeed::purge_deleted_items() deletes all items that have "
 	"\"deleted\" property set up",
-	"[rss]")
+	"[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -355,7 +355,7 @@ TEST_CASE(
 }
 
 TEST_CASE("If item's <title> is empty, try to deduce it from the URL",
-	"[rss]")
+	"[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -377,7 +377,7 @@ TEST_CASE("If item's <title> is empty, try to deduce it from the URL",
 TEST_CASE(
 	"RssFeed::is_query_feed() return true if feed is a query feed, i.e. "
 	"its \"rssurl\" starts with \"query:\" string",
-	"[rss]")
+	"[RssFeed]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -476,15 +476,14 @@ TEST_CASE("RssFeed contains a number of matchable attributes", "[RssFeed]")
 	}
 
 	SECTION("feeddate, feed's publication date") {
-		const time_t pubdate = 1; // one second into the Unix epoch
-		f.set_pubDate(pubdate);
-		// The implementation of this attribute was broken in
-		// 48a9fdc1a37bf5eff1c35fa168f372f4258f31ef (2006), when it started
-		// returning "TODO" instead of actual date.
+		TestHelpers::EnvVar tzEnv("TZ");
+		tzEnv.set("UTC");
+
+		f.set_pubDate(1); // one second into the Unix epoch
 
 		const auto attr = "feeddate";
 		REQUIRE(f.has_attribute(attr));
-		REQUIRE(f.get_attribute(attr) == "TODO"); // it's buggy so it returns "TODO"
+		REQUIRE(f.get_attribute(attr) == "Thu, 01 Jan 1970 00:00:01 +0000");
 	}
 
 	SECTION("rssurl, the URL by which this feed is fetched (specified in the urls file)") {

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -469,15 +469,10 @@ TEST_CASE("RssFeed contains a number of matchable attributes", "[RssFeed]")
 	SECTION("feedlink, feed's notion of its own location") {
 		const auto feedlink = std::string("https://example.com/feed.xml");
 		f.set_link(feedlink);
-		// The implementation of this attribute was buggy ever since its
-		// inception in b094a4e260f74b37e4a8e366452046c02cb2a91a (committed
-		// 2007). It returns feed title instead. Let's test for that, too
-		f.set_title("bug sentry");
 
 		const auto attr = "feedlink";
 		REQUIRE(f.has_attribute(attr));
-		REQUIRE(f.get_attribute(attr) != feedlink); // != because it's buggy
-		REQUIRE(f.get_attribute(attr) == "bug sentry");
+		REQUIRE(f.get_attribute(attr) == feedlink);
 	}
 
 	SECTION("feeddate, feed's publication date") {

--- a/test/rssitem.cpp
+++ b/test/rssitem.cpp
@@ -8,6 +8,7 @@
 #include "rssfeed.h"
 
 #include "test-helpers/envvar.h"
+#include "test-helpers/stringmaker/optional.h"
 
 using namespace newsboat;
 
@@ -43,8 +44,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto title = "Example title";
 		item.set_title(title);
 
-		REQUIRE(item.has_attribute(attr));
-		REQUIRE(item.get_attribute(attr) == title);
+		REQUIRE(item.attribute_value(attr) == title);
 
 		SECTION("it is encoded to the locale's charset") {
 			// Due to differences in how platforms handle //TRANSLIT in iconv,
@@ -66,8 +66,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 
 			item.set_title(title);
 
-			REQUIRE(item.has_attribute(attr));
-			REQUIRE_FALSE(item.get_attribute(attr) == title);
+			REQUIRE_FALSE(item.attribute_value(attr) == title);
 		}
 	}
 
@@ -77,8 +76,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto url = "http://example.com/newest-update.html";
 		item.set_link(url);
 
-		REQUIRE(item.has_attribute(attr));
-		REQUIRE(item.get_attribute(attr) == url);
+		REQUIRE(item.attribute_value(attr) == url);
 	}
 
 	SECTION("author") {
@@ -87,8 +85,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto name = "John Doe";
 		item.set_author(name);
 
-		REQUIRE(item.has_attribute(attr));
-		REQUIRE(item.get_attribute(attr) == name);
+		REQUIRE(item.attribute_value(attr) == name);
 
 		SECTION("it is encoded to the locale's charset") {
 			// Due to differences in how platforms handle //TRANSLIT in iconv,
@@ -110,8 +107,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 
 			item.set_author(author);
 
-			REQUIRE(item.has_attribute(attr));
-			REQUIRE_FALSE(item.get_attribute(attr) == author);
+			REQUIRE_FALSE(item.attribute_value(attr) == author);
 		}
 	}
 
@@ -121,8 +117,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto description = "First line.\nSecond one.\nAnd finally the third";
 		item.set_description(description);
 
-		REQUIRE(item.has_attribute(attr));
-		REQUIRE(item.get_attribute(attr) == description);
+		REQUIRE(item.attribute_value(attr) == description);
 
 		SECTION("it is encoded to the locale's charset") {
 			// Due to differences in how platforms handle //TRANSLIT in iconv,
@@ -144,8 +139,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 
 			item.set_description(description);
 
-			REQUIRE(item.has_attribute(attr));
-			REQUIRE_FALSE(item.get_attribute(attr) == description);
+			REQUIRE_FALSE(item.attribute_value(attr) == description);
 		}
 	}
 
@@ -157,8 +151,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 
 		item.set_pubDate(1); // 1 second into the Unix epoch
 
-		REQUIRE(item.has_attribute(attr));
-		REQUIRE(item.get_attribute(attr) == "Thu, 01 Jan 1970 00:00:01 +0000");
+		REQUIRE(item.attribute_value(attr) == "Thu, 01 Jan 1970 00:00:01 +0000");
 	}
 
 	SECTION("guid") {
@@ -167,8 +160,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto guid = "unique-identifier-of-this-item";
 		item.set_guid(guid);
 
-		REQUIRE(item.has_attribute(attr));
-		REQUIRE(item.get_attribute(attr) == guid);
+		REQUIRE(item.attribute_value(attr) == guid);
 	}
 
 	SECTION("unread") {
@@ -177,15 +169,13 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		SECTION("for read items, attribute equals \"no\"") {
 			item.set_unread(false);
 
-			REQUIRE(item.has_attribute(attr));
-			REQUIRE(item.get_attribute(attr) == "no");
+			REQUIRE(item.attribute_value(attr) == "no");
 		}
 
 		SECTION("for unread items, attribute equals \"yes\"") {
 			item.set_unread(true);
 
-			REQUIRE(item.has_attribute(attr));
-			REQUIRE(item.get_attribute(attr) == "yes");
+			REQUIRE(item.attribute_value(attr) == "yes");
 		}
 	}
 
@@ -195,8 +185,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto url = "https://example.com/podcast-ep-01.mp3";
 		item.set_enclosure_url(url);
 
-		REQUIRE(item.has_attribute(attr));
-		REQUIRE(item.get_attribute(attr) == url);
+		REQUIRE(item.attribute_value(attr) == url);
 	}
 
 	SECTION("enclosure_type, MIME type of the enclosure") {
@@ -205,8 +194,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto type = "audio/ogg";
 		item.set_enclosure_type(type);
 
-		REQUIRE(item.has_attribute(attr));
-		REQUIRE(item.get_attribute(attr) == type);
+		REQUIRE(item.attribute_value(attr) == type);
 	}
 
 	SECTION("flags") {
@@ -215,8 +203,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto flags = "abcdefg";
 		item.set_flags(flags);
 
-		REQUIRE(item.has_attribute(attr));
-		REQUIRE(item.get_attribute(attr) == flags);
+		REQUIRE(item.attribute_value(attr) == flags);
 	}
 
 	SECTION("age, the number of days since publication") {
@@ -230,12 +217,11 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 			const auto seconds_per_day = 24 * 60 * 60;
 			const auto unix_days = current_time / seconds_per_day;
 
-			REQUIRE(item.has_attribute(attr));
-			REQUIRE(item.get_attribute(attr) == std::to_string(unix_days));
+			REQUIRE(item.attribute_value(attr) == std::to_string(unix_days));
 		};
 
 		// check() evaluates current time twice: once explicitly by calling
-		// time(), once implicitly by calling get_attribute("age"). On
+		// time(), once implicitly by calling attribute_value("age"). On
 		// a midnight, it's possible for the first call to execute on one day,
 		// and the second call to execute on the next day. That'll lead to the
 		// test failing. To avoid that, we perform a dirty trick: we run the
@@ -258,8 +244,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto check = [&attr, &item](unsigned int index) {
 			item.set_index(index);
 
-			REQUIRE(item.has_attribute(attr));
-			REQUIRE(item.get_attribute(attr) == std::to_string(index));
+			REQUIRE(item.attribute_value(attr) == std::to_string(index));
 		};
 
 		check(1);
@@ -279,14 +264,13 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto attr = "feedindex";
 
 		SECTION("no parent feed => attribute unavailable") {
-			REQUIRE_FALSE(item->has_attribute(attr));
+			REQUIRE(item->attribute_value(attr) == nonstd::nullopt);
 		}
 
 		SECTION("request forwarded to parent feed") {
 			item->set_feedptr(feed);
 
-			REQUIRE(item->has_attribute(attr));
-			REQUIRE(item->get_attribute(attr) == std::to_string(feedindex));
+			REQUIRE(item->attribute_value(attr) == std::to_string(feedindex));
 		}
 	}
 }

--- a/test/rssitem.cpp
+++ b/test/rssitem.cpp
@@ -6,7 +6,7 @@
 
 using namespace newsboat;
 
-TEST_CASE("RssItem::sort_flags() cleans up flags", "[rss]")
+TEST_CASE("RssItem::sort_flags() cleans up flags", "[RssItem]")
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);

--- a/test/rssitem.cpp
+++ b/test/rssitem.cpp
@@ -46,7 +46,29 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		REQUIRE(item.has_attribute(attr));
 		REQUIRE(item.get_attribute(attr) == title);
 
-		// TODO: check that the result is in the locale charset
+		SECTION("it is encoded to the locale's charset") {
+			// Due to differences in how platforms handle //TRANSLIT in iconv,
+			// we can't compare results to a known-good value. Instead, we
+			// merely check that the result is *not* UTF-8.
+
+			TestHelpers::EnvVar lc_ctype("LC_CTYPE");
+			lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
+				if (new_charset.has_value()) {
+					::setlocale(LC_CTYPE, new_charset.value().c_str());
+				} else {
+					::setlocale(LC_CTYPE, "");
+				}
+			});
+
+			lc_ctype.set("C"); // This means ASCII
+
+			const auto title = "こんにちは"; // "good afternoon"
+
+			item.set_title(title);
+
+			REQUIRE(item.has_attribute(attr));
+			REQUIRE_FALSE(item.get_attribute(attr) == title);
+		}
 	}
 
 	SECTION("link") {
@@ -68,7 +90,29 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		REQUIRE(item.has_attribute(attr));
 		REQUIRE(item.get_attribute(attr) == name);
 
-		// TODO: check that the result is in the locale charset
+		SECTION("it is encoded to the locale's charset") {
+			// Due to differences in how platforms handle //TRANSLIT in iconv,
+			// we can't compare results to a known-good value. Instead, we
+			// merely check that the result is *not* UTF-8.
+
+			TestHelpers::EnvVar lc_ctype("LC_CTYPE");
+			lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
+				if (new_charset.has_value()) {
+					::setlocale(LC_CTYPE, new_charset.value().c_str());
+				} else {
+					::setlocale(LC_CTYPE, "");
+				}
+			});
+
+			lc_ctype.set("C"); // This means ASCII
+
+			const auto author = "李白"; // "Li Bai"
+
+			item.set_author(author);
+
+			REQUIRE(item.has_attribute(attr));
+			REQUIRE_FALSE(item.get_attribute(attr) == author);
+		}
 	}
 
 	SECTION("content") {
@@ -80,7 +124,29 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		REQUIRE(item.has_attribute(attr));
 		REQUIRE(item.get_attribute(attr) == description);
 
-		// TODO: check that the result is in the locale charset
+		SECTION("it is encoded to the locale's charset") {
+			// Due to differences in how platforms handle //TRANSLIT in iconv,
+			// we can't compare results to a known-good value. Instead, we
+			// merely check that the result is *not* UTF-8.
+
+			TestHelpers::EnvVar lc_ctype("LC_CTYPE");
+			lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
+				if (new_charset.has_value()) {
+					::setlocale(LC_CTYPE, new_charset.value().c_str());
+				} else {
+					::setlocale(LC_CTYPE, "");
+				}
+			});
+
+			lc_ctype.set("C"); // This means ASCII
+
+			const auto description = "こんにちは"; // "good afternoon"
+
+			item.set_description(description);
+
+			REQUIRE(item.has_attribute(attr));
+			REQUIRE_FALSE(item.get_attribute(attr) == description);
+		}
 	}
 
 	SECTION("date") {

--- a/test/rsspp_rssparser.cpp
+++ b/test/rsspp_rssparser.cpp
@@ -66,7 +66,7 @@ TEST_CASE(
 	auto expected = "Tue, 30 Dec 2008 18:03:15 +0000";
 
 	TestHelpers::EnvVar tzEnv("TZ");
-	tzEnv.on_change([]() {
+	tzEnv.on_change([](nonstd::optional<std::string>) {
 		::tzset();
 	});
 

--- a/test/test-helpers/envvar.cpp
+++ b/test/test-helpers/envvar.cpp
@@ -21,7 +21,7 @@ TestHelpers::EnvVar::~EnvVar()
 	}
 }
 
-void TestHelpers::EnvVar::set(std::string new_value) const
+void TestHelpers::EnvVar::set(const std::string& new_value) const
 {
 	const auto overwrite = true;
 	::setenv(name.c_str(), new_value.c_str(), overwrite);
@@ -303,7 +303,7 @@ TEST_CASE("EnvVar::unset() runs a function (set by on_change()) after changing "
 }
 
 TEST_CASE("EnvVar's destructor runs a function (set by on_change()) after "
-	"restoring the varibale to its original state",
+	"restoring the variable to its original state",
 	"[test-helpers]")
 {
 	const char var[] = "nEwSb0a7-tEsT-eNvIroNm3Nt-v4rIabLe";

--- a/test/test-helpers/envvar.cpp
+++ b/test/test-helpers/envvar.cpp
@@ -58,7 +58,7 @@ TEST_CASE("EnvVar object restores the environment variable to its original "
 
 	const auto overwrite = true;
 
-	::setenv(var, expected.c_str(), overwrite);
+	REQUIRE(::setenv(var, expected.c_str(), overwrite) == 0);
 	REQUIRE(expected == ::getenv(var));
 
 	{
@@ -66,14 +66,14 @@ TEST_CASE("EnvVar object restores the environment variable to its original "
 		REQUIRE(expected == ::getenv(var));
 
 		const auto newValue = std::string("totally new value");
-		::setenv(var, newValue.c_str(), overwrite);
+		REQUIRE(::setenv(var, newValue.c_str(), overwrite) == 0);
 
 		REQUIRE_FALSE(expected == ::getenv(var));
 	}
 
 	REQUIRE(expected == ::getenv(var));
 
-	::unsetenv(var);
+	REQUIRE(::unsetenv(var) == 0);
 }
 
 TEST_CASE("EnvVar::set() changes the current state of the environment variable",
@@ -109,7 +109,7 @@ TEST_CASE("EnvVar::set() doesn't change the value to which the environment "
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), overwrite);
+	REQUIRE(::setenv(var, expected.c_str(), overwrite) == 0);
 	REQUIRE(expected == ::getenv(var));
 
 	{
@@ -119,7 +119,7 @@ TEST_CASE("EnvVar::set() doesn't change the value to which the environment "
 
 	REQUIRE(expected == ::getenv(var));
 
-	::unsetenv(var);
+	REQUIRE(::unsetenv(var) == 0);
 }
 
 TEST_CASE("EnvVar::set() runs a function (set by on_change()) after changing "
@@ -135,7 +135,7 @@ TEST_CASE("EnvVar::set() runs a function (set by on_change()) after changing "
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), overwrite);
+	REQUIRE(::setenv(var, expected.c_str(), overwrite) == 0);
 
 	SECTION("The function is ran *after* the change") {
 		// It's important to declare `newValue` before declaring `envVar`,
@@ -175,7 +175,7 @@ TEST_CASE("EnvVar::set() runs a function (set by on_change()) after changing "
 		REQUIRE(counter == 3);
 	}
 
-	::unsetenv(var);
+	REQUIRE(::unsetenv(var) == 0);
 }
 
 TEST_CASE("EnvVar::unset() completely removes the variable from the environment",
@@ -190,7 +190,7 @@ TEST_CASE("EnvVar::unset() completely removes the variable from the environment"
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), overwrite);
+	REQUIRE(::setenv(var, expected.c_str(), overwrite) == 0);
 
 	char* value = ::getenv(var);
 	REQUIRE_FALSE(value == nullptr);
@@ -212,7 +212,7 @@ TEST_CASE("EnvVar::unset() completely removes the variable from the environment"
 		value = nullptr;
 	}
 
-	::unsetenv(var);
+	REQUIRE(::unsetenv(var) == 0);
 }
 
 TEST_CASE("EnvVar::unset() doesn't change the value to which the environment "
@@ -228,7 +228,7 @@ TEST_CASE("EnvVar::unset() doesn't change the value to which the environment "
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), overwrite);
+	REQUIRE(::setenv(var, expected.c_str(), overwrite) == 0);
 
 	char* value = ::getenv(var);
 	REQUIRE_FALSE(value == nullptr);
@@ -255,7 +255,7 @@ TEST_CASE("EnvVar::unset() doesn't change the value to which the environment "
 	REQUIRE(expected == value);
 	value = nullptr;
 
-	::unsetenv(var);
+	REQUIRE(::unsetenv(var) == 0);
 }
 
 TEST_CASE("EnvVar::unset() runs a function (set by on_change()) after changing "
@@ -271,7 +271,7 @@ TEST_CASE("EnvVar::unset() runs a function (set by on_change()) after changing "
 	const auto expected = std::string("let's try this out, shall we?");
 
 	const auto overwrite = true;
-	::setenv(var, expected.c_str(), overwrite);
+	REQUIRE(::setenv(var, expected.c_str(), overwrite) == 0);
 
 	char* value = ::getenv(var);
 	REQUIRE_FALSE(value == nullptr);
@@ -299,7 +299,7 @@ TEST_CASE("EnvVar::unset() runs a function (set by on_change()) after changing "
 		REQUIRE(counter == 1);
 	}
 
-	::unsetenv(var);
+	REQUIRE(::unsetenv(var) == 0);
 }
 
 TEST_CASE("EnvVar's destructor runs a function (set by on_change()) after "
@@ -343,13 +343,13 @@ TEST_CASE("EnvVar's destructor runs a function (set by on_change()) after "
 
 	SECTION("Variable was set before EnvVar is created") {
 		const auto overwrite = true;
-		::setenv(var, expected.c_str(), overwrite);
+		REQUIRE(::setenv(var, expected.c_str(), overwrite) == 0);
 
 		check();
 	}
 
 	// It's a no-op if the variable is absent from the environment, so we don't
 	// need to put this inside a conditional to match SECTIONs above.
-	::unsetenv(var);
+	REQUIRE(::unsetenv(var) == 0);
 }
 

--- a/test/test-helpers/envvar.h
+++ b/test/test-helpers/envvar.h
@@ -47,7 +47,7 @@ public:
 	/// restore the variable when the test finished running. The variable is
 	/// always restored to the state it was in when EnvVar object was
 	/// constructed.
-	void set(std::string new_value) const;
+	void set(const std::string& new_value) const;
 
 	/// \brief Unsets the environment variable.
 	///

--- a/test/test-helpers/envvar.h
+++ b/test/test-helpers/envvar.h
@@ -4,6 +4,8 @@
 #include <functional>
 #include <string>
 
+#include "3rd-party/optional.hpp"
+
 namespace TestHelpers {
 
 /* \brief Automatically restores environment variable to its original state
@@ -23,7 +25,7 @@ namespace TestHelpers {
  * thread).
  */
 class EnvVar {
-	std::function<void(void)> on_change_fn;
+	std::function<void(nonstd::optional<std::string>)> on_change_fn;
 	std::string name;
 	std::string value;
 	bool was_set = false;
@@ -61,7 +63,12 @@ public:
 	///
 	/// In other words, the function will be ran after each change done via or
 	/// by this class.
-	void on_change(std::function<void(void)> fn);
+	///
+	/// The function is passed an argument which can be either:
+	/// - nonstd::nullopt  --  meaning the environment variable is now unset
+	/// - std::string      --  meaning the environment variable is now set to
+	///                        this value
+	void on_change(std::function<void(nonstd::optional<std::string> new_value)> fn);
 };
 
 } // namespace TestHelpers

--- a/test/test-helpers/stringmaker/optional.h
+++ b/test/test-helpers/stringmaker/optional.h
@@ -1,0 +1,23 @@
+#ifndef NEWSBOAT_TEST_HELPERS_STRINGMAKER_OPTIONAL_H_
+#define NEWSBOAT_TEST_HELPERS_STRINGMAKER_OPTIONAL_H_
+
+#include "3rd-party/optional.hpp"
+#include "3rd-party/catch.hpp"
+
+namespace Catch {
+template<typename T>
+struct StringMaker<nonstd::optional<T>> {
+	static std::string convert(const nonstd::optional<T>& opt)
+	{
+		if (opt.has_value()) {
+			return std::string("nonstd::optional( ")
+				+ StringMaker<T>::convert(opt.value())
+				+ std::string(" )");
+		} else {
+			return "{ }";
+		}
+	}
+};
+}
+
+#endif /* NEWSBOAT_TEST_HELPERS_STRINGMAKER_OPTIONAL_H_ */

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -10,6 +10,7 @@
 #include "rs_utils.h"
 #include "test-helpers/chdir.h"
 #include "test-helpers/envvar.h"
+#include "test-helpers/stringmaker/optional.h"
 #include "test-helpers/tempdir.h"
 #include "test-helpers/tempfile.h"
 
@@ -1109,9 +1110,7 @@ TEST_CASE("podcast_mime_to_link_type() returns HtmlRenderer's LinkType that "
 {
 	SECTION("Valid podcast MIME types") {
 		const auto check = [](std::string mime, LinkType expected) {
-			bool ok = false;
-			REQUIRE(utils::podcast_mime_to_link_type(mime, ok) == expected);
-			REQUIRE(ok);
+			REQUIRE(utils::podcast_mime_to_link_type(mime) == expected);
 		};
 
 		check("audio/mpeg", LinkType::AUDIO);
@@ -1125,9 +1124,7 @@ TEST_CASE("podcast_mime_to_link_type() returns HtmlRenderer's LinkType that "
 
 	SECTION("Sets `ok` to `false` if given MIME type is not a podcast type") {
 		const auto check = [](std::string mime) {
-			bool ok = true;
-			utils::podcast_mime_to_link_type(mime, ok);
-			REQUIRE_FALSE(ok);
+			REQUIRE(utils::podcast_mime_to_link_type(mime) == nonstd::nullopt);
 		};
 
 		check("image/jpeg");


### PR DESCRIPTION
The goal here is to streamline some of the interfaces and move our C++ a bit closer to Rust. Now we can refactor to `optional` on the C++ side, and move that code to Rust with its `Option`. This is easier, more pleasant, and less error-prone than dealing with pairs of a `bool` and a value.

Refactoring `Matchable` interface required tests for its implementations, which in turn required `EnvVar` to run `setlocale()`. I also ran into a couple bugs while testing, so fixed those as well… That's why there are so many "preparatory" commits here. Happy to split into multiple PRs if it's too hard to review.

Reviews from everyone are welcome. Will merge in three days.