### PR TITLE
Fix backslash escaping inside double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ acknowledge contributions from the following people:
     Batischev)
 - "date" attribute containing fixed string instead of item's publication date
     and time (Alexander Batischev)
+- Backslash inside double quotes requiring three escapes instead of one, every
+    other time (Alexander Batischev) (#536, #642, #926)
 ### Security
 
 

--- a/doc/chapter-snownews.asciidoc
+++ b/doc/chapter-snownews.asciidoc
@@ -16,14 +16,15 @@ configuration lines like the following ones:
 The first line shows how to add an execurl script to your configuration: start
 the line with `exec:` and then immediately append the path of the script that
 shall be executed.  If this script requires additional parameters, simply use
-quotes:
+quotes (see <<_using_double_quotes>> for details):
 
 	"exec:~/bin/execurl-script param1 param2"
 
 The second line shows how to add a filter script to your configuration: start
 the line with `filter:`, then immediately append the path of the script, then
 append a colon (`:`), and then append the URL of the file that shall be fed to
-the script. Again, if the script requires any parameters, simply quote:
+the script. Again, if the script requires any parameters,
+<<_using_double_quotes,simply quote the whole thing>>:
 
 	"filter:~/bin/filter-script param1 param2:https://url/foobar"
 

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -177,6 +177,34 @@ unbind-key       R
 bind-key         ^R    reload-all
 ----
 
+=== Using Double Quotes
+
+_**TL;DR**: use double quotes for strings that contain spaces or double quotes.
+Escape double quotes (use `\"`) and backslashes (use `\\`). Don't escape stuff
+outside of double quotes, and don't use single quotes for quoting — Newsboat
+doesn't support that._
+
+Many of Newsboat's options expect strings as arguments, be it commands,
+passwords, dialog titles, URLs etc. Some options even take _multiple_ strings
+at once. These strings can contain spaces, which might confuse Newsboat since
+it already uses spaces to separate option names from option arguments.
+
+To help Newsboat understand your intent, put such strings into double quotes:
+
+    browser "firefox --new-tab %u"
+
+What if you need a double quote inside a string? Escape it with a backslash:
+
+    ocnews-password "UnbalancedQuotes\"AreSoFun!"
+
+And what about the backslash itself? Escape it, too! Suppose you have a program
+called `my favourite pager`, and you want to view articles with it. Newsboat
+ultimately passes commands to the shell, and shell expects spaces to be escaped
+if you want them preserved. But since Newsboat interprets backslashes, you have
+to add _another_ layer of escaping. Thus, you end up with a command like this:
+
+    pager "/usr/bin/my\\ favourite\\ pager"
+
 === Configuring Colors
 
 It is possible to configure custom color settings in newsboat. The basic configuration
@@ -836,7 +864,8 @@ is <<ignore-article,`ignore-article`>>:
 It takes two parameters. The first one is either a URL of a feed, or `"*"` to
 match any feed (asterisk is _not_ a pattern, glob or regex—we simply reserve it
 to mean "all feeds").  The second argument is <<_filter_language,a filter
-expression>> for an article. If newsboat hits an article in the specified RSS
+expression>> for an article, probably <<_using_double_quotes,in double quotes
+to preserve spaces inside>>. If newsboat hits an article in the specified RSS
 feed that matches the specified filter expression, then this article is ignored
 and never presented to the user. The configuration itself can contain as many
 <<ignore-article,`ignore-article`>> commands as desired.
@@ -890,8 +919,8 @@ This feature is often used to create a feed that contains all unread articles:
 
 	"query:Unread Articles:unread = \"yes\""
 
-Note the quotes that are necessary around the complete query "URL" and the
-backslashes that are necessary to escape the quotes in the filter expression.
+Note the <<_using_double_quotes,use of double quotes>> to preserve spaces in
+the filter expression.
 
 If you want to combine several feeds to one single feed, a good solution is to
 tag the feeds that you want to combine with one certain tag, and then create a
@@ -1204,6 +1233,8 @@ Examples for possible highlighting configurations are:
 	highlight article "^(Feed|Title|Author|Link|Date):" default default underline
 	highlight feedlist "https?://[^ ]+" yellow red bold
 
+Note the <<_using_double_quotes,use of double quotes>> to preserve spaces in
+the regular expressions.
 
 ==== Highlighting Articles in the Article List
 
@@ -1222,6 +1253,8 @@ Example:
 
 	highlight-article "author =~ \"Andreas Krennmair\"" white red bold
 
+Note the <<_using_double_quotes,use of double quotes>> to preserve spaces in
+the filter expression.
 
 === Advanced Dialog Management
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -134,35 +134,25 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 				++pos;
 			}
 
