### PR TITLE
Constify getters in ConfigContainer

### DIFF
--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -24,8 +24,8 @@ enum class ArtSortMethod { TITLE, FLAGS, AUTHOR, LINK, GUID, DATE, RANDOM };
 enum class SortDirection { ASC, DESC };
 
 struct FeedSortStrategy {
-	FeedSortMethod sm;
-	SortDirection sd;
+	FeedSortMethod sm = FeedSortMethod::NONE;
+	SortDirection sd = SortDirection::DESC;
 
 	bool operator==(const FeedSortStrategy& other) const
 	{

--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -91,21 +91,21 @@ public:
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) override;
 
-	bool get_configvalue_as_bool(const std::string& key);
-	int get_configvalue_as_int(const std::string& key);
-	std::string get_configvalue(const std::string& key);
+	bool get_configvalue_as_bool(const std::string& key) const;
+	int get_configvalue_as_int(const std::string& key) const;
+	std::string get_configvalue(const std::string& key) const;
 	void set_configvalue(const std::string& key, const std::string& value);
 	void reset_to_default(const std::string& key);
 	void toggle(const std::string& key);
-	std::vector<std::string> get_suggestions(const std::string& fragment);
-	FeedSortStrategy get_feed_sort_strategy();
-	ArticleSortStrategy get_article_sort_strategy();
+	std::vector<std::string> get_suggestions(const std::string& fragment) const;
+	FeedSortStrategy get_feed_sort_strategy() const;
+	ArticleSortStrategy get_article_sort_strategy() const;
 
 	static const std::string PARTIAL_FILE_SUFFIX;
 
 private:
 	std::map<std::string, ConfigData> config_data;
-	std::recursive_mutex config_data_mtx;
+	mutable std::recursive_mutex config_data_mtx;
 };
 
 } // namespace newsboat

--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -106,9 +106,6 @@ public:
 private:
 	std::map<std::string, ConfigData> config_data;
 	std::recursive_mutex config_data_mtx;
-
-	bool is_bool(const std::string& s);
-	bool is_int(const std::string& s);
 };
 
 } // namespace newsboat

