### PR TITLE
Add FAQ item about browser errors in 2.18

### DIFF
--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -78,3 +78,28 @@ Finally, if you understand what a "MITM attack" is, and are certain that it
 can't happen in your setup, check out <<newsboat#_first_steps,a list of
 Newsboat's configuration options>> for ways to entirely disable SSL
 verification.
+
+== Newsboat 2.18 complains that "Browser returned error code <some number>"
+
+That Newsboat version misinterprets the browser's exit code. Please upgrade to
+Newsboat 2.19 or newer.
+
+If upgrading is not an option, wrap the browser in a script to hide its exit
+code from Newsboat:
+
+1. Put this in `~/bin/newsboat-browser.sh`:
++
+    #/bin/sh
+    /usr/bin/firefox "$@"
+    exit 0
++
+Replace `/usr/bin/firefox` with the path to your browser. The last line is the
+important bit.
+
+2. Make it executable:
++
+    $ chmod +x ~/bin/newsboat-browser.sh
+
+3. Add the following to your Newsboat's config:
++
+    browser "~/bin/newsboat-browser.sh"


### PR DESCRIPTION
This summarizes my findings from #825.

I tested it with a simple C program: `int main() { return 1; }`. If I use that as a `browser` on r2.18 tag, navigate to some feed, and try to open an articlce, Newsboat says "Browser returned error code 1". If I wrap the program in a script as described in the FAQ, the message doesn't appear.

I considered re-arranging the questions somehow, but with just five of them, it's hard to see any useful structure. Let them be a list for now. I definitely *don't* want to combine the two browser questions into one, because I think answers should be laser-focused on a particular problem; it's better to have two similar, but simple, answers than to have a single complicated one.

I requested a review from @der-lyse since I run all the docs by him, but everyone else are welcome—and encouraged!—to take a peek at this as well.

I plan to merge this for 2.20, so tomorrow or Sunday. Sorry for the close review deadline; should've looked into #825 sooner, but oh well.