### PR TITLE
Add missing make dependency + various small Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,17 +186,21 @@ doc/podboat-cmds-linked.asciidoc: doc/podboat-cmds.dsv
 doc/cmdline-commands-linked.asciidoc: doc/cmdline-commands.dsv
 	sed 's/||/\t/g' doc/cmdline-commands.dsv | awk -f doc/createAvailableCommandlineCommandsListView.awk > doc/cmdline-commands-linked.asciidoc
 
-doc/xhtml/newsboat.html: doc/newsboat.asciidoc doc/chapter-firststeps.asciidoc \
-		doc/chapter-tagging.asciidoc doc/chapter-snownews.asciidoc \
-		doc/chapter-cmdline.asciidoc doc/chapter-podcasts.asciidoc \
-		doc/chapter-files.asciidoc doc/chapter-password.asciidoc \
-		doc/chapter-environment-variables.asciidoc doc/configcommands-linked.asciidoc \
-		doc/availableoperations-linked.asciidoc doc/podboat-cmds-linked.asciidoc \
-		doc/cmdline-commands-linked.asciidoc | doc/xhtml
-	$(ASCIIDOCTOR) --backend=html5 -a webfonts! --destination-dir=doc/xhtml doc/newsboat.asciidoc
+doc/xhtml/newsboat.html: doc/chapter-firststeps.asciidoc
+doc/xhtml/newsboat.html: doc/chapter-tagging.asciidoc
+doc/xhtml/newsboat.html: doc/chapter-snownews.asciidoc
+doc/xhtml/newsboat.html: doc/chapter-cmdline.asciidoc
+doc/xhtml/newsboat.html: doc/chapter-podcasts.asciidoc
+doc/xhtml/newsboat.html: doc/chapter-files.asciidoc
+doc/xhtml/newsboat.html: doc/chapter-password.asciidoc
+doc/xhtml/newsboat.html: doc/chapter-environment-variables.asciidoc
+doc/xhtml/newsboat.html: doc/configcommands-linked.asciidoc
+doc/xhtml/newsboat.html: doc/availableoperations-linked.asciidoc
+doc/xhtml/newsboat.html: doc/podboat-cmds-linked.asciidoc
+doc/xhtml/newsboat.html: doc/cmdline-commands-linked.asciidoc
 
-doc/xhtml/faq.html: doc/faq.asciidoc | doc/xhtml
-	$(ASCIIDOCTOR) --backend=html5 -a webfonts! --destination-dir=doc/xhtml doc/faq.asciidoc
+doc/xhtml/%.html: doc/%.asciidoc | doc/xhtml
+	$(ASCIIDOCTOR) --backend=html5 -a webfonts! --destination-dir=doc/xhtml $<
 
 doc/generate: doc/generate.cpp doc/split.h
 	$(CXX_FOR_BUILD) $(CXXFLAGS_FOR_BUILD) -o doc/generate doc/generate.cpp

--- a/Makefile
+++ b/Makefile
@@ -174,16 +174,25 @@ doc: doc/$(NEWSBOAT).1 doc/$(PODBOAT).1 doc/xhtml/newsboat.html doc/xhtml/faq.ht
 doc/xhtml:
 	$(MKDIR) doc/xhtml
 
+doc/configcommands-linked.asciidoc: doc/configcommands.dsv
+	sed 's/||/\t/g' doc/configcommands.dsv | awk -f doc/createConfigurationCommandsListView.awk > doc/configcommands-linked.asciidoc
+
+doc/availableoperations-linked.asciidoc: doc/keycmds.dsv
+	sed 's/||/\t/g' doc/keycmds.dsv | awk -f doc/createAvailableOperationsListView.awk > doc/availableoperations-linked.asciidoc
+
+doc/podboat-cmds-linked.asciidoc: doc/podboat-cmds.dsv
+	sed 's/||/\t/g' doc/podboat-cmds.dsv | awk -f doc/createPodboatConfigurationCommandsListView.awk > doc/podboat-cmds-linked.asciidoc
+
+doc/cmdline-commands-linked.asciidoc: doc/cmdline-commands.dsv
+	sed 's/||/\t/g' doc/cmdline-commands.dsv | awk -f doc/createAvailableCommandlineCommandsListView.awk > doc/cmdline-commands-linked.asciidoc
+
 doc/xhtml/newsboat.html: doc/newsboat.asciidoc doc/chapter-firststeps.asciidoc \
 		doc/chapter-tagging.asciidoc doc/chapter-snownews.asciidoc \
 		doc/chapter-cmdline.asciidoc doc/chapter-podcasts.asciidoc \
 		doc/chapter-files.asciidoc doc/chapter-password.asciidoc \
