### PR TITLE
Always include json-c as 'json-c/json.h'

### DIFF
--- a/include/newsblurapi.h
+++ b/include/newsblurapi.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_NEWSBLURAPI_H_
 #define NEWSBOAT_NEWSBLURAPI_H_
 
-#include <json.h>
+#include <json-c/json.h>
 
 #include "remoteapi.h"
 #include "rss/feed.h"

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -1,831 +1,921 @@
 filter/FilterParser.o: filter/FilterParser.cpp filter/FilterParser.h \
- include/logger.h config.h include/strprintf.h filter/Parser.h \
- filter/Scanner.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h filter/Parser.h filter/Scanner.h include/utils.h \
+  3rd-party/optional.hpp include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h
 filter/Parser.o: filter/Parser.cpp filter/Parser.h filter/FilterParser.h \
- filter/Scanner.h
+  filter/Scanner.h
 filter/Scanner.o: filter/Scanner.cpp filter/Scanner.h
 rss/atomparser.o: rss/atomparser.cpp rss/atomparser.h rss/rssparser.h \
- config.h rss/exception.h rss/feed.h rss/item.h rss/rsspp_uris.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- include/strprintf.h
+  config.h /usr/local/include/libintl.h rss/exception.h rss/feed.h \
+  rss/item.h rss/rsspp_uris.h include/utils.h 3rd-party/optional.hpp \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/logger.h include/strprintf.h
 rss/exception.o: rss/exception.cpp rss/exception.h
 rss/parser.o: rss/parser.cpp rss/parser.h include/remoteapi.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h rss/feed.h rss/item.h config.h \
- rss/exception.h include/logger.h include/strprintf.h rss/rssparser.h \
- rss/rssparserfactory.h rss/rsspp_uris.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/logger.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h rss/feed.h rss/item.h config.h \
+  /usr/local/include/libintl.h rss/exception.h include/logger.h \
+  include/strprintf.h rss/rssparser.h rss/rssparserfactory.h \
+  rss/rsspp_uris.h include/utils.h 3rd-party/optional.hpp
 rss/rss09xparser.o: rss/rss09xparser.cpp rss/rss09xparser.h \
- rss/rssparser.h config.h rss/exception.h rss/feed.h rss/item.h \
- rss/rsspp_uris.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h include/strprintf.h
+  rss/rssparser.h config.h /usr/local/include/libintl.h rss/exception.h \
+  rss/feed.h rss/item.h rss/rsspp_uris.h include/utils.h \
+  3rd-party/optional.hpp include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h include/logger.h \
+  include/strprintf.h
 rss/rss10parser.o: rss/rss10parser.cpp rss/rss10parser.h rss/rssparser.h \
- config.h rss/exception.h rss/feed.h rss/item.h rss/rsspp_uris.h
+  config.h /usr/local/include/libintl.h rss/exception.h rss/feed.h \
+  rss/item.h rss/rsspp_uris.h
 rss/rss20parser.o: rss/rss20parser.cpp rss/rss20parser.h \
- rss/rss09xparser.h rss/rssparser.h config.h rss/exception.h rss/feed.h \
- rss/item.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h include/strprintf.h
+  rss/rss09xparser.h rss/rssparser.h config.h \
+  /usr/local/include/libintl.h rss/exception.h rss/feed.h rss/item.h \
+  include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h include/logger.h \
+  include/strprintf.h
 rss/rssparser.o: rss/rssparser.cpp rss/rssparser.h rss/exception.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h
+  include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h
 rss/rssparserfactory.o: rss/rssparserfactory.cpp rss/rssparserfactory.h \
- rss/rssparser.h rss/atomparser.h config.h rss/exception.h rss/feed.h \
- rss/item.h rss/rss09xparser.h rss/rss10parser.h rss/rss20parser.h
+  rss/rssparser.h rss/atomparser.h config.h /usr/local/include/libintl.h \
+  rss/exception.h rss/feed.h rss/item.h rss/rss09xparser.h \
+  rss/rss10parser.h rss/rss20parser.h
 src/cache.o: src/cache.cpp include/cache.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h config.h \
- include/configcontainer.h include/controller.h include/cache.h \
- include/colormanager.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- include/dbexception.h include/logger.h include/strprintf.h \
- include/matcherexception.h include/rssfeed.h include/utils.h \
- include/logger.h include/scopemeasure.h include/strprintf.h \
- include/utils.h
+  include/configparser.h include/configactionhandler.h config.h \
+  /usr/local/include/libintl.h include/controller.h \
+  include/colormanager.h include/feedcontainer.h \
+  include/filtercontainer.h include/fslock.h include/opml.h \
+  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+  include/regexmanager.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/reloader.h include/remoteapi.h \
+  include/rssignores.h include/rssitem.h include/matchable.h \
+  3rd-party/optional.hpp include/dbexception.h include/logger.h \
+  include/strprintf.h include/matcherexception.h include/rssfeed.h \
+  include/utils.h include/scopemeasure.h
 src/cliargsparser.o: src/cliargsparser.cpp include/cliargsparser.h \
- 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
- include/globals.h include/ruststring.h include/strprintf.h
+  3rd-party/optional.hpp include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h include/globals.h \
+  include/ruststring.h
 src/colormanager.o: src/colormanager.cpp include/colormanager.h \
- include/configparser.h include/configactionhandler.h config.h \
- include/confighandlerexception.h include/feedlistformaction.h \
- include/history.h include/listformaction.h include/formaction.h \
- include/keymap.h include/stflpp.h include/listwidget.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/view.h \
- include/colormanager.h include/configcontainer.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h 3rd-party/optional.hpp \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h \
- include/filebrowserformaction.h include/helpformaction.h \
- include/textviewwidget.h include/itemlistformaction.h \
- include/itemviewformaction.h include/logger.h include/strprintf.h \
- include/matcherexception.h include/pbview.h include/selectformaction.h \
- include/strprintf.h include/urlviewformaction.h include/utils.h \
- include/logger.h
+  include/configparser.h include/configactionhandler.h config.h \
+  /usr/local/include/libintl.h include/confighandlerexception.h \
+  include/feedlistformaction.h include/history.h \
+  include/listformaction.h include/formaction.h include/keymap.h \
+  include/stflpp.h /usr/local/include/stfl.h include/listwidget.h \
+  include/listformatter.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/view.h \
+  include/configcontainer.h include/controller.h include/cache.h \
+  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+  include/opml.h include/fileurlreader.h include/urlreader.h \
+  include/queuemanager.h include/reloader.h include/remoteapi.h \
+  include/rssignores.h include/rssitem.h include/matchable.h \
+  3rd-party/optional.hpp include/filebrowserformaction.h \
+  include/dirbrowserformaction.h include/htmlrenderer.h \
+  include/textformatter.h include/helpformaction.h \
+  include/textviewwidget.h include/itemlistformaction.h \
+  include/itemviewformaction.h include/logger.h include/strprintf.h \
+  include/matcherexception.h include/pbview.h include/selectformaction.h \
+  include/urlviewformaction.h include/utils.h
 src/configcontainer.o: src/configcontainer.cpp include/configcontainer.h \
- include/configparser.h include/configactionhandler.h config.h \
- include/configparser.h include/confighandlerexception.h include/logger.h \
- include/strprintf.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h
+  include/configparser.h include/configactionhandler.h config.h \
+  /usr/local/include/libintl.h include/confighandlerexception.h \
+  include/logger.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp
 src/confighandlerexception.o: src/confighandlerexception.cpp \
- include/confighandlerexception.h include/configparser.h \
- include/configactionhandler.h config.h
+  include/confighandlerexception.h include/configparser.h \
+  include/configactionhandler.h config.h /usr/local/include/libintl.h
 src/configparser.o: src/configparser.cpp include/configparser.h \
- include/configactionhandler.h config.h include/configexception.h \
- include/confighandlerexception.h include/configparser.h include/logger.h \
- include/strprintf.h include/strprintf.h include/tagsouppullparser.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h
+  include/configactionhandler.h config.h /usr/local/include/libintl.h \
+  include/configexception.h include/confighandlerexception.h \
+  include/logger.h include/strprintf.h include/tagsouppullparser.h \
+  include/utils.h 3rd-party/optional.hpp include/configcontainer.h
 src/configpaths.o: src/configpaths.cpp include/configpaths.h \
- include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
- include/strprintf.h include/globals.h include/ruststring.h \
- include/strprintf.h
+  include/cliargsparser.h 3rd-party/optional.hpp include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h \
+  include/globals.h include/ruststring.h
 src/controller.o: src/controller.cpp include/controller.h include/cache.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/colormanager.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h 3rd-party/optional.hpp include/cliargsparser.h \
