### PR TITLE
Add Clippy (Rust linter) to CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,6 +35,7 @@ freebsd_task:
     # Running three jobs because by default, VMs have 2 cores.
     build_script: su testuser -c 'cd ~ && gmake --jobs=3 --keep-going all test'
     test_script: su testuser -c 'cd ~ && ( cd test && ./test --order rand ); ret=$?; (RUST_BACKTRACE=1 cargo test --jobs=3) && sh -c "exit $ret"'
+    clippy_script: su testuser -c 'cd ~ && cargo clippy --all-targets --all-features -- -D warnings'
     # This installs everything into a "fake filesystem root", then uninstalls
     # everything and checks that there are no files left over. The purpose of
     # this check is to ensure that: 1) `make install` doesn't fail; 2) `make
@@ -59,6 +60,8 @@ freebsd_task:
         # command to fail if one of the test suites fails. That's why we store
         # the C++'s exit code and chain it to Rust's in the end.
         - ( cd test && ./test --order rand ); ret=$?; (RUST_BACKTRACE=1 cargo test --jobs=3) && sh -c "exit $ret"
+    clippy_script: &clippy_script
+        - cargo clippy --all-targets --all-features -- -D warnings
     # For explanation of what this script does, please see the FreeBSD job
     # above.
     fake_install_script: &fake_install_script
@@ -110,6 +113,7 @@ macos_task:
 
     build_script: *build_script
     test_script: *test_script
+    clippy_script: *clippy_script
     fake_install_script: *fake_install_script
     before_cache_script: *before_cache_script
 
@@ -291,6 +295,7 @@ linux_task:
 
     build_script: *build_script
     test_script: *test_script
+    clippy_script: *clippy_script
     fake_install_script: *fake_install_script
     before_cache_script: *before_cache_script
 

--- a/docker/ubuntu_16.04-build-tools.dockerfile
+++ b/docker/ubuntu_16.04-build-tools.dockerfile
@@ -89,8 +89,6 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && $HOME/rustup.sh -y \
         --default-host x86_64-unknown-linux-gnu \
         --default-toolchain $rust_version \
-        # Install only rustc, rust-std, and cargo
-        --profile minimal \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -89,8 +89,6 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && $HOME/rustup.sh -y \
         --default-host x86_64-unknown-linux-gnu \
         --default-toolchain $rust_version \
-        # Install only rustc, rust-std, and cargo
-        --profile minimal \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -74,8 +74,6 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
         --default-toolchain 1.44.1 \
-        # Install only rustc, rust-std, and cargo
-        --profile minimal \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -89,8 +89,6 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && $HOME/rustup.sh -y \
         --default-host x86_64-unknown-linux-gnu \
         --default-toolchain $rust_version \
-        # Install only rustc, rust-std, and cargo
-        --profile minimal \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/include/history.h
+++ b/include/history.h
@@ -10,8 +10,8 @@ public:
 	History();
 	~History();
 	void add_line(const std::string& line);
-	std::string prev();
-	std::string next();
+	std::string previous_line();
+	std::string next_line();
 	void load_from_file(const std::string& file);
 	void save_to_file(const std::string& file, unsigned int limit);
 

