### PR TITLE
Rust FilterParser: store values as strings

### DIFF
--- a/include/matcher.h
+++ b/include/matcher.h
@@ -16,6 +16,13 @@ public:
 	std::string get_parse_error();
 	std::string get_expression();
 
+	/// Convert numerical prefix of the string to an `int`.
+	///
+	/// Return 0 if there is no numeric prefix. On underflow, return `int`'s
+	/// minimum. On overflow, return `int`'s maximum.
+	// This is made public so it can be tested. DON'T USE OUTSIDE OF MATCHER.
+	static int string_to_num(const std::string& number);
+
 private:
 	bool matches_r(expression* e, Matchable* item);
 

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -210,7 +210,7 @@ mod tests {
             .unwrap()
             .matches(&mock)
             .unwrap());
-        assert!(Matcher::parse("answer = 0042")
+        assert!(!Matcher::parse("answer = 0042")
             .unwrap()
             .matches(&mock)
             .unwrap());
@@ -219,7 +219,7 @@ mod tests {
             .matches(&mock)
             .unwrap());
 
-        assert!(Matcher::parse("agent = 7").unwrap().matches(&mock).unwrap());
+        assert!(!Matcher::parse("agent = 7").unwrap().matches(&mock).unwrap());
         assert!(Matcher::parse("agent = 007")
             .unwrap()
             .matches(&mock)
@@ -272,7 +272,7 @@ mod tests {
             .matches(&mock)
             .unwrap());
 
-        assert!(!Matcher::parse("agent != 7")
+        assert!(Matcher::parse("agent != 7")
             .unwrap()
             .matches(&mock)
             .unwrap());
@@ -334,15 +334,15 @@ mod tests {
     }
 
     #[test]
-    fn t_test_regex_match_doesnt_work_with_numbers() {
+    fn t_test_regex_match_converts_numbers_to_strings_and_uses_them_as_regexes() {
         let mock = MockMatchable::new(&[("AAAA", "12345")]);
 
-        assert!(!Matcher::parse("AAAA =~ 12345")
+        assert!(Matcher::parse("AAAA =~ 12345")
             .unwrap()
             .matches(&mock)
             .unwrap());
-        assert!(!Matcher::parse("AAAA =~ 1").unwrap().matches(&mock).unwrap());
-        assert!(!Matcher::parse("AAAA =~ 45")
+        assert!(Matcher::parse("AAAA =~ 1").unwrap().matches(&mock).unwrap());
+        assert!(Matcher::parse("AAAA =~ 45")
             .unwrap()
             .matches(&mock)
             .unwrap());
@@ -350,7 +350,7 @@ mod tests {
     }
 
     #[test]
-    fn t_test_regex_match_doesnt_work_with_ranges() {
+    fn t_test_regex_match_treats_ranges_as_strings() {
         let mock = MockMatchable::new(&[("AAAA", "12345"), ("range", "0:123")]);
 
         assert!(!Matcher::parse("AAAA =~ 0:123456")
@@ -366,11 +366,11 @@ mod tests {
             .matches(&mock)
             .unwrap());
 
-        assert!(!Matcher::parse("range =~ 0:123")
+        assert!(Matcher::parse("range =~ 0:123")
             .unwrap()
             .matches(&mock)
             .unwrap());
-        assert!(!Matcher::parse("range =~ 0:12")
+        assert!(Matcher::parse("range =~ 0:12")
             .unwrap()
             .matches(&mock)
             .unwrap());
@@ -451,15 +451,15 @@ mod tests {
     }
 
     #[test]
-    fn t_test_not_regex_match_doesnt_work_with_numbers() {
+    fn t_test_not_regex_match_converts_numbers_into_strings_and_uses_them_as_regexes() {
         let mock = MockMatchable::new(&[("AAAA", "12345")]);
 
-        assert!(Matcher::parse("AAAA !~ 12345")
+        assert!(!Matcher::parse("AAAA !~ 12345")
             .unwrap()
             .matches(&mock)
             .unwrap());
-        assert!(Matcher::parse("AAAA !~ 1").unwrap().matches(&mock).unwrap());
-        assert!(Matcher::parse("AAAA !~ 45")
+        assert!(!Matcher::parse("AAAA !~ 1").unwrap().matches(&mock).unwrap());
+        assert!(!Matcher::parse("AAAA !~ 45")
             .unwrap()
             .matches(&mock)
             .unwrap());
@@ -677,7 +677,7 @@ mod tests {
     }
 
     #[test]
-    fn t_test_comparisons_dont_work_with_strings() {
+    fn t_test_comparisons_convert_string_arguments_to_numbers() {
         let mock = MockMatchable::new(&[("AAAA", "12345")]);
 
         assert!(Matcher::parse("AAAA > \"12344\"")
@@ -685,12 +685,12 @@ mod tests {
             .matches(&mock)
             .unwrap());
 
-        assert!(Matcher::parse("AAAA > \"12345\"")
+        assert!(!Matcher::parse("AAAA > \"12345\"")
             .unwrap()
             .matches(&mock)
             .unwrap());
 
-        assert!(Matcher::parse("AAAA > \"123456\"")
+        assert!(!Matcher::parse("AAAA > \"123456\"")
             .unwrap()
             .matches(&mock)
             .unwrap());
@@ -700,12 +700,12 @@ mod tests {
             .matches(&mock)
             .unwrap());
 
-        assert!(!Matcher::parse("AAAA < \"12346\"")
+        assert!(Matcher::parse("AAAA < \"12346\"")
             .unwrap()
             .matches(&mock)
             .unwrap());
 
-        assert!(!Matcher::parse("AAAA < \"123456\"")
+        assert!(Matcher::parse("AAAA < \"123456\"")
             .unwrap()
             .matches(&mock)
             .unwrap());
@@ -720,7 +720,7 @@ mod tests {
             .matches(&mock)
             .unwrap());
 
-        assert!(Matcher::parse("AAAA >= \"12346\"")
+        assert!(!Matcher::parse("AAAA >= \"12346\"")
             .unwrap()
             .matches(&mock)
             .unwrap());
@@ -730,12 +730,76 @@ mod tests {
             .matches(&mock)
             .unwrap());
 
-        assert!(!Matcher::parse("AAAA <= \"12345\"")
+        assert!(Matcher::parse("AAAA <= \"12345\"")
             .unwrap()
             .matches(&mock)
             .unwrap());
 
-        assert!(!Matcher::parse("AAAA <= \"12346\"")
+        assert!(Matcher::parse("AAAA <= \"12346\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_comparisons_use_numeric_prefix_of_the_string() {
+        let mock = MockMatchable::new(&[("AAAA", "12345xx")]);
+
+        assert!(Matcher::parse("AAAA >= \"12345\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("AAAA > \"1234a\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA < \"12345a\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA < \"1234a\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("AAAA < \"9999b\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_comparisons_use_zero_if_string_cant_be_converted_to_number() {
+        let mock = MockMatchable::new(&[("zero", "0"), ("same_zero", "yeah")]);
+
+        assert!(!Matcher::parse("zero < \"unknown\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("zero > \"unknown\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("zero <= \"unknown\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("zero >= \"unknown\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("same_zero < \"0\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("same_zero > \"0\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("same_zero <= \"0\"")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("same_zero >= \"0\"")
             .unwrap()
             .matches(&mock)
             .unwrap());
@@ -838,6 +902,28 @@ mod tests {
             .matches(&mock)
             .unwrap());
         assert!(Matcher::parse("AAAA between 12346:12344")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+    }
+
+    #[test]
+    fn t_test_operator_between_converts_numeric_prefix_of_the_attribute() {
+        let mock = MockMatchable::new(&[("value", "123four"), ("practically_zero", "sure")]);
+
+        assert!(Matcher::parse("value between 122:124")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("value between 124:130")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(Matcher::parse("practically_zero between 0:1")
+            .unwrap()
+            .matches(&mock)
+            .unwrap());
+        assert!(!Matcher::parse("practically_zero between 1:100")
             .unwrap()
             .matches(&mock)
             .unwrap());

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -91,48 +91,40 @@ std::string get_attr_or_throw(Matchable* item, const std::string& attr_name)
 
 bool Matcher::matchop_lt(expression* e, Matchable* item)
 {
-	const auto attr = get_attr_or_throw(item, e->name);
+	const int ilit = string_to_num(e->literal);
 
-	std::istringstream islit(e->literal);
-	std::istringstream isatt(attr);
-	int ilit, iatt;
-	islit >> ilit;
-	isatt >> iatt;
+	const auto attr = get_attr_or_throw(item, e->name);
+	const int iatt = string_to_num(attr);
+
 	return iatt < ilit;
 }
 
 bool Matcher::matchop_between(expression* e, Matchable* item)
 {
 	const auto attr = get_attr_or_throw(item, e->name);
+	const int att = string_to_num(attr);
 
 	const std::vector<std::string> lit = utils::tokenize(e->literal, ":");
-	std::istringstream isatt(attr);
-	int att;
-	isatt >> att;
 	if (lit.size() < 2) {
 		return false;
 	}
-	std::istringstream is1(lit[0]), is2(lit[1]);
-	int i1, i2;
-	is1 >> i1;
-	is2 >> i2;
+
+	int i1 = string_to_num(lit[0]);
+	int i2 = string_to_num(lit[1]);
 	if (i1 > i2) {
-		int tmp = i1;
-		i1 = i2;
-		i2 = tmp;
+		std::swap(i1, i2);
 	}
+
 	return (att >= i1 && att <= i2);
 }
 
 bool Matcher::matchop_gt(expression* e, Matchable* item)
 {
 	const auto attr = get_attr_or_throw(item, e->name);
+	const int iatt = string_to_num(attr);
 
-	std::istringstream islit(e->literal);
-	std::istringstream isatt(attr);
-	int ilit, iatt;
-	islit >> ilit;
-	isatt >> iatt;
+	const int ilit = string_to_num(e->literal);
+
 	return iatt > ilit;
 }
 
@@ -245,6 +237,13 @@ bool Matcher::matches_r(expression* e, Matchable* item)
 std::string Matcher::get_parse_error()
 {
 	return errmsg;
+}
+
+int Matcher::string_to_num(const std::string& number)
+{
+	int result = 0;
+	std::istringstream(number) >> result;
+	return result;
 }
 
 } // namespace newsboat

--- a/test/filterparser.cpp
+++ b/test/filterparser.cpp
@@ -31,6 +31,19 @@ TEST_CASE("FilterParser raises errors on invalid queries", "[FilterParser]")
 	SECTION("non-existent operator") {
 		REQUIRE_FALSE(fp.parse_string("a !! \"b\""));
 	}
+
+	SECTION("incorrect syntax for range") {
+		REQUIRE_FALSE(fp.parse_string("AAAA between 0:15:30"));
+	}
+
+	SECTION("no whitespace after the `and` operator") {
+		REQUIRE_FALSE(fp.parse_string("x = 42andy=0"));
+		REQUIRE_FALSE(fp.parse_string("x = 42 andy=0"));
+	}
+
+	SECTION("operator without arguments") {
+		REQUIRE_FALSE(fp.parse_string("=!"));
+	}
 }
 
 TEST_CASE("FilterParser doesn't raise errors on valid queries",

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -645,15 +645,6 @@ TEST_CASE("Operator `between` checks if field's value is in given range",
 	}
 }
 
-TEST_CASE("Invalid expression results in parsing error", "[Matcher]")
-{
-	Matcher m;
-
-	REQUIRE_FALSE(m.parse("AAAA between 0:15:30"));
-	REQUIRE_FALSE(m.parse("x = 42andy=0"));
-	REQUIRE_FALSE(m.parse("x = 42 andy=0"));
-}
-
 TEST_CASE("get_expression() returns previously parsed expression", "[Matcher]")
 {
 	Matcher m("AAAA between 1:30000");

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -804,3 +804,27 @@ TEST_CASE("Whitespace before and/or is not required", "[Matcher]")
 	REQUIRE(m.parse("x = \"42\"or y=42"));
 	REQUIRE(m.matches(&mock));
 }
+
+TEST_CASE("string_to_num() converts numeric prefix of the string to int",
+	"[Matcher]")
+{
+	REQUIRE(Matcher::string_to_num("7654") == 7654);
+	REQUIRE(Matcher::string_to_num("123foo") == 123);
+	REQUIRE(Matcher::string_to_num("-999999bar") == -999999);
+
+	REQUIRE(Matcher::string_to_num("-2147483648min") == -2147483648);
+	REQUIRE(Matcher::string_to_num("2147483647 is ok") == 2147483647);
+
+	// On under-/over-flow, returns min/max representable value
+	REQUIRE(Matcher::string_to_num("-2147483649 is too small for i32") ==
+		-2147483648);
+	REQUIRE(Matcher::string_to_num("2147483648 is too large for i32") ==
+		2147483647);
+}
+
+TEST_CASE("string_to_num() returns 0 if there is no numeric prefix",
+	"[Matcher]")
+{
+	REQUIRE(Matcher::string_to_num("hello") == 0);
+	REQUIRE(Matcher::string_to_num("") == 0);
+}

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -627,7 +627,7 @@ TEST_CASE("Operator `between` checks if field's value is in given range",
 		REQUIRE(m.parse("AAAA between 12346:12344"));
 		REQUIRE(m.matches(&mock));
 
-		SECTION("...converting numering prefix of the attribute if necessary") {
+		SECTION("...converting numeric prefix of the attribute if necessary") {
 			MatcherMockMatchable mock({{"value", "123four"}, {"practically_zero", "sure"}});
 
 			REQUIRE(m.parse("value between 122:124"));


### PR DESCRIPTION
As described in https://github.com/newsboat/newsboat/issues/631#issuecomment-651060230, I believe it's best to keep C++ and Rust implementations of `FilterParser` and `Matcher` identical for now. This PR achieves that by removing the only difference between the two: the way the right-hand-side values are stored. Rust now mimics C++, storing everything as a string and converting to a more appropriate type upon evaluation.

Reviews are welcome! Will merge in three days if no issues are raised.