### PR TITLE
Disable remote fonts in html documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,11 +180,11 @@ doc/xhtml/newsboat.html: doc/newsboat.asciidoc doc/chapter-firststeps.asciidoc \
 		doc/chapter-environment-variables.asciidoc \
 		doc/chapter-files.asciidoc
 	$(MKDIR) doc/xhtml
-	$(ASCIIDOCTOR) --backend=html5 --destination-dir=doc/xhtml doc/newsboat.asciidoc
+	$(ASCIIDOCTOR) --backend=html5 -a webfonts! --destination-dir=doc/xhtml doc/newsboat.asciidoc
 
 doc/xhtml/faq.html: doc/faq.asciidoc
 	$(MKDIR) doc/xhtml
-	$(ASCIIDOCTOR) --backend=html5 --destination-dir=doc/xhtml doc/faq.asciidoc
+	$(ASCIIDOCTOR) --backend=html5 -a webfonts! --destination-dir=doc/xhtml doc/faq.asciidoc
 
 doc/generate: doc/generate.cpp doc/split.h
 	$(CXX_FOR_BUILD) $(CXXFLAGS_FOR_BUILD) -o doc/generate doc/generate.cpp


### PR DESCRIPTION
Remote fonts are considered a privacy breach by lintian, so it's best to disable them IMO.

```
newsboat_2.19-1_amd64.deb

    W privacy-breach-generic usr/share/doc/newsboat/faq.html [<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=open+sans:300,300italic,400,400italic,600,600italic%7cnoto+serif:400,400italic,700,700italic%7cdroid+sans+mono:400,700">] (https://fonts.googleapis.com/css?family=open+sans:300,300italic,400,400italic,600,600italic%7cnoto+serif:400,400italic,700,700italic%7cdroid+sans+mono:400,700)
    W privacy-breach-generic usr/share/doc/newsboat/newsboat.html [<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=open+sans:300,300italic,400,400italic,600,600italic%7cnoto+serif:400,400italic,700,700italic%7cdroid+sans+mono:400,700">] (https://fonts.googleapis.com/css?family=open+sans:300,300italic,400,400italic,600,600italic%7cnoto+serif:400,400italic,700,700italic%7cdroid+sans+mono:400,700)

```