### PR TITLE
Send emails on CI failures

### DIFF
--- a/.github/workflows/email.yml
+++ b/.github/workflows/email.yml
@@ -1,0 +1,25 @@
+on:
+  check_suite:
+    type: ['completed']
+
+name: Email about Cirrus CI failures
+jobs:
+  continue:
+    name: After Cirrus CI Failure
+    if: github.event.check_suite.app.name == 'Cirrus CI' && github.event.check_suite.conclusion != 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octokit/request-action@v2.x
+        id: get_failed_check_run
+        with:
+          route: GET /repos/${{ github.repository }}/check-suites/${{ github.event.check_suite.id }}/check-runs?status=completed
+          mediaType: '{"previews": ["antiope"]}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          echo "Cirrus CI ${{ github.event.check_suite.conclusion }} on ${{ github.event.check_suite.head_branch }} branch!"
+          echo "SHA ${{ github.event.check_suite.head_sha }}"
+          echo $MESSAGE
+          echo "##[error]See $CHECK_RUN_URL for details" && false
+        env:
+          CHECK_RUN_URL: ${{ fromJson(steps.get_failed_check_run.outputs.data).check_runs[0].html_url }}


### PR DESCRIPTION
Workflow copied from https://cirrus-ci.org/guide/notifications/.

I never used GitHub Actions before, so I'm not sure how this is supposed to work. According to [this forum post](https://github.community/t/who-receives-notifications/17680), the emails are sent to whoever triggered the action; that's whoever submitted the PR or created a merge commit. I'm not entirely happy with that, since I'd like to know about *everything* that's going on in this repo, but oh well, still better than nothing.

The workflow file also doesn't mention email itself. As far as I understand, this is because the workflow generates a *notification*, which is then delivered over web and/or email [depending on your personal preferences](https://help.github.com/en/github/managing-subscriptions-and-notifications-on-github/configuring-notifications#github-actions-notification-options). That link mentions "repositories that you're watching", so perhaps I *will* receive emails about all Newsboat-related stuff? We'll see.

Please, please report any weird notifications or emails about Cirrus CI that you receive after I've merged this.

Fixes #807.

The file is copied from the Cirrus CI docs, so I don't think we need a review for this :) But I'd be happy to know if anyone has experience with GitHub Actions and can answer my noob questions.