### PR TITLE
Bump Rust to 1.44.1 on CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -170,98 +170,98 @@ linux_task:
                 cxx: clang++-10
           env: *extra_warnings_and_checks_env
 
-        - name: Rust 1.43.1, GCC 4.9 (Ubuntu 16.04)
+        - name: Rust 1.44.1, GCC 4.9 (Ubuntu 16.04)
           container:
             dockerfile: docker/ubuntu_16.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-4.9
                 cc: gcc-4.9
                 cxx: g++-4.9
-        - name: Rust 1.43.1, GCC 5 (Ubuntu 18.04)
+        - name: Rust 1.44.1, GCC 5 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-5
                 cc: gcc-5
                 cxx: g++-5
-        - name: Rust 1.43.1, GCC 6 (Ubuntu 18.04)
+        - name: Rust 1.44.1, GCC 6 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-6
                 cc: gcc-6
                 cxx: g++-6
-        - name: Rust 1.43.1, GCC 7 (Ubuntu 18.04)
+        - name: Rust 1.44.1, GCC 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-7
                 cc: gcc-7
                 cxx: g++-7
-        - name: Rust 1.43.1, GCC 8 (Ubuntu 18.04)
+        - name: Rust 1.44.1, GCC 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-8
                 cc: gcc-8
                 cxx: g++-8
-        - name: Rust 1.43.1, GCC 9 (Ubuntu 20.04)
+        - name: Rust 1.44.1, GCC 9 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-9
                 cc: gcc-9
                 cxx: g++-9
-        - name: Rust 1.43.1, GCC 10 (Ubuntu 20.04)
+        - name: Rust 1.44.1, GCC 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-10
                 cc: gcc-10
                 cxx: g++-10
-        - name: Rust 1.43.1, Clang 4.0 (Ubuntu 18.04)
+        - name: Rust 1.44.1, Clang 4.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-4.0
                 cc: clang-4.0
                 cxx: clang++-4.0
-        - name: Rust 1.43.1, Clang 5.0 (Ubuntu 18.04)
+        - name: Rust 1.44.1, Clang 5.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-5.0
                 cc: clang-5.0
                 cxx: clang++-5.0
-        - name: Rust 1.43.1, Clang 6.0 (Ubuntu 18.04)
+        - name: Rust 1.44.1, Clang 6.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-6.0
                 cc: clang-6.0
                 cxx: clang++-6.0
-        - name: Rust 1.43.1, Clang 7 (Ubuntu 18.04)
+        - name: Rust 1.44.1, Clang 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-7
                 cc: clang-7
                 cxx: clang++-7
-        - name: Rust 1.43.1, Clang 8 (Ubuntu 18.04)
+        - name: Rust 1.44.1, Clang 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-8
                 cc: clang-8
                 cxx: clang++-8
-        - name: Rust 1.43.1, Clang 9 (Ubuntu 18.04)
+        - name: Rust 1.44.1, Clang 9 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-9
                 cc: clang-9
                 cxx: clang++-9
-        - name: Rust 1.43.1, Clang 10 (Ubuntu 20.04)
+        - name: Rust 1.44.1, Clang 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:

--- a/docker/ubuntu_16.04-build-tools.dockerfile
+++ b/docker/ubuntu_16.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with an older
-# C++ compiler. Contains GCC 4.9 and Rust 1.43.1 by default.
+# C++ compiler. Contains GCC 4.9 and Rust 1.44.1 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-4.9
-# - rust_version -- Rust version to install. Default: 1.43.1
+# - rust_version -- Rust version to install. Default: 1.44.1
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-4.9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -82,7 +82,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.43.1
+ARG rust_version=1.44.1
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.43.1 by default.
+# and Rust 1.44.1 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-8
-# - rust_version -- Rust version to install. Default: 1.43.1
+# - rust_version -- Rust version to install. Default: 1.44.1
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-8
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -82,7 +82,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.43.1
+ARG rust_version=1.44.1
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -73,7 +73,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain 1.43.1 \
+        --default-toolchain 1.44.1 \
         # Install only rustc, rust-std, and cargo
         --profile minimal \
     && chmod a+w $HOME/.cargo

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 9 and Rust 1.43.1 by default.
+# compilers. Contains GCC 9 and Rust 1.44.1 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.43.1
+# - rust_version -- Rust version to install. Default: 1.44.1
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -82,7 +82,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.43.1
+ARG rust_version=1.44.1
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \


### PR DESCRIPTION
Just a regular update of our CI jobs. I missed the 1.44 release, so we go straight to current stable.

To be clear, this PR does *not* bump the *minimum* supported version. It just updates the CI to check that Newsboat can be built with current stable Rust.

Will merge once CI is green.