-			if (pos >= str.length()) {
+			// Invariant: pos <= str.length()
+
+			std::string token;
+			while (last_pos < pos) {
+				if (str[last_pos] == '\\') {
+					if (last_pos + 1 < str.length()) {
+						append_escapes(token, str[last_pos + 1]);
+					}
+					last_pos += 2;
+				} else {
+					token.push_back(str[last_pos]);
+					++last_pos;
+				}
+			}
+			tokens.push_back(token);
+
+			if (pos == str.length()) {
 				pos = std::string::npos;
-				std::string token;
-				while (last_pos < str.length()) {
-					if (str[last_pos] == '\\') {
-						if (last_pos + 1 < str.length()) {
-							append_escapes(token, str[last_pos + 1]);
-						}
-						last_pos += 2;
-					} else {
-						token.push_back(str[last_pos]);
-						++last_pos;
-					}
-				}
-				tokens.push_back(token);
 			} else {
-				std::string token;
-				while (last_pos < pos) {
-					if (str[last_pos] == '\\') {
-						if (last_pos + 1 < str.length()) {
-							append_escapes(token, str[last_pos + 1]);
-						}
-						last_pos += 2;
-					} else {
-						token.push_back(str[last_pos]);
-						++last_pos;
-					}
-				}
-				tokens.push_back(token);
 				++pos;
 			}
 		} else {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -121,31 +121,21 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 		if (str[last_pos] == '"') {
 			++last_pos;
 			pos = last_pos;
-			// Is the character at position `pos` escaped, i.e. is `str[pos-1]
-			// == '\\'`? We can't actually use that char comparison because
-			// `pos` might be zero.
-			bool is_escaped = false;
-			while (pos < str.length() && !(str[pos] == '"' && !is_escaped)) {
-				if (str[pos] == '\\') {
-					is_escaped = !is_escaped;
-				} else {
-					is_escaped = false;
-				}
-				++pos;
-			}
-
-			// Invariant: pos <= str.length()
 
 			std::string token;
-			while (last_pos < pos) {
-				if (str[last_pos] == '\\') {
-					if (last_pos + 1 < str.length()) {
-						append_escapes(token, str[last_pos + 1]);
+			while (pos < str.length()) {
+				if (str[pos] == '"') {
+					// We've reached the end of this quoted token.
+					++pos;
+					break;
+				} else if (str[pos] == '\\') {
+					if (pos + 1 < str.length()) {
+						append_escapes(token, str[pos + 1]);
 					}
-					last_pos += 2;
+					pos += 2;
 				} else {
-					token.push_back(str[last_pos]);
-					++last_pos;
+					token.push_back(str[pos]);
+					++pos;
 				}
 			}
 			tokens.push_back(token);
@@ -159,6 +149,7 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 			pos = str.find_first_of(delimiters, last_pos);
 			tokens.push_back(str.substr(last_pos, pos - last_pos));
 		}
+
 		last_pos = str.find_first_not_of(delimiters, pos);
 	}
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -121,16 +121,19 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 		if (str[last_pos] == '"') {
 			++last_pos;
 			pos = last_pos;
-			int backslash_count = 0;
-			while (pos < str.length() &&
-				(str[pos] != '"' || (backslash_count % 2))) {
+			// Is the character at position `pos` escaped, i.e. is `str[pos-1]
+			// == '\\'`? We can't actually use that char comparison because
+			// `pos` might be zero.
+			bool is_escaped = false;
+			while (pos < str.length() && !(str[pos] == '"' && !is_escaped)) {
 				if (str[pos] == '\\') {
-					++backslash_count;
+					is_escaped = !is_escaped;
 				} else {
-					backslash_count = 0;
+					is_escaped = false;
 				}
 				++pos;
 			}
+
 			if (pos >= str.length()) {
 				pos = std::string::npos;
 				std::string token;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -138,16 +138,13 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 					if (str[last_pos] == '\\') {
 						if (str[last_pos - 1] == '\\') {
 							if (attach_backslash) {
-								token.append(
-									"\\");
+								token.append("\\");
 							}
-							attach_backslash =
-								!attach_backslash;
+							attach_backslash = !attach_backslash;
 						}
 					} else {
 						if (str[last_pos - 1] == '\\') {
-							append_escapes(token,
-								str[last_pos]);
+							append_escapes(token, str[last_pos]);
 						} else {
 							token.push_back(str[last_pos]);
 						}
@@ -161,16 +158,13 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 					if (str[last_pos] == '\\') {
 						if (str[last_pos - 1] == '\\') {
 							if (attach_backslash) {
-								token.append(
-									"\\");
+								token.append("\\");
 							}
-							attach_backslash =
-								!attach_backslash;
+							attach_backslash = !attach_backslash;
 						}
 					} else {
 						if (str[last_pos - 1] == '\\') {
-							append_escapes(token,
-								str[last_pos]);
+							append_escapes(token, str[last_pos]);
 						} else {
 							token.push_back(str[last_pos]);
 						}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -70,6 +70,7 @@ void append_escapes(std::string& str, char c)
 		str.append("\\`");
 		break;
 	case '\\':
+		str.append("\\");
 		break;
 	default:
 		str.push_back(c);
@@ -108,7 +109,6 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 	 * know from C/C++ strings.
 	 *
 	 */
-	bool attach_backslash = true;
 	std::vector<std::string> tokens;
 	std::string::size_type last_pos = str.find_first_not_of(delimiters, 0);
 	std::string::size_type pos = last_pos;
@@ -136,40 +136,28 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 				std::string token;
 				while (last_pos < str.length()) {
 					if (str[last_pos] == '\\') {
-						if (str[last_pos - 1] == '\\') {
-							if (attach_backslash) {
-								token.append("\\");
-							}
-							attach_backslash = !attach_backslash;
+						if (last_pos + 1 < str.length()) {
+							append_escapes(token, str[last_pos + 1]);
 						}
+						last_pos += 2;
 					} else {
-						if (str[last_pos - 1] == '\\') {
-							append_escapes(token, str[last_pos]);
-						} else {
-							token.push_back(str[last_pos]);
-						}
+						token.push_back(str[last_pos]);
+						++last_pos;
 					}
-					++last_pos;
 				}
 				tokens.push_back(token);
 			} else {
 				std::string token;
 				while (last_pos < pos) {
 					if (str[last_pos] == '\\') {
-						if (str[last_pos - 1] == '\\') {
-							if (attach_backslash) {
-								token.append("\\");
-							}
-							attach_backslash = !attach_backslash;
+						if (last_pos + 1 < str.length()) {
+							append_escapes(token, str[last_pos + 1]);
 						}
+						last_pos += 2;
 					} else {
-						if (str[last_pos - 1] == '\\') {
-							append_escapes(token, str[last_pos]);
-						} else {
-							token.push_back(str[last_pos]);
-						}
+						token.push_back(str[last_pos]);
+						++last_pos;
 					}
-					++last_pos;
 				}
 				tokens.push_back(token);
 				++pos;

--- a/test/data/926-urls
+++ b/test/data/926-urls
@@ -1,0 +1,1 @@
+"exec:curl --silent https://feeds.metaebene.me/raumzeit/m4a  | sed 's#\\(</guid>\\|</id>\\)#-M4A&#'"

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -83,3 +83,15 @@ TEST_CASE("URL reader writes files that it can understand later",
 		REQUIRE(u.get_tags(url) == u2.get_tags(url));
 	}
 }
+
+TEST_CASE("Preserves URLs as-is", "[FileUrlReader][issue926]")
+{
+	const std::string testDataPath("data/926-urls");
+
+	FileUrlReader u(testDataPath);
+	u.reload();
+
+	REQUIRE(u.get_urls().size() == 1);
+	REQUIRE(u.get_urls()[0] ==
+		R"_(exec:curl --silent https://feeds.metaebene.me/raumzeit/m4a  | sed 's#\(</guid>\|</id>\)#-M4A&#')_");
+}

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -162,6 +162,11 @@ TEST_CASE(
 	tokens = utils::tokenize_quoted("\"\\\\\\\\\\\\\"");
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == "\\\\\\");
+
+	// https://github.com/newsboat/newsboat/issues/642
+	tokens = utils::tokenize_quoted(R"("\\bgit\\b")");
+	REQUIRE(tokens.size() == 1);
+	REQUIRE(tokens[0] == R"(\bgit\b)");
 }
 
 TEST_CASE("tokenize_quoted() doesn't un-escape escaped backticks", "[utils]")

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -167,6 +167,14 @@ TEST_CASE(
 	tokens = utils::tokenize_quoted(R"("\\bgit\\b")");
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == R"(\bgit\b)");
+
+	// https://github.com/newsboat/newsboat/issues/536
+	tokens = utils::tokenize_quoted(
+			R"(browser "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --app %u")");
+	REQUIRE(tokens.size() == 2);
+	REQUIRE(tokens[0] == "browser");
+	REQUIRE(tokens[1] ==
+		R"(/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --app %u)");
 }
 
 TEST_CASE("tokenize_quoted() doesn't un-escape escaped backticks", "[utils]")

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -114,6 +114,10 @@ TEST_CASE("tokenize_quoted() implicitly closes quotes at the end of the string",
 	REQUIRE(tokens[0] == "\\");
 	REQUIRE(tokens[1] == "and");
 	REQUIRE(tokens[2] == "some other stuff");
+
+	tokens = utils::tokenize_quoted(R"("abc\)");
+	REQUIRE(tokens.size() == 1);
+	REQUIRE(tokens[0] == "abc");
 }
 
 TEST_CASE(
@@ -122,6 +126,26 @@ TEST_CASE(
 	"[utils]")
 {
 	std::vector<std::string> tokens;
+
+	tokens = utils::tokenize_quoted(R"_("")_");
+	REQUIRE(tokens.size() == 1);
+	REQUIRE(tokens[0] == "");
+
+	tokens = utils::tokenize_quoted(R"_("\\")_");
+	REQUIRE(tokens.size() == 1);
+	REQUIRE(tokens[0] == R"_(\)_");
+
+	tokens = utils::tokenize_quoted(R"_("#\\")_");
+	REQUIRE(tokens.size() == 1);
+	REQUIRE(tokens[0] == R"_(#\)_");
+
+	tokens = utils::tokenize_quoted(R"_("'#\\'")_");
+	REQUIRE(tokens.size() == 1);
+	REQUIRE(tokens[0] == R"_('#\')_");
+
+	tokens = utils::tokenize_quoted(R"_("'#\\ \\'")_");
+	REQUIRE(tokens.size() == 1);
+	REQUIRE(tokens[0] == R"_('#\ \')_");
 
 	tokens = utils::tokenize_quoted("\"\\\\\\\\");
 	REQUIRE(tokens.size() == 1);


### PR DESCRIPTION
This fixes the issue where every other time, backslash had to be escaped three times instead of one, i.e. to get `\ \ \ \` (four backslashes separated by spaces) one had to write `\\ \\\\ \\ \\\\`. For a detailed explanation of the problem and the solution, see [the commit message here](https://github.com/newsboat/newsboat/commit/8f6b73a33036bb05084c36a9f445c00ed32c672a).

This PR also:
- documents double quotes and how escapes in them work (it doesn't mention `\n`, `\t`, `\v`, and `\r` because #928) (@der-lyse, that's the part I'd like you to take a look at);
- performs a little refactoring of the offending function;
- of course, adds tests for all the issue that this fixes.

Fixes #536
Fixes #642 
Fixes #926

Reviews from everyone are welcome. I'll merge this in three days.