### PR TITLE
Clear list of links before rendering article

### DIFF
--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -121,6 +121,7 @@ void ItemViewFormAction::prepare()
 					&rxman,
 					"article");
 		} else {
+			links.clear();
 			if (!item->enclosure_url().empty()) {
 				const auto link_type = utils::podcast_mime_to_link_type(item->enclosure_type());
 				if (link_type.has_value()) {


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/969

The `HtmlRenderer` did not have the duplication issue because it only added links if the url was not yet in the `links` container.