- include/logger.h config.h include/strprintf.h include/colormanager.h \
- include/configcontainer.h include/configexception.h \
- include/configparser.h include/configpaths.h include/cliargsparser.h \
- include/dbexception.h include/downloadthread.h include/exception.h \
- include/feedhqapi.h include/feedhqurlreader.h include/fileurlreader.h \
- include/globals.h include/inoreaderapi.h include/inoreaderurlreader.h \
- include/itemrenderer.h include/htmlrenderer.h include/textformatter.h \
- include/logger.h include/newsblurapi.h rss/feed.h rss/item.h \
- include/newsblururlreader.h include/ocnewsapi.h \
- include/ocnewsurlreader.h include/oldreaderapi.h \
- include/oldreaderurlreader.h include/opmlurlreader.h \
- include/regexmanager.h include/remoteapi.h include/rssfeed.h \
- include/utils.h include/rssparser.h include/scopemeasure.h \
- include/stflpp.h include/strprintf.h include/ttrssapi.h \
- 3rd-party/json.hpp include/ttrssurlreader.h include/utils.h \
- include/view.h include/controller.h include/filebrowserformaction.h \
- include/listformatter.h include/listwidget.h include/stflpp.h \
- include/formaction.h include/history.h include/keymap.h \
- include/dirbrowserformaction.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/colormanager.h \
+  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+  include/opml.h include/fileurlreader.h include/urlreader.h \
+  include/queuemanager.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/reloader.h \
+  include/remoteapi.h include/rssignores.h include/rssitem.h \
+  include/matchable.h 3rd-party/optional.hpp include/cliargsparser.h \
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h include/configexception.h include/configpaths.h \
+  include/dbexception.h include/downloadthread.h include/exception.h \
+  include/feedhqapi.h include/feedhqurlreader.h include/globals.h \
+  include/inoreaderapi.h include/inoreaderurlreader.h \
+  include/itemrenderer.h include/htmlrenderer.h include/textformatter.h \
+  include/newsblurapi.h /usr/local/include/json-c/json.h \
+  /usr/local/include/json-c/debug.h /usr/local/include/json-c/linkhash.h \
+  /usr/local/include/json-c/json_object.h \
+  /usr/local/include/json-c/json_inttypes.h \
+  /usr/local/include/json-c/json_config.h \
+  /usr/local/include/json-c/printbuf.h \
+  /usr/local/include/json-c/arraylist.h \
+  /usr/local/include/json-c/json_util.h \
+  /usr/local/include/json-c/json_pointer.h \
+  /usr/local/include/json-c/json_tokener.h \
+  /usr/local/include/json-c/json_object_iterator.h \
+  /usr/local/include/json-c/json_c_version.h rss/feed.h rss/item.h \
+  include/newsblururlreader.h include/ocnewsapi.h \
+  include/ocnewsurlreader.h include/oldreaderapi.h \
+  include/oldreaderurlreader.h include/opmlurlreader.h include/rssfeed.h \
+  include/utils.h include/rssparser.h include/scopemeasure.h \
+  include/stflpp.h /usr/local/include/stfl.h include/ttrssapi.h \
+  3rd-party/json.hpp include/ttrssurlreader.h include/view.h \
+  include/filebrowserformaction.h include/listformatter.h \
+  include/listwidget.h include/formaction.h include/history.h \
+  include/keymap.h include/dirbrowserformaction.h
 src/dialogsformaction.o: src/dialogsformaction.cpp \
- include/dialogsformaction.h include/formaction.h include/history.h \
- include/keymap.h include/configparser.h include/configactionhandler.h \
- include/stflpp.h include/listwidget.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h config.h include/fmtstrformatter.h \
- include/listformatter.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- include/strprintf.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+  include/dialogsformaction.h include/formaction.h include/history.h \
+  include/keymap.h include/configparser.h include/configactionhandler.h \
+  include/stflpp.h /usr/local/include/stfl.h include/listwidget.h \
+  include/listformatter.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h config.h \
+  /usr/local/include/libintl.h include/fmtstrformatter.h \
+  include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+  include/configcontainer.h include/logger.h include/view.h \
+  include/colormanager.h include/controller.h include/cache.h \
+  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+  include/opml.h include/fileurlreader.h include/urlreader.h \
+  include/queuemanager.h include/reloader.h include/remoteapi.h \
+  include/rssignores.h include/rssitem.h include/matchable.h \
+  include/filebrowserformaction.h include/dirbrowserformaction.h \
+  include/htmlrenderer.h include/textformatter.h
 src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
- include/dirbrowserformaction.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/listwidget.h \
- include/stflpp.h include/formaction.h include/history.h include/keymap.h \
- config.h include/fmtstrformatter.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+  include/dirbrowserformaction.h include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h \
+  include/listformatter.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/listwidget.h \
+  include/stflpp.h /usr/local/include/stfl.h include/formaction.h \
+  include/history.h include/keymap.h config.h \
+  /usr/local/include/libintl.h include/fmtstrformatter.h \
+  include/logger.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp include/view.h include/colormanager.h \
+  include/controller.h include/cache.h include/feedcontainer.h \
+  include/filtercontainer.h include/fslock.h include/opml.h \
+  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+  include/reloader.h include/remoteapi.h include/rssignores.h \
+  include/rssitem.h include/matchable.h include/filebrowserformaction.h \
+  include/htmlrenderer.h include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
- include/pbcontroller.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/download.h include/fslock.h \
- include/queueloader.h
+  /usr/local/include/libintl.h include/pbcontroller.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/fslock.h include/queueloader.h
 src/downloadthread.o: src/downloadthread.cpp include/downloadthread.h \
- include/reloader.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h
-src/exception.o: src/exception.cpp include/exception.h config.h
+  include/reloader.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
+src/exception.o: src/exception.cpp include/exception.h config.h \
+  /usr/local/include/libintl.h
 src/feedcontainer.o: src/feedcontainer.cpp include/feedcontainer.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/utils.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/rssfeed.h include/matchable.h \
+  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+  filter/FilterParser.h include/utils.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
 src/feedhqapi.o: src/feedhqapi.cpp include/feedhqapi.h include/cache.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/remoteapi.h config.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h include/strprintf.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/remoteapi.h \
+  /usr/local/include/json-c/json.h /usr/local/include/json-c/debug.h \
+  /usr/local/include/json-c/linkhash.h \
+  /usr/local/include/json-c/json_object.h \
+  /usr/local/include/json-c/json_inttypes.h \
+  /usr/local/include/json-c/json_config.h \
+  /usr/local/include/json-c/printbuf.h \
+  /usr/local/include/json-c/arraylist.h \
+  /usr/local/include/json-c/json_util.h \
+  /usr/local/include/json-c/json_pointer.h \
+  /usr/local/include/json-c/json_tokener.h \
+  /usr/local/include/json-c/json_object_iterator.h \
+  /usr/local/include/json-c/json_c_version.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp include/logger.h
 src/feedhqurlreader.o: src/feedhqurlreader.cpp include/feedhqurlreader.h \
- include/urlreader.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/fileurlreader.h include/logger.h \
- config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h
+  include/urlreader.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/fileurlreader.h include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h \
+  include/remoteapi.h include/utils.h 3rd-party/optional.hpp
 src/feedlistformaction.o: src/feedlistformaction.cpp \
- include/feedlistformaction.h include/history.h include/listformaction.h \
- include/formaction.h include/keymap.h include/configparser.h \
- include/configactionhandler.h include/stflpp.h include/listwidget.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/view.h \
- include/colormanager.h include/configcontainer.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h 3rd-party/optional.hpp \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h config.h \
- include/dbexception.h include/feedcontainer.h include/fmtstrformatter.h \
- include/listformatter.h include/logger.h include/strprintf.h \
- include/reloader.h include/rssfeed.h include/utils.h include/logger.h \
- include/scopemeasure.h include/strprintf.h include/utils.h \
- include/view.h
+  include/feedlistformaction.h include/history.h \
+  include/listformaction.h include/formaction.h include/keymap.h \
+  include/configparser.h include/configactionhandler.h include/stflpp.h \
+  /usr/local/include/stfl.h include/listwidget.h include/listformatter.h \
+  include/regexmanager.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/view.h include/colormanager.h \
+  include/configcontainer.h include/controller.h include/cache.h \
+  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+  include/opml.h include/fileurlreader.h include/urlreader.h \
+  include/queuemanager.h include/reloader.h include/remoteapi.h \
+  include/rssignores.h include/rssitem.h include/matchable.h \
+  3rd-party/optional.hpp include/filebrowserformaction.h \
+  include/dirbrowserformaction.h include/htmlrenderer.h \
+  include/textformatter.h config.h /usr/local/include/libintl.h \
+  include/dbexception.h include/fmtstrformatter.h include/logger.h \
+  include/strprintf.h include/rssfeed.h include/utils.h \
+  include/scopemeasure.h
 src/filebrowserformaction.o: src/filebrowserformaction.cpp \
