### PR TITLE
ListWidget: Accept ListFormatter reference instead of separate <formatted text> and <number of lines>

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -96,6 +96,11 @@ public:
 		return api;
 	}
 
+	RegexManager& get_regexmanager()
+	{
+		return rxman;
+	}
+
 private:
 	void import_opml(const std::string& opmlFile, const std::string& urlFile);
 	void export_opml();

--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -18,7 +18,8 @@ public:
 		std::string formstr,
 		Cache* cc,
 		FilterContainer* f,
-		ConfigContainer* cfg);
+		ConfigContainer* cfg,
+		RegexManager& r);
 	~FeedListFormAction() override;
 	void prepare() override;
 	void init() override;
@@ -46,9 +47,9 @@ public:
 
 	void mark_pos_if_visible(unsigned int pos);
 
-	void set_regexmanager(RegexManager* r);
-
 private:
+	void register_format_styles();
+
 	int get_pos(unsigned int realidx);
 	bool process_operation(Operation op,
 		bool automatic = false,
@@ -89,7 +90,7 @@ private:
 	unsigned int filterpos;
 	bool set_filterpos;
 
-	RegexManager* rxman;
+	RegexManager& rxman;
 
 	unsigned int old_width;
 

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -22,7 +22,8 @@ public:
 		std::string formstr,
 		Cache* cc,
 		FilterContainer* f,
-		ConfigContainer* cfg);
+		ConfigContainer* cfg,
+		RegexManager& r);
 	~ItemListFormAction() override;
 	void prepare() override;
 	void init() override;
@@ -75,9 +76,9 @@ public:
 
 	void recalculate_form() override;
 
-	void set_regexmanager(RegexManager* r);
-
 private:
+	void register_format_styles();
+
 	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
@@ -142,7 +143,7 @@ private:
 	bool set_filterpos;
 	unsigned int filterpos;
 
-	RegexManager* rxman;
+	RegexManager& rxman;
 
 	unsigned int old_width;
 	int old_itempos;

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -14,7 +14,7 @@ namespace newsboat {
 
 typedef std::pair<std::shared_ptr<RssItem>, unsigned int> ItemPtrPosPair;
 
-enum class InvalidationMode { PARTIAL, COMPLETE };
+enum class InvalidationMode { NONE, PARTIAL, COMPLETE };
 
 class ItemListFormAction : public ListFormAction {
 public:
@@ -105,18 +105,15 @@ private:
 
 	void invalidate_everything()
 	{
-		invalidated = true;
 		invalidation_mode = InvalidationMode::COMPLETE;
 	}
 
 	void invalidate(const unsigned int invalidated_pos)
 	{
-		if (invalidated == true &&
-			invalidation_mode == InvalidationMode::COMPLETE) {
+		if (invalidation_mode == InvalidationMode::COMPLETE) {
 			return;
 		}
 
-		invalidated = true;
 		invalidation_mode = InvalidationMode::PARTIAL;
 		invalidated_itempos.push_back(invalidated_pos);
 	}
@@ -149,7 +146,6 @@ private:
 	int old_itempos;
 	ArticleSortStrategy old_sort_strategy;
 
-	bool invalidated;
 	InvalidationMode invalidation_mode;
 	std::vector<unsigned int> invalidated_itempos;
 

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -19,7 +19,8 @@ public:
 		std::shared_ptr<ItemListFormAction> il,
 		std::string formstr,
 		Cache* cc,
-		ConfigContainer* cfg);
+		ConfigContainer* cfg,
+		RegexManager& r);
 	~ItemViewFormAction() override;
 	void prepare() override;
 	void init() override;
@@ -49,11 +50,11 @@ public:
 		std::vector<LinkPair>& thelinks,
 		const std::string& url);
 
-	void set_regexmanager(RegexManager* r);
-
 	void update_percent();
 
 private:
+	void register_format_styles();
+
 	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
@@ -75,7 +76,7 @@ private:
 	bool show_source;
 	std::vector<LinkPair> links;
 	bool quit;
-	RegexManager* rxman;
+	RegexManager& rxman;
 	unsigned int num_lines;
 	std::shared_ptr<ItemListFormAction> itemlist;
 	bool in_search;

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -29,15 +29,14 @@ public:
 	{
 		lines.clear();
 	}
-	std::string format_list();
-	unsigned int get_lines_count()
+	std::string format_list() const;
+	unsigned int get_lines_count() const
 	{
 		return lines.size();
 	}
 
 private:
 	std::vector<LineIdPair> lines;