--- a/rust/libnewsboat-ffi/src/history.rs
+++ b/rust/libnewsboat-ffi/src/history.rs
@@ -41,13 +41,13 @@ pub unsafe extern "C" fn rs_history_add_line(hst: *mut c_void, line: *const c_ch
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_history_prev(hst: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_history_previous_line(hst: *mut c_void) -> *mut c_char {
     abort_on_panic(|| {
         let mut hst = {
             assert!(!hst.is_null());
             Box::from_raw(hst as *mut History)
         };
-        let result = hst.prev();
+        let result = hst.previous_line();
         // Panic here can't happen because:
         // 1. panic can only happen if `result` contains null bytes;
         // 2. `result` either contains what `line` in `rs_history_add_line` contained
@@ -64,13 +64,13 @@ pub unsafe extern "C" fn rs_history_prev(hst: *mut c_void) -> *mut c_char {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_history_next(hst: *mut c_void) -> *mut c_char {
+pub unsafe extern "C" fn rs_history_next_line(hst: *mut c_void) -> *mut c_char {
     abort_on_panic(|| {
         let mut hst = {
             assert!(!hst.is_null());
             Box::from_raw(hst as *mut History)
         };
-        let result = hst.next();
+        let result = hst.next_line();
         // Panic here can't happen because:
         // 1. panic can only happen if `result` contains null bytes;
         // 2. `result` either contains what `line` in `rs_history_add_line` contained

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -2,6 +2,8 @@
 // make sense to document these functions because they are basically an internal detail and don't
 // stand on their own.
 #![allow(clippy::missing_safety_doc)]
+// This lint is nitpicky, I don't think it's really important how the literals are written.
+#![allow(clippy::unreadable_literal)]
 
 use libc::c_char;
 use std::ffi::CString;

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -1,3 +1,8 @@
+// Each function in this crate is used in a single place: a corresponding C++ wrapper. It doesn't
+// make sense to document these functions because they are basically an internal detail and don't
+// stand on their own.
+#![allow(clippy::missing_safety_doc)]
+
 use libc::c_char;
 use std::ffi::CString;
 use std::panic::{catch_unwind, UnwindSafe};

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -11,8 +11,8 @@ use std::ptr;
 
 #[repr(C)]
 pub struct FilterUrl {
-    filter: *mut char,
-    url: *mut char,
+    filter: *mut c_char,
+    url: *mut c_char,
 }
 
 #[no_mangle]
@@ -664,8 +664,8 @@ pub unsafe extern "C" fn rs_extract_filter(line: *const c_char) -> FilterUrl {
         let url = CString::new(url).unwrap();
 
         FilterUrl {
-            filter: filter.into_raw() as *mut char,
-            url: url.into_raw() as *mut char,
+            filter: filter.into_raw() as *mut c_char,
+            url: url.into_raw() as *mut c_char,
         }
     })
 }

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -342,7 +342,7 @@ mod tests {
         ]);
         check(vec![
             "newsboat".to_string(),
-            "--import-from-opml=".to_string() + &filename,
+            "--import-from-opml=".to_string() + filename,
         ]);
     }
 
@@ -445,7 +445,7 @@ mod tests {
 
         check(vec![
             "newsboat".to_string(),
-            "--url-file=".to_string() + &filename,
+            "--url-file=".to_string() + filename,
         ]);
     }
 
@@ -471,7 +471,7 @@ mod tests {
         ]);
         check(vec![
             "newsboat".to_string(),
-            "--cache-file=".to_string() + &filename,
+            "--cache-file=".to_string() + filename,
         ]);
     }
 
@@ -493,7 +493,7 @@ mod tests {
         ]);
         check(vec![
             "newsboat".to_string(),
-            "--config-file=".to_string() + &filename,
+            "--config-file=".to_string() + filename,
         ]);
     }
 
@@ -645,7 +645,7 @@ mod tests {
         ]);
         check(vec![
             "newsboat".to_string(),
-            "--import-from-file=".to_string() + &filename,
+            "--import-from-file=".to_string() + filename,
         ]);
     }
 
@@ -666,7 +666,7 @@ mod tests {
         ]);
         check(vec![
             "newsboat".to_string(),
-            "--export-to-file=".to_string() + &filename,
+            "--export-to-file=".to_string() + filename,
         ]);
     }
 
@@ -715,7 +715,7 @@ mod tests {
         ]);
         check(vec![
             "newsboat".to_string(),
-            "--log-file=".to_string() + &filename,
+            "--log-file=".to_string() + filename,
         ]);
     }
 

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -368,9 +368,9 @@ mod tests {
         check(vec![
             "newsboat".to_string(),
             "-e".to_string(),
-            exportf.clone(),
+            exportf,
             "-i".to_string(),
-            importf.to_string(),
+            importf,
         ]);
     }
 