- include/filebrowserformaction.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/listwidget.h \
- include/stflpp.h include/formaction.h include/history.h include/keymap.h \
- config.h include/fmtstrformatter.h include/listformatter.h \
- include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+  include/filebrowserformaction.h include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h \
+  include/listformatter.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/listwidget.h \
+  include/stflpp.h /usr/local/include/stfl.h include/formaction.h \
+  include/history.h include/keymap.h config.h \
+  /usr/local/include/libintl.h include/fmtstrformatter.h \
+  include/logger.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp include/view.h include/colormanager.h \
+  include/controller.h include/cache.h include/feedcontainer.h \
+  include/filtercontainer.h include/fslock.h include/opml.h \
+  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+  include/reloader.h include/remoteapi.h include/rssignores.h \
+  include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+  include/htmlrenderer.h include/textformatter.h
 src/fileurlreader.o: src/fileurlreader.cpp include/fileurlreader.h \
- include/urlreader.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h
+  include/urlreader.h include/utils.h 3rd-party/optional.hpp \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
 src/filtercontainer.o: src/filtercontainer.cpp include/filtercontainer.h \
- include/configparser.h include/configactionhandler.h config.h \
- include/confighandlerexception.h include/matcher.h filter/FilterParser.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h include/strprintf.h
+  include/configparser.h include/configactionhandler.h config.h \
+  /usr/local/include/libintl.h include/confighandlerexception.h \
+  include/matcher.h filter/FilterParser.h include/strprintf.h \
+  include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+  include/logger.h
 src/fmtstrformatter.o: src/fmtstrformatter.cpp include/fmtstrformatter.h \
- include/logger.h config.h include/strprintf.h include/ruststring.h
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h include/ruststring.h
 src/formaction.o: src/formaction.cpp include/formaction.h \
- include/history.h include/keymap.h include/configparser.h \
- include/configactionhandler.h include/stflpp.h config.h \
- include/configexception.h include/logger.h include/strprintf.h \
- include/matcherexception.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/listformatter.h include/listwidget.h include/formaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+  include/history.h include/keymap.h include/configparser.h \
+  include/configactionhandler.h include/stflpp.h \
+  /usr/local/include/stfl.h config.h /usr/local/include/libintl.h \
+  include/configexception.h include/logger.h include/strprintf.h \
+  include/matcherexception.h include/utils.h 3rd-party/optional.hpp \
+  include/configcontainer.h include/view.h include/colormanager.h \
+  include/controller.h include/cache.h include/feedcontainer.h \
+  include/filtercontainer.h include/fslock.h include/opml.h \
+  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+  include/regexmanager.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/reloader.h include/remoteapi.h \
+  include/rssignores.h include/rssitem.h include/matchable.h \
+  include/filebrowserformaction.h include/listformatter.h \
+  include/listwidget.h include/dirbrowserformaction.h \
+  include/htmlrenderer.h include/textformatter.h
 src/fslock.o: src/fslock.cpp include/fslock.h include/logger.h config.h \
- include/strprintf.h
+  /usr/local/include/libintl.h include/strprintf.h
 src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
- include/formaction.h include/history.h include/keymap.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- include/textviewwidget.h config.h include/fmtstrformatter.h \
- include/keymap.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h include/strprintf.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/filebrowserformaction.h \
- include/listformatter.h include/listwidget.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+  include/formaction.h include/history.h include/keymap.h \
+  include/configparser.h include/configactionhandler.h include/stflpp.h \
+  /usr/local/include/stfl.h include/textviewwidget.h config.h \
+  /usr/local/include/libintl.h include/fmtstrformatter.h \
+  include/listformatter.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/strprintf.h \
+  include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+  include/logger.h include/view.h include/colormanager.h \
+  include/controller.h include/cache.h include/feedcontainer.h \
+  include/filtercontainer.h include/fslock.h include/opml.h \
+  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+  include/reloader.h include/remoteapi.h include/rssignores.h \
+  include/rssitem.h include/matchable.h include/filebrowserformaction.h \
+  include/listwidget.h include/dirbrowserformaction.h \
+  include/htmlrenderer.h include/textformatter.h
 src/history.o: src/history.cpp include/history.h include/ruststring.h
 src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
- include/textformatter.h include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h config.h include/logger.h include/strprintf.h \
- include/strprintf.h include/tagsouppullparser.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h
+  include/textformatter.h include/regexmanager.h include/configparser.h \
+  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h config.h /usr/local/include/libintl.h \
+  include/logger.h include/strprintf.h include/tagsouppullparser.h \
+  include/utils.h 3rd-party/optional.hpp include/configcontainer.h
 src/inoreaderapi.o: src/inoreaderapi.cpp include/inoreaderapi.h \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/remoteapi.h include/urlreader.h \
- config.h include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h include/strprintf.h
+  include/cache.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/remoteapi.h include/urlreader.h \
+  /usr/local/include/json-c/json.h /usr/local/include/json-c/debug.h \
+  /usr/local/include/json-c/linkhash.h \
+  /usr/local/include/json-c/json_object.h \
+  /usr/local/include/json-c/json_inttypes.h \
+  /usr/local/include/json-c/json_config.h \
+  /usr/local/include/json-c/printbuf.h \
+  /usr/local/include/json-c/arraylist.h \
+  /usr/local/include/json-c/json_util.h \
+  /usr/local/include/json-c/json_pointer.h \
+  /usr/local/include/json-c/json_tokener.h \
+  /usr/local/include/json-c/json_object_iterator.h \
+  /usr/local/include/json-c/json_c_version.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp include/logger.h
 src/inoreaderurlreader.o: src/inoreaderurlreader.cpp \
- include/inoreaderurlreader.h include/urlreader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/fileurlreader.h include/logger.h \
- config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h
+  include/inoreaderurlreader.h include/urlreader.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/fileurlreader.h include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h \
+  include/remoteapi.h include/utils.h 3rd-party/optional.hpp
 src/itemlistformaction.o: src/itemlistformaction.cpp \
- include/itemlistformaction.h include/history.h include/listformaction.h \
- include/formaction.h include/keymap.h include/configparser.h \
- include/configactionhandler.h include/stflpp.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/listwidget.h include/view.h \
- include/colormanager.h include/configcontainer.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h 3rd-party/optional.hpp \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h config.h \
- include/controller.h include/dbexception.h include/fmtstrformatter.h \
- include/logger.h include/strprintf.h include/matcherexception.h \
- include/rssfeed.h include/utils.h include/logger.h \
- include/scopemeasure.h include/strprintf.h include/utils.h \
- include/view.h
+  include/itemlistformaction.h include/history.h \
+  include/listformaction.h include/formaction.h include/keymap.h \
+  include/configparser.h include/configactionhandler.h include/stflpp.h \
+  /usr/local/include/stfl.h include/listformatter.h \
+  include/regexmanager.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/listwidget.h include/view.h \
+  include/colormanager.h include/configcontainer.h include/controller.h \
+  include/cache.h include/feedcontainer.h include/filtercontainer.h \
+  include/fslock.h include/opml.h include/fileurlreader.h \
+  include/urlreader.h include/queuemanager.h include/reloader.h \
+  include/remoteapi.h include/rssignores.h include/rssitem.h \
+  include/matchable.h 3rd-party/optional.hpp \
+  include/filebrowserformaction.h include/dirbrowserformaction.h \
+  include/htmlrenderer.h include/textformatter.h config.h \
+  /usr/local/include/libintl.h include/dbexception.h \
+  include/fmtstrformatter.h include/logger.h include/strprintf.h \
+  include/matcherexception.h include/rssfeed.h include/utils.h \
+  include/scopemeasure.h
 src/itemrenderer.o: src/itemrenderer.cpp include/itemrenderer.h \
- include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
- include/configparser.h include/configactionhandler.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/configcontainer.h \
- include/htmlrenderer.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/utils.h \
- include/configcontainer.h include/logger.h config.h include/strprintf.h \
- include/textformatter.h
+  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
+  include/configparser.h include/configactionhandler.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/configcontainer.h \
+  include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
+  include/rssitem.h include/utils.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
 src/itemviewformaction.o: src/itemviewformaction.cpp \
