### PR TITLE
A bit of CI upkeep

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,7 +40,7 @@ freebsd_task:
         - rm -rf $HOME/.cargo/registry/index
 
 32bit_ubuntu_task:
-    name: Linux i686
+    name: Linux i686 (Ubuntu 18.04)
     container:
         dockerfile: docker/ubuntu_18.04-i686.dockerfile
     cargo_cache:
@@ -133,7 +133,7 @@ linux_task:
     matrix:
         # This job tests our minimum supported Rust version, so only bump on
         # Newsboat release day
-        - name: Rust 1.40.0, GCC 4.9
+        - name: Rust 1.40.0, GCC 4.9 (Ubuntu 16.04)
           container:
             dockerfile: docker/ubuntu_16.04-build-tools.dockerfile
             docker_arguments:
@@ -143,7 +143,7 @@ linux_task:
                 rust_version: 1.40.0
         # This job tests our minimum supported Rust version, so only bump on
         # Newsboat release day
-        - name: Rust 1.40.0, GCC 9
+        - name: Rust 1.40.0, GCC 9 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
@@ -151,84 +151,84 @@ linux_task:
                 cc: gcc-9
                 cxx: g++-9
                 rust_version: 1.40.0
-        - name: Rust 1.43.1, GCC 4.9
+        - name: Rust 1.43.1, GCC 4.9 (Ubuntu 16.04)
           container:
             dockerfile: docker/ubuntu_16.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-4.9
                 cc: gcc-4.9
                 cxx: g++-4.9
-        - name: Rust 1.43.1, GCC 5
+        - name: Rust 1.43.1, GCC 5 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-5
                 cc: gcc-5
                 cxx: g++-5
-        - name: Rust 1.43.1, GCC 6
+        - name: Rust 1.43.1, GCC 6 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-6
                 cc: gcc-6
                 cxx: g++-6
-        - name: Rust 1.43.1, GCC 7
+        - name: Rust 1.43.1, GCC 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-7
                 cc: gcc-7
                 cxx: g++-7
-        - name: Rust 1.43.1, GCC 8
+        - name: Rust 1.43.1, GCC 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-8
                 cc: gcc-8
                 cxx: g++-8
-        - name: Rust 1.43.1, GCC 9
+        - name: Rust 1.43.1, GCC 9 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-9
                 cc: gcc-9
                 cxx: g++-9
-        - name: Rust 1.43.1, Clang 4.0
+        - name: Rust 1.43.1, Clang 4.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-4.0
                 cc: clang-4.0
                 cxx: clang++-4.0
-        - name: Rust 1.43.1, Clang 5.0
+        - name: Rust 1.43.1, Clang 5.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-5.0
                 cc: clang-5.0
                 cxx: clang++-5.0
-        - name: Rust 1.43.1, Clang 6.0
+        - name: Rust 1.43.1, Clang 6.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-6.0
                 cc: clang-6.0
                 cxx: clang++-6.0
-        - name: Rust 1.43.1, Clang 7
+        - name: Rust 1.43.1, Clang 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-7
                 cc: clang-7
                 cxx: clang++-7
-        - name: Rust 1.43.1, Clang 8
+        - name: Rust 1.43.1, Clang 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-8
                 cc: clang-8
                 cxx: clang++-8
-        - name: Rust 1.43.1, Clang 9
+        - name: Rust 1.43.1, Clang 9 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
@@ -245,7 +245,7 @@ linux_task:
     before_cache_script: *before_cache_script
 
 address_sanitizer_task:
-    name: AddressSanitizer
+    name: AddressSanitizer (Clang 9, Ubuntu 18.04)
 
     container:
       dockerfile: docker/ubuntu_18.04-build-tools.dockerfile

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,7 +135,7 @@ linux_task:
         # Newsboat release day
         - name: Rust 1.40.0, GCC 9
           container:
-            dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
+            dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-9
                 cc: gcc-9
@@ -171,7 +171,7 @@ linux_task:
                 cxx: g++-8
         - name: Rust 1.43.1, GCC 9
           container:
-            dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
+            dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-9
                 cc: gcc-9
