### PR TITLE
Apply Clippy warning: Convert and_then() -> map()

### DIFF
--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -44,9 +44,7 @@ impl Operator {
     fn apply(&self, attr: &str, value: &Value) -> Result<bool, MatcherError> {
         match self {
             Operator::Equals => Ok(attr == value.0),
-            Operator::NotEquals => Operator::Equals
-                .apply(attr, value)
-                .and_then(|result| Ok(!result)),
+            Operator::NotEquals => Operator::Equals.apply(attr, value).map(|result| !result),
             Operator::RegexMatches => match Regex::new(
                 &value.0,
                 CompFlags::EXTENDED | CompFlags::IGNORE_CASE | CompFlags::NO_SUB,
@@ -68,7 +66,7 @@ impl Operator {
             },
             Operator::NotRegexMatches => Operator::RegexMatches
                 .apply(attr, value)
-                .and_then(|result| Ok(!result)),
+                .map(|result| !result),
             Operator::LessThan => Ok(string_to_num(attr) < string_to_num(&value.0)),
             Operator::GreaterThan => Ok(dbg!(string_to_num(attr)) > dbg!(string_to_num(&value.0))),
             Operator::LessThanOrEquals => Ok(string_to_num(attr) <= string_to_num(&value.0)),
@@ -95,9 +93,7 @@ impl Operator {
                 }
                 Ok(false)
             }
-            Operator::NotContains => Operator::Contains
-                .apply(attr, value)
-                .and_then(|result| Ok(!result)),
+            Operator::NotContains => Operator::Contains.apply(attr, value).map(|result| !result),
         }
     }
 }

--- a/rust/libnewsboat/tests/configpaths_helpers/mod.rs
+++ b/rust/libnewsboat/tests/configpaths_helpers/mod.rs
@@ -168,7 +168,7 @@ impl<'a> Chmod<'a> {
 
         // `from_mode` takes `u32`, but `libc::mode_t` is either `u16` (macOS, FreeBSD) or `u32`
         // (Linux). Suppress the warning to prevent Clippy on Linux from complaining.
-        #[allow(clippy::identity_conversion)]
+        #[allow(clippy::useless_conversion)]
         fs::set_permissions(path, fs::Permissions::from_mode(new_mode.into()))
             .unwrap_or_else(|_| panic!("Chmod: couldn't change mode for `{}'", path.display()));
 

--- a/rust/libnewsboat/tests/configpaths_helpers/mod.rs
+++ b/rust/libnewsboat/tests/configpaths_helpers/mod.rs
@@ -123,10 +123,10 @@ pub fn create_file(path: &path::Path, content: &str) -> bool {
 
 pub fn file_contents(path: &path::Path) -> String {
     fs::File::open(path)
-        .and_then(|mut f| {
+        .map(|mut f| {
             let mut buf = String::new();
             let _ = f.read_to_string(&mut buf);
-            Ok(buf)
+            buf
         })
         // If failed to open/read file, return an empty string
         .unwrap_or_else(|_| String::new())


### PR DESCRIPTION
The MacOS builds started failing due to Clippy errors (I think these checks were introduced with Rust 1.45):
- https://cirrus-ci.com/task/6387177510666240
- https://cirrus-ci.com/task/4979802627112960

This PR includes the changes suggested by Clippy.