- include/itemviewformaction.h include/formaction.h include/history.h \
- include/keymap.h include/configparser.h include/configactionhandler.h \
- include/stflpp.h include/htmlrenderer.h include/textformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/textviewwidget.h config.h \
- include/confighandlerexception.h include/dbexception.h \
- include/fmtstrformatter.h include/itemrenderer.h include/htmlrenderer.h \
- include/logger.h include/strprintf.h include/rssfeed.h \
- include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
- include/utils.h include/configcontainer.h include/logger.h \
- include/scopemeasure.h include/strprintf.h include/textformatter.h \
- include/utils.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/filebrowserformaction.h include/listformatter.h \
- include/listwidget.h include/dirbrowserformaction.h
+  include/itemviewformaction.h include/formaction.h include/history.h \
+  include/keymap.h include/configparser.h include/configactionhandler.h \
+  include/stflpp.h /usr/local/include/stfl.h include/htmlrenderer.h \
+  include/textformatter.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/textviewwidget.h \
+  config.h /usr/local/include/libintl.h include/confighandlerexception.h \
+  include/dbexception.h include/fmtstrformatter.h include/itemrenderer.h \
+  include/logger.h include/strprintf.h include/rssfeed.h \
+  include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
+  include/utils.h include/configcontainer.h include/scopemeasure.h \
+  include/view.h include/colormanager.h include/controller.h \
+  include/cache.h include/feedcontainer.h include/filtercontainer.h \
+  include/fslock.h include/opml.h include/fileurlreader.h \
+  include/urlreader.h include/queuemanager.h include/reloader.h \
+  include/remoteapi.h include/rssignores.h \
+  include/filebrowserformaction.h include/listformatter.h \
+  include/listwidget.h include/dirbrowserformaction.h
 src/keymap.o: src/keymap.cpp include/keymap.h include/configparser.h \
- include/configactionhandler.h config.h include/confighandlerexception.h \
- include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h
+  include/configactionhandler.h config.h /usr/local/include/libintl.h \
+  include/confighandlerexception.h include/logger.h include/strprintf.h \
+  include/utils.h 3rd-party/optional.hpp include/configcontainer.h
 src/listformaction.o: src/listformaction.cpp include/listformaction.h \
- include/formaction.h include/history.h include/keymap.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
- include/rssitem.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/configcontainer.h include/logger.h config.h \
- include/strprintf.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/regexowner.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/filebrowserformaction.h \
- include/listformatter.h include/listwidget.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+  include/formaction.h include/history.h include/keymap.h \
+  include/configparser.h include/configactionhandler.h include/stflpp.h \
+  /usr/local/include/stfl.h include/rssfeed.h include/matchable.h \
+  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+  filter/FilterParser.h include/utils.h include/configcontainer.h \
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h include/view.h include/colormanager.h \
+  include/controller.h include/cache.h include/feedcontainer.h \
+  include/filtercontainer.h include/fslock.h include/opml.h \
+  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+  include/regexmanager.h include/regexowner.h include/reloader.h \
+  include/remoteapi.h include/rssignores.h \
+  include/filebrowserformaction.h include/listformatter.h \
+  include/listwidget.h include/dirbrowserformaction.h \
+  include/htmlrenderer.h include/textformatter.h
 src/listformatter.o: src/listformatter.cpp include/listformatter.h \
- include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/stflpp.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h config.h include/strprintf.h
+  include/regexmanager.h include/configparser.h \
+  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/stflpp.h /usr/local/include/stfl.h \
+  include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+  include/configcontainer.h include/logger.h config.h \
+  /usr/local/include/libintl.h
 src/listwidget.o: src/listwidget.cpp include/listwidget.h \
- include/listformatter.h include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/stflpp.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- config.h include/strprintf.h
+  include/listformatter.h include/regexmanager.h include/configparser.h \
+  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/stflpp.h /usr/local/include/stfl.h \
+  include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h
 src/logger.o: src/logger.cpp include/logger.h config.h \
- include/strprintf.h
+  /usr/local/include/libintl.h include/strprintf.h
 src/matcher.o: src/matcher.cpp include/matcher.h filter/FilterParser.h \
- include/logger.h config.h include/strprintf.h include/matchable.h \
- 3rd-party/optional.hpp include/matcherexception.h include/scopemeasure.h \
- include/logger.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h include/matchable.h 3rd-party/optional.hpp \
+  include/matcherexception.h include/scopemeasure.h include/utils.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h
 src/matcherexception.o: src/matcherexception.cpp \
- include/matcherexception.h config.h include/ruststring.h \
- include/strprintf.h
+  include/matcherexception.h config.h /usr/local/include/libintl.h \
+  include/ruststring.h include/strprintf.h
 src/newsblurapi.o: src/newsblurapi.cpp include/newsblurapi.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h rss/feed.h rss/item.h include/remoteapi.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h config.h include/strprintf.h
+  /usr/local/include/json-c/json.h /usr/local/include/json-c/debug.h \
+  /usr/local/include/json-c/linkhash.h \
+  /usr/local/include/json-c/json_object.h \
+  /usr/local/include/json-c/json_inttypes.h \
+  /usr/local/include/json-c/json_config.h \
+  /usr/local/include/json-c/printbuf.h \
+  /usr/local/include/json-c/arraylist.h \
+  /usr/local/include/json-c/json_util.h \
+  /usr/local/include/json-c/json_pointer.h \
+  /usr/local/include/json-c/json_tokener.h \
+  /usr/local/include/json-c/json_object_iterator.h \
+  /usr/local/include/json-c/json_c_version.h include/remoteapi.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h rss/feed.h rss/item.h \
+  include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+  include/logger.h config.h /usr/local/include/libintl.h
 src/newsblururlreader.o: src/newsblururlreader.cpp \
- include/newsblururlreader.h rss/feed.h rss/item.h include/urlreader.h \
- include/fileurlreader.h include/logger.h config.h include/strprintf.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h
+  include/newsblururlreader.h rss/feed.h rss/item.h include/urlreader.h \
+  include/fileurlreader.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h include/remoteapi.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/utils.h 3rd-party/optional.hpp
 src/ocnewsapi.o: src/ocnewsapi.cpp include/ocnewsapi.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h
+  /usr/local/include/json-c/json.h /usr/local/include/json-c/debug.h \
+  /usr/local/include/json-c/linkhash.h \
+  /usr/local/include/json-c/json_object.h \
+  /usr/local/include/json-c/json_inttypes.h \
+  /usr/local/include/json-c/json_config.h \
+  /usr/local/include/json-c/printbuf.h \
+  /usr/local/include/json-c/arraylist.h \
+  /usr/local/include/json-c/json_util.h \
+  /usr/local/include/json-c/json_pointer.h \
+  /usr/local/include/json-c/json_tokener.h \
+  /usr/local/include/json-c/json_object_iterator.h \
+  /usr/local/include/json-c/json_c_version.h include/remoteapi.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
+  3rd-party/optional.hpp include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
 src/ocnewsurlreader.o: src/ocnewsurlreader.cpp include/ocnewsurlreader.h \
- include/urlreader.h include/fileurlreader.h include/logger.h config.h \
- include/strprintf.h include/remoteapi.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h
+  include/urlreader.h include/fileurlreader.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h include/remoteapi.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/utils.h 3rd-party/optional.hpp
 src/oldreaderapi.o: src/oldreaderapi.cpp include/oldreaderapi.h \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/remoteapi.h config.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h include/strprintf.h
+  include/cache.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/remoteapi.h \
+  /usr/local/include/json-c/json.h /usr/local/include/json-c/debug.h \
+  /usr/local/include/json-c/linkhash.h \
+  /usr/local/include/json-c/json_object.h \
+  /usr/local/include/json-c/json_inttypes.h \
+  /usr/local/include/json-c/json_config.h \
+  /usr/local/include/json-c/printbuf.h \
+  /usr/local/include/json-c/arraylist.h \
+  /usr/local/include/json-c/json_util.h \
+  /usr/local/include/json-c/json_pointer.h \
+  /usr/local/include/json-c/json_tokener.h \
+  /usr/local/include/json-c/json_object_iterator.h \
+  /usr/local/include/json-c/json_c_version.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp include/logger.h
 src/oldreaderurlreader.o: src/oldreaderurlreader.cpp \
- include/oldreaderurlreader.h include/urlreader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/fileurlreader.h include/logger.h \
- config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h
+  include/oldreaderurlreader.h include/urlreader.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/fileurlreader.h include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h \
+  include/remoteapi.h include/utils.h 3rd-party/optional.hpp
 src/opml.o: src/opml.cpp include/opml.h include/feedcontainer.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/fileurlreader.h \
- include/urlreader.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/fileurlreader.h \
+  include/urlreader.h include/rssfeed.h include/matchable.h \
+  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+  filter/FilterParser.h include/utils.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
 src/opmlurlreader.o: src/opmlurlreader.cpp include/opmlurlreader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/urlreader.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/urlreader.h include/utils.h \
+  3rd-party/optional.hpp include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
 src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/download.h include/fslock.h \
