### PR TITLE
Implement OP_PREV and OP_NEXT for all dialogs containing a ListWidget

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -10,8 +10,8 @@ save||s||Save the currently selected article to a file.
 save-all||n/a||Save all articles from currently selected feed.
 next-unread||n||Jump to the next unread article.
 prev-unread||p||Jump to the previous unread article.
-next||J||Jump to next article.
-prev||K||Jump to previous article.
+next||J||Jump to next list entry.
+prev||K||Jump to previous list entry.
 random-unread||^K||Jump to a random unread article.
 open-in-browser||o||Open the URL associated with the current article, or selection when in the URL view.
 open-in-browser-and-mark-read||O||Open the URL associated with the current article, or selection when in the URL view. When used in the article view, it will also mark the article as read.

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -98,9 +98,11 @@ bool DialogsFormAction::process_operation(Operation op,
 		}
 	}
 	break;
+	case OP_PREV:
 	case OP_SK_UP:
 		dialogs_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
+	case OP_NEXT:
 	case OP_SK_DOWN:
 		dialogs_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -144,6 +144,7 @@ bool DirBrowserFormAction::process_operation(Operation op,
 		}
 		break;
 	}
+	case OP_PREV:
 	case OP_SK_UP:
 		if (f.get_focus() == "files") {
 			files_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
@@ -151,6 +152,7 @@ bool DirBrowserFormAction::process_operation(Operation op,
 			f.set_focus("files");
 		}
 		break;
+	case OP_NEXT:
 	case OP_SK_DOWN:
 		if (f.get_focus() == "files") {
 			if (!files_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"))) {

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -145,6 +145,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 		}
 		break;
 	}
+	case OP_PREV:
 	case OP_SK_UP:
 		if (f.get_focus() == "files") {
 			files_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
@@ -152,6 +153,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 			f.set_focus("files");
 		}
 		break;
+	case OP_NEXT:
 	case OP_SK_DOWN:
 		if (f.get_focus() == "files") {
 			if (!files_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"))) {

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -84,15 +84,15 @@ static const std::vector<OpDesc> opdescs = {
 		OP_NEXT,
 		"next",
 		"J",
-		_("Go to next article"),
-		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE
+		_("Go to next entry"),
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE | KM_DIALOGS | KM_DIRBROWSER | KM_FILEBROWSER | KM_FILTERSELECT | KM_TAGSELECT | KM_URLVIEW | KM_PODBOAT
 	},
 	{
 		OP_PREV,
 		"prev",
 		"K",
-		_("Go to previous article"),
-		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE
+		_("Go to previous entry"),
+		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE | KM_DIALOGS | KM_DIRBROWSER | KM_FILEBROWSER | KM_FILTERSELECT | KM_TAGSELECT | KM_URLVIEW | KM_PODBOAT
 	},
 	{
 		OP_NEXTUNREAD,

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -129,9 +129,11 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		case OP_REDRAW:
 			Stfl::reset();
 			break;
+		case OP_PREV:
 		case OP_SK_UP:
 			downloads_list.move_up(wrap_scroll);
 			break;
+		case OP_NEXT:
 		case OP_SK_DOWN:
 			downloads_list.move_down(wrap_scroll);
 			break;

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -53,9 +53,11 @@ bool SelectFormAction::process_operation(Operation op,
 {
 	bool hardquit = false;
 	switch (op) {
+	case OP_PREV:
 	case OP_SK_UP:
 		tags_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
+	case OP_NEXT:
 	case OP_SK_DOWN:
 		tags_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -38,9 +38,11 @@ bool UrlViewFormAction::process_operation(Operation op,
 {
 	bool hardquit = false;
 	switch (op) {
+	case OP_PREV:
 	case OP_SK_UP:
 		urls_list.move_up(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
+	case OP_NEXT:
 	case OP_SK_DOWN:
 		urls_list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -676,7 +676,7 @@ TEST_CASE("OP_HARDQUIT command is processed", "[ItemListFormAction]")
 	REQUIRE_NOTHROW(itemlist.process_op(OP_HARDQUIT));
 }
 
-TEST_CASE("Navigate back and forth using OP_NEXT and OP_PREVIOUS",
+TEST_CASE("Navigate back and forth using OP_NEXT and OP_PREV",
 	"[ItemListFormAction]")
 {
 	// We are using the OP_SHOWURLS command to print the current


### PR DESCRIPTION
Related to a question by a user (ruhrdolf) on irc:
```
<ruhrdolf> hi. I updated to 2.20.1 and now the arrows are not working anymore in the Tags menu (key t)
<ruhrdolf> arrows up/down
<ruhrdolf> arrows left/right work
<ruhrdolf> in config i got: bind-key "UP" prev
<ruhrdolf> bind-key "DOWN" next
<ruhrdolf> bind-key j next
<ruhrdolf> bind-key k prev
<ruhrdolf> but neither up/down arrows, nor j/k work in that menu. both work fine in any other context
```

It looks like this configuration is "broken" since https://github.com/newsboat/newsboat/commit/18ddc5a0f96e4833b28022731043ed7f7c6a57ba (PR #913, first included in Newsboat 2.20).
Before that commit, the `UP` and `DOWN` keys were handled directly by STFL (`bind-key` commands had no effect for those keys).