### PR TITLE
Make FeedContainer methods thread-safe

### DIFF
--- a/include/feedcontainer.h
+++ b/include/feedcontainer.h
@@ -43,7 +43,7 @@ public:
 	std::vector<std::shared_ptr<RssFeed>> feeds;
 
 private:
-	std::mutex feeds_mutex;
+	mutable std::mutex feeds_mutex;
 };
 } // namespace newsboat
 

--- a/src/feedcontainer.cpp
+++ b/src/feedcontainer.cpp
@@ -193,6 +193,7 @@ unsigned int FeedContainer::get_unread_item_count_per_tag(
 std::shared_ptr<RssFeed> FeedContainer::get_feed_by_url(
 	const std::string& feedurl)
 {
+	std::lock_guard<std::mutex> feedslock(feeds_mutex);
 	for (const auto& feed : feeds) {
 		if (feedurl == feed->rssurl()) {
 			return feed;
@@ -257,6 +258,7 @@ void FeedContainer::clear_feeds_items()
 
 unsigned int FeedContainer::unread_feed_count() const
 {
+	std::lock_guard<std::mutex> feedslock(feeds_mutex);
 	return std::count_if(feeds.begin(),
 			feeds.end(),
 	[](const std::shared_ptr<RssFeed> feed) {
@@ -266,6 +268,7 @@ unsigned int FeedContainer::unread_feed_count() const
 
 unsigned int FeedContainer::unread_item_count() const
 {
+	std::lock_guard<std::mutex> feedslock(feeds_mutex);
 	return std::accumulate(feeds.begin(),
 			feeds.end(),
 			0,


### PR DESCRIPTION
Fixes #1025.

Thanks to @dennisschagt for investigating that issue to a point where the problem was rather obvious.

Reviews are welcome! Asking for one from @dennisschagt, since he reproduced the original issue and should be able to easily double-check the fix.

Will merge for 2.20.1 tomorrow.