- include/queueloader.h include/colormanager.h config.h \
- include/configcontainer.h include/configexception.h include/globals.h \
- include/keymap.h include/logger.h include/strprintf.h \
- include/matcherexception.h include/nullconfigactionhandler.h \
- include/pbview.h include/colormanager.h include/keymap.h \
- include/listwidget.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/stflpp.h include/textviewwidget.h include/poddlthread.h \
- include/queueloader.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/download.h include/fslock.h \
+  include/queueloader.h include/colormanager.h config.h \
+  /usr/local/include/libintl.h include/configexception.h \
+  include/globals.h include/keymap.h include/logger.h \
+  include/strprintf.h include/matcherexception.h \
+  include/nullconfigactionhandler.h include/pbview.h \
+  include/listwidget.h include/listformatter.h include/regexmanager.h \
+  include/matcher.h filter/FilterParser.h include/regexowner.h \
+  include/stflpp.h /usr/local/include/stfl.h include/textviewwidget.h \
+  include/poddlthread.h include/utils.h 3rd-party/optional.hpp
 src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
- include/configparser.h include/configactionhandler.h include/keymap.h \
- include/listwidget.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/stflpp.h include/textviewwidget.h config.h \
- include/configcontainer.h stfl/dllist.h include/download.h \
- include/fmtstrformatter.h stfl/help.h include/listformatter.h \
- include/logger.h include/strprintf.h include/pbcontroller.h \
- include/configcontainer.h include/download.h include/fslock.h \
- include/queueloader.h include/poddlthread.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/logger.h
+  include/configparser.h include/configactionhandler.h include/keymap.h \
+  include/listwidget.h include/listformatter.h include/regexmanager.h \
+  include/matcher.h filter/FilterParser.h include/regexowner.h \
+  include/stflpp.h /usr/local/include/stfl.h include/textviewwidget.h \
+  config.h /usr/local/include/libintl.h include/configcontainer.h \
+  stfl/dllist.h include/download.h include/fmtstrformatter.h stfl/help.h \
+  include/logger.h include/strprintf.h include/pbcontroller.h \
+  include/fslock.h include/queueloader.h include/poddlthread.h \
+  include/utils.h 3rd-party/optional.hpp
 src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/download.h config.h \
- include/logger.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/download.h config.h \
+  /usr/local/include/libintl.h include/logger.h include/strprintf.h \
+  include/utils.h 3rd-party/optional.hpp
 src/queueloader.o: src/queueloader.cpp include/queueloader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/download.h config.h \
- include/configcontainer.h include/logger.h include/strprintf.h \
- include/stflpp.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/download.h config.h \
+  /usr/local/include/libintl.h include/logger.h include/strprintf.h \
+  include/stflpp.h /usr/local/include/stfl.h include/utils.h \
+  3rd-party/optional.hpp
 src/queuemanager.o: src/queuemanager.cpp include/queuemanager.h \
- include/configpaths.h include/cliargsparser.h 3rd-party/optional.hpp \
- include/logger.h config.h include/strprintf.h include/fmtstrformatter.h \
- include/rssfeed.h include/matchable.h include/rssitem.h \
- include/matcher.h filter/FilterParser.h include/utils.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/stflpp.h include/utils.h
+  include/configpaths.h include/cliargsparser.h 3rd-party/optional.hpp \
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h include/fmtstrformatter.h include/rssfeed.h \
+  include/matchable.h include/rssitem.h include/matcher.h \
+  filter/FilterParser.h include/utils.h include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h include/stflpp.h \
+  /usr/local/include/stfl.h
 src/regexmanager.o: src/regexmanager.cpp include/regexmanager.h \
- include/configparser.h include/configactionhandler.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h config.h \
- include/confighandlerexception.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h
+  include/configparser.h include/configactionhandler.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h config.h \
+  /usr/local/include/libintl.h include/confighandlerexception.h \
+  include/logger.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp include/configcontainer.h
 src/regexowner.o: src/regexowner.cpp include/regexowner.h
 src/reloader.o: src/reloader.cpp include/reloader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/controller.h include/cache.h \
- include/colormanager.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- include/curlhandle.h include/dbexception.h include/downloadthread.h \
- include/fmtstrformatter.h include/reloadrangethread.h \
- include/reloadthread.h include/controller.h rss/exception.h \
- include/rssfeed.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/rssparser.h rss/feed.h rss/item.h \
- include/scopemeasure.h include/utils.h include/view.h \
- include/filebrowserformaction.h include/listformatter.h \
- include/listwidget.h include/stflpp.h include/formaction.h \
- include/history.h include/keymap.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/controller.h include/cache.h \
+  include/colormanager.h include/feedcontainer.h \
+  include/filtercontainer.h include/fslock.h include/opml.h \
+  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+  include/regexmanager.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/remoteapi.h include/rssignores.h \
+  include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
+  include/curlhandle.h include/dbexception.h include/downloadthread.h \
+  include/fmtstrformatter.h include/reloadrangethread.h \
+  include/reloadthread.h rss/exception.h include/rssfeed.h \
+  include/utils.h include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h include/rssparser.h rss/feed.h rss/item.h \
+  include/scopemeasure.h include/view.h include/filebrowserformaction.h \
+  include/listformatter.h include/listwidget.h include/stflpp.h \
+  /usr/local/include/stfl.h include/formaction.h include/history.h \
+  include/keymap.h include/dirbrowserformaction.h include/htmlrenderer.h \
+  include/textformatter.h
 src/reloadrangethread.o: src/reloadrangethread.cpp \
- include/reloadrangethread.h include/reloader.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h
+  include/reloadrangethread.h include/reloader.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h
 src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/controller.h include/cache.h \
- include/colormanager.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- include/logger.h config.h include/strprintf.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/controller.h include/cache.h \
+  include/colormanager.h include/feedcontainer.h \
+  include/filtercontainer.h include/fslock.h include/opml.h \
+  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+  include/regexmanager.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/reloader.h include/remoteapi.h \
+  include/rssignores.h include/rssitem.h include/matchable.h \
+  3rd-party/optional.hpp include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
 src/remoteapi.o: src/remoteapi.cpp include/remoteapi.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h config.h include/strprintf.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/utils.h 3rd-party/optional.hpp \
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h
 src/rssfeed.o: src/rssfeed.cpp include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h include/cache.h include/configcontainer.h \
- include/confighandlerexception.h include/dbexception.h \
- include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
- include/regexowner.h include/logger.h include/scopemeasure.h \
- include/strprintf.h include/tagsouppullparser.h include/utils.h
+  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+  filter/FilterParser.h include/utils.h include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h \
+  include/cache.h include/confighandlerexception.h include/dbexception.h \
+  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
+  include/regexowner.h include/scopemeasure.h \
+  include/tagsouppullparser.h
 src/rssignores.o: src/rssignores.cpp include/rssignores.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- include/cache.h include/configcontainer.h include/configparser.h \
- config.h include/configcontainer.h include/confighandlerexception.h \
- include/dbexception.h include/htmlrenderer.h include/textformatter.h \
- include/regexmanager.h include/regexowner.h include/logger.h \
- include/strprintf.h include/rssfeed.h include/utils.h include/logger.h \
- include/strprintf.h include/tagsouppullparser.h include/utils.h
+  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+  include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
+  include/cache.h include/configcontainer.h include/configparser.h \
+  config.h /usr/local/include/libintl.h include/confighandlerexception.h \
+  include/dbexception.h include/htmlrenderer.h include/textformatter.h \
+  include/regexmanager.h include/regexowner.h include/logger.h \
+  include/strprintf.h include/rssfeed.h include/utils.h \
+  include/tagsouppullparser.h
 src/rssitem.o: src/rssitem.cpp include/rssitem.h include/matchable.h \
- 3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/dbexception.h include/rssfeed.h \
- include/rssitem.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/strprintf.h include/utils.h
+  3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
+  include/cache.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/dbexception.h include/rssfeed.h \
+  include/utils.h include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h
 src/rssparser.o: src/rssparser.cpp include/rssparser.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h rss/feed.h rss/item.h include/cache.h \
