### PR TITLE
Cirrus: use debug config for most Linux builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -178,6 +178,7 @@ linux_task:
                 cxx: g++-10
           env: &extra_warnings_and_checks_env
             CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
+            PROFILE: 0
         - name: Clang 10, more warnings and checks (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
@@ -292,6 +293,7 @@ linux_task:
 
     env:
         RUSTFLAGS: '-D warnings'
+        PROFILE: 1
 
     build_script: *build_script
     test_script: *test_script


### PR DESCRIPTION
Tasks on Cirrus CI can be roughly split into the following categories:

1) "ordinary": Linux, different compilers, run both C++ and Rust test   suites;

2) "extra checks": Linux, latest Clang and GCC, run C++ test suite;

3) "platform-specific": FreeBSD, macOS, Linux i686, run both test    suites.

All of these build Newsboat in release mode, since that's how the program is going to be built by the end users. Rust tests are always built in debug mode because they're more useful this way (arithmetic overflow causes panics, making it easier to spot bugs).

Unfortunately, building Rust tests in debug mode means we have to compile most of Rust's stuff *twice*: once in release mode for libnewsboat.a, once in debug mode for tests. Furthermore, release builds take longer than debug builds. Combined, these two factors significantly increase the time it takes for code to pass CI.

This commit tries to lower the time by switching the first category of builds to debug mode. I believe we don't loose much because:

1) debug builds still demonstrate that Newsboat can be built with these    particular compilers;

2) newer compilers probably have all the same warnings as the old ones,    so "extra checks" category should still give us all the warnings that    we would otherwise get.

Reviews are welcome! I'll merge this in three days if no issues are raised.