### PR TITLE
Add OPENBROWSER_AND_MARK to url and item viewformaction

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -13,8 +13,8 @@ prev-unread||p||Jump to the previous unread article.
 next||J||Jump to next article.
 prev||K||Jump to previous article.
 random-unread||^K||Jump to a random unread article.
-open-in-browser||o||Open the URL associated with the current article.
-open-in-browser-and-mark-read||O||Open the URL associated with the current article and mark the article as read.
+open-in-browser||o||Open the URL associated with the current article, or selection when in the URL view.
+open-in-browser-and-mark-read||O||Open the URL associated with the current article, or selection when in the URL view. When used in the article view, it will also mark the article as read.
 open-all-unread-in-browser||n/a||Open all the unread URLs in the current feed.
 open-all-unread-in-browser-and-mark-read||n/a||Open all the unread URLs in the current feed and mark them as read.
 help||?||Run the help screen.

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -241,6 +241,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_OPENINBROWSER:
+	case OP_OPENBROWSER_AND_MARK:
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: starting browser");
 		v->set_status(_("Starting browser..."));
 		if (int err = v->open_in_browser(item->link())) {

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -140,7 +140,7 @@ static OpDesc opdescs[] = {
 		"open-in-browser",
 		"o",
 		_("Open article in browser"),
-		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE | KM_URLVIEW
 	},
 	{
 		OP_HELP,

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -118,7 +118,7 @@ static OpDesc opdescs[] = {
 		"open-in-browser-and-mark-read",
 		"O",
 		_("Open article in browser and mark read"),
-		KM_ARTICLELIST
+		KM_ARTICLELIST | KM_ARTICLE | KM_URLVIEW
 	},
 	{
 		OP_OPENALLUNREADINBROWSER,

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -56,6 +56,7 @@ bool UrlViewFormAction::process_operation(Operation op,
 		urls_list.move_page_down();
 		break;
 	case OP_OPENINBROWSER:
+	case OP_OPENBROWSER_AND_MARK:
 	case OP_OPEN: {
 		std::string posstr = f.get("urls_pos");
 		if (posstr.length() > 0) {


### PR DESCRIPTION
This makes user-defined macros with `open-in-browser-and-mark-read` behave the same way as `open-in-browser` for the URL and item/article views instead of being ignored.

I have a macro like `macro r set browser "rtv"; open-in-browser-and-mark-read ; set browser qutebrowser` and before this fix, it's only usable in the article list.