### PR TITLE
Inoreader: do not request token

### DIFF
--- a/include/inoreaderapi.h
+++ b/include/inoreaderapi.h
@@ -24,15 +24,11 @@ public:
 
 private:
 	std::vector<std::string> get_tags(xmlNode* node);
-	std::string get_new_token();
 	std::string retrieve_auth();
 	std::string post_content(const std::string& url,
 		const std::string& postdata);
 	bool star_article(const std::string& guid, bool star);
 	bool share_article(const std::string& guid, bool share);
-	bool mark_article_read_with_token(const std::string& guid,
-		bool read,
-		const std::string& token);
 	std::string auth;
 	std::string auth_header;
 };


### PR DESCRIPTION
API docs don't mention that token. I assume it's just leftovers from copy-paste of The Old Reader code.

I tested this and it still marks articles as read just fine.

(This fulfils a promise I made in https://github.com/newsboat/newsboat/issues/949#issuecomment-633143294).

Reviews are welcome as always. Otherwise I'll merge in three days.