@@ -260,7 +260,7 @@ depslist_task:
     container:
       cpu: 1
       memory: 512MB
-      dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
+      dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
       docker_arguments:
           cxx_package: g++-9
           cc: gcc-9

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -210,6 +210,13 @@ linux_task:
                 cxx_package: g++-9
                 cc: gcc-9
                 cxx: g++-9
+        - name: Rust 1.43.1, GCC 10 (Ubuntu 20.04)
+          container:
+            dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: g++-10
+                cc: gcc-10
+                cxx: g++-10
         - name: Rust 1.43.1, Clang 4.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -131,7 +131,7 @@ formatting_task:
 
 linux_task:
     matrix:
-        # This job tests our minimum supported Rust version, so only bump on
+        # These two jobs test our minimum supported Rust version, so only bump on
         # Newsboat release day
         - name: Rust 1.40.0, GCC 4.9 (Ubuntu 16.04)
           container:
@@ -141,8 +141,6 @@ linux_task:
                 cc: gcc-4.9
                 cxx: g++-4.9
                 rust_version: 1.40.0
-        # This job tests our minimum supported Rust version, so only bump on
-        # Newsboat release day
         - name: Rust 1.40.0, GCC 9 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
@@ -151,6 +149,25 @@ linux_task:
                 cc: gcc-9
                 cxx: g++-9
                 rust_version: 1.40.0
+
+        - name: GCC 8, more warnings and checks (Ubuntu 18.04)
+          container:
+            dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: g++-8
+                cc: gcc-8
+                cxx: g++-8
+          env: &extra_warnings_and_checks_env
+            CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
+        - name: Clang 8, more warnings and checks (Ubuntu 18.04)
+          container:
+            dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: clang-8
+                cc: clang-8
+                cxx: clang++-8
+          env: *extra_warnings_and_checks_env
+
         - name: Rust 1.43.1, GCC 4.9 (Ubuntu 16.04)
           container:
             dockerfile: docker/ubuntu_16.04-build-tools.dockerfile

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -133,6 +133,16 @@ linux_task:
     matrix:
         # This job tests our minimum supported Rust version, so only bump on
         # Newsboat release day
+        - name: Rust 1.40.0, GCC 4.9
+          container:
+            dockerfile: docker/ubuntu_16.04-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: g++-4.9
+                cc: gcc-4.9
+                cxx: g++-4.9
+                rust_version: 1.40.0
+        # This job tests our minimum supported Rust version, so only bump on
+        # Newsboat release day
         - name: Rust 1.40.0, GCC 9
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
@@ -141,6 +151,13 @@ linux_task:
                 cc: gcc-9
                 cxx: g++-9
                 rust_version: 1.40.0
+        - name: Rust 1.43.1, GCC 4.9
+          container:
+            dockerfile: docker/ubuntu_16.04-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: g++-4.9
+                cc: gcc-4.9
+                cxx: g++-4.9
         - name: Rust 1.43.1, GCC 5
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -259,6 +259,13 @@ linux_task:
                 cxx_package: clang-9
                 cc: clang-9
                 cxx: clang++-9
+        - name: Rust 1.43.1, Clang 10 (Ubuntu 20.04)
+          container:
+            dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: clang-10
+                cc: clang-10
+                cxx: clang++-10
 
     cargo_cache:
         folder: $HOME/.cargo/registry

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,31 +60,6 @@ matrix:
       env:
         - COMPILER=clang++-8
       script: *release_build_script
-    - compiler: gcc-4.9
-      os: linux
-      dist: xenial
-      rust: 1.40.0
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:
-            - g++-4.9
-            - *global_deps
-      env:
-        - COMPILER=g++-4.9
-    - compiler: gcc-4.9
-      os: linux
-      dist: xenial
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:
-            - g++-4.9
-            - *global_deps
-      env:
-        - COMPILER=g++-4.9
     - name: "Test Coverage"
       compiler: clang-8
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,35 +31,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - compiler: gcc-8
-      os: linux
-      dist: bionic
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:
-            - g++-8
-            - *global_deps
-      env:
-        - COMPILER=g++-8
-      script: &release_build_script
-        - CXXFLAGS="$CXXFLAGS -Wnull-dereference -Wdouble-promotion -O3" make -j2 --keep-going all test
-        - ( cd test && ./test --order rand ); ret=$?; (cargo test) && sh -c "exit $ret"
-    - compiler: clang-8
-      os: linux
-      dist: bionic
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:
-            - clang-8
-            - llvm-8
-            - *clang_deps
-      env:
-        - COMPILER=clang++-8
-      script: *release_build_script
     - name: "Test Coverage"
       compiler: clang-8
       os: linux

