### PR TITLE
Fix #1013

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -142,8 +142,6 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 
 			if (pos == str.length()) {
 				pos = std::string::npos;
-			} else {
-				++pos;
 			}
 		} else {
 			pos = str.find_first_of(delimiters, last_pos);

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -98,6 +98,16 @@ TEST_CASE(
 		REQUIRE(tokens[0] == "foo \\xxx");
 		REQUIRE(tokens[1] == " ");
 	}
+
+	SECTION("Closing double quote marks the end of a token") {
+		tokens = utils::tokenize_quoted(R"(set browser "mpv %u";)");
+
+		REQUIRE(tokens.size() == 4);
+		REQUIRE(tokens[0] == "set");
+		REQUIRE(tokens[1] == "browser");
+		REQUIRE(tokens[2] == "mpv %u");
+		REQUIRE(tokens[3] == ";");
+	}
 }
 
 TEST_CASE("tokenize_quoted() implicitly closes quotes at the end of the string",


### PR DESCRIPTION
4b327fbff264c69bb78765304e16c2403c65b5e1 (#929) introduced a bug which made utils::tokenize_quoted() skip the character that follows the closing double quote. This surfaced as #1013, where Newsboat fails to extract the semicolon from:

    set browser "whatever"; some-other-token

The problem was caused by incrementing the position twice.

Fixes #1013.

Reviews are welcome. Will merge on Wednesday to make a 2.20.1 release.