### PR TITLE
Make utils::run_interactively return Option<u8>

### DIFF
--- a/include/listformaction.h
+++ b/include/listformaction.h
@@ -1,6 +1,10 @@
 #ifndef NEWSBOAT_LISTFORMACTION_H_
 #define NEWSBOAT_LISTFORMACTION_H_
 
+#include <cstdint>
+
+#include "3rd-party/optional.hpp"
+
 #include "formaction.h"
 
 namespace newsboat {
@@ -13,7 +17,8 @@ protected:
 	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
-	int open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
+	nonstd::optional<std::uint8_t> open_unread_items_in_browser(
+		std::shared_ptr<RssFeed> feed,
 		bool markread);
 };
 

--- a/include/rs_utils.h
+++ b/include/rs_utils.h
@@ -1,6 +1,10 @@
 #ifndef NEWSBOAT_RS_UTILS_H_
 #define NEWSBOAT_RS_UTILS_H_
 
+#include <cstdint>
+
+#include "3rd-party/optional.hpp"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -55,7 +59,8 @@ char* rs_unescape_url(const char* str);
 
 char* rs_make_title(const char* str);
 
-int32_t rs_run_interactively(const char* command, const char* caller);
+std::uint8_t rs_run_interactively(const char* command, const char* caller,
+	bool* success);
 
 char* rs_getcwd();
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,6 +1,7 @@
 #ifndef NEWSBOAT_UTIL_H_
 #define NEWSBOAT_UTIL_H_
 
+#include <cstdint>
 #include <curl/curl.h>
 #include <libxml/parser.h>
 #include <memory>