-	std::string format_cache;
 	RegexManager* rxman;
 	std::string location;
 };

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -14,7 +14,7 @@ class ListFormatter {
 	typedef std::pair<std::string, std::string> LineIdPair;
 
 public:
-	ListFormatter();
+	ListFormatter(RegexManager* r = nullptr, const std::string& loc = "");
 	~ListFormatter();
 	void add_line(const std::string& text,
 		const std::string& id = "",
@@ -29,8 +29,7 @@ public:
 	{
 		lines.clear();
 	}
-	std::string format_list(RegexManager* r = nullptr,
-		const std::string& location = "");
+	std::string format_list();
 	unsigned int get_lines_count()
 	{
 		return lines.size();
@@ -39,6 +38,8 @@ public:
 private:
 	std::vector<LineIdPair> lines;
 	std::string format_cache;
+	RegexManager* rxman;
+	std::string location;
 };
 
 } // namespace newsboat

--- a/include/listwidget.h
+++ b/include/listwidget.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <string>
 
+#include "listformatter.h"
 #include "stflpp.h"
 
 namespace newsboat {
@@ -13,7 +14,7 @@ class ListWidget {
 public:
 	ListWidget(const std::string& list_name, Stfl::Form& form);
 	void stfl_replace_list(std::uint32_t number_of_lines, std::string stfl);
-	void stfl_replace_lines(std::uint32_t number_of_lines, std::string stfl);
+	void stfl_replace_lines(const ListFormatter& listfmt);
 
 	bool move_up(bool wrap_scroll);
 	bool move_down(bool wrap_scroll);

--- a/include/view.h
+++ b/include/view.h
@@ -110,7 +110,6 @@ public:
 
 	void feedlist_mark_pos_if_visible(unsigned int pos);
 
-	void set_regexmanager(RegexManager* r);
 	void set_cache(Cache* c);
 	void set_filters(FilterContainer* f);
 
@@ -157,7 +156,7 @@ protected:
 
 	std::vector<std::string> tags;
 
-	RegexManager* rxman;
+	RegexManager& rxman;
 
 	std::map<std::string, std::string> fg_colors;
 	std::map<std::string, std::string> bg_colors;

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -56,15 +56,15 @@ src/colormanager.o: src/colormanager.cpp include/colormanager.h \
  include/configparser.h include/configactionhandler.h config.h \
  include/confighandlerexception.h include/feedlistformaction.h \
  include/history.h include/listformaction.h include/formaction.h \
- include/keymap.h include/stflpp.h include/listwidget.h include/matcher.h \
- filter/FilterParser.h include/regexmanager.h include/view.h \
- include/colormanager.h include/configcontainer.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h 3rd-party/optional.hpp \
- include/filebrowserformaction.h include/listformatter.h \
+ include/keymap.h include/stflpp.h include/listwidget.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/view.h include/colormanager.h \
+ include/configcontainer.h include/controller.h include/cache.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ 3rd-party/optional.hpp include/filebrowserformaction.h \
  include/dirbrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h include/filebrowserformaction.h \
  include/helpformaction.h include/textviewwidget.h \
@@ -120,17 +120,17 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
 src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/dialogsformaction.h include/formaction.h include/history.h \
  include/keymap.h include/configparser.h include/configactionhandler.h \
- include/stflpp.h include/listwidget.h config.h include/fmtstrformatter.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- include/strprintf.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/listformatter.h include/dirbrowserformaction.h \
+ include/stflpp.h include/listwidget.h include/listformatter.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h config.h \
+ include/fmtstrformatter.h include/listformatter.h include/strprintf.h \
+ include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h include/strprintf.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/filebrowserformaction.h include/dirbrowserformaction.h \
  include/htmlrenderer.h include/textformatter.h
 src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/dirbrowserformaction.h include/configcontainer.h \
@@ -178,14 +178,14 @@ src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/feedlistformaction.h include/history.h include/listformaction.h \
  include/formaction.h include/keymap.h include/configparser.h \
  include/configactionhandler.h include/stflpp.h include/listwidget.h \
- include/matcher.h filter/FilterParser.h include/regexmanager.h \
- include/view.h include/colormanager.h include/configcontainer.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- include/filebrowserformaction.h include/listformatter.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/view.h include/colormanager.h \
+ include/configcontainer.h include/controller.h include/cache.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ 3rd-party/optional.hpp include/filebrowserformaction.h \
  include/dirbrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h config.h include/dbexception.h \
  include/feedcontainer.h include/fmtstrformatter.h \
@@ -344,10 +344,10 @@ src/listformatter.o: src/listformatter.cpp include/listformatter.h \
  3rd-party/optional.hpp include/configcontainer.h include/logger.h \
  config.h include/strprintf.h
 src/listwidget.o: src/listwidget.cpp include/listwidget.h \
+ include/listformatter.h include/regexmanager.h include/configparser.h \
+ include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/stflpp.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h
+ include/configcontainer.h include/logger.h config.h include/strprintf.h
 src/logger.o: src/logger.cpp include/logger.h config.h \
  include/strprintf.h
 src/matcher.o: src/matcher.cpp include/matcher.h filter/FilterParser.h \
@@ -409,19 +409,22 @@ src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
  include/keymap.h include/logger.h include/strprintf.h \
  include/matcherexception.h include/nullconfigactionhandler.h \
  include/pbview.h include/colormanager.h include/keymap.h \
- include/listwidget.h include/stflpp.h include/textviewwidget.h \
- include/poddlthread.h include/queueloader.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/logger.h
+ include/listwidget.h include/listformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/stflpp.h \
+ include/textviewwidget.h include/poddlthread.h include/queueloader.h \
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h
 src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
  include/configparser.h include/configactionhandler.h include/keymap.h \
- include/listwidget.h include/stflpp.h include/textviewwidget.h config.h \
- include/configcontainer.h stfl/dllist.h include/download.h \
- include/fmtstrformatter.h stfl/help.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/logger.h include/strprintf.h include/pbcontroller.h \
- include/configcontainer.h include/download.h include/fslock.h \
- include/queueloader.h include/poddlthread.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/logger.h
+ include/listwidget.h include/listformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/stflpp.h \
+ include/textviewwidget.h config.h include/configcontainer.h \
+ stfl/dllist.h include/download.h include/fmtstrformatter.h stfl/help.h \
+ include/listformatter.h include/logger.h include/strprintf.h \
+ include/pbcontroller.h include/configcontainer.h include/download.h \
+ include/fslock.h include/queueloader.h include/poddlthread.h \
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h
 src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h config.h \
@@ -523,18 +526,18 @@ src/selectformaction.o: src/selectformaction.cpp \
  include/selectformaction.h include/filtercontainer.h \
  include/configparser.h include/configactionhandler.h \
  include/formaction.h include/history.h include/keymap.h include/stflpp.h \
- include/listwidget.h config.h include/fmtstrformatter.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- include/strprintf.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/filebrowserformaction.h \
- include/listformatter.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/listwidget.h include/listformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h config.h \
+ include/fmtstrformatter.h include/listformatter.h include/strprintf.h \
+ include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h include/strprintf.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/feedcontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/filebrowserformaction.h \
+ include/dirbrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/stflpp.o: src/stflpp.cpp include/stflpp.h include/exception.h \
  include/logger.h config.h include/strprintf.h include/utils.h \
  3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
@@ -573,17 +576,17 @@ src/urlviewformaction.o: src/urlviewformaction.cpp \
  include/keymap.h include/configparser.h include/configactionhandler.h \
  include/stflpp.h include/htmlrenderer.h include/textformatter.h \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/listwidget.h config.h include/fmtstrformatter.h \
- include/listformatter.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/utils.h \
- include/configcontainer.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h include/view.h \
+ include/listwidget.h include/listformatter.h config.h \
+ include/fmtstrformatter.h include/listformatter.h include/rssfeed.h \
+ include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
+ include/utils.h include/configcontainer.h include/logger.h \
+ include/strprintf.h include/strprintf.h include/utils.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
  include/opml.h include/fileurlreader.h include/urlreader.h \
  include/queuemanager.h include/reloader.h include/remoteapi.h \
  include/rssignores.h include/filebrowserformaction.h \
- include/listformatter.h include/dirbrowserformaction.h
+ include/dirbrowserformaction.h
 src/utils.o: src/utils.cpp include/utils.h 3rd-party/optional.hpp \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h config.h \

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -845,8 +845,6 @@ void Controller::export_read_information(const std::string& readinfofile)
 
 void Controller::update_config()
 {
-	v->set_regexmanager(&rxman);
-
 	if (colorman.colors_loaded()) {
 		v->set_colors(colorman.get_fgcolors(),
 			colorman.get_bgcolors(),

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -61,8 +61,7 @@ void DialogsFormAction::prepare()
 			i++;
 		}
 
-		dialogs_list.stfl_replace_lines(listfmt.get_lines_count(),
-			listfmt.format_list());
+		dialogs_list.stfl_replace_lines(listfmt);
 
 		update_list = false;
 	}

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -271,7 +271,7 @@ void DirBrowserFormAction::prepare()
 			add_directory(listfmt, directory);
 		}
 
-		files_list.stfl_replace_lines(listfmt.get_lines_count(), listfmt.format_list());
+		files_list.stfl_replace_lines(listfmt);
 		do_redraw = false;
 	}
 

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -617,8 +617,7 @@ void FeedListFormAction::set_feedlist(
 
 	total_feeds = i;
 
-	feeds_list.stfl_replace_lines(listfmt.get_lines_count(),
-		listfmt.format_list());
+	feeds_list.stfl_replace_lines(listfmt);
 
 	std::string title_format =
 		cfg->get_configvalue("feedlist-title-format");

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -598,7 +598,7 @@ void FeedListFormAction::set_feedlist(
 
 	std::string feedlist_format = cfg->get_configvalue("feedlist-format");
 
-	ListFormatter listfmt;
+	ListFormatter listfmt(&rxman, "feedlist");
 
 	update_visible_feeds(feeds);
 
@@ -618,7 +618,7 @@ void FeedListFormAction::set_feedlist(
 	total_feeds = i;
 
 	feeds_list.stfl_replace_lines(listfmt.get_lines_count(),
-		listfmt.format_list(&rxman, "feedlist"));
+		listfmt.format_list());
 
 	std::string title_format =
 		cfg->get_configvalue("feedlist-title-format");

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -26,7 +26,8 @@ FeedListFormAction::FeedListFormAction(View* vv,
 	std::string formstr,
 	Cache* cc,
 	FilterContainer* f,
-	ConfigContainer* cfg)
+	ConfigContainer* cfg,
+	RegexManager& r)
 	: ListFormAction(vv, formstr, cfg)
 	, zero_feedpos(false)
 	, feeds_shown(0)
@@ -35,7 +36,7 @@ FeedListFormAction::FeedListFormAction(View* vv,
 	, search_dummy_feed(new RssFeed(cc))
 	, filterpos(0)
 	, set_filterpos(false)
-	, rxman(0)
+	, rxman(r)
 	, old_width(0)
 	, unread_feeds(0)
 	, total_feeds(0)
@@ -47,6 +48,7 @@ FeedListFormAction::FeedListFormAction(View* vv,
 	std::sort(valid_cmds.begin(), valid_cmds.end());
 	old_sort_order = cfg->get_configvalue("feed-sort-order");
 	search_dummy_feed->set_search_feed(true);
+	register_format_styles();
 }
 
 void FeedListFormAction::init()
@@ -616,7 +618,7 @@ void FeedListFormAction::set_feedlist(
 	total_feeds = i;
 
 	feeds_list.stfl_replace_lines(listfmt.get_lines_count(),
-		listfmt.format_list(rxman, "feedlist"));
+		listfmt.format_list(&rxman, "feedlist"));
 
 	std::string title_format =
 		cfg->get_configvalue("feedlist-title-format");
@@ -926,10 +928,9 @@ void FeedListFormAction::save_filterpos()
 	}
 }
 
-void FeedListFormAction::set_regexmanager(RegexManager* r)
+void FeedListFormAction::register_format_styles()
 {
-	rxman = r;
-	const std::string attrstr = r->get_attrs_stfl_string("feedlist", true);
+	const std::string attrstr = rxman.get_attrs_stfl_string("feedlist", true);
 	const std::string textview = strprintf::fmt(
 			"{!list[feeds] .expand:vh style_normal[listnormal]: "
 			"style_focus[listfocus]:fg=yellow,bg=blue,attr=bold "

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -263,7 +263,7 @@ void FileBrowserFormAction::prepare()
 			add_file(listfmt, filename);
 		}
 
-		files_list.stfl_replace_lines(listfmt.get_lines_count(), listfmt.format_list());
+		files_list.stfl_replace_lines(listfmt);
 		do_redraw = false;
 	}
 

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1020,8 +1020,7 @@ void ItemListFormAction::prepare()
 		break;
 	}
 
-	items_list.stfl_replace_lines(listfmt.get_lines_count(),
-		listfmt.format_list());
+	items_list.stfl_replace_lines(listfmt);
 
 	invalidated_itempos.clear();
 	invalidated = false;

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -39,8 +39,7 @@ ItemListFormAction::ItemListFormAction(View* vv,
 	, old_width(0)
 	, old_itempos(-1)
 	, old_sort_strategy({ArtSortMethod::TITLE, SortDirection::DESC})
-, invalidated(false)
-, invalidation_mode(InvalidationMode::COMPLETE)
+, invalidation_mode(InvalidationMode::NONE)
 , listfmt(&rxman, "articlelist")
 , rsscache(cc)
 , filters(f)
@@ -913,7 +912,7 @@ void ItemListFormAction::qna_start_search()
 
 void ItemListFormAction::do_update_visible_items()
 {
-	if (!(invalidated && invalidation_mode == InvalidationMode::COMPLETE)) {
+	if (invalidation_mode != InvalidationMode::COMPLETE) {
 		return;
 	}
 
@@ -987,7 +986,7 @@ void ItemListFormAction::prepare()
 		old_width = width;
 	}
 
-	if (!invalidated) {
+	if (invalidation_mode == InvalidationMode::NONE) {
 		return;
 	}
 
@@ -1018,12 +1017,14 @@ void ItemListFormAction::prepare()
 			listfmt.set_line(itempos, line, std::to_string(item.second));
 		}
 		break;
+	case InvalidationMode::NONE:
+		break;
 	}
 
 	items_list.stfl_replace_lines(listfmt);
 
 	invalidated_itempos.clear();
-	invalidated = false;
+	invalidation_mode = InvalidationMode::NONE;
 
 	set_head(feed->title(),
 		feed->unread_item_count(),

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -41,6 +41,7 @@ ItemListFormAction::ItemListFormAction(View* vv,
 	, old_sort_strategy({ArtSortMethod::TITLE, SortDirection::DESC})
 , invalidated(false)
 , invalidation_mode(InvalidationMode::COMPLETE)
+, listfmt(&rxman, "articlelist")
 , rsscache(cc)
 , filters(f)
 , items_list("items", FormAction::f)
@@ -1020,7 +1021,7 @@ void ItemListFormAction::prepare()
 	}
 
 	items_list.stfl_replace_lines(listfmt.get_lines_count(),
-		listfmt.format_list(&rxman, "articlelist"));
+		listfmt.format_list());
 
 	invalidated_itempos.clear();
 	invalidated = false;

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -75,9 +75,9 @@ void ListFormatter::add_lines(const std::vector<std::string>& thelines,
 	}
 }
 
-std::string ListFormatter::format_list()
+std::string ListFormatter::format_list() const
 {
-	format_cache = "{list";
+	std::string format_cache = "{list";
 	for (const auto& line : lines) {
 		std::string str = line.first;
 		if (rxman) {

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -9,7 +9,10 @@
 
 namespace newsboat {
 
-ListFormatter::ListFormatter() {}
+ListFormatter::ListFormatter(RegexManager* r, const std::string& loc)
+	: rxman(r)
+	, location(loc)
+{}
 
 ListFormatter::~ListFormatter() {}
 
@@ -72,8 +75,7 @@ void ListFormatter::add_lines(const std::vector<std::string>& thelines,
 	}
 }
 
-std::string ListFormatter::format_list(RegexManager* rxman,
-	const std::string& location)
+std::string ListFormatter::format_list()
 {
 	format_cache = "{list";
 	for (const auto& line : lines) {

--- a/src/listwidget.cpp
+++ b/src/listwidget.cpp
@@ -21,11 +21,10 @@ void ListWidget::stfl_replace_list(std::uint32_t number_of_lines,
 	form.modify(list_name, "replace", stfl);
 }
 
-void ListWidget::stfl_replace_lines(std::uint32_t number_of_lines,
-	std::string stfl)
+void ListWidget::stfl_replace_lines(const ListFormatter& listfmt)
 {
-	num_lines = number_of_lines;
-	form.modify(list_name, "replace_inner", stfl);
+	num_lines = listfmt.get_lines_count();
+	form.modify(list_name, "replace_inner", listfmt.format_list());
 }
 
 bool ListWidget::move_up(bool wrap_scroll)

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -100,8 +100,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 				i++;
 			}
 
-			downloads_list.stfl_replace_lines(listfmt.get_lines_count(),
-				listfmt.format_list());
+			downloads_list.stfl_replace_lines(listfmt);
 
 			ctrl->set_view_update_necessary(false);
 		}

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -150,7 +150,7 @@ void SelectFormAction::prepare()
 		default:
 			assert(0);
 		}
-		tags_list.stfl_replace_lines(listfmt.get_lines_count(), listfmt.format_list());
+		tags_list.stfl_replace_lines(listfmt);
 
 		do_redraw = false;
 	}

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -132,7 +132,7 @@ void UrlViewFormAction::prepare()
 				std::to_string(i));
 			i++;
 		}
