### PR TITLE
macro: require at least two arguments

### DIFF
--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -715,9 +715,9 @@ void KeyMap::handle_action(const std::string& action,
 			unset_key(params[0], context);
 		}
 	} else if (action == "macro") {
-		if (params.size() < 2)
-			throw ConfigHandlerException(
-				ActionHandlerStatus::TOO_FEW_PARAMS);
+		if (params.size() < 2) {
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
 		auto it = params.begin();
 		std::string macrokey = *it;
 		std::vector<MacroCmd> cmds;
@@ -730,17 +730,15 @@ void KeyMap::handle_action(const std::string& action,
 			if (first && *it != ";") {
 				tmpcmd.op = get_opcode(*it);
 				LOG(Level::DEBUG,
-					"KeyMap::handle_action: new operation "
-					"`%s' "
-					"(op = %u)",
+					"KeyMap::handle_action: new operation `%s' (op = %u)",
 					*it,
 					tmpcmd.op);
-				if (tmpcmd.op == OP_NIL)
+				if (tmpcmd.op == OP_NIL) {
 					throw ConfigHandlerException(
 						strprintf::fmt(
-							_("`%s' is not a valid "
-								"key command"),
+							_("`%s' is not a valid key command"),
 							*it));
+				}
 				first = false;
 			} else {
 				if (*it == ";") {
@@ -752,8 +750,7 @@ void KeyMap::handle_action(const std::string& action,
 					first = true;
 				} else {
 					LOG(Level::DEBUG,
-						"KeyMap::handle_action: new "
-						"parameter `%s' (op = %u)",
+						"KeyMap::handle_action: new parameter `%s' (op = %u)",
 						*it,
 						tmpcmd.op);
 					tmpcmd.args.push_back(*it);
@@ -766,9 +763,9 @@ void KeyMap::handle_action(const std::string& action,
 		}
 
 		macros_[macrokey] = cmds;
-	} else
-		throw ConfigHandlerException(
-			ActionHandlerStatus::INVALID_PARAMS);
+	} else {
+		throw ConfigHandlerException(ActionHandlerStatus::INVALID_PARAMS);
+	}
 }
 
 std::vector<std::string> KeyMap::get_keys(Operation op,

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -715,7 +715,7 @@ void KeyMap::handle_action(const std::string& action,
 			unset_key(params[0], context);
 		}
 	} else if (action == "macro") {
-		if (params.size() < 1)
+		if (params.size() < 2)
 			throw ConfigHandlerException(
 				ActionHandlerStatus::TOO_FEW_PARAMS);
 		auto it = params.begin();

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -193,6 +193,8 @@ TEST_CASE("handle_action()", "[KeyMap]")
 		REQUIRE_THROWS_AS(k.handle_action("bind-key", params),
 			ConfigHandlerException);
 		REQUIRE_NOTHROW(k.handle_action("unbind-key", params));
+		REQUIRE_THROWS_AS(k.handle_action("macro", params),
+			ConfigHandlerException);
 	}
 
 	SECTION("with two parameters") {


### PR DESCRIPTION
A user on IRC showed a config like this:

```
macro a `false`
```

This evaluates to `macro a`, i.e. a macro without a command list. This makes no sense, and docs clearly state that the command list is required, so I upped the check.

Reviews are welcome. Otherwise I'll merge in three days.