- config.h include/configcontainer.h include/curlhandle.h \
- include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/logger.h include/strprintf.h include/newsblurapi.h \
- include/ocnewsapi.h rss/exception.h rss/parser.h include/remoteapi.h \
- rss/feed.h rss/rssparser.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/utils.h \
- include/logger.h include/rssignores.h include/strprintf.h \
- include/ttrssapi.h 3rd-party/json.hpp include/cache.h include/utils.h
+  include/remoteapi.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h rss/feed.h rss/item.h include/cache.h \
+  config.h /usr/local/include/libintl.h include/curlhandle.h \
+  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
+  include/matcher.h filter/FilterParser.h include/regexowner.h \
+  include/logger.h include/strprintf.h include/newsblurapi.h \
+  /usr/local/include/json-c/json.h /usr/local/include/json-c/debug.h \
+  /usr/local/include/json-c/linkhash.h \
+  /usr/local/include/json-c/json_object.h \
+  /usr/local/include/json-c/json_inttypes.h \
+  /usr/local/include/json-c/json_config.h \
+  /usr/local/include/json-c/printbuf.h \
+  /usr/local/include/json-c/arraylist.h \
+  /usr/local/include/json-c/json_util.h \
+  /usr/local/include/json-c/json_pointer.h \
+  /usr/local/include/json-c/json_tokener.h \
+  /usr/local/include/json-c/json_object_iterator.h \
+  /usr/local/include/json-c/json_c_version.h include/ocnewsapi.h \
+  rss/exception.h rss/parser.h rss/rssparser.h include/rssfeed.h \
+  include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
+  include/utils.h include/rssignores.h include/ttrssapi.h \
+  3rd-party/json.hpp
 src/ruststring.o: src/ruststring.cpp include/ruststring.h
 src/scopemeasure.o: src/scopemeasure.cpp include/scopemeasure.h \
- include/logger.h config.h include/strprintf.h
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h
 src/selectformaction.o: src/selectformaction.cpp \
- include/selectformaction.h include/filtercontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/formaction.h include/history.h include/keymap.h include/stflpp.h \
- include/listwidget.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h config.h \
- include/fmtstrformatter.h include/listformatter.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h include/strprintf.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
-src/stflpp.o: src/stflpp.cpp include/stflpp.h include/exception.h \
- include/logger.h config.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h
+  include/selectformaction.h include/filtercontainer.h \
+  include/configparser.h include/configactionhandler.h \
+  include/formaction.h include/history.h include/keymap.h \
+  include/stflpp.h /usr/local/include/stfl.h include/listwidget.h \
+  include/listformatter.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h config.h \
+  /usr/local/include/libintl.h include/fmtstrformatter.h \
+  include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+  include/configcontainer.h include/logger.h include/view.h \
+  include/colormanager.h include/controller.h include/cache.h \
+  include/feedcontainer.h include/fslock.h include/opml.h \
+  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+  include/reloader.h include/remoteapi.h include/rssignores.h \
+  include/rssitem.h include/matchable.h include/filebrowserformaction.h \
+  include/dirbrowserformaction.h include/htmlrenderer.h \
+  include/textformatter.h
+src/stflpp.o: src/stflpp.cpp include/stflpp.h /usr/local/include/stfl.h \
+  include/exception.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h
 src/strprintf.o: src/strprintf.cpp include/strprintf.h
 src/tagsouppullparser.o: src/tagsouppullparser.cpp \
- include/tagsouppullparser.h config.h include/logger.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h include/xmlexception.h
+  include/tagsouppullparser.h config.h /usr/local/include/libintl.h \
+  include/logger.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h \
+  include/xmlexception.h
 src/textformatter.o: src/textformatter.cpp include/textformatter.h \
- include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/htmlrenderer.h include/textformatter.h \
- include/stflpp.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- config.h include/strprintf.h
+  include/regexmanager.h include/configparser.h \
+  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/htmlrenderer.h include/stflpp.h \
+  /usr/local/include/stfl.h include/strprintf.h include/utils.h \
+  3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+  config.h /usr/local/include/libintl.h
 src/textviewwidget.o: src/textviewwidget.cpp include/textviewwidget.h \
- include/stflpp.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h
+  include/stflpp.h /usr/local/include/stfl.h include/utils.h \
+  3rd-party/optional.hpp include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h
 src/ttrssapi.o: src/ttrssapi.cpp include/ttrssapi.h 3rd-party/json.hpp \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/remoteapi.h include/logger.h \
- config.h include/strprintf.h include/remoteapi.h rss/feed.h rss/item.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h
+  include/cache.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/remoteapi.h include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h rss/feed.h \
+  rss/item.h include/utils.h 3rd-party/optional.hpp
 src/ttrssurlreader.o: src/ttrssurlreader.cpp include/ttrssurlreader.h \
- include/urlreader.h include/fileurlreader.h include/logger.h config.h \
- include/strprintf.h include/remoteapi.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h
+  include/urlreader.h include/fileurlreader.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h include/remoteapi.h \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/utils.h 3rd-party/optional.hpp
 src/urlreader.o: src/urlreader.cpp include/urlreader.h
 src/urlviewformaction.o: src/urlviewformaction.cpp \
- include/urlviewformaction.h include/formaction.h include/history.h \
- include/keymap.h include/configparser.h include/configactionhandler.h \
- include/stflpp.h include/htmlrenderer.h include/textformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/listwidget.h include/listformatter.h \
- config.h include/fmtstrformatter.h include/listformatter.h \
- include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
- include/rssitem.h include/utils.h include/configcontainer.h \
- include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/filebrowserformaction.h \
- include/dirbrowserformaction.h
+  include/urlviewformaction.h include/formaction.h include/history.h \
+  include/keymap.h include/configparser.h include/configactionhandler.h \
+  include/stflpp.h /usr/local/include/stfl.h include/htmlrenderer.h \
+  include/textformatter.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/listwidget.h \
+  include/listformatter.h config.h /usr/local/include/libintl.h \
+  include/fmtstrformatter.h include/rssfeed.h include/matchable.h \
+  3rd-party/optional.hpp include/rssitem.h include/utils.h \
+  include/configcontainer.h include/logger.h include/strprintf.h \
+  include/view.h include/colormanager.h include/controller.h \
+  include/cache.h include/feedcontainer.h include/filtercontainer.h \
+  include/fslock.h include/opml.h include/fileurlreader.h \
+  include/urlreader.h include/queuemanager.h include/reloader.h \
+  include/remoteapi.h include/rssignores.h \
+  include/filebrowserformaction.h include/dirbrowserformaction.h
 src/utils.o: src/utils.cpp include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h include/htmlrenderer.h include/textformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/logger.h include/ruststring.h \
- include/strprintf.h include/rs_utils.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h \
+  /usr/local/include/stfl.h include/htmlrenderer.h \
+  include/textformatter.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/ruststring.h \
+  include/rs_utils.h
 src/view.o: src/view.cpp include/view.h include/colormanager.h \
- include/configparser.h include/configactionhandler.h \
- include/configcontainer.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h 3rd-party/optional.hpp \
- include/filebrowserformaction.h include/listformatter.h \
- include/listwidget.h include/stflpp.h include/formaction.h \
- include/history.h include/keymap.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h config.h \
- include/dbexception.h stfl/dialogs.h include/dialogsformaction.h \
- include/exception.h stfl/feedlist.h include/feedlistformaction.h \
- include/listformaction.h include/view.h stfl/filebrowser.h \
- include/fmtstrformatter.h include/formaction.h stfl/help.h \
- include/helpformaction.h include/textviewwidget.h include/htmlrenderer.h \
- stfl/itemlist.h include/itemlistformaction.h stfl/itemview.h \
- include/itemviewformaction.h include/keymap.h include/logger.h \
- include/strprintf.h include/matcherexception.h include/regexmanager.h \
- include/reloadthread.h include/rssfeed.h include/utils.h \
- include/logger.h include/selectformaction.h stfl/selecttag.h \
- include/strprintf.h stfl/urlview.h include/urlviewformaction.h \
- include/utils.h
+  include/configparser.h include/configactionhandler.h \
+  include/configcontainer.h include/controller.h include/cache.h \
+  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+  include/opml.h include/fileurlreader.h include/urlreader.h \
+  include/queuemanager.h include/regexmanager.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h include/reloader.h \
+  include/remoteapi.h include/rssignores.h include/rssitem.h \
+  include/matchable.h 3rd-party/optional.hpp \
+  include/filebrowserformaction.h include/listformatter.h \
+  include/listwidget.h include/stflpp.h /usr/local/include/stfl.h \
+  include/formaction.h include/history.h include/keymap.h \
+  include/dirbrowserformaction.h include/htmlrenderer.h \
+  include/textformatter.h config.h /usr/local/include/libintl.h \
+  include/dbexception.h stfl/dialogs.h include/dialogsformaction.h \
+  include/exception.h stfl/feedlist.h include/feedlistformaction.h \
+  include/listformaction.h stfl/filebrowser.h include/fmtstrformatter.h \
+  stfl/help.h include/helpformaction.h include/textviewwidget.h \
+  stfl/itemlist.h include/itemlistformaction.h stfl/itemview.h \
+  include/itemviewformaction.h include/logger.h include/strprintf.h \
+  include/matcherexception.h include/reloadthread.h include/rssfeed.h \
+  include/utils.h include/selectformaction.h stfl/selecttag.h \
+  stfl/urlview.h include/urlviewformaction.h
 test/cache.o: test/cache.cpp include/cache.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h 3rd-party/catch.hpp \
