### PR TITLE
Store most recent history

### DIFF
--- a/rust/libnewsboat/src/history.rs
+++ b/rust/libnewsboat/src/history.rs
@@ -65,8 +65,8 @@ impl History {
 
         self.lines
             .iter()
-            .rev()
             .take(limit)
+            .rev()
             .map(|ln| writeln!(f, "{}", ln).map(|_| ()))
             .collect()
     }
@@ -136,5 +136,30 @@ mod tests {
         assert_eq!(loaded_h.next_line(), "testline");
         assert_eq!(loaded_h.next_line(), "foobar");
         assert_eq!(loaded_h.next_line(), "");
+    }
+
+    #[test]
+    fn t_save_and_load_limited_history() {
+        let tmp_dir = TempDir::new().unwrap();
+        let file_path = tmp_dir.path().join("history.cmdline");
+        let max_lines = 3;
+
+        let mut h = History::new();
+        h.add_line("1".to_string());
+        h.add_line("2".to_string());
+        h.add_line("3".to_string());
+        h.add_line("4".to_string());
+
+        // lines are written to file
+        h.save_to_file(file_path.clone(), max_lines).unwrap();
+        assert!(file_path.exists());
+
+        // lines are loaded to new History
+        let mut loaded_h = History::new();
+        loaded_h.load_from_file(file_path).unwrap();
+        assert_eq!(loaded_h.previous_line(), "4");
+        assert_eq!(loaded_h.previous_line(), "3");
+        assert_eq!(loaded_h.previous_line(), "2");
+        assert_eq!(loaded_h.previous_line(), "2");
     }
 }

--- a/test/history.cpp
+++ b/test/history.cpp
@@ -68,3 +68,31 @@ TEST_CASE("History can be saved and loaded from file", "[History]")
 		}
 	}
 }
+
+TEST_CASE("Only the most recent lines are saved when limiting history",
+	"[History]")
+{
+	TestHelpers::TempDir tmp;
+	const auto filepath = tmp.get_path() + "history.cmdline";
+	const int max_lines = 3;
+
+	History h;
+	h.add_line("1");
+	h.add_line("2");
+	h.add_line("3");
+	h.add_line("4");
+
+	SECTION("file with history lines is created") {
+		h.save_to_file(filepath, max_lines);
+		REQUIRE(0 == ::access(filepath.c_str(), R_OK | W_OK));
+
+		SECTION("when loading, only a limited number of lines are returned") {
+			History loaded_h;
+			loaded_h.load_from_file(filepath);
+			REQUIRE(loaded_h.previous_line() == "4");
+			REQUIRE(loaded_h.previous_line() == "3");
+			REQUIRE(loaded_h.previous_line() == "2");
+			REQUIRE(loaded_h.previous_line() == "2");
+		}
+	}
+}


### PR DESCRIPTION
`History.lines` stores history sorted from most recent to least recent.
We now only reverse the order after taking the `limit` most recent items.

Fixes #1081.