### PR TITLE
Update read percentage after every operation on ItemViewFormAction

### DIFF
--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -460,6 +460,9 @@ bool ItemViewFormAction::process_operation(Operation op,
 	} else if (quit) {
 		v->pop_current_formaction();
 	}
+
+	update_percent();
+
 	return true;
 }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -181,11 +181,6 @@ int View::run()
 			}
 
 			if (!event || strcmp(event, "TIMEOUT") == 0) {
-				if (fa->id() == "article")
-					std::dynamic_pointer_cast<
-					ItemViewFormAction,
-					FormAction>(fa)
-					->update_percent();
 				continue;
 			}
 


### PR DESCRIPTION
This fixes the issue described below.

---

The "percentage read" field is no longer updated when scrolling up or down.

Before, when stfl was handling keys like `UP` and `DOWN`, it returned an empty event after processing such a keypress.
Now, stfl instead returns the actual key name and we process it like regular keypresses (changed by https://github.com/newsboat/newsboat/pull/913).
This caused the following piece of code to stop working (`update_percent()` only gets called on a `TIMEOUT` event which happens when no key is pressed for 60 seconds).

https://github.com/newsboat/newsboat/blob/5f1ed85aed15636695f7cfc61fbf93b63a9c5ee5/src/view.cpp#L183-L190