-		doc/chapter-environment-variables.asciidoc doc/configcommands.dsv \
-		doc/keycmds.dsv doc/podboat-cmds.dsv doc/cmdline-commands.dsv | doc/xhtml
-	sed 's/||/\t/g' doc/configcommands.dsv | awk -f doc/createConfigurationCommandsListView.awk > doc/configcommands-linked.asciidoc
-	sed 's/||/\t/g' doc/keycmds.dsv | awk -f doc/createAvailableOperationsListView.awk > doc/availableoperations-linked.asciidoc
-	sed 's/||/\t/g' doc/podboat-cmds.dsv | awk -f doc/createPodboatConfigurationCommandsListView.awk > doc/podboat-cmds-linked.asciidoc
-	sed 's/||/\t/g' doc/cmdline-commands.dsv | awk -f doc/createAvailableCommandlineCommandsListView.awk > doc/cmdline-commands-linked.asciidoc
+		doc/chapter-environment-variables.asciidoc doc/configcommands-linked.asciidoc \
+		doc/availableoperations-linked.asciidoc doc/podboat-cmds-linked.asciidoc \
+		doc/cmdline-commands-linked.asciidoc | doc/xhtml
 	$(ASCIIDOCTOR) --backend=html5 -a webfonts! --destination-dir=doc/xhtml doc/newsboat.asciidoc
 
 doc/xhtml/faq.html: doc/faq.asciidoc | doc/xhtml

--- a/Makefile
+++ b/Makefile
@@ -171,21 +171,22 @@ distclean: clean clean-mo clean-test profclean
 
 doc: doc/$(NEWSBOAT).1 doc/$(PODBOAT).1 doc/xhtml/newsboat.html doc/xhtml/faq.html doc/example-config
 
+doc/xhtml:
+	$(MKDIR) doc/xhtml
+
 doc/xhtml/newsboat.html: doc/newsboat.asciidoc doc/chapter-firststeps.asciidoc \
 		doc/chapter-tagging.asciidoc doc/chapter-snownews.asciidoc \
 		doc/chapter-cmdline.asciidoc doc/chapter-podcasts.asciidoc \
 		doc/chapter-files.asciidoc doc/chapter-password.asciidoc \
 		doc/chapter-environment-variables.asciidoc doc/configcommands.dsv \
-		doc/keycmds.dsv doc/podboat-cmds.dsv doc/cmdline-commands.dsv
+		doc/keycmds.dsv doc/podboat-cmds.dsv doc/cmdline-commands.dsv | doc/xhtml
 	sed 's/||/\t/g' doc/configcommands.dsv | awk -f doc/createConfigurationCommandsListView.awk > doc/configcommands-linked.asciidoc
 	sed 's/||/\t/g' doc/keycmds.dsv | awk -f doc/createAvailableOperationsListView.awk > doc/availableoperations-linked.asciidoc
 	sed 's/||/\t/g' doc/podboat-cmds.dsv | awk -f doc/createPodboatConfigurationCommandsListView.awk > doc/podboat-cmds-linked.asciidoc
 	sed 's/||/\t/g' doc/cmdline-commands.dsv | awk -f doc/createAvailableCommandlineCommandsListView.awk > doc/cmdline-commands-linked.asciidoc
-	$(MKDIR) doc/xhtml
 	$(ASCIIDOCTOR) --backend=html5 -a webfonts! --destination-dir=doc/xhtml doc/newsboat.asciidoc
 
-doc/xhtml/faq.html: doc/faq.asciidoc
-	$(MKDIR) doc/xhtml
+doc/xhtml/faq.html: doc/faq.asciidoc | doc/xhtml
 	$(ASCIIDOCTOR) --backend=html5 -a webfonts! --destination-dir=doc/xhtml doc/faq.asciidoc
 
 doc/generate: doc/generate.cpp doc/split.h

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,8 @@ doc/xhtml/newsboat.html: doc/newsboat.asciidoc doc/chapter-firststeps.asciidoc \
 		doc/chapter-tagging.asciidoc doc/chapter-snownews.asciidoc \
 		doc/chapter-cmdline.asciidoc doc/chapter-podcasts.asciidoc \
 		doc/chapter-files.asciidoc doc/chapter-password.asciidoc \
-		doc/chapter-environment-variables.asciidoc doc/cmdline-commands.dsv
+		doc/chapter-environment-variables.asciidoc doc/configcommands.dsv \
+		doc/keycmds.dsv doc/podboat-cmds.dsv doc/cmdline-commands.dsv
 	sed 's/||/\t/g' doc/configcommands.dsv | awk -f doc/createConfigurationCommandsListView.awk > doc/configcommands-linked.asciidoc
 	sed 's/||/\t/g' doc/keycmds.dsv | awk -f doc/createAvailableOperationsListView.awk > doc/availableoperations-linked.asciidoc
 	sed 's/||/\t/g' doc/podboat-cmds.dsv | awk -f doc/createPodboatConfigurationCommandsListView.awk > doc/podboat-cmds-linked.asciidoc


### PR DESCRIPTION
For PR https://github.com/newsboat/newsboat/pull/1092 I had to update `doc/keycmds.dsv`.
When invoking make, it did not update `doc/xhtml/newsboat.html`.

The first commit fixes the issue by specifying the missing dependencies.
The other commits are added to slightly improve readability.