### PR TITLE
CI: use newest compilers for checks

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -150,22 +150,22 @@ linux_task:
                 cxx: g++-9
                 rust_version: 1.40.0
 
-        - name: GCC 8, more warnings and checks (Ubuntu 18.04)
+        - name: GCC 10, more warnings and checks (Ubuntu 20.04)
           container:
-            dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
+            dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
-                cxx_package: g++-8
-                cc: gcc-8
-                cxx: g++-8
+                cxx_package: g++-10
+                cc: gcc-10
+                cxx: g++-10
           env: &extra_warnings_and_checks_env
             CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
-        - name: Clang 8, more warnings and checks (Ubuntu 18.04)
+        - name: Clang 10, more warnings and checks (Ubuntu 20.04)
           container:
-            dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
+            dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
-                cxx_package: clang-8
-                cc: clang-8
-                cxx: clang++-8
+                cxx_package: clang-10
+                cc: clang-10
+                cxx: clang++-10
           env: *extra_warnings_and_checks_env
 
         - name: Rust 1.43.1, GCC 4.9 (Ubuntu 16.04)
@@ -276,16 +276,16 @@ linux_task:
     before_cache_script: *before_cache_script
 
 address_sanitizer_task:
-    name: AddressSanitizer (Clang 9, Ubuntu 18.04)
+    name: AddressSanitizer (Clang 10, Ubuntu 20.04)
 
     container:
-      dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
+      dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
       docker_arguments:
-          # We need llvm-symbolizer from llvm-9-tools to demangle symbols in
+          # We need llvm-symbolizer from llvm-10-tools to demangle symbols in
           # sanitizer's reports
-          cxx_package: "clang-9 llvm-9"
-          cc: clang-9
-          cxx: clang++-9
+          cxx_package: "clang-10 llvm-10"
+          cc: clang-10
+          cxx: clang++-10
 
     env:
       CXXFLAGS: "-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-optimize-sibling-calls -g"


### PR DESCRIPTION
We've got a couple CI jobs that run additional checks: AddressSanitizer
and extra compilation flags. Newer compilers might bring improvements to
these checks, so let's run them with the latest compilers.

Reviews welcome. This is an uncontroversial, boring change, though, so I'll merge it in 24 hours.