--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -39,8 +39,8 @@ struct FeedSortStrategy {
 };
 
 struct ArticleSortStrategy {
-	ArtSortMethod sm;
-	SortDirection sd;
+	ArtSortMethod sm = ArtSortMethod::DATE;
+	SortDirection sd = SortDirection::ASC;
 
 	bool operator==(const ArticleSortStrategy& other) const
 	{

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -404,30 +404,47 @@ void ConfigContainer::handle_action(const std::string& action,
 	}
 }
 
-std::string ConfigContainer::get_configvalue(const std::string& key)
+std::string ConfigContainer::get_configvalue(const std::string& key) const
 {
 	std::lock_guard<std::recursive_mutex> guard(config_data_mtx);
-	std::string retval = config_data[key].value;
-	if (config_data[key].type == ConfigDataType::PATH) {
-		retval = utils::resolve_tilde(retval);
+	auto it = config_data.find(key);
+	if (it != config_data.cend()) {
+		const auto& entry = it->second;
+		std::string value = entry.value;
+		if (entry.type == ConfigDataType::PATH) {
+			value = utils::resolve_tilde(value);
+		}
+		return value;
 	}
-	return retval;
+
+	return {};
 }
 
-int ConfigContainer::get_configvalue_as_int(const std::string& key)
+int ConfigContainer::get_configvalue_as_int(const std::string& key) const
 {
 	std::lock_guard<std::recursive_mutex> guard(config_data_mtx);
-	std::istringstream is(config_data[key].value);
-	int i;
-	is >> i;
-	return i;
+	auto it = config_data.find(key);
+	if (it != config_data.cend()) {
+		const auto& value = it->second.value;
+		std::istringstream is(value);
+		int i;
+		is >> i;
+		return i;
+	}
+
+	return 0;
 }
 
-bool ConfigContainer::get_configvalue_as_bool(const std::string& key)
+bool ConfigContainer::get_configvalue_as_bool(const std::string& key) const
 {
 	std::lock_guard<std::recursive_mutex> guard(config_data_mtx);
-	std::string value = config_data[key].value;
-	return (value == "true" || value == "yes");
+	auto it = config_data.find(key);
+	if (it != config_data.cend()) {
+		const auto& value = it->second.value;
+		return (value == "true" || value == "yes");
+	}
+
+	return false;
 }
 
 void ConfigContainer::set_configvalue(const std::string& key,
@@ -503,7 +520,7 @@ void ConfigContainer::dump_config(std::vector<std::string>& config_output)
 }
 
 std::vector<std::string> ConfigContainer::get_suggestions(
-	const std::string& fragment)
+	const std::string& fragment) const
 {
 	std::vector<std::string> result;
 	std::lock_guard<std::recursive_mutex> guard(config_data_mtx);
@@ -516,7 +533,7 @@ std::vector<std::string> ConfigContainer::get_suggestions(
 	return result;
 }
 
-FeedSortStrategy ConfigContainer::get_feed_sort_strategy()
+FeedSortStrategy ConfigContainer::get_feed_sort_strategy() const
 {
 	FeedSortStrategy ss;
 
@@ -556,7 +573,7 @@ FeedSortStrategy ConfigContainer::get_feed_sort_strategy()
 	return ss;
 }
 
-ArticleSortStrategy ConfigContainer::get_article_sort_strategy()
+ArticleSortStrategy ConfigContainer::get_article_sort_strategy() const
 {
 	ArticleSortStrategy ss;
 	const auto methods =

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -16,6 +16,19 @@
 
 namespace newsboat {
 
+bool is_bool(const std::string& s)
+{
+	const auto bool_values = std::vector<std::string>(
+	{"yes", "no", "true", "false"});
+	return (std::find(bool_values.begin(), bool_values.end(), s) !=
+			bool_values.end());
+}
+
+bool is_int(const std::string& s)
+{
+	return std::all_of(s.begin(), s.end(), ::isdigit);
+}
+
 const std::string ConfigContainer::PARTIAL_FILE_SUFFIX = ".part";
 
 ConfigContainer::ConfigContainer()
@@ -389,19 +402,6 @@ void ConfigContainer::handle_action(const std::string& action,
 		// we already handled this at the beginning of the function
 		break;
 	}
-}
-
-bool ConfigContainer::is_bool(const std::string& s)
-{
-	const auto bool_values = std::vector<std::string>(
-	{"yes", "no", "true", "false"});
-	return (std::find(bool_values.begin(), bool_values.end(), s) !=
-			bool_values.end());
-}
-
-bool ConfigContainer::is_int(const std::string& s)
-{
-	return std::all_of(s.begin(), s.end(), ::isdigit);
 }
 
 std::string ConfigContainer::get_configvalue(const std::string& key)

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -519,14 +519,14 @@ std::vector<std::string> ConfigContainer::get_suggestions(
 FeedSortStrategy ConfigContainer::get_feed_sort_strategy()
 {
 	FeedSortStrategy ss;
-	const auto sortmethod_info =
-		utils::tokenize(get_configvalue("feed-sort-order"), "-");
-	const std::string sortmethod = sortmethod_info[0];
 
-	std::string direction = "desc";
-	if (sortmethod_info.size() > 1) {
-		direction = sortmethod_info[1];
+	const auto setting = get_configvalue("feed-sort-order");
+	if (setting.empty()) {
+		return ss;
 	}
+
+	const auto sortmethod_info = utils::tokenize(setting, "-");
+	const std::string sortmethod = sortmethod_info[0];
 
 	if (sortmethod == "none") {
 		ss.sm = FeedSortMethod::NONE;
@@ -540,6 +540,11 @@ FeedSortStrategy ConfigContainer::get_feed_sort_strategy()
 		ss.sm = FeedSortMethod::UNREAD_ARTICLE_COUNT;
 	} else if (sortmethod == "lastupdated") {
 		ss.sm = FeedSortMethod::LAST_UPDATED;
+	}
+
+	std::string direction = "desc";
+	if (sortmethod_info.size() > 1) {
+		direction = sortmethod_info[1];
 	}
 
 	if (direction == "asc") {

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -638,3 +638,57 @@ TEST_CASE(
 		REQUIRE(sort_strategy.sd == SortDirection::DESC);
 	}
 }
+
+TEST_CASE("get_article_sort_strategy() returns \"date\" method "
+	"if it can't parse it",
+	"[ConfigContainer]")
+{
+	ConfigContainer cfg;
+
+	const auto check = [&cfg]() {
+		const auto s = cfg.get_article_sort_strategy();
+		REQUIRE(s.sm == ArtSortMethod::DATE);
+		REQUIRE(s.sd == SortDirection::ASC);
+	};
+
+	SECTION("empty value") {
+		cfg.set_configvalue("article-sort-order", "");
+		check();
+	}
+
+	SECTION("unknown method") {
+		SECTION("without a direction") {
+			cfg.set_configvalue("article-sort-order", "funniness");
+			check();
+		}
+
+		SECTION("with an unknown direction") {
+			cfg.set_configvalue("article-sort-order", "funniness-increasing");
+			check();
+		}
+
+		SECTION("with a valid direction") {
+			cfg.set_configvalue("article-sort-order", "funniness-desc");
+			const auto s = cfg.get_article_sort_strategy();
+			REQUIRE(s.sm == ArtSortMethod::DATE);
+			REQUIRE(s.sd == SortDirection::DESC);
+		}
+	}
+}
+
+TEST_CASE("get_article_sort_strategy() returns ascending direction "
+	"if it can't parse it",
+	"[ConfigContainer]")
+{
+	ConfigContainer cfg;
+
+	SECTION("no direction specified and method is not \"date\"") {
+		cfg.set_configvalue("article-sort-order", "author");
+		REQUIRE(cfg.get_article_sort_strategy().sd == SortDirection::ASC);
+	}
+
+	SECTION("unknown direction") {
+		cfg.set_configvalue("article-sort-order", "author-increasing");
+		REQUIRE(cfg.get_article_sort_strategy().sd == SortDirection::ASC);
+	}
+}

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -122,6 +122,13 @@ TEST_CASE("reset_to_default changes setting to its default value",
 	}
 }
 
+TEST_CASE("get_configvalue() returns empty string if settings doesn't exist",
+	"[ConfigContainer]")
+{
+	ConfigContainer cfg;
+	REQUIRE(cfg.get_configvalue("nonexistent-key") == "");
+}
+
 TEST_CASE("get_configvalue_as_bool() recognizes several boolean formats",
 	"[ConfigContainer]")
 {
@@ -147,6 +154,27 @@ TEST_CASE("get_configvalue_as_bool() recognizes several boolean formats",
 		REQUIRE_FALSE(
 			cfg.get_configvalue_as_bool("bookmark-interactive"));
 	}
+}
+
+TEST_CASE("get_configvalue_as_int() returns zero if setting doesn't exist",
+	"[ConfigContainer]")
+{
+	ConfigContainer cfg;
+
+	REQUIRE(cfg.get_configvalue_as_int("setting-name") == 0);
+}
+
+TEST_CASE("get_configvalue_as_int() returns zero if value can't be parsed as int",
+	"[ConfigContainer]")
+{
+	const auto key = std::string("unparseable-value");
+	const auto value = std::string("is here");
+
+	ConfigContainer cfg;
+	cfg.set_configvalue(key, value);
+
+	REQUIRE(cfg.get_configvalue(key) == value);
+	REQUIRE(cfg.get_configvalue_as_int(key) == 0);
 }
 
 TEST_CASE("toggle() inverts the value of a boolean setting",
@@ -537,6 +565,23 @@ TEST_CASE(
 		cfg.set_configvalue("article-sort-order", "date-desc");
 		sort_strategy = cfg.get_article_sort_strategy();
 		REQUIRE(sort_strategy.sm == ArtSortMethod::DATE);
+		REQUIRE(sort_strategy.sd == SortDirection::DESC);
+	}
+
+	SECTION("random") {
+		cfg.set_configvalue("article-sort-order", "random");
+		sort_strategy = cfg.get_article_sort_strategy();
+		REQUIRE(sort_strategy.sm == ArtSortMethod::RANDOM);
+		REQUIRE(sort_strategy.sd == SortDirection::ASC);
+
+		cfg.set_configvalue("article-sort-order", "random-asc");
+		sort_strategy = cfg.get_article_sort_strategy();
+		REQUIRE(sort_strategy.sm == ArtSortMethod::RANDOM);
+		REQUIRE(sort_strategy.sd == SortDirection::ASC);
+
+		cfg.set_configvalue("article-sort-order", "random-desc");
+		sort_strategy = cfg.get_article_sort_strategy();
+		REQUIRE(sort_strategy.sm == ArtSortMethod::RANDOM);
 		REQUIRE(sort_strategy.sd == SortDirection::DESC);
 	}
 }

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -458,6 +458,59 @@ TEST_CASE(
 	}
 }
 
+TEST_CASE("get_feed_sort_strategy() returns \"none\" method if it can't parse it",
+	"[ConfigContainer]")
+{
+	ConfigContainer cfg;
+
+	const auto check = [&cfg]() {
+		const auto s = cfg.get_feed_sort_strategy();
+		REQUIRE(s.sm == FeedSortMethod::NONE);
+		REQUIRE(s.sd == SortDirection::DESC);
+	};
+
+	SECTION("empty value") {
+		cfg.set_configvalue("feed-sort-order", "");
+		check();
+	}
+
+	SECTION("unknown method") {
+		SECTION("without a direction") {
+			cfg.set_configvalue("feed-sort-order", "funniness");
+			check();
+		}
+
+		SECTION("with an unknown direction") {
+			cfg.set_configvalue("feed-sort-order", "funniness-increasing");
+			check();
+		}
+
+		SECTION("with a valid direction") {
+			cfg.set_configvalue("feed-sort-order", "funniness-asc");
+			const auto s = cfg.get_feed_sort_strategy();
+			REQUIRE(s.sm == FeedSortMethod::NONE);
+			REQUIRE(s.sd == SortDirection::ASC);
+		}
+	}
+}
+
+TEST_CASE("get_feed_sort_strategy() returns descending direction "
+	"if it can't parse it",
+	"[ConfigContainer]")
+{
+	ConfigContainer cfg;
+
+	SECTION("no direction specified") {
+		cfg.set_configvalue("feed-sort-order", "title");
+		REQUIRE(cfg.get_feed_sort_strategy().sd == SortDirection::DESC);
+	}
+
+	SECTION("unknown direction") {
+		cfg.set_configvalue("feed-sort-order", "title-increasing");
+		REQUIRE(cfg.get_feed_sort_strategy().sd == SortDirection::DESC);
+	}
+}
+
 TEST_CASE(
 	"get_article_sort_strategy() returns correctly filled "
 	"ArticleSortStrategy struct",


### PR DESCRIPTION
Fixes #318.

I'd like to make `dump_config()` constant as well, but it requires changes to other classes too, some of which don't have tests. This will have to wait until another time.

Reviews are welcome. Will merge in three days.