### PR TITLE
Don't use gettimeofday() to measure time

### DIFF
--- a/include/poddlthread.h
+++ b/include/poddlthread.h
@@ -1,9 +1,9 @@
 #ifndef PODBOAT_PODDLTHREAD_H_
 #define PODBOAT_PODDLTHREAD_H_
 
+#include <chrono>
 #include <fstream>
 #include <memory>
-#include <sys/time.h>
 #include <thread>
 #include <time.h>
 
@@ -27,8 +27,8 @@ private:
 	void run();
 	Download* dl;
 	std::shared_ptr<std::ofstream> f;
-	timeval tv1;
-	timeval tv2;
+	std::chrono::time_point<std::chrono::steady_clock> tv1;
+	std::chrono::time_point<std::chrono::steady_clock> tv2;
 	size_t bytecount;
 	newsboat::ConfigContainer* cfg;
 };

--- a/include/scopemeasure.h
+++ b/include/scopemeasure.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_SCOPEMEASURE_H_
 #define NEWSBOAT_SCOPEMEASURE_H_
 
-#include <sys/time.h>
+#include <chrono>
 #include <string>
 
 #include "logger.h"
@@ -15,9 +15,7 @@ public:
 	void stopover(const std::string& son = "");
 
 private:
-	// Can't use zero initialization (= {}) here because it fails with GCC 4.9:
-	// https://travis-ci.org/newsboat/newsboat/jobs/557484737#L760
-	struct timeval tv1 = {0, 0}, tv2 = {0, 0};
+	std::chrono::time_point<std::chrono::steady_clock> start_time;
 	std::string funcname;
 	Level lvl = Level::DEBUG;
 };

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -5,7 +5,6 @@
 #include <ctime>
 #include <regex.h>
 #include <sstream>
-#include <sys/time.h>
 #include <vector>
 
 #include "logger.h"
@@ -31,8 +30,7 @@ std::string Matcher::get_expression()
 
 bool Matcher::parse(const std::string& expr)
 {
-	struct timeval tv1, tv2;
-	gettimeofday(&tv1, nullptr);
+	ScopeMeasure measurer("Matcher::parse");
 
 	errmsg = "";
 
@@ -44,14 +42,9 @@ bool Matcher::parse(const std::string& expr)
 		errmsg = utils::wstr2str(p.get_error());
 	}
 
-	gettimeofday(&tv2, nullptr);
-	const uint64_t diff =
-		(((tv2.tv_sec - tv1.tv_sec) * 1000000) + tv2.tv_usec) -
-		tv1.tv_usec;
 	LOG(Level::DEBUG,
-		"Matcher::parse: parsing `%s' took %" PRIu64 " µs (success = %d)",
+		"Matcher::parse: parsing `%s' succeeded: %d",
 		expr,
-		diff,
 		b ? 1 : 0);
 
 	return b;

--- a/src/scopemeasure.cpp
+++ b/src/scopemeasure.cpp
@@ -1,7 +1,8 @@
 #include "scopemeasure.h"
 
 #include <cinttypes>
-#include <sys/time.h>
+
+using fpseconds = std::chrono::duration<double>;
 
 namespace newsboat {
 
@@ -9,35 +10,32 @@ ScopeMeasure::ScopeMeasure(const std::string& func, Level ll)
 	: funcname(func)
 	, lvl(ll)
 {
-	gettimeofday(&tv1, nullptr);
+	start_time = std::chrono::steady_clock::now();
 }
 
 void ScopeMeasure::stopover(const std::string& son)
 {
-	gettimeofday(&tv2, nullptr);
-	const uint64_t diff =
-		(((tv2.tv_sec - tv1.tv_sec) * 1000000) + tv2.tv_usec) -
-		tv1.tv_usec;
+	using namespace std::chrono;
+
+	const auto now = steady_clock::now();
+	const auto diff = duration_cast<fpseconds>(now - start_time).count();
 	LOG(lvl,
-		"ScopeMeasure: function `%s' (stop over `%s') took %" PRIu64 ".%06"
-		PRIu64 " s so far",
+		"ScopeMeasure: function `%s' (stop over `%s') took %.6f s so far",
 		funcname,
 		son,
-		diff / 1000000,
-		diff % 1000000);
+		diff);
 }
 
 ScopeMeasure::~ScopeMeasure()
 {
-	gettimeofday(&tv2, nullptr);
-	const uint64_t diff =
-		(((tv2.tv_sec - tv1.tv_sec) * 1000000) + tv2.tv_usec) -
-		tv1.tv_usec;
+	using namespace std::chrono;
+
+	const auto now = steady_clock::now();
+	const auto diff = duration_cast<fpseconds>(now - start_time).count();
 	LOG(lvl,
-		"ScopeMeasure: function `%s' took %" PRIu64 ".%06" PRIu64 " s",
+		"ScopeMeasure: function `%s' took %.6f s",
 		funcname,
-		diff / 1000000,
-		diff % 1000000);
+		diff);
 }
 
 } // namespace newsboat


### PR DESCRIPTION
[`gettimeofday()` is not a monotonic clock](https://blog.habets.se/2010/09/gettimeofday-should-never-be-used-to-measure-time.html), i.e. it can jump back and forth because of NTP, the administrator adjusting time, changes of timezone, etc. This PR replaces all these calls with a monotonic [`std::chrono::steady_clock`](https://en.cppreference.com/w/cpp/chrono/steady_clock).

Kudos to @tejr for sharing the linked article that prompted this.

Reviews are welcome. Will merge in three days.