### PR TITLE
Docker: suggest running `make distclean`

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -46,6 +46,13 @@ your current user and group IDs. "newsboat-build-tools" is the image from which
 we're creating the container, and `make -j9` is the command we're running inside
 of it.
 
+Sharing files between host system and the container has a downside: the
+resulting binaries are shared, too. This can lead to linking errors and other
+strange behaviour. When you're switching from container to host, or vice versa,
+remove all binaries with this command:
+
+    $ make distclean
+
 That's all the basics that you'll need to e.g. build Newsboat in Docker, or to
 reproduce an issue with CI. If you want to dive deeper, take a look at files in
 docker/ directory. All of them have a short description of what they're for, how

--- a/docker/ubuntu_16.04-build-tools.dockerfile
+++ b/docker/ubuntu_16.04-build-tools.dockerfile
@@ -28,6 +28,11 @@
 #       --build-arg rust_version=1.40.0 \
 #       docker
 #
+# Before building in a container, run this to remove any binaries that you
+# might've compiled on your host system (or in another container):
+#
+#   make distclean
+#
 # Run on your local files:
 #
 #   docker run \
@@ -37,6 +42,11 @@
 #       --user $(id -u):$(id -g) \
 #       newsboat-build-tools \
 #       make
+#
+# If you want to build on the host again, run this to remove binary files
+# compiled in the container:
+#
+#   make distclean
 
 FROM ubuntu:16.04
 

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -28,6 +28,11 @@
 #       --build-arg rust_version=1.26.1 \
 #       docker
 #
+# Before building in a container, run this to remove any binaries that you
+# might've compiled on your host system (or in another container):
+#
+#   make distclean
+#
 # Run on your local files:
 #
 #   docker run \
@@ -37,6 +42,11 @@
 #       --user $(id -u):$(id -g) \
 #       newsboat-build-tools \
 #       make
+#
+# If you want to build on the host again, run this to remove binary files
+# compiled in the container:
+#
+#   make distclean
 
 FROM ubuntu:18.04
 

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -7,6 +7,11 @@
 #       --file=docker/ubuntu_18.04-i686.dockerfile \
 #       docker
 #
+# Before building in a container, run this to remove any binaries that you
+# might've compiled on your host system (or in another container):
+#
+#   make distclean
+#
 # Run on your local files:
 #
 #   docker run \
@@ -16,6 +21,11 @@
 #       --user $(id -u):$(id -g) \
 #       newsboat-i686-build-tools \
 #       make
+#
+# If you want to build on the host again, run this to remove binary files
+# compiled in the container:
+#
+#   make distclean
 
 FROM ubuntu:18.04
 

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -28,6 +28,11 @@
 #       --build-arg rust_version=1.40.0 \
 #       docker
 #
+# Before building in a container, run this to remove any binaries that you
+# might've compiled on your host system (or in another container):
+#
+#   make distclean
+#
 # Run on your local files:
 #
 #   docker run \
@@ -37,6 +42,11 @@
 #       --user $(id -u):$(id -g) \
 #       newsboat-build-tools \
 #       make
+#
+# If you want to build on the host again, run this to remove binary files
+# compiled in the container:
+#
+#   make distclean
 
 FROM ubuntu:20.04
 


### PR DESCRIPTION
During an IRC discussion the other day I realized that our docs for Docker don't mention an important thing: binaries build in- and outside a container might be incompatible. This can lead to linking errors, doc/generate failing to run, or maybe even something weirder.

This PR adds the necessary documentation.

Reviews from everyone are welcome, though I requested one from @der-lyse specifically since I always run my doc edits by him :) Will merge in three days.