-		urls_list.stfl_replace_lines(listfmt.get_lines_count(), listfmt.format_list());
+		urls_list.stfl_replace_lines(listfmt);
 	}
 }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -125,8 +125,7 @@ int View::run()
 
 	// create feedlist
 	auto feedlist = std::make_shared<FeedListFormAction>(
-			this, feedlist_str, rsscache, filters, cfg);
-	feedlist->set_regexmanager(&rxman);
+			this, feedlist_str, rsscache, filters, cfg, rxman);
 	feedlist->set_tags(tags);
 	apply_colors(feedlist);
 	formaction_stack.push_back(feedlist);
@@ -416,8 +415,7 @@ void View::push_searchresult(std::shared_ptr<RssFeed> feed,
 	if (feed->total_item_count() > 0) {
 		std::shared_ptr<ItemListFormAction> searchresult(
 			new ItemListFormAction(
-				this, itemlist_str, rsscache, filters, cfg));
-		searchresult->set_regexmanager(&rxman);
+				this, itemlist_str, rsscache, filters, cfg, rxman));
 		searchresult->set_feed(feed);
 		searchresult->set_show_searchresult(true);
 		searchresult->set_searchphrase(phrase);
@@ -442,8 +440,7 @@ void View::push_itemlist(std::shared_ptr<RssFeed> feed)
 	if (feed->total_item_count() > 0) {
 		std::shared_ptr<ItemListFormAction> itemlist(
 			new ItemListFormAction(
-				this, itemlist_str, rsscache, filters, cfg));
-		itemlist->set_regexmanager(&rxman);
+				this, itemlist_str, rsscache, filters, cfg, rxman));
 		itemlist->set_feed(feed);
 		itemlist->set_show_searchresult(false);
 		apply_colors(itemlist);
