### PR TITLE
Add wrap scroll feature

### DIFF
--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -133,3 +133,4 @@ urls-source||<source>||"local"||This configuration command sets the source where
 urlview-title-format||<format>||"%N %V - URLs"||Format of the title in URL view. See "Format Strings" section of Newsboat manual for details on available formats.||urlview-title-format "URLs"
 use-proxy||[yes/no]||no||If set to `yes`, then the configured proxy will be used for downloading the RSS feeds.||use-proxy yes
 user-agent||<string>||""||If set to a non-zero-length string, this value will be used as HTTP User-Agent header for all HTTP requests.||user-agent "Lynx/2.8.5rel.1 libwww-FM/2.14"
+wrap-scroll||[yes/no]||no||If set to `yes`, moving down while on the last item in a list will wrap around to the top and vice versa.||wrap-scroll yes

--- a/include/listwidget.h
+++ b/include/listwidget.h
@@ -15,8 +15,8 @@ public:
 	void stfl_replace_list(std::uint32_t number_of_lines, std::string stfl);
 	void stfl_replace_lines(std::uint32_t number_of_lines, std::string stfl);
 
-	bool move_up();
-	bool move_down();
+	bool move_up(bool wrap_scroll);
+	bool move_down(bool wrap_scroll);
 	void move_to_first();
 	void move_to_last();
 	void move_page_up();

--- a/include/listwidget.h
+++ b/include/listwidget.h
@@ -19,8 +19,8 @@ public:
 	bool move_down(bool wrap_scroll);
 	void move_to_first();
 	void move_to_last();
-	void move_page_up();
-	void move_page_down();
+	void move_page_up(bool wrap_scroll);
+	void move_page_down(bool wrap_scroll);
 
 	std::uint32_t get_position();
 	void set_position(std::uint32_t pos);

