### PR TITLE
Only encode for stfl ('<' -> '<>') after running FmtStrFormatter

### DIFF
--- a/rust/libnewsboat/src/fmtstrformatter/limited_string.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/limited_string.rs
@@ -24,7 +24,7 @@ impl LimitedString {
 
     /// Returns the "displayed width" of the string
     pub fn length(&self) -> usize {
-        utils::strwidth_stfl(&self.content)
+        utils::strwidth(&self.content)
     }
 
     /// Adds given character to the end of the string, or does nothing if the string length reached
@@ -45,7 +45,7 @@ impl LimitedString {
         if let Some(limit) = self.max_length {
             let remaining_length = limit - self.length();
             self.content
-                .push_str(&utils::substr_with_width_stfl(s, remaining_length));
+                .push_str(&utils::substr_with_width(s, remaining_length));
         } else {
             self.content.push_str(s);
         }
@@ -90,7 +90,7 @@ mod tests {
         assert_eq!(s.length(), expected_length);
 
         let exported_string = s.into_string();
-        assert_eq!(utils::strwidth_stfl(&exported_string), expected_length);
+        assert_eq!(utils::strwidth(&exported_string), expected_length);
     }
 
     #[test]
@@ -102,7 +102,7 @@ mod tests {
         assert_eq!(s.length(), limit);
 
         let exported_string = s.into_string();
-        assert_eq!(utils::strwidth_stfl(&exported_string), limit);
+        assert_eq!(utils::strwidth(&exported_string), limit);
     }
 
     #[test]

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -83,7 +83,7 @@ impl FmtStrFormatter {
             result.push(c);
         } else {
             let padding_width = {
-                let content_width = utils::strwidth_stfl(&rest) + result.length();
+                let content_width = utils::strwidth(&rest) + result.length();
                 if content_width > width as usize {
                     0
                 } else {
@@ -91,7 +91,7 @@ impl FmtStrFormatter {
                 }
             };
 
-            let padding_value = utils::quote_for_stfl(&format!("{}", c));
+            let padding_value = &format!("{}", c);
             let padding = padding_value.repeat(padding_width);
             result.push_str(&padding);
         };
@@ -105,16 +105,16 @@ impl FmtStrFormatter {
             Padding::None => result.push_str(value),
 
             Padding::Left(total_width) => {
-                let text = &utils::substr_with_width_stfl(value, total_width);
-                let padding_width = total_width - utils::strwidth_stfl(text);
+                let text = &utils::substr_with_width(value, total_width);
+                let padding_width = total_width - utils::strwidth(text);
                 let padding = String::from(" ").repeat(padding_width);
                 result.push_str(&padding);
                 result.push_str(text);
             }
 
             Padding::Right(total_width) => {
-                let text = &utils::substr_with_width_stfl(value, total_width);
-                let padding_width = total_width - utils::strwidth_stfl(text);
+                let text = &utils::substr_with_width(value, total_width);
+                let padding_width = total_width - utils::strwidth(text);
                 let padding = String::from(" ").repeat(padding_width);
                 result.push_str(text);
                 result.push_str(&padding);
@@ -163,16 +163,15 @@ impl FmtStrFormatter {
                 }
 
                 Specifier::Text(s) => {
-                    let s = &utils::quote_for_stfl(s);
                     if width == 0 {
                         result.push_str(s);
                     } else {
                         let remaining = width as usize - result.length();
-                        let count = utils::strwidth_stfl(&s);
+                        let count = utils::strwidth(&s);
                         if remaining >= count {
                             result.push_str(&s);
                         } else {
-                            result.push_str(&utils::substr_with_width_stfl(s, remaining));
+                            result.push_str(&utils::substr_with_width(s, remaining));
                         }
                     }
                 }
@@ -239,7 +238,7 @@ mod tests {
 
         assert_eq!(
             fmt.do_format("<%a> <%5b> | %-5c%%", 0),
-            "<>AAA> <>  BBB> | CCC  %"
+            "<AAA> <  BBB> | CCC  %"
         );
         assert_eq!(
             fmt.do_format("asdf | %a | %?c?%a%b&%b%a? | qwert", 0),
@@ -322,7 +321,7 @@ mod tests {
 
         assert_eq!(
             fmt.do_format("<%a> <%5b> | %-5c%%", 0),
-            "<>АБВ> <>буква> | ещё о%"
+            "<АБВ> <буква> | ещё о%"
         );
         assert_eq!(
             fmt.do_format("asdf | %a | %?c?%a%b&%b%a? | qwert", 0),
@@ -389,24 +388,24 @@ mod tests {
     }
 
     #[test]
-    fn t_do_format_escapes_less_than_sign_in_regular_text() {
+    fn t_do_format_does_not_escape_less_than_signs_in_regular_text() {
         let mut fmt = FmtStrFormatter::new();
 
         fmt.register_fmt('a', "AAA".to_string());
         fmt.register_fmt('b', "BBB".to_string());
 
-        assert_eq!(fmt.do_format("%a <%b>", 0), "AAA <>BBB>");
+        assert_eq!(fmt.do_format("%a <%b>", 0), "AAA <BBB>");
     }
 
     #[test]
-    fn t_do_format_escapes_less_than_sign_in_filling_format() {
+    fn t_do_format_does_not_escape_less_than_signs_in_filling_format() {
         let mut fmt = FmtStrFormatter::new();
 
         fmt.register_fmt('a', "AAA".to_string());
         fmt.register_fmt('b', "BBB".to_string());
 
         assert_eq!(fmt.do_format("%a%>.%b", 10), "AAA....BBB");
-        assert_eq!(fmt.do_format("%a%><%b", 10), "AAA<><><><>BBB");
+        assert_eq!(fmt.do_format("%a%><%b", 10), "AAA<<<<BBB");
         assert_eq!(fmt.do_format("%a%>>%b", 10), "AAA>>>>BBB");
     }
 
@@ -612,7 +611,7 @@ mod tests {
         fn result_is_never_longer_than_specified_width(length in 1u32..10000, ref input in "\\PC*") {
             let fmt = FmtStrFormatter::new();
             let result = fmt.do_format(&input, length);
-            assert!(utils::strwidth_stfl(&result) <= length as usize);
+            assert!(utils::strwidth(&result) <= length as usize);
         }
     }
 }

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -48,13 +48,14 @@ void DialogsFormAction::prepare()
 				v->get_formaction(fa.first).get(),
 				get_parent_formaction().get());
 			listfmt.add_line(
-				strprintf::fmt("%4u %s %s",
-					i,
-					(v->get_formaction(fa.first).get() ==
-						get_parent_formaction().get())
-					? "*"
-					: " ",
-					fa.second),
+				utils::quote_for_stfl(
+					strprintf::fmt("%4u %s %s",
+						i,
+						(v->get_formaction(fa.first).get() ==
+							get_parent_formaction().get())
+						? "*"
+						: " ",
+						fa.second)),
 				fa.first);
 			i++;
 		}

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -354,7 +354,7 @@ std::string DirBrowserFormAction::add_directory(std::string dirname)
 		retval = strprintf::fmt("{listitem[%c%s] text:%s}",
 				ftype,
 				Stfl::quote(dirname),
-				Stfl::quote(line));
+				Stfl::quote(utils::quote_for_stfl(line)));
 	}
 	return retval;
 }

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -1062,13 +1062,14 @@ std::string FeedListFormAction::format_line(const std::string& feedlist_format,
 	fmt.register_fmt('c', std::to_string(feed->total_item_count()));
 	fmt.register_fmt('n', unread_count > 0 ? "N" : " ");
 	fmt.register_fmt('S', feed->get_status());
-	fmt.register_fmt('t', utils::quote_for_stfl(get_title(feed)));
+	fmt.register_fmt('t', get_title(feed));
 	fmt.register_fmt('T', feed->get_firsttag());
 	fmt.register_fmt('l', utils::censor_url(feed->link()));
 	fmt.register_fmt('L', utils::censor_url(feed->rssurl()));
 	fmt.register_fmt('d', utils::utf8_to_locale(feed->description()));
 
 	auto formattedLine = fmt.do_format(feedlist_format, width);
+	formattedLine = utils::quote_for_stfl(formattedLine);
 	if (unread_count > 0) {
 		formattedLine = strprintf::fmt("<unread>%s</>", formattedLine);
 	}

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -344,7 +344,7 @@ std::string FileBrowserFormAction::add_file(std::string filename)
 		retval = strprintf::fmt("{listitem[%c%s] text:%s}",
 				ftype,
 				Stfl::quote(filename),
-				Stfl::quote(line));
+				Stfl::quote(utils::quote_for_stfl(line)));
 	}
 	return retval;
 }

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1047,25 +1047,23 @@ std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 			item.first->pubDate_timestamp()));
 	if (feed->rssurl() != item.first->feedurl() &&
 		item.first->get_feedptr() != nullptr) {
-		auto feedtitle = utils::quote_for_stfl(
-				item.first->get_feedptr()->title());
+		auto feedtitle = item.first->get_feedptr()->title();
 		utils::remove_soft_hyphens(feedtitle);
 		fmt.register_fmt('T', feedtitle);
 	}
 
-	auto itemtitle = utils::quote_for_stfl(utils::utf8_to_locale(
-				item.first->title()));
+	auto itemtitle = utils::utf8_to_locale(item.first->title());
 	utils::remove_soft_hyphens(itemtitle);
 	fmt.register_fmt('t', itemtitle);
 
-	auto itemauthor = utils::quote_for_stfl(utils::utf8_to_locale(
-				item.first->author()));
+	auto itemauthor = utils::utf8_to_locale(item.first->author());
 	utils::remove_soft_hyphens(itemauthor);
 	fmt.register_fmt('a', itemauthor);
 
 	fmt.register_fmt('L', item.first->length());
 
 	auto formattedLine = fmt.do_format(itemlist_format, width);
+	formattedLine = utils::quote_for_stfl(formattedLine);
 
 	if (rxman) {
 		int id;

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -412,6 +412,7 @@ std::string PbView::format_line(const std::string& podlist_format,
 	fmt.register_fmt('b', strprintf::fmt("%s", dl.basename()));
 
 	auto formattedLine = fmt.do_format(podlist_format, width);
+	formattedLine = utils::quote_for_stfl(formattedLine);
 	return formattedLine;
 }
 

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -100,8 +100,7 @@ std::string QueueManager::generate_enqueue_filename(std::shared_ptr<RssItem>
 
 	if (feed->rssurl() != item->feedurl() &&
 		item->get_feedptr() != nullptr) {
-		std::string feedtitle = utils::quote_for_stfl(
-				item->get_feedptr()->title());
+		std::string feedtitle = item->get_feedptr()->title();
 		utils::remove_soft_hyphens(feedtitle);
 		fmt.register_fmt('N', feedtitle);
 	} else {

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -209,6 +209,7 @@ std::string SelectFormAction::format_line(const std::string& selecttag_format,
 	fmt.register_fmt('u', std::to_string(total_feeds));
 
 	auto formattedLine = fmt.do_format(selecttag_format, width);
+	formattedLine = utils::quote_for_stfl(formattedLine);
 
 	return formattedLine;
 }

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -128,10 +128,12 @@ void SelectFormAction::prepare()
 		switch (type) {
 		case SelectionType::TAG:
 			for (const auto& tag : tags) {
-				listfmt.add_line(format_line(selecttag_format,
-						tag,
-						i + 1,
-						width),
+				listfmt.add_line(
+					utils::quote_for_stfl(
+						format_line(selecttag_format,
+							tag,
+							i + 1,
+							width)),
 					i);
 				i++;
 			}
@@ -140,7 +142,7 @@ void SelectFormAction::prepare()
 			for (const auto& filter : filters) {
 				std::string tagstr = strprintf::fmt(
 						"%4u  %s", i + 1, filter.name);
-				listfmt.add_line(tagstr, i);
+				listfmt.add_line(utils::quote_for_stfl(tagstr), i);
 				i++;
 			}
 			break;
@@ -209,7 +211,6 @@ std::string SelectFormAction::format_line(const std::string& selecttag_format,
 	fmt.register_fmt('u', std::to_string(total_feeds));
 
 	auto formattedLine = fmt.do_format(selecttag_format, width);
-	formattedLine = utils::quote_for_stfl(formattedLine);
 
 	return formattedLine;
 }

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -126,7 +126,7 @@ void UrlViewFormAction::prepare()
 		unsigned int i = 0;
 		for (const auto& link : links) {
 			listfmt.add_line(
-				strprintf::fmt("%2u  %s", i + 1, link.first),
+				utils::quote_for_stfl(strprintf::fmt("%2u  %s", i + 1, link.first)),
 				i);
 			i++;
 		}

--- a/stfl/dialogs.stfl
+++ b/stfl/dialogs.stfl
@@ -16,6 +16,7 @@ vbox
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     .expand:vh
+    richtext:1
     pos_name[dialogposname]:
     pos[dialogs_pos]:0
   vbox[hints]

--- a/stfl/dllist.stfl
+++ b/stfl/dllist.stfl
@@ -16,6 +16,7 @@ vbox
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     .expand:vh
+    richtext:1
     pos_name[dlposname]:
     pos[dls_pos]:0
   vbox[hints]

--- a/stfl/filebrowser.stfl
+++ b/stfl/filebrowser.stfl
@@ -15,6 +15,7 @@ vbox
   list[files]
     * this height is only a hack to expand the list correctly (bug?)
     .expand:vh .height:65535
+    richtext:1
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     pos_name[listposname]:

--- a/stfl/selecttag.stfl
+++ b/stfl/selecttag.stfl
@@ -14,6 +14,7 @@ vbox
     .display[showtitle]:1
   list[taglist]
     .expand:vh
+    richtext:1
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     pos_name[tagposname]:

--- a/stfl/urlview.stfl
+++ b/stfl/urlview.stfl
@@ -16,6 +16,7 @@ vbox
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     .expand:vh
+    richtext:1
     pos_name[feedposname]:
     pos[urls_pos]:0
   vbox[hints]

--- a/test/fmtstrformatter.cpp
+++ b/test/fmtstrformatter.cpp
@@ -56,7 +56,7 @@ TEST_CASE("do_format replaces variables with values", "[FmtStrFormatter]")
 				SECTION("Complex format string") {
 					REQUIRE(fmt.do_format("<%a> <%5b> | "
 							"%-5c%%") ==
-						"<>AAA> <>  BBB> | CCC  %");
+						"<AAA> <  BBB> | CCC  %");
 					REQUIRE(fmt.do_format("asdf | %a | "
 							"%?c?%a%b&%b%a? "
 							"| qwert") ==
@@ -133,7 +133,7 @@ TEST_CASE("do_format supports multibyte characters", "[FmtStrFormatter]")
 				SECTION("Complex format string") {
 					REQUIRE(fmt.do_format("<%a> <%5b> | "
 							"%-5c%%") ==
-						"<>АБВ> <>буква> | ещё о%");
+						"<АБВ> <буква> | ещё о%");
 					REQUIRE(fmt.do_format("asdf | %a | "
 							"%?c?%a%b&%b%a? "
 							"| qwert") ==
@@ -194,7 +194,7 @@ TEST_CASE("do_format() does not include wide character if only 1 colum is left",
 	REQUIRE(fmt.do_format("%4a", 0) == "ＡＢ");
 }
 
-TEST_CASE("do_format() escapes less-than sign in regular text",
+TEST_CASE("do_format() does not escape less-than signs in regular text",
 	"[FmtStrFormatter]")
 {
 	FmtStrFormatter fmt;
@@ -202,10 +202,10 @@ TEST_CASE("do_format() escapes less-than sign in regular text",
 	fmt.register_fmt('a', "AAA");
 	fmt.register_fmt('b', "BBB");
 
-	REQUIRE(fmt.do_format("%a <%b>", 0) == "AAA <>BBB>");
+	REQUIRE(fmt.do_format("%a <%b>", 0) == "AAA <BBB>");
 }
 
-TEST_CASE("do_format() escapes less-than sign in filling format",
+TEST_CASE("do_format() does not escape less-than signs in filling format",
 	"[FmtStrFormatter]")
 {
 	FmtStrFormatter fmt;
@@ -214,7 +214,7 @@ TEST_CASE("do_format() escapes less-than sign in filling format",
 	fmt.register_fmt('b', "BBB");
 
 	REQUIRE(fmt.do_format("%a%>.%b", 10) == "AAA....BBB");
-	REQUIRE(fmt.do_format("%a%><%b", 10) == "AAA<><><><>BBB");
+	REQUIRE(fmt.do_format("%a%><%b", 10) == "AAA<<<<BBB");
 	REQUIRE(fmt.do_format("%a%>>%b", 10) == "AAA>>>>BBB");
 }
 


### PR DESCRIPTION
Changes:
- Stop FmtStrFormatter from quoting for stfl and don't quote arguments passed to it
- Instead, quote the output of do_format() for stfl wherever necessary

This moves the quoting for stfl closer to the places where we actually interact with stfl.
It also makes it possible (or at least easier) to implement https://github.com/newsboat/newsboat/issues/806.

---

There were 3 different cases of FmtStrFormatter usage:
- lines in listviews (those are the only lines which need quoting for stfl):
  - [src/feedlistformactioncpp:1071](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/feedlistformaction.cpp#L1071-L1077)
  - [src/itemlistformaction.cpp:1065](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/itemlistformaction.cpp#L1065-L1080)
  - [src/pbview.cpp:414](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/pbview.cpp#L414-L416)
  - [src/selectformaction.cpp:211](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/selectformaction.cpp#L211)

- form titles (`"head"`) which are not "richtext" so `<` should not be escaped:
  - [src/dialogsformaction.cpp:36](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/dialogsformaction.cpp#L36)
  - [src/dirbrowserformaction.cpp:215](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/dirbrowserformaction.cpp#L215-L218)
  - [src/feedlistformaction.cpp:631](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/feedlistformaction.cpp#L631)
  - [src/filebrowserformaction.cpp:215](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/filebrowserformaction.cpp#L215-L216)
  - [src/helpformaction.cpp:93](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/helpformaction.cpp#L93-L94)
  - [src/itemlistformaction.cpp:1022](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/itemlistformaction.cpp#L1121-L1130)
  - [src/itemviewformaction.cpp:501](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/itemviewformaction.cpp#L501-L503)
  - [src/selectformaction.cpp:176](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/selectformaction.cpp#L175-L187)
  - [src/urlviewformaction.cpp:150](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/urlviewformaction.cpp#L150-L152)

- uses which should definitely not be quoted for stfl (similar to https://github.com/newsboat/newsboat/issues/917#issuecomment-623389025):
  - [src/queuemanager.cpp:110](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/queuemanager.cpp#L110)
  - [src/reloader.cpp:309](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/reloader.cpp#L309)
  - [src/view.cpp:327](https://github.com/newsboat/newsboat/blob/2d4246d4d92e8c432b6aef40c8db27cc31c3c520/src/view.cpp#L327-L341)