@@ -487,8 +484,7 @@ void View::push_itemview(std::shared_ptr<RssFeed> f,
 		assert(itemlist != nullptr);
 		std::shared_ptr<ItemViewFormAction> itemview(
 			new ItemViewFormAction(
-				this, itemlist, itemview_str, rsscache, cfg));
-		itemview->set_regexmanager(&rxman);
+				this, itemlist, itemview_str, rsscache, cfg, rxman));
 		itemview->set_feed(f);
 		itemview->set_guid(guid);
 		itemview->set_parent_formaction(fa);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -64,7 +64,7 @@ View::View(Controller* c)
 	, cfg(0)
 	, keys(0)
 	, current_formaction(0)
-	, rxman(nullptr)
+	, rxman(c->get_regexmanager())
 	, is_inside_qna(false)
 	, is_inside_cmdline(false)
 	, tab_count(0)
@@ -126,7 +126,7 @@ int View::run()
 	// create feedlist
 	auto feedlist = std::make_shared<FeedListFormAction>(
 			this, feedlist_str, rsscache, filters, cfg);
-	feedlist->set_regexmanager(rxman);
+	feedlist->set_regexmanager(&rxman);
 	feedlist->set_tags(tags);
 	apply_colors(feedlist);
 	formaction_stack.push_back(feedlist);