--- a/include/pbview.h
+++ b/include/pbview.h
@@ -20,7 +20,7 @@ class PbView {
 public:
 	explicit PbView(PbController* c = 0);
 	~PbView();
-	void run(bool auto_download);
+	void run(bool auto_download, bool wrap_scroll);
 	void set_keymap(newsboat::KeyMap* k)
 	{
 		keys = k;

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -302,7 +302,10 @@ ConfigContainer::ConfigContainer()
 			ConfigDataType::STR)},
 	{
 		"urlview-title-format",
-		ConfigData(_("%N %V - URLs"), ConfigDataType::STR)}}
+		ConfigData(_("%N %V - URLs"), ConfigDataType::STR)},
+	{
+		"wrap-scroll",
+		ConfigData("no", ConfigDataType::BOOL)}}
 {
 }
 

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -108,10 +108,10 @@ bool DialogsFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_SK_UP:
-		dialogs_list.move_up();
+		dialogs_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_DOWN:
-		dialogs_list.move_down();
+		dialogs_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_HOME:
 		dialogs_list.move_to_first();

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -120,10 +120,10 @@ bool DialogsFormAction::process_operation(Operation op,
 		dialogs_list.move_to_last();
 		break;
 	case OP_SK_PGUP:
-		dialogs_list.move_page_up();
+		dialogs_list.move_page_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_PGDOWN:
-		dialogs_list.move_page_down();
+		dialogs_list.move_page_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_QUIT:
 		v->pop_current_formaction();

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -146,14 +146,14 @@ bool DirBrowserFormAction::process_operation(Operation op,
 	}
 	case OP_SK_UP:
 		if (f.get_focus() == "files") {
-			files_list.move_up();
+			files_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		} else {
 			f.set_focus("files");
 		}
 		break;
 	case OP_SK_DOWN:
 		if (f.get_focus() == "files") {
-			if (!files_list.move_down()) {
+			if (!files_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"))) {
 				f.set_focus("filename");
 			}
 		}

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -175,12 +175,12 @@ bool DirBrowserFormAction::process_operation(Operation op,
 		break;
 	case OP_SK_PGUP:
 		if (f.get_focus() == "files") {
-			files_list.move_page_up();
+			files_list.move_page_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		}
 		break;
 	case OP_SK_PGDOWN:
 		if (f.get_focus() == "files") {
-			files_list.move_page_down();
+			files_list.move_page_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		}
 		break;
 	case OP_QUIT:

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -143,10 +143,10 @@ REDO:
 		v->get_ctrl()->reload_urls_file();
 		break;
 	case OP_SK_UP:
-		feeds_list.move_up();
+		feeds_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_DOWN:
-		feeds_list.move_down();
+		feeds_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_HOME:
 		feeds_list.move_to_first();

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -155,10 +155,10 @@ REDO:
 		feeds_list.move_to_last();
 		break;
 	case OP_SK_PGUP:
-		feeds_list.move_page_up();
+		feeds_list.move_page_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_PGDOWN:
-		feeds_list.move_page_down();
+		feeds_list.move_page_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SORT: {
 		/// This string is related to the letters in parentheses in the

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -146,14 +146,14 @@ bool FileBrowserFormAction::process_operation(Operation op,
 	}
 	case OP_SK_UP:
 		if (f.get_focus() == "files") {
-			files_list.move_up();
+			files_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		} else {
 			f.set_focus("files");
 		}
 		break;
 	case OP_SK_DOWN:
 		if (f.get_focus() == "files") {
-			if (!files_list.move_down()) {
+			if (!files_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"))) {
 				f.set_focus("filename");
 			}
 		}

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -175,12 +175,12 @@ bool FileBrowserFormAction::process_operation(Operation op,
 		break;
 	case OP_SK_PGUP:
 		if (f.get_focus() == "files") {
-			files_list.move_page_up();
+			files_list.move_page_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		}
 		break;
 	case OP_SK_PGDOWN:
 		if (f.get_focus() == "files") {
-			files_list.move_page_down();
+			files_list.move_page_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		}
 		break;
 	case OP_QUIT:

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -96,10 +96,10 @@ bool ItemListFormAction::process_operation(Operation op,
 		items_list.move_to_last();
 		break;
 	case OP_SK_PGUP:
-		items_list.move_page_up();
+		items_list.move_page_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_PGDOWN:
-		items_list.move_page_down();
+		items_list.move_page_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_DELETE: {
 		ScopeMeasure m1("OP_DELETE");

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -84,10 +84,10 @@ bool ItemListFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_SK_UP:
-		items_list.move_up();
+		items_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_DOWN:
-		items_list.move_down();
+		items_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_HOME:
 		items_list.move_to_first();

--- a/src/listwidget.cpp
+++ b/src/listwidget.cpp
@@ -74,18 +74,20 @@ void ListWidget::move_to_last()
 	set_position(maxpos);
 }
 
-void ListWidget::move_page_up()
+void ListWidget::move_page_up(bool wrap_scroll)
 {
 	const std::uint32_t curpos = get_position();
 	const std::uint32_t list_height = get_height();
 	if (curpos > list_height) {
 		set_position(curpos - list_height);
+	} else if (wrap_scroll && curpos == 0) {
+		move_to_last();
 	} else {
 		set_position(0);
 	}
 }
 
-void ListWidget::move_page_down()
+void ListWidget::move_page_down(bool wrap_scroll)
 {
 	if (num_lines == 0) {
 		// Ignore if list is empty
@@ -96,6 +98,8 @@ void ListWidget::move_page_down()
 	const std::uint32_t list_height = get_height();
 	if (curpos + list_height < maxpos) {
 		set_position(curpos + list_height);
+	} else if (wrap_scroll && curpos == maxpos) {
+		move_to_first();
 	} else {
 		set_position(maxpos);
 	}

--- a/src/listwidget.cpp
+++ b/src/listwidget.cpp
@@ -28,17 +28,20 @@ void ListWidget::stfl_replace_lines(std::uint32_t number_of_lines,
 	form.modify(list_name, "replace_inner", stfl);
 }
 
-bool ListWidget::move_up()
+bool ListWidget::move_up(bool wrap_scroll)
 {
 	const std::uint32_t curpos = get_position();
 	if (curpos > 0) {
 		set_position(curpos - 1);
 		return true;
+	} else if (wrap_scroll) {
+		move_to_last();
+		return true;
 	}
 	return false;
 }
 
-bool ListWidget::move_down()
+bool ListWidget::move_down(bool wrap_scroll)
 {
 	if (num_lines == 0) {
 		// Ignore if list is empty
@@ -48,6 +51,9 @@ bool ListWidget::move_down()
 	const std::uint32_t curpos = get_position();
 	if (curpos + 1 <= maxpos) {
 		set_position(curpos + 1);
+		return true;
+	} else if (wrap_scroll) {
+		move_to_first();
 		return true;
 	}
 	return false;

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -306,7 +306,7 @@ int PbController::run(int argc, char* argv[])
 
 	v->set_keymap(&keys);
 
-	v->run(automatic_dl);
+	v->run(automatic_dl, cfg->get_configvalue_as_bool("wrap-scroll"));
 
 	Stfl::reset();
 

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -41,7 +41,7 @@ PbView::~PbView()
 	Stfl::reset();
 }
 
-void PbView::run(bool auto_download)
+void PbView::run(bool auto_download, bool wrap_scroll)
 {
 	bool quit = false;
 
@@ -131,10 +131,10 @@ void PbView::run(bool auto_download)
 
 		switch (op) {
 		case OP_SK_UP:
-			downloads_list.move_up(false);
+			downloads_list.move_up(wrap_scroll);
 			break;
 		case OP_SK_DOWN:
-			downloads_list.move_down(false);
+			downloads_list.move_down(wrap_scroll);
 			break;
 		case OP_SK_HOME:
 			downloads_list.move_to_first();
@@ -143,10 +143,10 @@ void PbView::run(bool auto_download)
 			downloads_list.move_to_last();
 			break;
 		case OP_SK_PGUP:
-			downloads_list.move_page_up(false);
+			downloads_list.move_page_up(wrap_scroll);
 			break;
 		case OP_SK_PGDOWN:
-			downloads_list.move_page_down(false);
+			downloads_list.move_page_down(wrap_scroll);
 			break;
 		case OP_PB_TOGGLE_DLALL:
 			auto_download = !auto_download;

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -143,10 +143,10 @@ void PbView::run(bool auto_download)
 			downloads_list.move_to_last();
 			break;
 		case OP_SK_PGUP:
-			downloads_list.move_page_up();
+			downloads_list.move_page_up(false);
 			break;
 		case OP_SK_PGDOWN:
-			downloads_list.move_page_down();
+			downloads_list.move_page_down(false);
 			break;
 		case OP_PB_TOGGLE_DLALL:
 			auto_download = !auto_download;

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -131,10 +131,10 @@ void PbView::run(bool auto_download)
 
 		switch (op) {
 		case OP_SK_UP:
-			downloads_list.move_up();
+			downloads_list.move_up(false);
 			break;
 		case OP_SK_DOWN:
-			downloads_list.move_down();
+			downloads_list.move_down(false);
 			break;
 		case OP_SK_HOME:
 			downloads_list.move_to_first();

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -65,10 +65,10 @@ bool SelectFormAction::process_operation(Operation op,
 		tags_list.move_to_last();
 		break;
 	case OP_SK_PGUP:
-		tags_list.move_page_up();
+		tags_list.move_page_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_PGDOWN:
-		tags_list.move_page_down();
+		tags_list.move_page_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_QUIT:
 		value = "";

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -53,10 +53,10 @@ bool SelectFormAction::process_operation(Operation op,
 	bool hardquit = false;
 	switch (op) {
 	case OP_SK_UP:
-		tags_list.move_up();
+		tags_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_DOWN:
-		tags_list.move_down();
+		tags_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_HOME:
 		tags_list.move_to_first();

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -50,10 +50,10 @@ bool UrlViewFormAction::process_operation(Operation op,
 		urls_list.move_to_last();
 		break;
 	case OP_SK_PGUP:
-		urls_list.move_page_up();
+		urls_list.move_page_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_PGDOWN:
-		urls_list.move_page_down();
+		urls_list.move_page_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_OPENINBROWSER:
 	case OP_OPEN: {

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -38,10 +38,10 @@ bool UrlViewFormAction::process_operation(Operation op,
 	bool hardquit = false;
 	switch (op) {
 	case OP_SK_UP:
-		urls_list.move_up();
+		urls_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_DOWN:
-		urls_list.move_down();
+		urls_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_SK_HOME:
 		urls_list.move_to_first();


### PR DESCRIPTION
This will add an optional wrap scroll feature. When enabled, moving down while on the last item in a list will wrap around to the top and vice versa.

There are equivalent features in ranger, lf, etc. https://ranger.github.io/ranger.1.html#wrap_scroll-bool

Note: I'm not sure if you want the Newsboat config added to Podboat as it's currently missing. So I just set the wrap scroll value to `false` for it in `pbview.cpp`.