@@ -692,9 +692,9 @@ mod tests {
         check(vec![
             "newsboat".to_string(),
             "-E".to_string(),
-            exportf.clone(),
+            exportf,
             "-I".to_string(),
-            importf.to_string(),
+            importf,
         ]);
     }
 

--- a/rust/libnewsboat/src/configpaths.rs
+++ b/rust/libnewsboat/src/configpaths.rs
@@ -2,13 +2,11 @@ use crate::cliargsparser::CliArgsParser;
 use crate::logger::{self, Level};
 use crate::utils;
 use gettextrs::gettext;
-use libc;
 use std::fs::{self, DirBuilder};
 use std::io;
 use std::os::unix::fs::DirBuilderExt;
 use std::path::{Path, PathBuf};
 use strprintf::fmt;
-use xdg;
 
 pub const NEWSBOAT_SUBDIR_XDG: &str = "newsboat";
 pub const NEWSBOAT_CONFIG_SUBDIR: &str = ".newsboat";

--- a/rust/libnewsboat/src/fmtstrformatter/parser.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/parser.rs
@@ -2,6 +2,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take, take_till1, take_while};
 use nom::multi::many0;
 use nom::IResult;
+use std::cmp::Ordering;
 use std::str;
 
 /// Describes how formats should be padded: on the left, on the right, or not at all.