@@ -417,7 +417,7 @@ void View::push_searchresult(std::shared_ptr<RssFeed> feed,
 		std::shared_ptr<ItemListFormAction> searchresult(
 			new ItemListFormAction(
 				this, itemlist_str, rsscache, filters, cfg));
-		searchresult->set_regexmanager(rxman);
+		searchresult->set_regexmanager(&rxman);
 		searchresult->set_feed(feed);
 		searchresult->set_show_searchresult(true);
 		searchresult->set_searchphrase(phrase);
@@ -443,7 +443,7 @@ void View::push_itemlist(std::shared_ptr<RssFeed> feed)
 		std::shared_ptr<ItemListFormAction> itemlist(
 			new ItemListFormAction(
 				this, itemlist_str, rsscache, filters, cfg));
-		itemlist->set_regexmanager(rxman);
+		itemlist->set_regexmanager(&rxman);
 		itemlist->set_feed(feed);
 		itemlist->set_show_searchresult(false);
 		apply_colors(itemlist);
@@ -488,7 +488,7 @@ void View::push_itemview(std::shared_ptr<RssFeed> f,
 		std::shared_ptr<ItemViewFormAction> itemview(
 			new ItemViewFormAction(
 				this, itemlist, itemview_str, rsscache, cfg));
-		itemview->set_regexmanager(rxman);
+		itemview->set_regexmanager(&rxman);
 		itemview->set_feed(f);
 		itemview->set_guid(guid);
 		itemview->set_parent_formaction(fa);
@@ -1103,11 +1103,6 @@ void View::feedlist_mark_pos_if_visible(unsigned int pos)
 			formaction_stack[0])
 		->mark_pos_if_visible(pos);
 	}
