### PR TITLE
Move strprintf::(anon)::fmt_impl to a `detail` namespace

### DIFF
--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -9,7 +9,7 @@
 namespace newsboat {
 
 namespace strprintf {
-namespace {
+namespace detail {
 template<typename T, typename... Args>
 std::string fmt_impl(const std::string& format, const T& argument,
 	Args... args);
@@ -23,46 +23,46 @@ std::string fmt(const std::string& format);
 template<typename... Args>
 std::string fmt(const std::string& format, const char* argument, Args... args)
 {
-	return fmt_impl(format, argument, args...);
+	return detail::fmt_impl(format, argument, args...);
 }
 
 template<typename... Args>
 std::string fmt(const std::string& format, const int32_t argument, Args... args)
 {
-	return fmt_impl(format, argument, args...);
+	return detail::fmt_impl(format, argument, args...);
 }
 
 template<typename... Args>
 std::string fmt(const std::string& format, const std::uint32_t argument,
 	Args... args)
 {
-	return fmt_impl(format, argument, args...);
+	return detail::fmt_impl(format, argument, args...);
 }
 
 template<typename... Args>
 std::string fmt(const std::string& format, const int64_t argument, Args... args)
 {
-	return fmt_impl(format, argument, args...);
+	return detail::fmt_impl(format, argument, args...);
 }
 
 template<typename... Args>
 std::string fmt(const std::string& format, const uint64_t argument,
 	Args... args)
 {
-	return fmt_impl(format, argument, args...);
+	return detail::fmt_impl(format, argument, args...);
 }
 
 template<typename... Args>
 std::string fmt(const std::string& format, const void* argument, Args... args)
 {
-	return fmt_impl(format, argument, args...);
+	return detail::fmt_impl(format, argument, args...);
 }
 
 template<typename... Args>
 std::string fmt(const std::string& format, const std::nullptr_t argument,
 	Args... args)
 {
-	return fmt_impl(format, argument, args...);
+	return detail::fmt_impl(format, argument, args...);
 }
 
 template<typename... Args>
@@ -70,13 +70,13 @@ std::string fmt(const std::string& format, const float argument, Args... args)
 {
 	// Variadic functions (like snprintf) do not accept `float`, so let's
 	// convert that.
-	return fmt_impl(format, static_cast<double>(argument), args...);
+	return detail::fmt_impl(format, static_cast<double>(argument), args...);
 }
 
 template<typename... Args>
 std::string fmt(const std::string& format, const double argument, Args... args)
 {
-	return fmt_impl(format, argument, args...);
+	return detail::fmt_impl(format, argument, args...);
 }
 
 template<typename... Args>
@@ -95,7 +95,7 @@ std::string fmt(const std::string& format,
 	return fmt(format, argument->c_str(), args...);
 }
 
-namespace {
+namespace detail {
 template<typename T, typename... Args>
 std::string fmt_impl(const std::string& format, const T& argument, Args... args)
 {


### PR DESCRIPTION
When I wrote our strprintf, I didn't realize that anonymous namespaces have internal linkage, i.e. each .cpp file will have its own implementations. As a result, Newsboat binary contained multiple instantiations for the same types, for the grand total of 191Kb:

```
$ bloaty -d symbols -n 50 newsboat | grep -i fmt_impl
0.2%   191Ki   3.6%   183Ki    newsboat::strprintf::(anonymous namespace)::fmt_impl<>()
```

By moving the function into a named namespace, I'm allowing the linker to throw out duplicates, reducing the amount of code almost twofold:

```
0.1%   108Ki   2.0%  98.7Ki newsboat::strprintf::detail::fmt_impl<>()
```

`bloaty` above is Bloaty McBloatface, a size profiler for binaries: https://github.com/google/bloaty

This commit is inspired by this blog post: https://www.zverovich.net/2020/05/21/reducing-library-size.html

Kudos to @ttldtor for pointing out my mistake with namespaces.

I looked through the rest of `-d symbols` output, but didn't spot anything else. Apparently a more trained eye is required for that.

Reviews are welcome. Otherwise, I'll just merge in three days.