### PR TITLE
Drop LogLevel argument from ScopeMeasure c-tor

### DIFF
--- a/include/scopemeasure.h
+++ b/include/scopemeasure.h
@@ -3,13 +3,11 @@
 
 #include <string>
 
-#include "logger.h"
-
 namespace newsboat {
 
 class ScopeMeasure {
 public:
-	ScopeMeasure(const std::string& func, Level ll = Level::DEBUG);
+	ScopeMeasure(const std::string& func);
 	~ScopeMeasure();
 	void stopover(const std::string& son = "");
 

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -363,8 +363,8 @@ src/logger.o: src/logger.cpp include/logger.h config.h \
 src/matcher.o: src/matcher.cpp include/matcher.h filter/FilterParser.h \
  include/logger.h config.h include/strprintf.h include/matchable.h \
  3rd-party/optional.hpp include/matcherexception.h include/scopemeasure.h \
- include/logger.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h
+ include/utils.h include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h
 src/matcherexception.o: src/matcherexception.cpp \
  include/matcherexception.h config.h include/ruststring.h \
  include/strprintf.h
@@ -533,8 +533,7 @@ src/rssparser.o: src/rssparser.cpp include/rssparser.h \
  include/logger.h include/rssignores.h include/strprintf.h \
  include/ttrssapi.h 3rd-party/json.hpp include/cache.h include/utils.h
 src/ruststring.o: src/ruststring.cpp include/ruststring.h
-src/scopemeasure.o: src/scopemeasure.cpp include/scopemeasure.h \
- include/logger.h config.h include/strprintf.h
+src/scopemeasure.o: src/scopemeasure.cpp include/scopemeasure.h
 src/selectformaction.o: src/selectformaction.cpp \
  include/selectformaction.h include/filtercontainer.h \
  include/configparser.h include/configactionhandler.h \
@@ -796,7 +795,7 @@ test/rsspp_rssparser.o: test/rsspp_rssparser.cpp rss/rssparser.h \
 test/ruststring.o: test/ruststring.cpp include/ruststring.h \
  3rd-party/catch.hpp
 test/scopemeasure.o: test/scopemeasure.cpp include/scopemeasure.h \
- include/logger.h config.h include/strprintf.h 3rd-party/catch.hpp \
+ 3rd-party/catch.hpp include/logger.h config.h include/strprintf.h \
  test/test-helpers/loggerresetter.h test/test-helpers/tempfile.h \
  test/test-helpers/maintempdir.h
 test/strprintf.o: test/strprintf.cpp include/strprintf.h \

--- a/rust/libnewsboat-ffi/src/scopemeasure.rs
+++ b/rust/libnewsboat-ffi/src/scopemeasure.rs
@@ -1,17 +1,14 @@
 use crate::abort_on_panic;
 use libc::{c_char, c_void};
-use libnewsboat::{logger::Level, scopemeasure::ScopeMeasure};
+use libnewsboat::scopemeasure::ScopeMeasure;
 use std::ffi::CStr;
 use std::mem;
 
 #[no_mangle]
-pub unsafe extern "C" fn create_rs_scopemeasure(
-    scope_name: *const c_char,
-    log_level: Level,
-) -> *mut c_void {
+pub unsafe extern "C" fn create_rs_scopemeasure(scope_name: *const c_char) -> *mut c_void {
     abort_on_panic(|| {
         let scope_name = CStr::from_ptr(scope_name).to_string_lossy().into_owned();
-        Box::into_raw(Box::new(ScopeMeasure::new(scope_name, log_level))) as *mut c_void
+        Box::into_raw(Box::new(ScopeMeasure::new(scope_name))) as *mut c_void
     })
 }
 

--- a/rust/libnewsboat/src/scopemeasure.rs
+++ b/rust/libnewsboat/src/scopemeasure.rs
@@ -10,26 +10,24 @@ use crate::{
 /// Measures time spent in an enclosing scope, and writes it to the log.
 ///
 /// Upon construction, this struct remembers current (monotonic) time. Before being dropped, it
-/// will write a message to the log mentioning: 1) the name of the enclosing scope (as provided to
-/// the constructor); 2) the time that elapsed between constructing and dropping the object.
+/// will write a debug message to the log mentioning: 1) the name of the enclosing scope (as
+/// provided to the constructor); 2) the time that elapsed between constructing and dropping the
+/// object.
 ///
-/// Calling `stopover()` will write a message to the log mentioning: 1) the name of the enclosing
-/// scope; 2) the name of the stopover; 3) the time that elapsed between constructing the object
-/// and calling `stopover()`.
+/// Calling `stopover()` will write a debug message to the log mentioning: 1) the name of the
+/// enclosing scope; 2) the name of the stopover; 3) the time that elapsed between constructing the
+/// object and calling `stopover()`.
 pub struct ScopeMeasure {
     start_time: Instant,
     scope_name: String,
-    log_level: Level,
 }
 
 impl ScopeMeasure {
-    /// Construct an object that will measure time spent in the scope named `scope_name`. Log
-    /// messages will be written at `log_level`.
-    pub fn new(scope_name: String, log_level: Level) -> ScopeMeasure {
+    /// Construct an object that will measure time spent in the scope named `scope_name`.
+    pub fn new(scope_name: String) -> ScopeMeasure {
         ScopeMeasure {
             start_time: Instant::now(),
             scope_name,
-            log_level,
         }
     }
 
@@ -37,7 +35,7 @@ impl ScopeMeasure {
     /// since the object was constructed.
     pub fn stopover(&self, stopover_name: &str) {
         log!(
-            self.log_level,
+            Level::Debug,
             &format!(
                 "ScopeMeasure: function `{}' (stop over `{}') took {:.6} s so far",
                 self.scope_name,
@@ -51,7 +49,7 @@ impl ScopeMeasure {
 impl Drop for ScopeMeasure {
     fn drop(&mut self) {
         log!(
-            self.log_level,
+            Level::Debug,
             &format!(
                 "ScopeMeasure: function `{}' took {:.6} s",
                 self.scope_name,

--- a/rust/libnewsboat/tests/scopemeasure_dropping_writes_a_line_to_the_log.rs
+++ b/rust/libnewsboat/tests/scopemeasure_dropping_writes_a_line_to_the_log.rs
@@ -25,7 +25,7 @@ fn droppping_a_scopemeasure_writes_a_line_to_the_log() {
     {
         logger::get_instance().set_logfile(logfile.to_str().unwrap());
         logger::get_instance().set_loglevel(Level::Debug);
-        let _sm = ScopeMeasure::new(String::from("test"), Level::Debug);
+        let _sm = ScopeMeasure::new(String::from("test"));
     }
 
     assert_eq!(file_lines_count(&logfile).unwrap(), 1);

--- a/rust/libnewsboat/tests/scopemeasure_stopover_adds_an_extra_line_to_the_log_upon_each_call.rs
+++ b/rust/libnewsboat/tests/scopemeasure_stopover_adds_an_extra_line_to_the_log_upon_each_call.rs
@@ -26,7 +26,7 @@ fn stopover_adds_an_extra_line_to_the_log_upon_each_call() {
         {
             logger::get_instance().set_logfile(logfile.to_str().unwrap());
             logger::get_instance().set_loglevel(Level::Debug);
-            let sm = ScopeMeasure::new(String::from("test"), Level::Debug);
+            let sm = ScopeMeasure::new(String::from("test"));
 
             for i in 0..*calls {
                 sm.stopover(&format!("stopover No.{}", i));

--- a/src/scopemeasure.cpp
+++ b/src/scopemeasure.cpp
@@ -1,16 +1,16 @@
 #include "scopemeasure.h"
 
 extern "C" {
-	void* create_rs_scopemeasure(const char* scope_name, newsboat::Level log_level);
+	void* create_rs_scopemeasure(const char* scope_name);
 	void destroy_rs_scopemeasure(void* object);
 	void rs_scopemeasure_stopover(void* object, const char* stopover_name);
 }
 
 namespace newsboat {
 
-ScopeMeasure::ScopeMeasure(const std::string& func, Level ll)
+ScopeMeasure::ScopeMeasure(const std::string& func)
 {
-	rs_object = create_rs_scopemeasure(func.c_str(), ll);
+	rs_object = create_rs_scopemeasure(func.c_str());
 }
 
 void ScopeMeasure::stopover(const std::string& son)

--- a/test/scopemeasure.cpp
+++ b/test/scopemeasure.cpp
@@ -4,6 +4,8 @@
 
 #include <fstream>
 
+#include "logger.h"
+
 #include "test-helpers/loggerresetter.h"
 #include "test-helpers/tempfile.h"
 
@@ -31,7 +33,7 @@ TEST_CASE("Destroying a ScopeMeasure object writes a line to the log",
 		Logger::set_logfile(tmp.get_path());
 		Logger::set_loglevel(Level::DEBUG);
 
-		ScopeMeasure sm("test", Level::DEBUG);
+		ScopeMeasure sm("test");
 	}
 
 	REQUIRE(file_lines_count(tmp.get_path()) == 1);
@@ -51,7 +53,7 @@ TEST_CASE("stopover() adds an extra line to the log upon each call",
 		Logger::set_logfile(tmp.get_path());
 		Logger::set_loglevel(Level::DEBUG);
 
-		ScopeMeasure sm("test", Level::DEBUG);
+		ScopeMeasure sm("test");
 
 		SECTION("one call") {
 			sm.stopover("here");


### PR DESCRIPTION
Only tests specified that argument; the rest of the code relied on the
default. Rust doesn't have default arguments, though, relying instead on
the builder pattern. It's far better to drop code than to add it, so I'm
removing the argument altogether.

Should have done it before porting ScopeMeasure to Rust, but oh well.

Reviews are welcome! I'll merge in three days if no issues are raised.