### PR TITLE
Move to Rust 2018 and get rid of `extern crate`

### DIFF
--- a/rust/libnewsboat-ffi/Cargo.toml
+++ b/rust/libnewsboat-ffi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libnewsboat-ffi"
 version = "2.19.0"
 authors = ["Alexander Batischev <eual.jp@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 libnewsboat = { path="../libnewsboat" }

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -1,4 +1,4 @@
-use abort_on_panic;
+use crate::abort_on_panic;
 use libc::{c_char, c_void};
 use libnewsboat::cliargsparser::CliArgsParser;
 use libnewsboat::logger::Level;

--- a/rust/libnewsboat-ffi/src/configpaths.rs
+++ b/rust/libnewsboat-ffi/src/configpaths.rs
@@ -1,4 +1,4 @@
-use abort_on_panic;
+use crate::abort_on_panic;
 use libc::{c_char, c_void};
 use libnewsboat::cliargsparser::CliArgsParser;
 use libnewsboat::configpaths::ConfigPaths;

--- a/rust/libnewsboat-ffi/src/fmtstrformatter.rs
+++ b/rust/libnewsboat-ffi/src/fmtstrformatter.rs
@@ -1,4 +1,4 @@
-use abort_on_panic;
+use crate::abort_on_panic;
 use libc::{c_char, c_void};
 use libnewsboat::fmtstrformatter::FmtStrFormatter;
 use std::ffi::{CStr, CString};

--- a/rust/libnewsboat-ffi/src/history.rs
+++ b/rust/libnewsboat-ffi/src/history.rs
@@ -1,4 +1,4 @@
-use abort_on_panic;
+use crate::abort_on_panic;
 use libc::{c_char, c_void};
 use libnewsboat::history::History;
 use std::ffi::{CStr, CString};

--- a/rust/libnewsboat-ffi/src/human_panic.rs
+++ b/rust/libnewsboat-ffi/src/human_panic.rs
@@ -1,4 +1,4 @@
-use abort_on_panic;
+use crate::abort_on_panic;
 use libnewsboat::human_panic;
 
 #[no_mangle]

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate libc;
-#[macro_use]
-extern crate libnewsboat;
-
 use libc::c_char;
 use std::ffi::CString;
 use std::panic::{catch_unwind, UnwindSafe};

--- a/rust/libnewsboat-ffi/src/logger.rs
+++ b/rust/libnewsboat-ffi/src/logger.rs
@@ -1,4 +1,4 @@
-use abort_on_panic;
+use crate::abort_on_panic;
 use libc::c_char;
 use libnewsboat::logger;
 use std::ffi::CStr;

--- a/rust/libnewsboat-ffi/src/matchererror.rs
+++ b/rust/libnewsboat-ffi/src/matchererror.rs
@@ -1,4 +1,4 @@
-use abort_on_panic;
+use crate::abort_on_panic;
 use libc::c_char;
 use libnewsboat::matchererror::MatcherError;
 use std::ffi::CString;

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -1,4 +1,4 @@
-use abort_on_panic;
+use crate::abort_on_panic;
 use libc::{c_char, c_ulong};
 use libnewsboat::logger::{self, Level};
 use libnewsboat::utils;

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -1,7 +1,10 @@
 use crate::abort_on_panic;
 use libc::{c_char, c_ulong};
-use libnewsboat::logger::{self, Level};
 use libnewsboat::utils;
+use libnewsboat::{
+    log,
+    logger::{self, Level},
+};
 use std::ffi::{CStr, CString};
 use std::path;
 use std::ptr;

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libnewsboat"
 version = "2.19.0"
 authors = ["Alexander Batischev <eual.jp@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 strprintf = { path="../strprintf" }

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use crate::logger::Level;
 use crate::utils;
+use strprintf::fmt;
 
 #[derive(Default)]
 pub struct CliArgsParser {

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -3,8 +3,8 @@ use gettextrs::gettext;
 use libc::{EXIT_FAILURE, EXIT_SUCCESS};
 use std::path::PathBuf;
 
-use logger::Level;
-use utils;
+use crate::logger::Level;
+use crate::utils;
 
 #[derive(Default)]
 pub struct CliArgsParser {

--- a/rust/libnewsboat/src/configpaths.rs
+++ b/rust/libnewsboat/src/configpaths.rs
@@ -8,6 +8,7 @@ use std::fs::{self, DirBuilder};
 use std::io;
 use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
+use strprintf::fmt;
 use xdg;
 
 pub const NEWSBOAT_SUBDIR_XDG: &str = "newsboat";

--- a/rust/libnewsboat/src/configpaths.rs
+++ b/rust/libnewsboat/src/configpaths.rs
@@ -1,13 +1,13 @@
-use cliargsparser::CliArgsParser;
+use crate::cliargsparser::CliArgsParser;
+use crate::logger::{self, Level};
+use crate::utils;
 use dirs;
 use gettextrs::gettext;
 use libc;
-use logger::{self, Level};
 use std::fs::{self, DirBuilder};
 use std::io;
 use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
-use utils;
 use xdg;
 
 pub const NEWSBOAT_SUBDIR_XDG: &str = "newsboat";

--- a/rust/libnewsboat/src/filterparser.rs
+++ b/rust/libnewsboat/src/filterparser.rs
@@ -835,7 +835,7 @@ mod tests {
         );
     }
 
-    proptest! {
+    proptest::proptest! {
         #[test]
         fn does_not_crash_on_any_input(ref input in "\\PC*") {
             // Result explicitly ignored because we just want to make sure this call doesn't panic.

--- a/rust/libnewsboat/src/fmtstrformatter/limited_string.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/limited_string.rs
@@ -4,7 +4,7 @@
 //! This counts the number of "columns" the text would occupy if displayed with a monospace font.
 //! For example, "abc" has length 3, but "ＡＢＣ" has length 6, even though they both contain 3 graphemes.
 
-use utils;
+use crate::utils;
 
 pub struct LimitedString {
     /// Maximum length of this string, counted by "displayed width".

--- a/rust/libnewsboat/src/fmtstrformatter/limited_string.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/limited_string.rs
@@ -125,7 +125,7 @@ mod tests {
         assert_eq!(s.length(), limit);
     }
 
-    proptest! {
+    proptest::proptest! {
         #[test]
         fn length_never_exceeds_the_limit_one_string(
             limit in 1usize..1024,

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -3,9 +3,9 @@
 mod limited_string;
 mod parser;
 
-use self::limited_string::LimitedString;
-use self::parser::{parse, Padding, Specifier};
 use crate::utils;
+use limited_string::LimitedString;
+use parser::{parse, Padding, Specifier};
 use std::collections::BTreeMap;
 
 /// Produces strings of values in a specified format, strftime(3)-like.

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -587,7 +587,7 @@ mod tests {
         assert_eq!(fmt.do_format("%x? %y", 0), "What's the ultimate answer? 42");
     }
 
-    proptest! {
+    proptest::proptest! {
         #[test]
         fn does_not_crash_when_formatting_with_no_formats_registered(ref input in "\\PC*") {
             let fmt = FmtStrFormatter::new();

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -5,8 +5,8 @@ mod parser;
 
 use self::limited_string::LimitedString;
 use self::parser::{parse, Padding, Specifier};
+use crate::utils;
 use std::collections::BTreeMap;
-use utils;
 
 /// Produces strings of values in a specified format, strftime(3)-like.
 ///

--- a/rust/libnewsboat/src/history.rs
+++ b/rust/libnewsboat/src/history.rs
@@ -77,10 +77,8 @@ impl History {
 
 #[cfg(test)]
 mod tests {
-    use tempfile;
-
-    use self::tempfile::TempDir;
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn t_empty_history_returns_nothing() {

--- a/rust/libnewsboat/src/history.rs
+++ b/rust/libnewsboat/src/history.rs
@@ -77,7 +77,7 @@ impl History {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
+    use tempfile;
 
     use self::tempfile::TempDir;
     use super::*;

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -1,17 +1,9 @@
 #[macro_use]
 extern crate strprintf;
 
-extern crate backtrace;
-extern crate dirs;
-extern crate nom;
-extern crate once_cell;
-extern crate xdg;
 #[cfg(test)]
 #[macro_use]
 extern crate proptest;
-extern crate clap;
-extern crate gettextrs;
-extern crate libc;
 
 // This module must be declared before the others because it exports a `log!` macro that everyone
 // else uses.

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -1,10 +1,3 @@
-#[macro_use]
-extern crate strprintf;
-
-#[cfg(test)]
-#[macro_use]
-extern crate proptest;
-
 // This module must be declared before the others because it exports a `log!` macro that everyone
 // else uses.
 #[macro_use]

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -299,8 +299,7 @@ pub fn get_instance() -> &'static Logger {
 ///
 /// Most of the time, you should just use this. For example:
 /// ```no_run
-/// # #[macro_use] extern crate libnewsboat;
-/// use libnewsboat::logger::{self, Level};
+/// use libnewsboat::{log, logger::{self, Level}};
 ///
 /// fn super_cool_function(value: u32) {
 ///     log!(Level::Debug, "super_cool_function(): value = {}", value);

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -1,6 +1,6 @@
 //! Keeps a record of what the program did.
 
-extern crate chrono;
+use chrono;
 
 use self::chrono::{offset::Local, Datelike, Timelike};
 use once_cell::sync::OnceCell;
@@ -318,7 +318,7 @@ macro_rules! log {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
+    use tempfile;
 
     use super::*;
 

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -1,8 +1,6 @@
 //! Keeps a record of what the program did.
 
-use chrono;
-
-use self::chrono::{offset::Local, Datelike, Timelike};
+use chrono::{offset::Local, Datelike, Timelike};
 use once_cell::sync::OnceCell;
 use std::fmt;
 use std::fs::{File, OpenOptions};
@@ -317,14 +315,12 @@ macro_rules! log {
 
 #[cfg(test)]
 mod tests {
-    use tempfile;
-
     use super::*;
 
-    use self::chrono::{Duration, TimeZone};
-    use self::tempfile::TempDir;
+    use chrono::{Duration, TimeZone};
     use std::io::{self, BufRead, BufReader};
     use std::path;
+    use tempfile::TempDir;
 
     fn setup_logger() -> io::Result<(TempDir, path::PathBuf, path::PathBuf, Logger)> {
         let tmp = TempDir::new()?;

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -1,7 +1,7 @@
 //! Checks if given filter expression is true for a given feed or article.
 
-extern crate regex_rs;
-extern crate std;
+use regex_rs;
+use std;
 
 use self::regex_rs::{CompFlags, MatchFlags, Regex};
 use crate::filterparser::{self, Expression, Expression::*, Operator, Value};

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -4,9 +4,9 @@ extern crate regex_rs;
 extern crate std;
 
 use self::regex_rs::{CompFlags, MatchFlags, Regex};
-use filterparser::{self, Expression, Expression::*, Operator, Value};
-use matchable::Matchable;
-use matchererror::MatcherError;
+use crate::filterparser::{self, Expression, Expression::*, Operator, Value};
+use crate::matchable::Matchable;
+use crate::matchererror::MatcherError;
 
 /// Checks if given filter expression is true for a given feed or article.
 ///

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -1,12 +1,9 @@
 //! Checks if given filter expression is true for a given feed or article.
 
-use regex_rs;
-use std;
-
-use self::regex_rs::{CompFlags, MatchFlags, Regex};
 use crate::filterparser::{self, Expression, Expression::*, Operator, Value};
 use crate::matchable::Matchable;
 use crate::matchererror::MatcherError;
+use regex_rs::{CompFlags, MatchFlags, Regex};
 
 /// Checks if given filter expression is true for a given feed or article.
 ///

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -10,9 +10,9 @@ extern crate url;
 use self::unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use self::url::percent_encoding::*;
 use self::url::Url;
-use htmlrenderer;
+use crate::htmlrenderer;
+use crate::logger::{self, Level};
 use libc::c_ulong;
-use logger::{self, Level};
 use std::fs::DirBuilder;
 use std::io::{self, Write};
 use std::os::unix::fs::DirBuilderExt;
@@ -1080,7 +1080,7 @@ mod tests {
 
     #[test]
     fn t_podcast_mime_to_link_type() {
-        use htmlrenderer::LinkType::*;
+        use crate::htmlrenderer::LinkType::*;
 
         assert_eq!(podcast_mime_to_link_type("audio/mpeg"), Some(Audio));
         assert_eq!(podcast_mime_to_link_type("audio/mp3"), Some(Audio));

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -1,15 +1,3 @@
-use curl_sys;
-use dirs;
-use libc;
-use natord;
-use rand;
-use std;
-use unicode_width;
-use url;
-
-use self::unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
-use self::url::percent_encoding::*;
-use self::url::Url;
 use crate::htmlrenderer;
 use crate::logger::{self, Level};
 use libc::c_ulong;
@@ -18,6 +6,9 @@ use std::io::{self, Write};
 use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use url::percent_encoding::*;
+use url::Url;
 
 pub fn replace_all(input: String, from: &str, to: &str) -> String {
     input.replace(from, to)
@@ -1163,8 +1154,8 @@ mod tests {
 
     #[test]
     fn t_run_command_executes_given_command_with_given_argument() {
-        use self::tempfile::TempDir;
         use std::{thread, time};
+        use tempfile::TempDir;
 
         let tmp = TempDir::new().unwrap();
         let filepath = {
@@ -1333,9 +1324,9 @@ mod tests {
 
     #[test]
     fn t_mkdir_parents() {
-        use self::tempfile::TempDir;
         use std::fs;
         use std::os::unix::fs::PermissionsExt;
+        use tempfile::TempDir;
 
         let mode: u32 = 0o700;
         let tmp_dir = TempDir::new().unwrap();

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -1,11 +1,11 @@
-extern crate curl_sys;
-extern crate dirs;
-extern crate libc;
-extern crate natord;
-extern crate rand;
-extern crate std;
-extern crate unicode_width;
-extern crate url;
+use curl_sys;
+use dirs;
+use libc;
+use natord;
+use rand;
+use std;
+use unicode_width;
+use url;
 
 use self::unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use self::url::percent_encoding::*;
@@ -767,7 +767,7 @@ pub fn extract_filter(line: &str) -> (&str, &str) {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
+    use tempfile;
 
     use super::*;
 

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_cache_file.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_cache_file.rs
@@ -1,9 +1,6 @@
-use libnewsboat;
-use tempfile;
-
-use self::libnewsboat::cliargsparser::CliArgsParser;
-use self::tempfile::TempDir;
+use libnewsboat::cliargsparser::CliArgsParser;
 use std::{env, path::PathBuf};
+use tempfile::TempDir;
 
 #[test]
 fn t_cliargsparser_dash_c_resolves_tilde_to_homedir() {

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_cache_file.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_cache_file.rs
@@ -1,5 +1,5 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use libnewsboat;
+use tempfile;
 
 use self::libnewsboat::cliargsparser::CliArgsParser;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_config_file.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_config_file.rs
@@ -1,5 +1,5 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use libnewsboat;
+use tempfile;
 
 use self::libnewsboat::cliargsparser::CliArgsParser;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_config_file.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_config_file.rs
@@ -1,9 +1,6 @@
-use libnewsboat;
-use tempfile;
-
-use self::libnewsboat::cliargsparser::CliArgsParser;
-use self::tempfile::TempDir;
+use libnewsboat::cliargsparser::CliArgsParser;
 use std::{env, path::PathBuf};
+use tempfile::TempDir;
 
 #[test]
 fn t_cliargsparser_dash_capital_c_resolves_tilde_to_homedir() {

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_exportfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_exportfile.rs
@@ -1,5 +1,5 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use libnewsboat;
+use tempfile;
 
 use self::libnewsboat::cliargsparser::CliArgsParser;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_exportfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_exportfile.rs
@@ -1,9 +1,6 @@
-use libnewsboat;
-use tempfile;
-
-use self::libnewsboat::cliargsparser::CliArgsParser;
-use self::tempfile::TempDir;
+use libnewsboat::cliargsparser::CliArgsParser;
 use std::{env, path::PathBuf};
+use tempfile::TempDir;
 
 #[test]
 fn t_cliargsparser_dash_capital_e_resolves_tilde_to_homedir() {

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_importfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_importfile.rs
@@ -1,9 +1,6 @@
-use libnewsboat;
-use tempfile;
-
-use self::libnewsboat::cliargsparser::CliArgsParser;
-use self::tempfile::TempDir;
+use libnewsboat::cliargsparser::CliArgsParser;
 use std::{env, path::PathBuf};
+use tempfile::TempDir;
 
 #[test]
 fn t_cliargsparser_dash_capital_i_resolves_tilde_to_homedir() {

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_importfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_importfile.rs
@@ -1,5 +1,5 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use libnewsboat;
+use tempfile;
 
 use self::libnewsboat::cliargsparser::CliArgsParser;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_logfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_logfile.rs
@@ -1,5 +1,5 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use libnewsboat;
+use tempfile;
 
 use self::libnewsboat::cliargsparser::CliArgsParser;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_logfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_logfile.rs
@@ -1,9 +1,6 @@
-use libnewsboat;
-use tempfile;
-
-use self::libnewsboat::cliargsparser::CliArgsParser;
-use self::tempfile::TempDir;
+use libnewsboat::cliargsparser::CliArgsParser;
 use std::{env, path::PathBuf};
+use tempfile::TempDir;
 
 #[test]
 fn t_cliargsparser_dash_d_resolves_tilde_to_homedir() {

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_opmlfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_opmlfile.rs
@@ -1,9 +1,6 @@
-use libnewsboat;
-use tempfile;
-
-use self::libnewsboat::cliargsparser::CliArgsParser;
-use self::tempfile::TempDir;
+use libnewsboat::cliargsparser::CliArgsParser;
 use std::{env, path::PathBuf};
+use tempfile::TempDir;
 
 #[test]
 fn t_cliargsparser_dash_i_resolves_tilde_to_homedir() {

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_opmlfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_opmlfile.rs
@@ -1,5 +1,5 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use libnewsboat;
+use tempfile;
 
 use self::libnewsboat::cliargsparser::CliArgsParser;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_urlfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_urlfile.rs
@@ -1,5 +1,5 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use libnewsboat;
+use tempfile;
 
 use self::libnewsboat::cliargsparser::CliArgsParser;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_urlfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_urlfile.rs
@@ -1,9 +1,6 @@
-use libnewsboat;
-use tempfile;
-
-use self::libnewsboat::cliargsparser::CliArgsParser;
-use self::tempfile::TempDir;
+use libnewsboat::cliargsparser::CliArgsParser;
 use std::{env, path::PathBuf};
+use tempfile::TempDir;
 
 #[test]
 fn t_cliargsparser_dash_u_resolves_tilde_to_homedir() {

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_dotdir_doeesnt_exist_and_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_dotdir_doeesnt_exist_and_couldnt_be_created.rs
@@ -1,4 +1,4 @@
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use std::env;

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_dotdir_doeesnt_exist_and_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_dotdir_doeesnt_exist_and_couldnt_be_created.rs
@@ -1,7 +1,5 @@
-use tempfile;
-
-use self::tempfile::TempDir;
 use std::env;
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
@@ -1,8 +1,6 @@
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::tempfile::TempDir;
 use std::{env, fs};
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate section_testing;
+use section_testing::{enable_sections, section};
 use tempfile;
 
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate section_testing;
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use std::{env, fs};

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
@@ -1,6 +1,6 @@
-extern crate libnewsboat;
-extern crate rand;
-extern crate tempfile;
+use libnewsboat;
+use rand;
+use tempfile;
 #[macro_use]
 extern crate section_testing;
 

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
@@ -1,8 +1,7 @@
 use libnewsboat;
 use rand;
+use section_testing::{enable_sections, section};
 use tempfile;
-#[macro_use]
-extern crate section_testing;
 
 use self::libnewsboat::configpaths::ConfigPaths;
 use self::rand::random;

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
@@ -1,12 +1,8 @@
-use libnewsboat;
-use rand;
+use libnewsboat::configpaths::ConfigPaths;
+use rand::random;
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::libnewsboat::configpaths::ConfigPaths;
-use self::rand::random;
-use self::tempfile::TempDir;
 use std::{env, fs, path};
+use tempfile::TempDir;
 
 fn assert_dirs_exist_after_create_dirs(dirs: &[&path::Path], tmp: &TempDir) {
     let paths = ConfigPaths::new();

--- a/rust/libnewsboat/tests/configpaths_helpers/mod.rs
+++ b/rust/libnewsboat/tests/configpaths_helpers/mod.rs
@@ -5,16 +5,13 @@
 // `libc` contains file mode constants, like S_IXUSR, which are useful for `struct Chmod`. Thus it
 // makes sense to re-export the crate.
 pub use libc;
-use libnewsboat;
-use rand;
-use tempfile;
 
-use self::libnewsboat::configpaths::ConfigPaths;
-use self::rand::random;
-use self::tempfile::TempDir;
+use libnewsboat::configpaths::ConfigPaths;
+use rand::random;
 use std::io::{Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::{fs, path};
+use tempfile::TempDir;
 
 /// Strings that are placed in files before running commands, to see if commands modify those
 /// files.

--- a/rust/libnewsboat/tests/configpaths_helpers/mod.rs
+++ b/rust/libnewsboat/tests/configpaths_helpers/mod.rs
@@ -4,10 +4,10 @@
 
 // `libc` contains file mode constants, like S_IXUSR, which are useful for `struct Chmod`. Thus it
 // makes sense to re-export the crate.
-pub extern crate libc;
-extern crate libnewsboat;
-extern crate rand;
-extern crate tempfile;
+pub use libc;
+use libnewsboat;
+use rand;
+use tempfile;
 
 use self::libnewsboat::configpaths::ConfigPaths;
 use self::rand::random;

--- a/rust/libnewsboat/tests/configpaths_process_args_replaces_paths_with_the_ones_supplied_by_cliargsparser.rs
+++ b/rust/libnewsboat/tests/configpaths_process_args_replaces_paths_with_the_ones_supplied_by_cliargsparser.rs
@@ -1,4 +1,4 @@
-extern crate libnewsboat;
+use libnewsboat;
 
 use self::libnewsboat::{cliargsparser::CliArgsParser, configpaths::ConfigPaths};
 use std::env;

--- a/rust/libnewsboat/tests/configpaths_process_args_replaces_paths_with_the_ones_supplied_by_cliargsparser.rs
+++ b/rust/libnewsboat/tests/configpaths_process_args_replaces_paths_with_the_ones_supplied_by_cliargsparser.rs
@@ -1,6 +1,4 @@
-use libnewsboat;
-
-use self::libnewsboat::{cliargsparser::CliArgsParser, configpaths::ConfigPaths};
+use libnewsboat::{cliargsparser::CliArgsParser, configpaths::ConfigPaths};
 use std::env;
 use std::path::Path;
 

--- a/rust/libnewsboat/tests/configpaths_returns_paths_to_dotdir.rs
+++ b/rust/libnewsboat/tests/configpaths_returns_paths_to_dotdir.rs
@@ -1,10 +1,7 @@
-use libnewsboat;
-use tempfile;
-
-use self::libnewsboat::configpaths::ConfigPaths;
-use self::tempfile::TempDir;
+use libnewsboat::configpaths::ConfigPaths;
 use std::env;
 use std::fs;
+use tempfile::TempDir;
 
 #[test]
 fn t_returns_paths_to_newsboat_dotdir_if_no_newsboat_dirs_exist() {

--- a/rust/libnewsboat/tests/configpaths_returns_paths_to_dotdir.rs
+++ b/rust/libnewsboat/tests/configpaths_returns_paths_to_dotdir.rs
@@ -1,5 +1,5 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use libnewsboat;
+use tempfile;
 
 use self::libnewsboat::configpaths::ConfigPaths;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
+++ b/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
@@ -1,10 +1,7 @@
-use libnewsboat;
+use libnewsboat::configpaths::ConfigPaths;
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::libnewsboat::configpaths::ConfigPaths;
-use self::tempfile::TempDir;
 use std::{env, fs, path};
+use tempfile::TempDir;
 
 fn assert_paths_are_inside_dirs(config_dir: &path::Path, data_dir: &path::Path) {
     let paths = ConfigPaths::new();

--- a/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
+++ b/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
@@ -1,7 +1,7 @@
-extern crate libnewsboat;
+use libnewsboat;
 #[macro_use]
 extern crate section_testing;
-extern crate tempfile;
+use tempfile;
 
 use self::libnewsboat::configpaths::ConfigPaths;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
+++ b/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
@@ -1,6 +1,5 @@
 use libnewsboat;
-#[macro_use]
-extern crate section_testing;
+use section_testing::{enable_sections, section};
 use tempfile;
 
 use self::libnewsboat::configpaths::ConfigPaths;

--- a/rust/libnewsboat/tests/configpaths_set_cache_file_changes_paths_to_cache_and_lock_files.rs
+++ b/rust/libnewsboat/tests/configpaths_set_cache_file_changes_paths_to_cache_and_lock_files.rs
@@ -1,4 +1,4 @@
-extern crate libnewsboat;
+use libnewsboat;
 
 use self::libnewsboat::configpaths::ConfigPaths;
 use std::{env, path};

--- a/rust/libnewsboat/tests/configpaths_set_cache_file_changes_paths_to_cache_and_lock_files.rs
+++ b/rust/libnewsboat/tests/configpaths_set_cache_file_changes_paths_to_cache_and_lock_files.rs
@@ -1,6 +1,4 @@
-use libnewsboat;
-
-use self::libnewsboat::configpaths::ConfigPaths;
+use libnewsboat::configpaths::ConfigPaths;
 use std::{env, path};
 
 #[test]

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
@@ -1,6 +1,5 @@
 use libnewsboat;
-#[macro_use]
-extern crate section_testing;
+use section_testing::{enable_sections, section};
 use tempfile;
 
 use self::libnewsboat::{cliargsparser::CliArgsParser, configpaths::ConfigPaths};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
@@ -1,7 +1,7 @@
-extern crate libnewsboat;
+use libnewsboat;
 #[macro_use]
 extern crate section_testing;
-extern crate tempfile;
+use tempfile;
 
 use self::libnewsboat::{cliargsparser::CliArgsParser, configpaths::ConfigPaths};
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
@@ -1,10 +1,7 @@
-use libnewsboat;
+use libnewsboat::{cliargsparser::CliArgsParser, configpaths::ConfigPaths};
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::libnewsboat::{cliargsparser::CliArgsParser, configpaths::ConfigPaths};
-use self::tempfile::TempDir;
 use std::env;
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_dotdir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_dotdir_already_exists.rs
@@ -1,4 +1,4 @@
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use std::{env, fs};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_dotdir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_dotdir_already_exists.rs
@@ -1,7 +1,5 @@
-use tempfile;
-
-use self::tempfile::TempDir;
 use std::{env, fs};
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
@@ -1,8 +1,6 @@
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::tempfile::TempDir;
 use std::{env, fs};
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate section_testing;
+use section_testing::{enable_sections, section};
 use tempfile;
 
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate section_testing;
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use std::{env, fs};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
@@ -1,8 +1,6 @@
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::tempfile::TempDir;
 use std::{env, fs};
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate section_testing;
+use section_testing::{enable_sections, section};
 use tempfile;
 
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate section_testing;
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use std::{env, fs};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_dotdir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_dotdir_couldnt_be_created.rs
@@ -4,7 +4,7 @@ use self::tempfile::TempDir;
 use std::env;
 
 mod configpaths_helpers;
-use configpaths_helpers::libc::{S_IRUSR, S_IXUSR};
+use crate::configpaths_helpers::libc::{S_IRUSR, S_IXUSR};
 
 #[test]
 fn t_configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_dotdir_couldnt_be_created(

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_dotdir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_dotdir_couldnt_be_created.rs
@@ -1,4 +1,4 @@
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use std::env;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_dotdir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_dotdir_couldnt_be_created.rs
@@ -1,7 +1,5 @@
-use tempfile;
-
-use self::tempfile::TempDir;
 use std::env;
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 use crate::configpaths_helpers::libc::{S_IRUSR, S_IXUSR};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
@@ -6,7 +6,7 @@ use self::tempfile::TempDir;
 use std::{env, fs};
 
 mod configpaths_helpers;
-use configpaths_helpers::libc::{S_IRUSR, S_IXUSR};
+use crate::configpaths_helpers::libc::{S_IRUSR, S_IXUSR};
 
 enable_sections! {
 #[test]

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate section_testing;
+use section_testing::{enable_sections, section};
 use tempfile;
 
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate section_testing;
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use std::{env, fs};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
@@ -1,8 +1,6 @@
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::tempfile::TempDir;
 use std::{env, fs};
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 use crate::configpaths_helpers::libc::{S_IRUSR, S_IXUSR};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
@@ -6,7 +6,7 @@ use self::tempfile::TempDir;
 use std::{env, fs};
 
 mod configpaths_helpers;
-use configpaths_helpers::libc::{S_IRUSR, S_IXUSR};
+use crate::configpaths_helpers::libc::{S_IRUSR, S_IXUSR};
 
 enable_sections! {
 #[test]

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate section_testing;
+use section_testing::{enable_sections, section};
 use tempfile;
 
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate section_testing;
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use std::{env, fs};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
@@ -1,8 +1,6 @@
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::tempfile::TempDir;
 use std::{env, fs};
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 use crate::configpaths_helpers::libc::{S_IRUSR, S_IXUSR};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
@@ -1,10 +1,7 @@
-use libnewsboat;
+use libnewsboat::configpaths::ConfigPaths;
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::libnewsboat::configpaths::ConfigPaths;
-use self::tempfile::TempDir;
 use std::{env, fs, path};
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
@@ -1,7 +1,7 @@
-extern crate libnewsboat;
+use libnewsboat;
 #[macro_use]
 extern crate section_testing;
-extern crate tempfile;
+use tempfile;
 
 use self::libnewsboat::configpaths::ConfigPaths;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
@@ -1,6 +1,5 @@
 use libnewsboat;
-#[macro_use]
-extern crate section_testing;
+use section_testing::{enable_sections, section};
 use tempfile;
 
 use self::libnewsboat::configpaths::ConfigPaths;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_dotdir_to_default_newsboat_dotdir.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_dotdir_to_default_newsboat_dotdir.rs
@@ -1,5 +1,5 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use libnewsboat;
+use tempfile;
 
 use self::libnewsboat::configpaths::ConfigPaths;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_dotdir_to_default_newsboat_dotdir.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_dotdir_to_default_newsboat_dotdir.rs
@@ -1,9 +1,6 @@
-use libnewsboat;
-use tempfile;
-
-use self::libnewsboat::configpaths::ConfigPaths;
-use self::tempfile::TempDir;
+use libnewsboat::configpaths::ConfigPaths;
 use std::env;
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
@@ -1,10 +1,7 @@
-use libnewsboat;
+use libnewsboat::configpaths::ConfigPaths;
 use section_testing::{enable_sections, section};
-use tempfile;
-
-use self::libnewsboat::configpaths::ConfigPaths;
-use self::tempfile::TempDir;
 use std::{env, fs, path};
+use tempfile::TempDir;
 
 mod configpaths_helpers;
 

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
@@ -1,7 +1,7 @@
-extern crate libnewsboat;
+use libnewsboat;
 #[macro_use]
 extern crate section_testing;
-extern crate tempfile;
+use tempfile;
 
 use self::libnewsboat::configpaths::ConfigPaths;
 use self::tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
@@ -1,6 +1,5 @@
 use libnewsboat;
-#[macro_use]
-extern crate section_testing;
+use section_testing::{enable_sections, section};
 use tempfile;
 
 use self::libnewsboat::configpaths::ConfigPaths;

--- a/rust/libnewsboat/tests/get_default_browser.rs
+++ b/rust/libnewsboat/tests/get_default_browser.rs
@@ -1,5 +1,3 @@
-extern crate libnewsboat;
-
 use libnewsboat::utils;
 use std::env;
 

--- a/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
+++ b/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
@@ -1,5 +1,4 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use libnewsboat::utils;

--- a/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
+++ b/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
@@ -1,8 +1,6 @@
-use tempfile;
-
-use self::tempfile::TempDir;
 use libnewsboat::utils;
 use std::env;
+use tempfile::TempDir;
 
 #[test]
 fn t_getcwd_returns_an_error_if_current_directory_doesnt_exist() {

--- a/rust/libnewsboat/tests/getcwd_returns_non-empty_string.rs
+++ b/rust/libnewsboat/tests/getcwd_returns_non-empty_string.rs
@@ -1,5 +1,3 @@
-extern crate libnewsboat;
-
 use libnewsboat::utils;
 use std::path::Path;
 

--- a/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
+++ b/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
@@ -1,8 +1,6 @@
-use tempfile;
-
-use self::tempfile::TempDir;
 use libnewsboat::utils;
 use std::env;
+use tempfile::TempDir;
 
 #[test]
 fn t_getcwd_value_depends_on_current_directory() {

--- a/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
+++ b/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
@@ -1,5 +1,4 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use libnewsboat::utils;

--- a/rust/libnewsboat/tests/global_logger_creates_logfile.rs
+++ b/rust/libnewsboat/tests/global_logger_creates_logfile.rs
@@ -1,5 +1,4 @@
-extern crate libnewsboat;
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use libnewsboat::logger::get_instance;

--- a/rust/libnewsboat/tests/global_logger_creates_logfile.rs
+++ b/rust/libnewsboat/tests/global_logger_creates_logfile.rs
@@ -1,7 +1,5 @@
-use tempfile;
-
-use self::tempfile::TempDir;
 use libnewsboat::logger::get_instance;
+use tempfile::TempDir;
 
 #[test]
 fn t_get_instance_returns_valid_logger() {

--- a/rust/libnewsboat/tests/log_macro_works.rs
+++ b/rust/libnewsboat/tests/log_macro_works.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate libnewsboat;
-extern crate tempfile;
+use tempfile;
 
 use self::tempfile::TempDir;
 use libnewsboat::logger::{self, get_instance, Level};

--- a/rust/libnewsboat/tests/log_macro_works.rs
+++ b/rust/libnewsboat/tests/log_macro_works.rs
@@ -1,6 +1,3 @@
-use tempfile;
-
-use self::tempfile::TempDir;
 use libnewsboat::{
     log,
     logger::{self, get_instance, Level},
@@ -8,6 +5,7 @@ use libnewsboat::{
 use std::fs::File;
 use std::io::{BufRead, BufReader, Result};
 use std::path;
+use tempfile::TempDir;
 
 fn log_contains_n_lines(logfile: &path::Path, n: usize) -> Result<()> {
     let file = File::open(logfile)?;

--- a/rust/libnewsboat/tests/log_macro_works.rs
+++ b/rust/libnewsboat/tests/log_macro_works.rs
@@ -1,9 +1,10 @@
-#[macro_use]
-extern crate libnewsboat;
 use tempfile;
 
 use self::tempfile::TempDir;
-use libnewsboat::logger::{self, get_instance, Level};
+use libnewsboat::{
+    log,
+    logger::{self, get_instance, Level},
+};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Result};
 use std::path;

--- a/rust/libnewsboat/tests/resolve_tilde.rs
+++ b/rust/libnewsboat/tests/resolve_tilde.rs
@@ -1,5 +1,3 @@
-extern crate libnewsboat;
-
 use libnewsboat::utils;
 use std::env;
 use std::path::{Path, PathBuf};

--- a/rust/strprintf/Cargo.toml
+++ b/rust/strprintf/Cargo.toml
@@ -2,6 +2,7 @@
 name = "strprintf"
 version = "0.1.0"
 authors = ["Alexander Batischev <eual.jp@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 libc = "0.2"

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -14,7 +14,7 @@
 // formatting macro accepts. Everything else will result in a compile-time error. See the docs in
 // `trait` module for more on that.
 
-extern crate libc;
+use libc;
 
 pub mod specifiers_iterator;
 // Re-exporting so that macro can just import the whole crate and get everything it needs.
@@ -136,7 +136,7 @@ macro_rules! fmt {
 
 #[cfg(test)]
 mod tests {
-    extern crate libc;
+    use libc;
 
     #[test]
     fn returns_first_argument_if_it_is_the_only_one() {

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -18,14 +18,14 @@ extern crate libc;
 
 pub mod specifiers_iterator;
 // Re-exporting so that macro can just import the whole crate and get everything it needs.
-pub use specifiers_iterator::SpecifiersIterator;
+pub use crate::specifiers_iterator::SpecifiersIterator;
 
 pub mod traits;
 
+use crate::traits::*;
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::vec::Vec;
-use traits::*;
 
 // Re-exporting platform-specific format specifiers.
 #[cfg(target_pointer_width = "32")]
@@ -36,7 +36,7 @@ pub use format_specifiers_32bit::*;
 #[cfg(target_pointer_width = "64")]
 mod format_specifiers_64bit;
 #[cfg(target_pointer_width = "64")]
-pub use format_specifiers_64bit::*;
+pub use crate::format_specifiers_64bit::*;
 
 /// Helper function to `fmt!`. **Use it only through that macro!**
 ///

--- a/rust/strprintf/src/traits.rs
+++ b/rust/strprintf/src/traits.rs
@@ -27,7 +27,7 @@
 //! For numeric types, the holder is the same as the type itself, and the values are simply copied.
 //! For example, `u64`'s "holder" is `u64`, which is then borrowed to get a `u64` again.
 
-extern crate libc;
+use libc;
 
 use std::ffi::CString;
 


### PR DESCRIPTION
`extern crate` makes it less obvious where a given macro comes from. Especially the way we use it, i.e. by putting all `extern crate` lines at the root of the crate, where they affect *all* of our modules. Rust 2018 brings a slightly different system where macros are imported just like functions, e.g. `use strprintf::fmt` instead of `#[macro_use] extern crate strprintf;`.

The majority of these changes were automated. All I did was:
1. `cargo fix --edition --package CRATE_NAME && cargo fmt`, review and commit;
2. edit rust/CRATE_NAME/Cargo.toml to include `edition = "2018"`. Commit;
3. `cargo fix --edition-idioms CRATE_NAME && cargo fmt`, review and commit.

(There were a few more changes from`cargo fix`, but I only committed those that related to `extern crate` and `use`.)

The only changes that were done manually are in https://github.com/newsboat/newsboat/commit/97665ae5f4038ce0297c31c000741b39ba6f8d53 and https://github.com/newsboat/newsboat/commit/09c3ed6c979fa0a47594b1d82be86213780e826d.

These changes mean our code now requires Rust 1.31+. Considering no-one responded to our warning about scheduled MSRV bumps (#709), and no-one complained about `master` requiring 1.40+, this should not be a problem.

Despite the number of changed files, this is a very lightweight PR, so I'll merge it in three days. Reviews are welcome as usual!