### PR TITLE
Update Rust 1.45 (and fix new Clippy warnings)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,7 +76,7 @@ freebsd_task:
         # the C++'s exit code and chain it to Rust's in the end.
         - ( cd test && ./test --order rand ); ret=$?; (RUST_BACKTRACE=1 cargo test --jobs=3) && sh -c "exit $ret"
     clippy_script: &clippy_script
-        - cargo clippy --all-targets --all-features -- -D warnings
+        - test "x$DONT_RUN_CLIPPY" = "x1" || cargo clippy --all-targets --all-features -- -D warnings
     # For explanation of what this script does, please see the FreeBSD job
     # above.
     fake_install_script: &fake_install_script
@@ -148,6 +148,10 @@ macos_task:
               CC: gcc
               CXX: g++
               RUST: 1.42.0
+              # Older Rust contains older Clippy, which might not support the
+              # newer lints. It doesn't make much sense to run multiple
+              # versions of the linter, so we disable the older version.
+              DONT_RUN_CLIPPY: 1
 
 formatting_task:
     name: Code formatting
@@ -173,6 +177,8 @@ linux_task:
                 cc: gcc-4.9
                 cxx: g++-4.9
                 rust_version: 1.42.0
+          env:
+              DONT_RUN_CLIPPY: 1
         - name: Rust 1.42.0, GCC 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
@@ -181,6 +187,8 @@ linux_task:
                 cc: gcc-10
                 cxx: g++-10
                 rust_version: 1.42.0
+          env:
+              DONT_RUN_CLIPPY: 1
 
         - name: GCC 10, more warnings and checks (Ubuntu 20.04)
           container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -201,98 +201,98 @@ linux_task:
                 cxx: clang++-10
           env: *extra_warnings_and_checks_env
 
-        - name: Rust 1.44.1, GCC 4.9 (Ubuntu 16.04)
+        - name: Rust 1.45, GCC 4.9 (Ubuntu 16.04)
           container:
             dockerfile: docker/ubuntu_16.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-4.9
                 cc: gcc-4.9
                 cxx: g++-4.9
-        - name: Rust 1.44.1, GCC 5 (Ubuntu 18.04)
+        - name: Rust 1.45, GCC 5 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-5
                 cc: gcc-5
                 cxx: g++-5
-        - name: Rust 1.44.1, GCC 6 (Ubuntu 18.04)
+        - name: Rust 1.45, GCC 6 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-6
                 cc: gcc-6
                 cxx: g++-6
-        - name: Rust 1.44.1, GCC 7 (Ubuntu 18.04)
+        - name: Rust 1.45, GCC 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-7
                 cc: gcc-7
                 cxx: g++-7
-        - name: Rust 1.44.1, GCC 8 (Ubuntu 18.04)
+        - name: Rust 1.45, GCC 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-8
                 cc: gcc-8
                 cxx: g++-8
-        - name: Rust 1.44.1, GCC 9 (Ubuntu 20.04)
+        - name: Rust 1.45, GCC 9 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-9
                 cc: gcc-9
                 cxx: g++-9
-        - name: Rust 1.44.1, GCC 10 (Ubuntu 20.04)
+        - name: Rust 1.45, GCC 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-10
                 cc: gcc-10
                 cxx: g++-10
-        - name: Rust 1.44.1, Clang 4.0 (Ubuntu 18.04)
+        - name: Rust 1.45, Clang 4.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-4.0
                 cc: clang-4.0
                 cxx: clang++-4.0
-        - name: Rust 1.44.1, Clang 5.0 (Ubuntu 18.04)
+        - name: Rust 1.45, Clang 5.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-5.0
                 cc: clang-5.0
                 cxx: clang++-5.0
-        - name: Rust 1.44.1, Clang 6.0 (Ubuntu 18.04)
+        - name: Rust 1.45, Clang 6.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-6.0
                 cc: clang-6.0
                 cxx: clang++-6.0
-        - name: Rust 1.44.1, Clang 7 (Ubuntu 18.04)
+        - name: Rust 1.45, Clang 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-7
                 cc: clang-7
                 cxx: clang++-7
-        - name: Rust 1.44.1, Clang 8 (Ubuntu 18.04)
+        - name: Rust 1.45, Clang 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-8
                 cc: clang-8
                 cxx: clang++-8
-        - name: Rust 1.44.1, Clang 9 (Ubuntu 18.04)
+        - name: Rust 1.45, Clang 9 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-9
                 cc: clang-9
                 cxx: clang++-9
-        - name: Rust 1.44.1, Clang 10 (Ubuntu 20.04)
+        - name: Rust 1.45, Clang 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,12 +135,12 @@ macos_task:
           env:
               CC: clang
               CXX: clang++