@@ -55,12 +56,10 @@ fn padded_format(input: &str) -> IResult<&str, Specifier> {
     let format = format.chars().next().unwrap();
 
     let width = width.parse::<isize>().unwrap_or(0);
-    let padding = if width == 0isize {
-        Padding::None
-    } else if width > 0isize {
-        Padding::Left(width.abs() as usize)
-    } else {
-        Padding::Right(width.abs() as usize)
+    let padding = match width.cmp(&0isize) {
+        Ordering::Equal => Padding::None,
+        Ordering::Greater => Padding::Left(width.abs() as usize),
+        Ordering::Less => Padding::Right(width.abs() as usize),
     };
 
     Ok((input, Specifier::Format(format, padding)))

--- a/rust/libnewsboat/src/history.rs
+++ b/rust/libnewsboat/src/history.rs
@@ -16,17 +16,14 @@ impl History {
         }
     }
     pub fn add_line(&mut self, line: String) {
-        /*
-         * When a line is added, we need to do so and
-         * reset the index so that the next prev/next
-         * operations start from the beginning again.
-         */
+        // When a line is added, we need to do so and reset the index so that the next
+        // previous_line()/next_line() operations start from the beginning again.
         if !line.is_empty() {
             self.lines.insert(0, line)
         }
         self.idx = 0;
     }
-    pub fn next(&mut self) -> String {
+    pub fn next_line(&mut self) -> String {
         match self.idx {
             0 => String::new(),
             _ => {
@@ -35,7 +32,7 @@ impl History {
             }
         }
     }
-    pub fn prev(&mut self) -> String {
+    pub fn previous_line(&mut self) -> String {
         match self.lines.len() {
             0 => String::new(),
             len if self.idx < len => {
@@ -83,20 +80,20 @@ mod tests {
     #[test]
     fn t_empty_history_returns_nothing() {
         let mut h = History::new();
-        assert_eq!(h.prev(), "");
-        assert_eq!(h.prev(), "");
-        assert_eq!(h.next(), "");
-        assert_eq!(h.next(), "");
+        assert_eq!(h.previous_line(), "");
+        assert_eq!(h.previous_line(), "");
+        assert_eq!(h.next_line(), "");
+        assert_eq!(h.next_line(), "");
     }
 
     #[test]
     fn t_one_line_in_history() {
         let mut h = History::new();
         h.add_line("testline".to_string());
-        assert_eq!(h.prev(), "testline");
-        assert_eq!(h.prev(), "testline");
-        assert_eq!(h.next(), "testline");
-        assert_eq!(h.next(), "");
+        assert_eq!(h.previous_line(), "testline");
+        assert_eq!(h.previous_line(), "testline");
+        assert_eq!(h.next_line(), "testline");
+        assert_eq!(h.next_line(), "");
     }
 
     #[test]
@@ -104,14 +101,14 @@ mod tests {
         let mut h = History::new();
         h.add_line("testline".to_string());
         h.add_line("foobar".to_string());
-        assert_eq!(h.prev(), "foobar");
-        assert_eq!(h.prev(), "testline");
-        assert_eq!(h.next(), "testline");
-        assert_eq!(h.prev(), "testline");
-        assert_eq!(h.next(), "testline");
-        assert_eq!(h.next(), "foobar");
-        assert_eq!(h.next(), "");
-        assert_eq!(h.next(), "");
+        assert_eq!(h.previous_line(), "foobar");
+        assert_eq!(h.previous_line(), "testline");
+        assert_eq!(h.next_line(), "testline");
+        assert_eq!(h.previous_line(), "testline");
+        assert_eq!(h.next_line(), "testline");
+        assert_eq!(h.next_line(), "foobar");
+        assert_eq!(h.next_line(), "");
+        assert_eq!(h.next_line(), "");
     }
 
     #[test]
@@ -134,10 +131,10 @@ mod tests {
         // lines are loaded to new History
         let mut loaded_h = History::new();
         loaded_h.load_from_file(file_path).unwrap();
-        assert_eq!(loaded_h.prev(), "foobar");
-        assert_eq!(loaded_h.prev(), "testline");
-        assert_eq!(loaded_h.next(), "testline");
-        assert_eq!(loaded_h.next(), "foobar");
-        assert_eq!(loaded_h.next(), "");
+        assert_eq!(loaded_h.previous_line(), "foobar");
+        assert_eq!(loaded_h.previous_line(), "testline");
+        assert_eq!(loaded_h.next_line(), "testline");
+        assert_eq!(loaded_h.next_line(), "foobar");
+        assert_eq!(loaded_h.next_line(), "");
     }
 }

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -1,3 +1,6 @@
+// This lint is nitpicky, I don't think it's really important how the literals are written.
+#![allow(clippy::unreadable_literal)]
+
 // This module must be declared before the others because it exports a `log!` macro that everyone
 // else uses.
 #[macro_use]

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -344,7 +344,7 @@ mod tests {
     }
 
     fn parse_log_line(line: &str) -> Option<(&str, &str, &str)> {
-        if !line.starts_with("[") {
+        if !line.starts_with('[') {
             return None;
         }
 
@@ -376,7 +376,7 @@ mod tests {
     }
 
     fn parse_errorlog_line(line: &str) -> Option<(&str, &str)> {
-        if !line.starts_with("[") {
+        if !line.starts_with('[') {
             return None;
         }
 

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -122,7 +122,7 @@ impl Operator {
                             return Ok(true);
                         }
                     }
-                    return Ok(false);
+                    Ok(false)
                 }
                 _ => Ok(false),
             },
@@ -140,11 +140,9 @@ fn evaluate_expression(expr: &Expression, item: &impl Matchable) -> Result<bool,
             op,
             value,
         } => match item.attribute_value(&attribute) {
-            None => {
-                return Err(MatcherError::AttributeUnavailable {
-                    attr: attribute.clone(),
-                })
-            }
+            None => Err(MatcherError::AttributeUnavailable {
+                attr: attribute.clone(),
+            }),
 
             Some(ref attr) => op.apply(attr, &value),
         },

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -117,7 +117,7 @@ impl Operator {
             Operator::Contains => match value {
                 Value::Int(i) => self.apply(attr, &Value::Str(format!("{}", i))),
                 Value::Str(ref s) => {
-                    for token in attr.split(" ") {
+                    for token in attr.split(' ') {
                         if token == s {
                             return Ok(true);
                         }

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -177,7 +177,7 @@ mod tests {
         pub fn new(values: &[(&str, &str)]) -> MockMatchable {
             MockMatchable {
                 values: values
-                    .into_iter()
+                    .iter()
                     .map(|(a, b)| (String::from(*a), String::from(*b)))
                     .collect::<BTreeMap<_, _>>(),
             }

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -640,7 +640,7 @@ pub fn run_interactively(command: &str, caller: &str) -> Option<u8> {
         })
         .ok()
         .and_then(|exit_status| exit_status.code())
-        .and_then(|exit_code| Some(exit_code as u8))
+        .map(|exit_code| exit_code as u8)
 }
 
 /// Get the current working directory.

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -420,7 +420,8 @@ pub fn remove_soft_hyphens(text: &mut String) {
 ///
 /// 2. figuring out the `LinkType` for a particular enclosure, given its MIME type
 ///    (`utils::podcast_mime_to_link_type`).
-const PODCAST_MIME_TO_LINKTYPE: [(fn(&str) -> bool, htmlrenderer::LinkType); 2] = [
+type MimeMatcher = (fn(&str) -> bool, htmlrenderer::LinkType);
+const PODCAST_MIME_TO_LINKTYPE: [MimeMatcher; 2] = [
     (
         |mime| {
             // RFC 5334, section 10.1 says "historically, some implementations expect .ogg files to be

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -1146,13 +1146,13 @@ mod tests {
 
     #[test]
     fn t_unescape_url() {
-        assert!(unescape_url(String::from("foo%20bar")).unwrap() == String::from("foo bar"));
+        assert!(unescape_url(String::from("foo%20bar")).unwrap() == "foo bar");
         assert!(
             unescape_url(String::from(
                 "%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"
             ))
             .unwrap()
-                == String::from("!#$&'()*+,/:;=?@[]")
+                == "!#$&'()*+,/:;=?@[]"
         );
     }
 

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -772,8 +772,6 @@ pub fn extract_filter(line: &str) -> (&str, &str) {
 
 #[cfg(test)]
 mod tests {
-    use tempfile;
-
     use super::*;
 
     #[test]

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_cache_file.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_cache_file.rs
@@ -1,5 +1,5 @@
 use libnewsboat::cliargsparser::CliArgsParser;
-use std::{env, path::PathBuf};
+use std::env;
 use tempfile::TempDir;
 
 #[test]
@@ -13,15 +13,10 @@ fn t_cliargsparser_dash_c_resolves_tilde_to_homedir() {
 
     let check = |opts| {
         let args = CliArgsParser::new(opts);
-        assert_eq!(
-            args.cache_file,
-            Some(PathBuf::from(tmp.path().join(filename)))
-        );
+        assert_eq!(args.cache_file, Some(tmp.path().join(filename)));
         assert_eq!(
             args.lock_file,
-            Some(PathBuf::from(
-                tmp.path().join(filename.to_owned() + ".lock")
-            ))
+            Some(tmp.path().join(filename.to_owned() + ".lock"))
         );
     };
 

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_config_file.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_config_file.rs
@@ -1,5 +1,5 @@
 use libnewsboat::cliargsparser::CliArgsParser;
-use std::{env, path::PathBuf};
+use std::env;
 use tempfile::TempDir;
 
 #[test]
@@ -13,10 +13,7 @@ fn t_cliargsparser_dash_capital_c_resolves_tilde_to_homedir() {
 
     let check = |opts| {
         let args = CliArgsParser::new(opts);
-        assert_eq!(
-            args.config_file,
-            Some(PathBuf::from(tmp.path().join(filename)))
-        );
+        assert_eq!(args.config_file, Some(tmp.path().join(filename)));
     };
 
     check(vec![

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_exportfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_exportfile.rs
@@ -1,5 +1,5 @@
 use libnewsboat::cliargsparser::CliArgsParser;
-use std::{env, path::PathBuf};
+use std::env;
 use tempfile::TempDir;
 
 #[test]
@@ -13,10 +13,7 @@ fn t_cliargsparser_dash_capital_e_resolves_tilde_to_homedir() {
 
     let check = |opts| {
         let args = CliArgsParser::new(opts);
-        assert_eq!(
-            args.readinfo_export_file,
-            Some(PathBuf::from(tmp.path().join(filename)))
-        );
+        assert_eq!(args.readinfo_export_file, Some(tmp.path().join(filename)));
     };
 
     check(vec![

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_importfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_importfile.rs
@@ -1,5 +1,5 @@
 use libnewsboat::cliargsparser::CliArgsParser;
-use std::{env, path::PathBuf};
+use std::env;
 use tempfile::TempDir;
 
 #[test]
@@ -13,10 +13,7 @@ fn t_cliargsparser_dash_capital_i_resolves_tilde_to_homedir() {
 
     let check = |opts| {
         let args = CliArgsParser::new(opts);
-        assert_eq!(
-            args.readinfo_import_file,
-            Some(PathBuf::from(tmp.path().join(filename)))
-        );
+        assert_eq!(args.readinfo_import_file, Some(tmp.path().join(filename)));
     };
 
     check(vec![

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_logfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_logfile.rs
@@ -1,5 +1,5 @@
 use libnewsboat::cliargsparser::CliArgsParser;
-use std::{env, path::PathBuf};
+use std::env;
 use tempfile::TempDir;
 
 #[test]
@@ -13,10 +13,7 @@ fn t_cliargsparser_dash_d_resolves_tilde_to_homedir() {
 
     let check = |opts| {
         let args = CliArgsParser::new(opts);
-        assert_eq!(
-            args.log_file,
-            Some(PathBuf::from(tmp.path().join(filename)))
-        );
+        assert_eq!(args.log_file, Some(tmp.path().join(filename)));
     };
 
     check(vec![

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_opmlfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_opmlfile.rs
@@ -1,5 +1,5 @@
 use libnewsboat::cliargsparser::CliArgsParser;
-use std::{env, path::PathBuf};
+use std::env;
 use tempfile::TempDir;
 
 #[test]
@@ -13,10 +13,7 @@ fn t_cliargsparser_dash_i_resolves_tilde_to_homedir() {
 
     let check = |opts| {
         let args = CliArgsParser::new(opts);
-        assert_eq!(
-            args.importfile,
-            Some(PathBuf::from(tmp.path().join(filename)))
-        );
+        assert_eq!(args.importfile, Some(tmp.path().join(filename)));
     };
 
     check(vec![

--- a/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_urlfile.rs
+++ b/rust/libnewsboat/tests/cliargsparser_resolves_tilde_to_homedir_in_urlfile.rs
@@ -1,5 +1,5 @@
 use libnewsboat::cliargsparser::CliArgsParser;
-use std::{env, path::PathBuf};
+use std::env;
 use tempfile::TempDir;
 
 #[test]
@@ -13,10 +13,7 @@ fn t_cliargsparser_dash_u_resolves_tilde_to_homedir() {
 
     let check = |opts| {
         let args = CliArgsParser::new(opts);
-        assert_eq!(
-            args.url_file,
-            Some(PathBuf::from(tmp.path().join(filename)))
-        );
+        assert_eq!(args.url_file, Some(tmp.path().join(filename)));
     };
 
     check(vec![

--- a/rust/libnewsboat/tests/configpaths_helpers/mod.rs
+++ b/rust/libnewsboat/tests/configpaths_helpers/mod.rs
@@ -34,12 +34,12 @@ impl FileSentries {
     /// Create a new struct with random strings for sentries.
     pub fn new() -> FileSentries {
         FileSentries {
-            config: random::<u32>().to_string() + &"config",
-            urls: random::<u32>().to_string() + &"urls",
-            cache: random::<u32>().to_string() + &"cache",
-            queue: random::<u32>().to_string() + &"queue",
-            search: random::<u32>().to_string() + &"search",
-            cmdline: random::<u32>().to_string() + &"cmdline",
+            config: random::<u32>().to_string() + "config",
+            urls: random::<u32>().to_string() + "urls",
+            cache: random::<u32>().to_string() + "cache",
+            queue: random::<u32>().to_string() + "queue",
+            search: random::<u32>().to_string() + "search",
+            cmdline: random::<u32>().to_string() + "cmdline",
         }
     }
 }

--- a/rust/libnewsboat/tests/configpaths_helpers/mod.rs
+++ b/rust/libnewsboat/tests/configpaths_helpers/mod.rs
@@ -166,6 +166,9 @@ impl<'a> Chmod<'a> {
             .permissions()
             .mode();
 
+        // `from_mode` takes `u32`, but `libc::mode_t` is either `u16` (macOS, FreeBSD) or `u32`
+        // (Linux). Suppress the warning to prevent Clippy on Linux from complaining.
+        #[allow(clippy::identity_conversion)]
         fs::set_permissions(path, fs::Permissions::from_mode(new_mode.into()))
             .unwrap_or_else(|_| panic!("Chmod: couldn't change mode for `{}'", path.display()));
 

--- a/rust/regex-rs/src/lib.rs
+++ b/rust/regex-rs/src/lib.rs
@@ -28,6 +28,9 @@
 //! assert_eq!(matches[0].end_pos, input.len());
 //! ```
 
+// This lint is nitpicky, I don't think it's really important how the literals are written.
+#![allow(clippy::unreadable_literal)]
+
 use bitflags::bitflags;
 use gettextrs::gettext;
 use libc::{regcomp, regerror, regex_t, regexec, regfree, regmatch_t};

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -14,8 +14,6 @@
 // formatting macro accepts. Everything else will result in a compile-time error. See the docs in
 // `trait` module for more on that.
 
-use libc;
-
 pub mod specifiers_iterator;
 // Re-exporting so that macro can just import the whole crate and get everything it needs.
 pub use crate::specifiers_iterator::SpecifiersIterator;
@@ -136,8 +134,6 @@ macro_rules! fmt {
 
 #[cfg(test)]
 mod tests {
-    use libc;
-
     #[test]
     fn returns_first_argument_if_it_is_the_only_one() {
         let input = String::from("Hello, world!");

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -148,7 +148,7 @@ mod tests {
     fn replaces_printf_format_with_text_representation_of_an_argument() {
         assert_eq!(fmt!("%i", 42), "42");
         assert_eq!(fmt!("%i", -13), "-13");
-        assert_eq!(fmt!("%.3f", 3.1416), "3.142");
+        assert_eq!(fmt!("%.3f", 1.2468), "1.247");
         assert_eq!(fmt!("%i %i", 100500, -191), "100500 -191");
     }
 

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -14,6 +14,9 @@
 // formatting macro accepts. Everything else will result in a compile-time error. See the docs in
 // `trait` module for more on that.
 
+// This lint is nitpicky, I don't think it's really important how the literals are written.
+#![allow(clippy::unreadable_literal)]
+
 pub mod specifiers_iterator;
 // Re-exporting so that macro can just import the whole crate and get everything it needs.
 pub use crate::specifiers_iterator::SpecifiersIterator;

--- a/rust/strprintf/src/traits.rs
+++ b/rust/strprintf/src/traits.rs
@@ -27,8 +27,6 @@
 //! For numeric types, the holder is the same as the type itself, and the values are simply copied.
 //! For example, `u64`'s "holder" is `u64`, which is then borrowed to get a `u64` again.
 
-use libc;
-
 use std::ffi::CString;
 
 /// Trait of all types that can be formatted with `fmt!` macro.

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -146,14 +146,14 @@ bool FormAction::process_op(Operation op,
 		break;
 	case OP_INT_QNA_NEXTHIST:
 		if (qna_history) {
-			std::string entry = qna_history->next();
+			std::string entry = qna_history->next_line();
 			f.set("qna_value", entry);
 			f.set("qna_value_pos", std::to_string(entry.length()));
 		}
 		break;
 	case OP_INT_QNA_PREVHIST:
 		if (qna_history) {
-			std::string entry = qna_history->prev();
+			std::string entry = qna_history->previous_line();
 			f.set("qna_value", entry);
 			f.set("qna_value_pos", std::to_string(entry.length()));
 		}

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -13,9 +13,9 @@ extern "C" {
 		void* hst,
 		const char* line);
 
-	char* rs_history_prev(void* hst);
+	char* rs_history_previous_line(void* hst);
 
-	char* rs_history_next(void* hst);
+	char* rs_history_next_line(void* hst);
 
 	void rs_history_load_from_file(
 		void* hst,
@@ -44,14 +44,14 @@ void History::add_line(const std::string& line)
 	rs_history_add_line(rs_hst, line.c_str());
 }
 
-std::string History::prev()
+std::string History::previous_line()
 {
-	return RustString(rs_history_prev(rs_hst));
+	return RustString(rs_history_previous_line(rs_hst));
 }
 
-std::string History::next()
+std::string History::next_line()
 {
-	return RustString(rs_history_next(rs_hst));
+	return RustString(rs_history_next_line(rs_hst));
 }
 
 void History::load_from_file(const std::string& file)

--- a/test/history.cpp
+++ b/test/history.cpp
@@ -12,28 +12,28 @@ TEST_CASE("History can be iterated on in any direction", "[History]")
 	History h;
 
 	SECTION("Empty History returns nothing") {
-		REQUIRE(h.prev() == "");
-		REQUIRE(h.prev() == "");
-		REQUIRE(h.next() == "");
-		REQUIRE(h.next() == "");
+		REQUIRE(h.previous_line() == "");
+		REQUIRE(h.previous_line() == "");
+		REQUIRE(h.next_line() == "");
+		REQUIRE(h.next_line() == "");
 
 		SECTION("One line in History") {
 			h.add_line("testline");
-			REQUIRE(h.prev() == "testline");
-			REQUIRE(h.prev() == "testline");
-			REQUIRE(h.next() == "testline");
-			REQUIRE(h.next() == "");
+			REQUIRE(h.previous_line() == "testline");
+			REQUIRE(h.previous_line() == "testline");
+			REQUIRE(h.next_line() == "testline");
+			REQUIRE(h.next_line() == "");
 
 			SECTION("Two lines in History") {
 				h.add_line("foobar");
-				REQUIRE(h.prev() == "foobar");
-				REQUIRE(h.prev() == "testline");
-				REQUIRE(h.next() == "testline");
-				REQUIRE(h.prev() == "testline");
-				REQUIRE(h.next() == "testline");
-				REQUIRE(h.next() == "foobar");
-				REQUIRE(h.next() == "");
-				REQUIRE(h.next() == "");
+				REQUIRE(h.previous_line() == "foobar");
+				REQUIRE(h.previous_line() == "testline");
+				REQUIRE(h.next_line() == "testline");
+				REQUIRE(h.previous_line() == "testline");
+				REQUIRE(h.next_line() == "testline");
+				REQUIRE(h.next_line() == "foobar");
+				REQUIRE(h.next_line() == "");
+				REQUIRE(h.next_line() == "");
 			}
 		}
 	}
@@ -60,11 +60,11 @@ TEST_CASE("History can be saved and loaded from file", "[History]")
 		SECTION("Load from file") {
 			History loaded_h;
 			loaded_h.load_from_file(filepath);
-			REQUIRE(loaded_h.prev() == "foobar");
-			REQUIRE(loaded_h.prev() == "testline");
-			REQUIRE(loaded_h.next() == "testline");
-			REQUIRE(loaded_h.next() == "foobar");
-			REQUIRE(loaded_h.next() == "");
+			REQUIRE(loaded_h.previous_line() == "foobar");
+			REQUIRE(loaded_h.previous_line() == "testline");
+			REQUIRE(loaded_h.next_line() == "testline");
+			REQUIRE(loaded_h.next_line() == "foobar");
+			REQUIRE(loaded_h.next_line() == "");
 		}
 	}
 }


### PR DESCRIPTION
When I introduced our first Rust code, I didn't add a linter to CI because I didn't want to be overwhelmed by new stuff: new language, new toolchain, new problems. Now that we've been at it for a while, I think it's time to add some more newness to the mix :)

There are a lot of commits here, but most of them are pretty mechanical. The first few fix the most interesting problems. Then come a lot of uninteresting fixes where I simply followed Clippy's suggestions. The final commit makes the CI fail if Clippy gives any warnings. IMHO, only the first three and the final commit deserve a thoughtful review.

Feedback is welcome! I'll merge this in three days if no issues are raised.