--- a/docker/ubuntu_16.04-build-tools.dockerfile
+++ b/docker/ubuntu_16.04-build-tools.dockerfile
@@ -1,0 +1,92 @@
+# All the programs and libraries necessary to build Newsboat with an older
+# C++ compiler. Contains GCC 4.9 and Rust 1.43.1 by default.
+#
+# Configurable via build-args:
+#
+# - cxx_package -- additional Ubuntu packages to install. Default: g++-4.9
+# - rust_version -- Rust version to install. Default: 1.43.1
+# - cc -- C compiler to use. This gets copied into CC environment variable.
+#       Default: gcc-4.9
+# - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
+#       Default: g++-4.9
+#
+# Build with defaults:
+#
+#   docker build \
+#       --tag=newsboat-build-tools \
+#       --file=docker/ubuntu_16.04-build-tools.dockerfile \
+#       docker
+#
+# Build with non-default compiler and Rust version:
+#
+#   docker build \
+#       --tag=newsboat-build-tools \
+#       --file=docker/ubuntu_16.04-build-tools.dockerfile \
+#       --build-arg cxx_package=clang-3.6 \
+#       --build-arg cc=clang-3.6 \
+#       --build-arg cxx=clang++-3.6 \
+#       --build-arg rust_version=1.40.0 \
+#       docker
+#
+# Run on your local files:
+#
+#   docker run \
+#       --rm \
+#       --mount type=bind,source=$(pwd),target=/home/builder/src \
+#       --mount type=bind,source=$HOME/.cargo,target=/home/builder/.cargo \
+#       --user $(id -u):$(id -g) \
+#       newsboat-build-tools \
+#       make
+
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PATH /home/builder/.cargo/bin:$PATH
+
+RUN apt-get update \
+    && apt-get upgrade --assume-yes
+
+ARG cxx_package=g++-4.9
+
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends \
+        build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
+        libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
+        pkg-config asciidoctor wget \
+    && apt-get autoremove \
+    && apt-get clean
+
+RUN addgroup --gid 1000 builder \
+    && adduser --home /home/builder --uid 1000 --ingroup builder \
+        --disabled-password --shell /bin/bash builder \
+    && mkdir -p /home/builder/src \
+    && chown -R builder:builder /home/builder
+
+RUN apt-get install locales \
+    && echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
+    && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+USER builder
+WORKDIR /home/builder/src
+
+ARG rust_version=1.43.1
+
+RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
+    && chmod +x $HOME/rustup.sh \
+    && $HOME/rustup.sh -y \
+        --default-host x86_64-unknown-linux-gnu \
+        --default-toolchain $rust_version \
+        # Install only rustc, rust-std, and cargo
+        --profile minimal \
+    && chmod a+w $HOME/.cargo
+
+ENV HOME /home/builder
+
+ARG cc=gcc-4.9
+ARG cxx=g++-4.9
+
+ENV CC=$cc
+ENV CXX=$cxx

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,11 +1,11 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 9
-# and Rust 1.41.0 by default. It has ubuntu-toolchain-r/test PPA already
+# and Rust 1.43.1 by default. It has ubuntu-toolchain-r/test PPA already
 # connected, so most of the compilers that Newsboat supports are available.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.41.0
+# - rust_version -- Rust version to install. Default: 1.43.1
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,6 +1,5 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.43.1 by default. It has ubuntu-toolchain-r/test PPA already
-# connected, so most of the compilers that Newsboat supports are available.
+# and Rust 1.43.1 by default.
 #
 # Configurable via build-args:
 #