-              RUST: stable
+              RUST: 1.45.0
         - name: macOS GCC Rust stable
           env:
               CC: gcc
               CXX: g++
-              RUST: stable
+              RUST: 1.45.0
         # This job tests our minimum supported Rust version, so only bump on
         # Newsboat release day
         - name: macOS GCC Rust 1.42.0

--- a/docker/ubuntu_16.04-build-tools.dockerfile
+++ b/docker/ubuntu_16.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with an older
-# C++ compiler. Contains GCC 4.9 and Rust 1.44.1 by default.
+# C++ compiler. Contains GCC 4.9 and Rust 1.45.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-4.9
-# - rust_version -- Rust version to install. Default: 1.44.1
+# - rust_version -- Rust version to install. Default: 1.45.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-4.9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -89,7 +89,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.44.1
+ARG rust_version=1.45.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.44.1 by default.
+# and Rust 1.45.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-8
-# - rust_version -- Rust version to install. Default: 1.44.1
+# - rust_version -- Rust version to install. Default: 1.45.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-8
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -89,7 +89,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.44.1
+ARG rust_version=1.45.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -80,7 +80,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain 1.44.1 \
+        --default-toolchain 1.45.0 \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 9 and Rust 1.44.1 by default.
+# compilers. Contains GCC 9 and Rust 1.45.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.44.1
+# - rust_version -- Rust version to install. Default: 1.45.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -89,7 +89,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.44.1
+ARG rust_version=1.45.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -44,9 +44,7 @@ impl Operator {
     fn apply(&self, attr: &str, value: &Value) -> Result<bool, MatcherError> {
         match self {
             Operator::Equals => Ok(attr == value.0),
-            Operator::NotEquals => Operator::Equals
-                .apply(attr, value)
-                .and_then(|result| Ok(!result)),
+            Operator::NotEquals => Operator::Equals.apply(attr, value).map(|result| !result),
             Operator::RegexMatches => match Regex::new(
                 &value.0,
                 CompFlags::EXTENDED | CompFlags::IGNORE_CASE | CompFlags::NO_SUB,
@@ -68,7 +66,7 @@ impl Operator {
             },
             Operator::NotRegexMatches => Operator::RegexMatches
                 .apply(attr, value)
-                .and_then(|result| Ok(!result)),
+                .map(|result| !result),
             Operator::LessThan => Ok(string_to_num(attr) < string_to_num(&value.0)),
             Operator::GreaterThan => Ok(dbg!(string_to_num(attr)) > dbg!(string_to_num(&value.0))),
             Operator::LessThanOrEquals => Ok(string_to_num(attr) <= string_to_num(&value.0)),
@@ -95,9 +93,7 @@ impl Operator {
                 }
                 Ok(false)
             }
-            Operator::NotContains => Operator::Contains
-                .apply(attr, value)
-                .and_then(|result| Ok(!result)),
+            Operator::NotContains => Operator::Contains.apply(attr, value).map(|result| !result),
         }
     }
 }

--- a/rust/libnewsboat/tests/configpaths_helpers/mod.rs
+++ b/rust/libnewsboat/tests/configpaths_helpers/mod.rs
@@ -123,10 +123,10 @@ pub fn create_file(path: &path::Path, content: &str) -> bool {
 
 pub fn file_contents(path: &path::Path) -> String {
     fs::File::open(path)
-        .and_then(|mut f| {
+        .map(|mut f| {
             let mut buf = String::new();
             let _ = f.read_to_string(&mut buf);
-            Ok(buf)
+            buf
         })
         // If failed to open/read file, return an empty string
         .unwrap_or_else(|_| String::new())
@@ -168,7 +168,7 @@ impl<'a> Chmod<'a> {
 
         // `from_mode` takes `u32`, but `libc::mode_t` is either `u16` (macOS, FreeBSD) or `u32`
         // (Linux). Suppress the warning to prevent Clippy on Linux from complaining.
-        #[allow(clippy::identity_conversion)]
+        #[allow(clippy::useless_conversion)]
         fs::set_permissions(path, fs::Permissions::from_mode(new_mode.into()))
             .unwrap_or_else(|_| panic!("Chmod: couldn't change mode for `{}'", path.display()));
 


### PR DESCRIPTION
This supersedes #1099. @dennisschagt there notes that a lint was renamed, making it impossible for our code to pass both Clippy 1.44 and Clippy 1.45. I think it's fine to break compatibility with older Clippy here, because it's a linter—a developers' tool. It would be a totally different story if it was a compiler warning, of course.

I intend to merge this as soon as I've seen the CI pass.