### PR TITLE
Prevent PRs from "master" interfering with this repo's coverage

### DIFF
--- a/submit-to-coveralls.sh
+++ b/submit-to-coveralls.sh
@@ -17,7 +17,7 @@ else
     branch="${TRAVIS_BRANCH}"
 fi
 
-if [ "${TRAVIS_PULL_REQUEST}" = "true" ]
+if [ "${TRAVIS_PULL_REQUEST}" != "false" ]
 then
     service_pull_request="--service-pull-request ${TRAVIS_PULL_REQUEST}"
 fi

--- a/submit-to-coveralls.sh
+++ b/submit-to-coveralls.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # For pull requests, TRAVIS_BRANCH is the *target* branch, usually "master".
-# This leads to mis-assigned coverage reports: they aren't assigned to PR's
-# source branch. To combat this, we detect if the build is triggered by a PR,
-# and explicitly use PR's source branch if so. That branch might not actually
-# exist in our main repo, but that's fine -- Coveralls doesn't check.
+# This leads to mis-assigned coverage reports. To combat this, we detect if the
+# build is triggered by a PR, and explicitly use PR's source branch if so. We
+# add PR's slug ("owner_name/repo_name") in front of the branch name, to avoid
+# PRs from "master" branch to affect our master's coverage.
 #
 # Similar distinction exists between TRAVIS_COMMIT and TRAVIS_PULL_REQUEST_SHA,
 # but we don't paper over it there because we *do* want the report to attach to
@@ -12,7 +12,7 @@
 # if the merge commit affected our coverage somehow.
 if [ "${TRAVIS_EVENT_TYPE}" = "pull_request" ]
 then
-    branch="${TRAVIS_PULL_REQUEST_BRANCH}"
+    branch="${TRAVIS_PULL_REQUEST_SLUG}/${TRAVIS_PULL_REQUEST_BRANCH}"
 else
     branch="${TRAVIS_BRANCH}"
 fi


### PR DESCRIPTION
#951 changed a few lines that shouldn't have affected coverage at all, but Coveralls said it went up by 0.01%. After looking into it, I noticed that a few previous PR builds are also attribute to master, lowering its coverage. Those PRs were made from a master branch, i.e. the contributor didn't create a feature branch to make their changes in.

This PR (hopefuly) fixes that loophole by adding an "owner_name/repo_name" slug in front of all PR branches. All currently outstanding PRs (#842, #889, #914, #950) are still affected by this problem, so we should either rebase them after merging this one, or just ignore their coverage reports.

I also tried to fix a smaller problem where we apparently didn't pass Coveralls the PR number. No idea how it worked before. I'll have to wait for a report on this PR to see if it worked.

I intend to merge this pretty much immediately, so if you have any comments — please post them even if the PR is closed.