@@ -45,9 +44,6 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PATH /home/builder/.cargo/bin:$PATH
 
 RUN apt-get update \
-    && apt-get install --assume-yes --no-install-recommends software-properties-common \
-    && add-apt-repository "ppa:ubuntu-toolchain-r/test" \
-    && apt-get update \
     && apt-get upgrade --assume-yes
 
 ARG cxx_package=g++-8

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,32 +1,31 @@
-# All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.43.1 by default. It has ubuntu-toolchain-r/test PPA already
-# connected, so most of the compilers that Newsboat supports are available.
+# All the programs and libraries necessary to build Newsboat with newer
+# compilers. Contains GCC 9 and Rust 1.43.1 by default.
 #
 # Configurable via build-args:
 #
-# - cxx_package -- additional Ubuntu packages to install. Default: g++-8
+# - cxx_package -- additional Ubuntu packages to install. Default: g++-9
 # - rust_version -- Rust version to install. Default: 1.43.1
 # - cc -- C compiler to use. This gets copied into CC environment variable.
-#       Default: gcc-8
+#       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
-#       Default: g++-8
+#       Default: g++-9
 #
 # Build with defaults:
 #
 #   docker build \
 #       --tag=newsboat-build-tools \
-#       --file=docker/ubuntu_18.04-build-tools.dockerfile \
+#       --file=docker/ubuntu_20.04-build-tools.dockerfile \
 #       docker
 #
 # Build with non-default compiler and Rust version:
 #
 #   docker build \
 #       --tag=newsboat-build-tools \
-#       --file=docker/ubuntu_18.04-build-tools.dockerfile \
-#       --build-arg cxx_package=clang-7 \
-#       --build-arg cc=clang-7 \
-#       --build-arg cxx=clang++-7 \
-#       --build-arg rust_version=1.26.1 \
+#       --file=docker/ubuntu_20.04-build-tools.dockerfile \
+#       --build-arg cxx_package=clang-10 \
+#       --build-arg cc=clang-10 \
+#       --build-arg cxx=clang++-10 \
+#       --build-arg rust_version=1.40.0 \
 #       docker
 #
 # Run on your local files:
@@ -39,24 +38,21 @@
 #       newsboat-build-tools \
 #       make
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV PATH /home/builder/.cargo/bin:$PATH
 
 RUN apt-get update \
-    && apt-get install --assume-yes --no-install-recommends software-properties-common \
-    && add-apt-repository "ppa:ubuntu-toolchain-r/test" \
-    && apt-get update \
     && apt-get upgrade --assume-yes
 
-ARG cxx_package=g++-8
+ARG cxx_package=g++-9
 
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
         build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
         libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
-        asciidoctor wget \
+        pkg-config zlib1g-dev asciidoctor wget \
     && apt-get autoremove \
     && apt-get clean
 
@@ -89,8 +85,8 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
 
 ENV HOME /home/builder
 
-ARG cc=gcc-8
-ARG cxx=g++-8
+ARG cc=gcc-9
+ARG cxx=g++-9
 
 ENV CC=$cc
 ENV CXX=$cxx


### PR DESCRIPTION
This PR mixes a number of small changes, so I think it's fine to bundle them like this.

First: back when we were only using Travis, we ran all our jobs on the same Ubuntu version. Official repos didn't contain all the C++ compilers we need, so we also added r/test PPA and apt.llvm.org. This made the .travis.yml slightly less complicated than it would've been otherwise.

Now that we're using Cirrus CI and Docker, it's far simpler to run a couple different Ubuntu versions such that they cover the whole range of compilers we support. That's what I did here: Ubuntu 18.04 keeps shouldering most of the load, while 16.04 is used for GCC 4.9, and 20.04 is used for GCC 9, GCC 10, and Clang 10.

Second: .travis.yml had some leftovers from my failed attempt to run builds with more warnings enabled, and run tests with more checks (like stack protector). This PR adds these jobs to Cirrus. I'm not yet sure how useful they will be; I made a note to re-evaluate in two months.

Fixes #838 
Fixes #922 

Reviews welcome. Will merge in 24 hours.