### PR TITLE
Use "-C panic=abort" instead of "-Zno-landing-pads"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ matrix:
 
           # Can't have these in the `env` section above, because these settings break `cargo install`
         - export CARGO_INCREMENTAL=0
-        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads"
+        - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
     - name: "i18nspector"
       addons:
         apt:


### PR DESCRIPTION
Needed because rust removed support for "-Zno-landing-pads":
https://github.com/rust-lang/rust/pull/70175

This caused our Test Coverage build to fail:
https://travis-ci.com/github/newsboat/newsboat/jobs/326201747#L651-L656