-}
-
-void View::set_regexmanager(RegexManager* r)
-{
-	rxman = r;
 }
 
 void View::set_cache(Cache* c)

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -37,6 +37,7 @@ TEST_CASE("OP_OPEN displays article using an external pager",
 
 	ConfigContainer cfg;
 	FilterContainer filters;
+	RegexManager rxman;
 
 	Cache rsscache(":memory:", &cfg);
 	cfg.set_configvalue("pager", "cat %f > " + pagerfile.get_path());
@@ -55,7 +56,7 @@ TEST_CASE("OP_OPEN displays article using an external pager",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	REQUIRE_NOTHROW(itemlist.process_op(OP_OPEN));
@@ -77,6 +78,7 @@ TEST_CASE("OP_PURGE_DELETED purges previously deleted items",
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	feed->add_item(item);
@@ -84,7 +86,7 @@ TEST_CASE("OP_PURGE_DELETED purges previously deleted items",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	SECTION("No items to purge") {
@@ -116,6 +118,7 @@ TEST_CASE(
 
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
@@ -126,7 +129,7 @@ TEST_CASE(
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 	itemlist.process_op(OP_OPENBROWSER_AND_MARK);
 	std::ifstream browserFileStream(browserfile.get_path());
@@ -152,6 +155,7 @@ TEST_CASE(
 
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
@@ -162,7 +166,7 @@ TEST_CASE(
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 	itemlist.process_op(OP_OPENBROWSER_AND_MARK);
 
@@ -184,6 +188,7 @@ TEST_CASE("OP_OPENINBROWSER passes the url to the browser",
 
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
@@ -193,7 +198,7 @@ TEST_CASE("OP_OPENINBROWSER passes the url to the browser",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 	itemlist.process_op(OP_OPENINBROWSER);
 	std::ifstream browserFileStream(browserfile.get_path());
@@ -219,6 +224,7 @@ TEST_CASE("OP_OPENALLUNREADINBROWSER passes the url list to the browser",
 
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
 
@@ -234,7 +240,7 @@ TEST_CASE("OP_OPENALLUNREADINBROWSER passes the url list to the browser",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	SECTION("unread >= max-browser-tabs") {
@@ -302,6 +308,7 @@ TEST_CASE(
 
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
 
@@ -317,7 +324,7 @@ TEST_CASE(
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	SECTION("unread >= max-browser-tabs") {
@@ -376,6 +383,7 @@ TEST_CASE("OP_SHOWURLS shows the article's properties", "[ItemListFormAction]")
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 	TestHelpers::TempFile urlFile;
 
 	const std::string test_url = "http://test_url";
@@ -400,7 +408,7 @@ TEST_CASE("OP_SHOWURLS shows the article's properties", "[ItemListFormAction]")
 	item->set_author(test_author);
 	item->set_description(test_description);
 	item->set_pubDate(test_pubDate);
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 
 	SECTION("with external-url-viewer") {
 		feed->add_item(item);
@@ -438,6 +446,7 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 	TestHelpers::TempFile bookmarkFile;
 	std::string line;
 	std::vector<std::string> bookmark_args;
@@ -458,7 +467,7 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 	item->set_link(test_url);
 	item->set_title(test_title);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 
 	feed->add_item(item);
 	itemlist.set_feed(feed);
@@ -486,6 +495,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	std::vector<std::string> op_args;
 
@@ -495,7 +505,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 
 	feed->add_item(item);
 	itemlist.set_feed(feed);
@@ -575,6 +585,7 @@ TEST_CASE("OP_SAVE writes an article's attributes to the specified file",
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	std::vector<std::string> op_args;
 	op_args.push_back(saveFile.get_path());
@@ -602,7 +613,7 @@ TEST_CASE("OP_SAVE writes an article's attributes to the specified file",
 	item->set_pubDate(test_pubDate);
 	item->set_description(test_description);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 
 	feed->add_item(item);
 	itemlist.set_feed(feed);
@@ -625,6 +636,7 @@ TEST_CASE("OP_HELP command is processed", "[ItemListFormAction]")
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	KeyMap k(KM_NEWSBOAT);
 	v.set_keymap(&k);
@@ -635,7 +647,7 @@ TEST_CASE("OP_HELP command is processed", "[ItemListFormAction]")
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	feed->add_item(item);
 	itemlist.set_feed(feed);
 
@@ -652,6 +664,7 @@ TEST_CASE("OP_HARDQUIT command is processed", "[ItemListFormAction]")
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	KeyMap k(KM_NEWSBOAT);
 	v.set_keymap(&k);
@@ -661,7 +674,7 @@ TEST_CASE("OP_HARDQUIT command is processed", "[ItemListFormAction]")
 
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	v.push_itemlist(feed);
@@ -684,6 +697,7 @@ TEST_CASE("Navigate back and forth using OP_NEXT and OP_PREVIOUS",
 		"external-url-viewer", "tee > " + articleFile.get_path());
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 	std::string line;
 
 	std::string first_article_title = "First_Article";
@@ -706,7 +720,7 @@ TEST_CASE("Navigate back and forth using OP_NEXT and OP_PREVIOUS",
 	item2->set_title(second_article_title);
 	feed->add_item(item2);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	v.push_itemlist(feed);
@@ -735,6 +749,7 @@ TEST_CASE("OP_TOGGLESHOWREAD switches the value of show-read-articles",
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	KeyMap k(KM_NEWSBOAT);
 	v.set_keymap(&k);
@@ -747,7 +762,7 @@ TEST_CASE("OP_TOGGLESHOWREAD switches the value of show-read-articles",
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	feed->add_item(item);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 	v.push_itemlist(feed);
 
@@ -775,6 +790,7 @@ TEST_CASE("OP_PIPE_TO pipes an article's content to an external command",
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
+	RegexManager rxman;
 
 	std::vector<std::string> op_args;
 	op_args.push_back("tee > " + articleFile.get_path());
@@ -802,7 +818,7 @@ TEST_CASE("OP_PIPE_TO pipes an article's content to an external command",
 	item->set_pubDate(test_pubDate);
 	item->set_description(test_description);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg);
+	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, &filters, &cfg, rxman);
 
 	feed->add_item(item);
 	itemlist.set_feed(feed);

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -621,7 +621,6 @@ TEST_CASE("OP_HELP command is processed", "[ItemListFormAction]")
 {
 	ConfigPaths paths;
 	Controller c(paths);
-	RegexManager regman;
 	newsboat::View v(&c);
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -630,7 +629,6 @@ TEST_CASE("OP_HELP command is processed", "[ItemListFormAction]")
 	KeyMap k(KM_NEWSBOAT);
 	v.set_keymap(&k);
 
-	v.set_regexmanager(&regman);
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
@@ -650,7 +648,6 @@ TEST_CASE("OP_HARDQUIT command is processed", "[ItemListFormAction]")
 {
 	ConfigPaths paths;
 	Controller c(paths);
-	RegexManager regman;
 	newsboat::View v(&c);
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -659,7 +656,6 @@ TEST_CASE("OP_HARDQUIT command is processed", "[ItemListFormAction]")
 	KeyMap k(KM_NEWSBOAT);
 	v.set_keymap(&k);
 
-	v.set_regexmanager(&regman);
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
@@ -682,7 +678,6 @@ TEST_CASE("Navigate back and forth using OP_NEXT and OP_PREVIOUS",
 	ConfigPaths paths;
 	Controller c(paths);
 	TestHelpers::TempFile articleFile;
-	RegexManager regman;
 	newsboat::View v(&c);
 	ConfigContainer cfg;
 	cfg.set_configvalue(
@@ -698,7 +693,6 @@ TEST_CASE("Navigate back and forth using OP_NEXT and OP_PREVIOUS",
 	KeyMap k(KM_NEWSBOAT);
 	v.set_keymap(&k);
 
-	v.set_regexmanager(&regman);
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
@@ -737,7 +731,6 @@ TEST_CASE("OP_TOGGLESHOWREAD switches the value of show-read-articles",
 {
 	ConfigPaths paths;
 	Controller c(paths);
-	RegexManager regman;
 	newsboat::View v(&c);
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
@@ -746,7 +739,6 @@ TEST_CASE("OP_TOGGLESHOWREAD switches the value of show-read-articles",
 	KeyMap k(KM_NEWSBOAT);
 	v.set_keymap(&k);
 
-	v.set_regexmanager(&regman);
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 

--- a/test/listformatter.cpp
+++ b/test/listformatter.cpp
@@ -51,7 +51,7 @@ TEST_CASE("add_line() splits overly long sequences to fit width",
 			"{listitem text:\"ut word bo\"}"
 			"{listitem text:\"undaries\"}"
 			"}";
-		REQUIRE(fmt.format_list(nullptr, "") == expected);
+		REQUIRE(fmt.format_list() == expected);
 	}
 
 	SECTION("numbered list") {
@@ -70,7 +70,7 @@ TEST_CASE("add_line() splits overly long sequences to fit width",
 			"{listitem[3] text:\"ut word bo\"}"
 			"{listitem[3] text:\"undaries\"}"
 			"}";
-		REQUIRE(fmt.format_list(nullptr, "") == expected);
+		REQUIRE(fmt.format_list() == expected);
 	}
 }
 
@@ -87,7 +87,7 @@ TEST_CASE("set_line() replaces the item in a list", "[ListFormatter]")
 		"{listitem[2] text:\"goodb\"}"
 		"{listitem[2] text:\"ye\"}"
 		"}";
-	REQUIRE(fmt.format_list(nullptr, "") == expected);
+	REQUIRE(fmt.format_list() == expected);
 
 	fmt.set_line(1, "oh", "3", 3);
 
@@ -97,17 +97,17 @@ TEST_CASE("set_line() replaces the item in a list", "[ListFormatter]")
 		"{listitem[3] text:\"oh\"}"
 		"{listitem[2] text:\"ye\"}"
 		"}";
-	REQUIRE(fmt.format_list(nullptr, "") == expected);
+	REQUIRE(fmt.format_list() == expected);
 }
 
 TEST_CASE("format_list() uses regex manager if one is passed",
 	"[ListFormatter]")
 {
-	ListFormatter fmt;
+	RegexManager rxmgr;
+	ListFormatter fmt(&rxmgr, "article");
 
 	fmt.add_line("Highlight me please!");
 
-	RegexManager rxmgr;
 	// the choice of green text on red background does not reflect my
 	// personal taste (or lack thereof) :)
 	rxmgr.handle_action(
@@ -118,5 +118,5 @@ TEST_CASE("format_list() uses regex manager if one is passed",
 		"{listitem text:\"Highlight me <0>please</>!\"}"
 		"}";
 
-	REQUIRE(fmt.format_list(&rxmgr, "article") == expected);
+	REQUIRE(fmt.format_list() == expected);
 }


### PR DESCRIPTION
All of those commits are meant to be refactors so there should be no change in behaviour.
Most of the commits are just there to make https://github.com/newsboat/newsboat/commit/f524e9407cc4ef692da7f50c88ace2780ca6e3c1 possible.
https://github.com/newsboat/newsboat/commit/a2ad4b7712360e4791d7b79b8267cbb0524f2baf is just an opportunity I saw while making the other changes, if needed, I can submit that commit separately.

These changes don't have much impact and might take some time to review.
@Minoru: Let me know if you rather don't want me to make these kind of changes (relatively high number of lines changed compared to the amount of improvement).