### PR TITLE
Implement OP_REDRAW in podboat

### DIFF
--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -126,6 +126,9 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		}
 
 		switch (op) {
+		case OP_REDRAW:
+			Stfl::reset();
+			break;
 		case OP_SK_UP:
 			downloads_list.move_up(wrap_scroll);
 			break;


### PR DESCRIPTION
I looked through all of the operations listed in `src/keymap.cpp`.
The only inconsistency I found is the one fixed in this PR.

Fixes https://github.com/newsboat/newsboat/issues/958.