- include/configcontainer.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/rssignores.h include/rssparser.h \
- include/remoteapi.h rss/feed.h rss/item.h test/test-helpers/tempfile.h \
- test/test-helpers/maintempdir.h
+  include/configparser.h include/configactionhandler.h \
+  3rd-party/catch.hpp include/rssfeed.h include/matchable.h \
+  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+  filter/FilterParser.h include/utils.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h include/rssignores.h \
+  include/rssparser.h include/remoteapi.h rss/feed.h rss/item.h \
+  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/cliargsparser.o: test/cliargsparser.cpp 3rd-party/catch.hpp \
- include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
- include/strprintf.h test/test-helpers/envvar.h test/test-helpers/opts.h \
- test/test-helpers/stringmaker/optional.h test/test-helpers/tempdir.h \
- test/test-helpers/maintempdir.h
+  include/cliargsparser.h 3rd-party/optional.hpp include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h \
+  test/test-helpers/envvar.h test/test-helpers/opts.h \
+  test/test-helpers/stringmaker/optional.h test/test-helpers/tempdir.h \
+  test/test-helpers/maintempdir.h
 test/colormanager.o: test/colormanager.cpp include/colormanager.h \
- include/configparser.h include/configactionhandler.h 3rd-party/catch.hpp \
- include/confighandlerexception.h
+  include/configparser.h include/configactionhandler.h \
+  3rd-party/catch.hpp include/confighandlerexception.h
 test/configcontainer.o: test/configcontainer.cpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h 3rd-party/catch.hpp \
- include/confighandlerexception.h include/configparser.h include/keymap.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h 3rd-party/catch.hpp \
+  include/confighandlerexception.h include/keymap.h
 test/configparser.o: test/configparser.cpp include/configparser.h \
- include/configactionhandler.h 3rd-party/catch.hpp include/keymap.h \
- include/configparser.h test/test-helpers/envvar.h 3rd-party/optional.hpp \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+  include/configactionhandler.h 3rd-party/catch.hpp include/keymap.h \
+  test/test-helpers/envvar.h 3rd-party/optional.hpp \
+  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/configpaths.o: test/configpaths.cpp include/configpaths.h \
- include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
- include/strprintf.h 3rd-party/catch.hpp test/test-helpers/chmod.h \
- test/test-helpers/envvar.h test/test-helpers/opts.h \
- test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
- include/utils.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h
+  include/cliargsparser.h 3rd-party/optional.hpp include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h \
+  3rd-party/catch.hpp test/test-helpers/chmod.h \
+  test/test-helpers/envvar.h test/test-helpers/opts.h \
+  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
+  include/utils.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h
 test/download.o: test/download.cpp include/download.h 3rd-party/catch.hpp
 test/feedcontainer.o: test/feedcontainer.cpp 3rd-party/catch.hpp \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/configcontainer.h \
- include/feedcontainer.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h
+  include/cache.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/feedcontainer.h \
+  include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
+  include/rssitem.h include/matcher.h filter/FilterParser.h \
+  include/utils.h include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h
 test/fileurlreader.o: test/fileurlreader.cpp include/fileurlreader.h \
- include/urlreader.h 3rd-party/catch.hpp test/test-helpers/misc.h \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+  include/urlreader.h 3rd-party/catch.hpp test/test-helpers/misc.h \
+  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/filtercontainer.o: test/filtercontainer.cpp \
- include/filtercontainer.h include/configparser.h \
- include/configactionhandler.h 3rd-party/catch.hpp \
- include/confighandlerexception.h
+  include/filtercontainer.h include/configparser.h \
+  include/configactionhandler.h 3rd-party/catch.hpp \
+  include/confighandlerexception.h
 test/filterparser.o: test/filterparser.cpp filter/FilterParser.h \
- 3rd-party/catch.hpp
+  3rd-party/catch.hpp
 test/fmtstrformatter.o: test/fmtstrformatter.cpp \
- include/fmtstrformatter.h 3rd-party/catch.hpp
+  include/fmtstrformatter.h 3rd-party/catch.hpp
 test/fslock.o: test/fslock.cpp include/fslock.h 3rd-party/catch.hpp \
- test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
- test/test-helpers/tempfile.h
+  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
+  test/test-helpers/tempfile.h
 test/history.o: test/history.cpp include/history.h 3rd-party/catch.hpp \
- test/test-helpers/tempdir.h test/test-helpers/maintempdir.h
+  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h
 test/htmlrenderer.o: test/htmlrenderer.cpp include/htmlrenderer.h \
- include/textformatter.h include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h 3rd-party/catch.hpp include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h config.h include/strprintf.h
+  include/textformatter.h include/regexmanager.h include/configparser.h \
+  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h 3rd-party/catch.hpp include/strprintf.h \
+  include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
+  include/logger.h config.h /usr/local/include/libintl.h
 test/itemlistformaction.o: test/itemlistformaction.cpp \
- include/itemlistformaction.h include/history.h include/listformaction.h \
- include/formaction.h include/keymap.h include/configparser.h \
- include/configactionhandler.h include/stflpp.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/listwidget.h include/view.h \
- include/colormanager.h include/configcontainer.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h 3rd-party/optional.hpp \
- include/filebrowserformaction.h include/dirbrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h 3rd-party/catch.hpp \
- include/cache.h include/configpaths.h include/cliargsparser.h \
- include/logger.h config.h include/strprintf.h \
- include/feedlistformaction.h stfl/itemlist.h include/keymap.h \
- include/regexmanager.h include/rssfeed.h include/utils.h \
- test/test-helpers/misc.h test/test-helpers/tempfile.h \
- test/test-helpers/maintempdir.h
+  include/itemlistformaction.h include/history.h \
+  include/listformaction.h include/formaction.h include/keymap.h \
+  include/configparser.h include/configactionhandler.h include/stflpp.h \
+  /usr/local/include/stfl.h include/listformatter.h \
+  include/regexmanager.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h include/listwidget.h include/view.h \
+  include/colormanager.h include/configcontainer.h include/controller.h \
+  include/cache.h include/feedcontainer.h include/filtercontainer.h \
+  include/fslock.h include/opml.h include/fileurlreader.h \
+  include/urlreader.h include/queuemanager.h include/reloader.h \
+  include/remoteapi.h include/rssignores.h include/rssitem.h \
+  include/matchable.h 3rd-party/optional.hpp \
+  include/filebrowserformaction.h include/dirbrowserformaction.h \
+  include/htmlrenderer.h include/textformatter.h 3rd-party/catch.hpp \
+  include/configpaths.h include/cliargsparser.h include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h \
+  include/feedlistformaction.h stfl/itemlist.h include/rssfeed.h \
+  include/utils.h test/test-helpers/misc.h test/test-helpers/tempfile.h \
+  test/test-helpers/maintempdir.h
 test/itemrenderer.o: test/itemrenderer.cpp include/itemrenderer.h \
- include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
- include/configparser.h include/configactionhandler.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h 3rd-party/catch.hpp \
- include/cache.h include/configcontainer.h include/configcontainer.h \
- include/regexmanager.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/utils.h \
- include/logger.h config.h include/strprintf.h test/test-helpers/envvar.h
+  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
+  include/configparser.h include/configactionhandler.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h 3rd-party/catch.hpp \
+  include/cache.h include/configcontainer.h include/rssfeed.h \
+  include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
+  include/utils.h include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h test/test-helpers/envvar.h
 test/keymap.o: test/keymap.cpp include/keymap.h include/configparser.h \
- include/configactionhandler.h 3rd-party/catch.hpp \
- include/confighandlerexception.h
+  include/configactionhandler.h 3rd-party/catch.hpp \
+  include/confighandlerexception.h
 test/listformatter.o: test/listformatter.cpp include/listformatter.h \
- include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h 3rd-party/catch.hpp
+  include/regexmanager.h include/configparser.h \
+  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h 3rd-party/catch.hpp
 test/matcher.o: test/matcher.cpp include/matcher.h filter/FilterParser.h \
- 3rd-party/catch.hpp include/matchable.h 3rd-party/optional.hpp \
- include/matcherexception.h test/test-helpers/stringmaker/optional.h
+  3rd-party/catch.hpp include/matchable.h 3rd-party/optional.hpp \
+  include/matcherexception.h test/test-helpers/stringmaker/optional.h
 test/matcherexception.o: test/matcherexception.cpp \
- include/matcherexception.h 3rd-party/catch.hpp
+  include/matcherexception.h 3rd-party/catch.hpp
 test/opml.o: test/opml.cpp include/opml.h include/feedcontainer.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/fileurlreader.h \