@@ -135,7 +136,7 @@ int mkdir_parents(const std::string& pathname,
 
 std::string make_title(const std::string& url);
 
-int32_t run_interactively(const std::string& command,
+nonstd::optional<std::uint8_t> run_interactively(const std::string& command,
 	const std::string& caller);
 
 std::string getcwd();

--- a/include/view.h
+++ b/include/view.h
@@ -1,10 +1,13 @@
 #ifndef NEWSBOAT_VIEW_H_
 #define NEWSBOAT_VIEW_H_
 
+#include <cstdint>
 #include <list>
 #include <mutex>
 #include <string>
 #include <vector>
+
+#include "3rd-party/optional.hpp"
 
 #include "colormanager.h"
 #include "configcontainer.h"
@@ -77,7 +80,7 @@ public:
 	std::string select_filter(
 		const std::vector<FilterNameExprPair>& filters);
 
-	int open_in_browser(const std::string& url);
+	nonstd::optional<std::uint8_t> open_in_browser(const std::string& url);
 	void open_in_pager(const std::string& filename);
 
 	std::string get_filename_suggestion(const std::string& s);

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -332,17 +332,17 @@ src/keymap.o: src/keymap.cpp include/keymap.h include/configparser.h \
  include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
  3rd-party/optional.hpp include/configcontainer.h include/logger.h
 src/listformaction.o: src/listformaction.cpp include/listformaction.h \
- include/formaction.h include/history.h include/keymap.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
- include/rssitem.h include/matcher.h filter/FilterParser.h \
- include/utils.h include/configcontainer.h include/logger.h config.h \
- include/strprintf.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/regexowner.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/filebrowserformaction.h \
+ 3rd-party/optional.hpp include/formaction.h include/history.h \
+ include/keymap.h include/configparser.h include/configactionhandler.h \
+ include/stflpp.h include/rssfeed.h include/matchable.h include/rssitem.h \
+ include/matcher.h filter/FilterParser.h include/utils.h \
+ include/configcontainer.h include/logger.h config.h include/strprintf.h \
+ include/view.h include/colormanager.h include/controller.h \
+ include/cache.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/regexmanager.h \
+ include/regexowner.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/filebrowserformaction.h \
  include/listformatter.h include/listwidget.h \
  include/dirbrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h
@@ -608,15 +608,15 @@ src/utils.o: src/utils.cpp include/utils.h 3rd-party/optional.hpp \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h include/logger.h include/ruststring.h \
  include/strprintf.h include/rs_utils.h
-src/view.o: src/view.cpp include/view.h include/colormanager.h \
- include/configparser.h include/configactionhandler.h \
- include/configcontainer.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h 3rd-party/optional.hpp \
+src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
+ include/colormanager.h include/configparser.h \
+ include/configactionhandler.h include/configcontainer.h \
+ include/controller.h include/cache.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
  include/filebrowserformaction.h include/listformatter.h \
  include/listwidget.h include/stflpp.h include/formaction.h \
  include/history.h include/keymap.h include/dirbrowserformaction.h \

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -330,7 +330,8 @@ pub unsafe extern "C" fn rs_make_title(input: *const c_char) -> *mut c_char {
 pub unsafe extern "C" fn rs_run_interactively(
     command: *const c_char,
     caller: *const c_char,
-) -> i32 {
+    success: *mut bool,
+) -> u8 {
     abort_on_panic(|| {
         let command = CStr::from_ptr(command);
         // This won't panic because all strings in Newsboat are in UTF-8
@@ -340,7 +341,17 @@ pub unsafe extern "C" fn rs_run_interactively(
         // This won't panic because all strings in Newsboat are in UTF-8
         let caller = caller.to_str().expect("caller contained invalid UTF-8");
 
-        utils::run_interactively(&command, &caller)
+        match utils::run_interactively(&command, &caller) {
+            Some(exit_code) => {
+                *success = true;
+                exit_code
+            }
+
+            None => {
+                *success = false;
+                0
+            }
+        }
     })
 }
 

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -151,9 +151,13 @@ bool ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO, "ItemListFormAction: opening item at pos `%u'", itempos);
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				auto link = visible_items[itempos].first->link();
-				if (int err = v->open_in_browser(link)) {
-					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+				const auto link = visible_items[itempos].first->link();
+				const auto exit_code = v->open_in_browser(link);
+				if (!exit_code.has_value()) {
+					v->show_error(_("Failed to spawn browser"));
+					break;
+				} else if (*exit_code != 0) {
+					v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
 					break;
 				}
 				visible_items[itempos].first->set_unread(false);
@@ -182,9 +186,13 @@ bool ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO, "ItemListFormAction: opening item at pos `%u'", itempos);
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				auto link = visible_items[itempos].first->link();
-				if (int err = v->open_in_browser(link)) {
-					v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+				const auto link = visible_items[itempos].first->link();
+				const auto exit_code = v->open_in_browser(link);
+				if (!exit_code.has_value()) {
+					v->show_error(_("Failed to spawn browser"));
+					return false;
+				} else if (*exit_code != 0) {
+					v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
 					return false;
 				}
 				invalidate(itempos);
@@ -201,8 +209,12 @@ bool ItemListFormAction::process_operation(Operation op,
 				"ItemListFormAction: opening all unread items "
 				"in "
 				"browser");
-			if (int err = open_unread_items_in_browser(feed, false)) {
-				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+			const auto exit_code = open_unread_items_in_browser(feed, false);
+			if (!exit_code.has_value()) {
+				v->show_error(_("Failed to spawn browser"));
+				return false;
+			} else if (*exit_code != 0) {
+				v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
 				return false;
 			}
 		}
@@ -214,8 +226,12 @@ bool ItemListFormAction::process_operation(Operation op,
 				"ItemListFormAction: opening all unread items "
 				"in "
 				"browser and marking read");
-			if (int err = open_unread_items_in_browser(feed, true)) {
-				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+			const auto exit_code = open_unread_items_in_browser(feed, true);
+			if (!exit_code.has_value()) {
+				v->show_error(_("Failed to spawn browser"));
+				return false;
+			} else if (*exit_code != 0) {
+				v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
 				return false;
 			}
 			invalidate_everything();

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -243,16 +243,21 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_OPENINBROWSER:
-	case OP_OPENBROWSER_AND_MARK:
+	case OP_OPENBROWSER_AND_MARK: {
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: starting browser");
 		v->set_status(_("Starting browser..."));
-		if (int err = v->open_in_browser(item->link())) {
-			v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+		const auto exit_code = v->open_in_browser(item->link());
+		if (!exit_code.has_value()) {
+			v->show_error(_("Failed to spawn browser"));
+			return false;
+		} else if (*exit_code != 0) {
+			v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
 			return false;
 		}
 
 		v->set_status("");
-		break;
+	}
+	break;
 	case OP_BOOKMARK:
 		if (automatic) {
 			qna_responses.clear();
@@ -428,8 +433,12 @@ bool ItemViewFormAction::process_operation(Operation op,
 		if (idx < links.size()) {
 			v->set_status(_("Starting browser..."));
 
-			if (int err = v->open_in_browser(links[idx].first)) {
-				v->show_error(strprintf::fmt(_("Browser returned error code %i"), err));
+			const auto exit_code = v->open_in_browser(links[idx].first);
+			if (!exit_code.has_value()) {
+				v->show_error(_("Failed to spawn browser"));
+				return false;
+			} else if (*exit_code != 0) {
+				v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
 				return false;
 			}
 

--- a/src/listformaction.cpp
+++ b/src/listformaction.cpp
@@ -50,7 +50,8 @@ bool ListFormAction::process_operation(Operation op,
 	return true;
 }
 
-int ListFormAction::open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
+nonstd::optional<std::uint8_t> ListFormAction::open_unread_items_in_browser(
+	std::shared_ptr<RssFeed> feed,
 	bool markread)
 {
 	int tabcount = 0;
@@ -58,9 +59,11 @@ int ListFormAction::open_unread_items_in_browser(std::shared_ptr<RssFeed> feed,
 		if (tabcount <
 			cfg->get_configvalue_as_int("max-browser-tabs")) {
 			if (item->unread()) {
-				if (int err = v->open_in_browser(item->link())) {
-					return err;
+				const auto exit_code = v->open_in_browser(item->link());
+				if (!exit_code.has_value() || *exit_code != 0) {
+					return exit_code;
 				}
+
 				tabcount += 1;
 				item->set_unread(!markread);
 			}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -870,10 +870,18 @@ std::string utils::make_title(const std::string& const_url)
 	return RustString(rs_make_title(const_url.c_str()));
 }
 
-int32_t utils::run_interactively(const std::string& command,
+nonstd::optional<std::uint8_t> utils::run_interactively(
+	const std::string& command,
 	const std::string& caller)
 {
-	return rs_run_interactively(command.c_str(), caller.c_str());
+	bool success = false;
+	const auto exit_code = rs_run_interactively(command.c_str(), caller.c_str(),
+			&success);
+	if (success) {
+		return exit_code;
+	}
+
+	return nonstd::nullopt;
 }
 
 std::string utils::getcwd()

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -332,7 +332,7 @@ void View::open_in_pager(const std::string& filename)
 	pop_current_formaction();
 }
 
-int View::open_in_browser(const std::string& url)
+nonstd::optional<std::uint8_t> View::open_in_browser(const std::string& url)
 {
 	formaction_stack.push_back(std::shared_ptr<FormAction>());
 	current_formaction = formaction_stack_size() - 1;
@@ -350,7 +350,7 @@ int View::open_in_browser(const std::string& url)
 		cmdline.append(" " + escaped_url);
 	}
 	Stfl::reset();
-	const int ret = utils::run_interactively(cmdline, "View::open_in_browser");
+	const auto ret = utils::run_interactively(cmdline, "View::open_in_browser");
 	pop_current_formaction();
 	return ret;
 }

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -899,16 +899,19 @@ TEST_CASE("utils::make_title extracts possible title from URL", "[utils]")
 	}
 }
 
-TEST_CASE("run_interactively", "[utils]")
+TEST_CASE("run_interactively runs a command with inherited I/O", "[utils]")
 {
 	SECTION("echo hello should return 0") {
-		int32_t result = utils::run_interactively("echo hello", "test");
+		const auto result = utils::run_interactively("echo hello", "test");
 		REQUIRE(result == 0);
 	}
 	SECTION("exit 1 should return 1") {
-		int32_t result = utils::run_interactively("exit 1", "test");
+		const auto result = utils::run_interactively("exit 1", "test");
 		REQUIRE(result == 1);
 	}
+
+	// Unfortunately, there is no easy way to provoke this function to return
+	// `nonstd::nullopt`, nor to test that it returns just the lower 8 bits.
 }
 
 TEST_CASE("remove_soft_hyphens remove all U+00AD characters from a string",


### PR DESCRIPTION
This fulfills the promise I made in https://github.com/newsboat/newsboat/issues/825#issuecomment-645615319.

For testing, I used the following config:

    bind-key O open-in-browser-and-mark-read
    bind-key w open-all-unread-in-browser
    bind-key W open-all-unread-in-browser-and-mark-read

Then I ran through these in three configurations:

1. `browser "firefox"` -- to test the happy path;

2. `browser "false"` -- to test the error path where the browser returns a non-zero error code (1, in this case);

3. `PATH= ./newsboat …` -- to test the error path where `sh` itself didn't start.

Reviews are welcome! I'll merge this in three days if no issues are raised.