### PR TITLE
Add GitHub Dependabot to the repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "12:30"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "12:30"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "12:30"


### PR DESCRIPTION
Dependabot will update dependencies in our Cargo.lock, GitHub Actions, and Docker files.

The presence of this file doesn't affect the build, and it does nothing while on a feature branch, so I'm going to merge this pretty much immediately to get some effect.