### PR TITLE
Bump minimum supported Rust version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -148,13 +148,13 @@ linux_task:
                 cc: gcc-4.9
                 cxx: g++-4.9
                 rust_version: 1.42.0
-        - name: Rust 1.42.0, GCC 9 (Ubuntu 20.04)
+        - name: Rust 1.42.0, GCC 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
-                cxx_package: g++-9
-                cc: gcc-9
-                cxx: g++-9
+                cxx_package: g++-10
+                cc: gcc-10
+                cxx: g++-10
                 rust_version: 1.42.0
 
         - name: GCC 10, more warnings and checks (Ubuntu 20.04)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,11 +118,11 @@ macos_task:
               RUST: stable
         # This job tests our minimum supported Rust version, so only bump on
         # Newsboat release day
-        - name: macOS GCC Rust 1.40.0
+        - name: macOS GCC Rust 1.42.0
           env:
               CC: gcc
               CXX: g++
-              RUST: 1.40.0
+              RUST: 1.42.0
 
 formatting_task:
     name: Code formatting
@@ -140,22 +140,22 @@ linux_task:
     matrix:
         # These two jobs test our minimum supported Rust version, so only bump on
         # Newsboat release day
-        - name: Rust 1.40.0, GCC 4.9 (Ubuntu 16.04)
+        - name: Rust 1.42.0, GCC 4.9 (Ubuntu 16.04)
           container:
             dockerfile: docker/ubuntu_16.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-4.9
                 cc: gcc-4.9
                 cxx: g++-4.9
-                rust_version: 1.40.0
-        - name: Rust 1.40.0, GCC 9 (Ubuntu 20.04)
+                rust_version: 1.42.0
+        - name: Rust 1.42.0, GCC 9 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-9
                 cc: gcc-9
                 cxx: g++-9
-                rust_version: 1.40.0
+                rust_version: 1.42.0
 
         - name: GCC 10, more warnings and checks (Ubuntu 20.04)
           container:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Newsboat can be compiled.
 -->
 - GCC 4.9 or newer, or Clang 3.6 or newer
 - Stable [Rust](https://www.rust-lang.org/en-US/) and Cargo (Rust's package
-    manager) (1.40.0 or newer; might work with older versions, but we don't
+    manager) (1.42.0 or newer; might work with older versions, but we don't
     check that)
 - [STFL (version 0.21 or newer)](http://www.clifford.at/stfl/)
 - [SQLite3 (version 3.5 or newer)](https://www.sqlite.org/download.html)

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -68,7 +68,7 @@ Debian and derivatives, headers are in `-dev` packages, e.g. `libsqlite3-dev`.)
 // UPDATE README.md IF YOU CHANGE THIS LIST
 - GCC 4.9 or newer, or Clang 3.6 or newer
 - Stable https://www.rust-lang.org/en-US/[Rust] and Cargo (Rust's package
-  manager) (1.40.0 or newer; might work with older versions, but we don't check
+  manager) (1.42.0 or newer; might work with older versions, but we don't check
   that)
 - http://www.clifford.at/stfl/[STFL (version 0.21 or newer)]
 - https://www.sqlite.org/download.html[SQLite3 (version 3.5 or newer)]


### PR DESCRIPTION
All in accordance with the schedule agreed upon in #709. I also took an opportunity to bump the GCC against which MSRV is tested.

Reviews are welcome! Will merge in three days if no issues are raised.