- include/urlreader.h 3rd-party/catch.hpp include/cache.h \
- include/fileurlreader.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h test/test-helpers/misc.h \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/fileurlreader.h \
+  include/urlreader.h 3rd-party/catch.hpp include/cache.h \
+  include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
+  include/rssitem.h include/matcher.h filter/FilterParser.h \
+  include/utils.h include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h test/test-helpers/misc.h \
+  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/opmlurlreader.o: test/opmlurlreader.cpp include/opmlurlreader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/urlreader.h 3rd-party/catch.hpp \
- test/test-helpers/misc.h test/test-helpers/tempfile.h \
- test/test-helpers/maintempdir.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h config.h include/strprintf.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/urlreader.h 3rd-party/catch.hpp \
+  test/test-helpers/misc.h test/test-helpers/tempfile.h \
+  test/test-helpers/maintempdir.h include/utils.h 3rd-party/optional.hpp \
+  include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h
 test/queueloader.o: test/queueloader.cpp include/queueloader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/download.h 3rd-party/catch.hpp \
- include/configcontainer.h include/download.h \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/download.h 3rd-party/catch.hpp \
+  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/regexmanager.o: test/regexmanager.cpp include/regexmanager.h \
- include/configparser.h include/configactionhandler.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h 3rd-party/catch.hpp \
- include/confighandlerexception.h include/matchable.h \
- 3rd-party/optional.hpp
+  include/configparser.h include/configactionhandler.h include/matcher.h \
+  filter/FilterParser.h include/regexowner.h 3rd-party/catch.hpp \
+  include/confighandlerexception.h include/matchable.h \
+  3rd-party/optional.hpp
 test/regexowner.o: test/regexowner.cpp include/regexowner.h \
- 3rd-party/catch.hpp
+  3rd-party/catch.hpp
 test/remoteapi.o: test/remoteapi.cpp include/remoteapi.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h 3rd-party/catch.hpp
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h 3rd-party/catch.hpp
 test/rssfeed.o: test/rssfeed.cpp include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h 3rd-party/catch.hpp include/cache.h \
- include/configcontainer.h include/rssparser.h include/remoteapi.h \
- rss/feed.h rss/item.h test/test-helpers/envvar.h \
- test/test-helpers/stringmaker/optional.h
+  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
+  filter/FilterParser.h include/utils.h include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h include/logger.h \
+  config.h /usr/local/include/libintl.h include/strprintf.h \
+  3rd-party/catch.hpp include/cache.h include/rssparser.h \
+  include/remoteapi.h rss/feed.h rss/item.h test/test-helpers/envvar.h \
+  test/test-helpers/stringmaker/optional.h
 test/rssignores.o: test/rssignores.cpp include/rssignores.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- 3rd-party/catch.hpp include/cache.h include/configcontainer.h \
- include/configparser.h include/confighandlerexception.h \
- include/rssitem.h
+  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+  include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
+  3rd-party/catch.hpp include/cache.h include/configcontainer.h \
+  include/configparser.h include/confighandlerexception.h
 test/rssitem.o: test/rssitem.cpp include/rssitem.h include/matchable.h \
- 3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
- 3rd-party/catch.hpp include/cache.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/configcontainer.h include/rssfeed.h include/rssitem.h \
- include/utils.h include/logger.h config.h include/strprintf.h \
- test/test-helpers/envvar.h test/test-helpers/stringmaker/optional.h
+  3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
+  3rd-party/catch.hpp include/cache.h include/configcontainer.h \
+  include/configparser.h include/configactionhandler.h include/rssfeed.h \
+  include/utils.h include/logger.h config.h /usr/local/include/libintl.h \
+  include/strprintf.h test/test-helpers/envvar.h \
+  test/test-helpers/stringmaker/optional.h
 test/rsspp_parser.o: test/rsspp_parser.cpp rss/parser.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h rss/feed.h rss/item.h 3rd-party/catch.hpp \
- rss/exception.h test/test-helpers/exceptionwithmsg.h
+  include/remoteapi.h include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h rss/feed.h rss/item.h \
+  3rd-party/catch.hpp rss/exception.h \
+  test/test-helpers/exceptionwithmsg.h
 test/rsspp_rssparser.o: test/rsspp_rssparser.cpp rss/rssparser.h \
- 3rd-party/catch.hpp test/test-helpers/envvar.h 3rd-party/optional.hpp
+  3rd-party/catch.hpp test/test-helpers/envvar.h 3rd-party/optional.hpp
 test/ruststring.o: test/ruststring.cpp include/ruststring.h \
- 3rd-party/catch.hpp
+  3rd-party/catch.hpp
 test/strprintf.o: test/strprintf.cpp include/strprintf.h \
- 3rd-party/catch.hpp
+  3rd-party/catch.hpp
 test/tagsouppullparser.o: test/tagsouppullparser.cpp \
- include/tagsouppullparser.h 3rd-party/catch.hpp
-test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
- include/strprintf.h
+  include/tagsouppullparser.h 3rd-party/catch.hpp
 test/test-helpers/chdir.o: test/test-helpers/chdir.cpp \
- test/test-helpers/chdir.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h
+  test/test-helpers/chdir.h include/utils.h 3rd-party/optional.hpp \
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
 test/test-helpers/chmod.o: test/test-helpers/chmod.cpp \
- test/test-helpers/chmod.h
+  test/test-helpers/chmod.h
 test/test-helpers/envvar.o: test/test-helpers/envvar.cpp \
- test/test-helpers/envvar.h 3rd-party/optional.hpp 3rd-party/catch.hpp
+  test/test-helpers/envvar.h 3rd-party/optional.hpp 3rd-party/catch.hpp
 test/test-helpers/maintempdir.o: test/test-helpers/maintempdir.cpp \
- test/test-helpers/maintempdir.h
+  test/test-helpers/maintempdir.h
 test/test-helpers/misc.o: test/test-helpers/misc.cpp \
- test/test-helpers/misc.h 3rd-party/catch.hpp
+  test/test-helpers/misc.h 3rd-party/catch.hpp
 test/test-helpers/opts.o: test/test-helpers/opts.cpp \
- test/test-helpers/opts.h
+  test/test-helpers/opts.h
 test/test-helpers/tempdir.o: test/test-helpers/tempdir.cpp \
- test/test-helpers/tempdir.h test/test-helpers/maintempdir.h
+  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h
 test/test-helpers/tempfile.o: test/test-helpers/tempfile.cpp \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h
 test/textformatter.o: test/textformatter.cpp include/textformatter.h \
- include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h 3rd-party/catch.hpp
+  include/regexmanager.h include/configparser.h \
+  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+  include/regexowner.h 3rd-party/catch.hpp
 test/utils.o: test/utils.cpp include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h 3rd-party/catch.hpp include/htmlrenderer.h \
- include/textformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/rs_utils.h \
- test/test-helpers/chdir.h test/test-helpers/envvar.h \
- test/test-helpers/stringmaker/optional.h test/test-helpers/tempdir.h \
- test/test-helpers/maintempdir.h test/test-helpers/tempfile.h
+  include/configcontainer.h include/configparser.h \
+  include/configactionhandler.h include/logger.h config.h \
+  /usr/local/include/libintl.h include/strprintf.h 3rd-party/catch.hpp \
+  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
+  include/matcher.h filter/FilterParser.h include/regexowner.h \
+  include/rs_utils.h test/test-helpers/chdir.h \
+  test/test-helpers/envvar.h test/test-helpers/stringmaker/optional.h \
+  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
+  test/test-helpers/tempfile.h

--- a/src/feedhqapi.cpp
+++ b/src/feedhqapi.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 #include <curl/curl.h>
-#include <json.h>
+#include <json-c/json.h>
 #include <vector>
 
 #include "config.h"

--- a/src/inoreaderapi.cpp
+++ b/src/inoreaderapi.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 #include <curl/curl.h>
-#include <json.h>
+#include <json-c/json.h>
 #include <vector>
 #include <thread>
 

--- a/src/newsblurapi.cpp
+++ b/src/newsblurapi.cpp
@@ -1,10 +1,10 @@
 #include "newsblurapi.h"
 
 #include <algorithm>
+#include <json-c/json.h>
 #include <string.h>
 #include <time.h>
 
-#include "json.h"
 #include "remoteapi.h"
 #include "strprintf.h"
 #include "utils.h"

--- a/src/oldreaderapi.cpp
+++ b/src/oldreaderapi.cpp
@@ -2,7 +2,7 @@
 
 #include <cstring>
 #include <curl/curl.h>
-#include <json.h>
+#include <json-c/json.h>
 #include <vector>
 
 #include "config.h"


### PR DESCRIPTION
Some systems (e.g. MacOS X) can't find json-c without the relative
directory. This means `make depslist` breaks the compilation there.