### PR TITLE
Snap: Specify 'g++' build dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,7 @@ parts:
       - libssl-dev
       - gettext
       - cargo
+      - g++
     stage-packages:
       - libxml2
       - librtmp1


### PR DESCRIPTION
I tried building with `snapcraft` but it failed because `g++` could not be found.
Relevant part of the output:
```
Building newsboat 
make -j2
g++ -std=c++11 -O0 -ggdb -Iinclude -Istfl -Ifilter -I. -Irss -Werror -Wall -Wextra -Wunreachable-code -DLOCALEDIR=\"/usr/local/share/locale\" -I/usr/include/libxml2  -I/usr/include/json-c  -D_GNU_SOURCE -D_DEFAULT_SOURCE  -DHAVE_OPENSSL=1  -o src/controller.o -c src/controller.cpp
make: g++: Command not found
Makefile:136: recipe for target 'src/controller.o' failed
make: *** [src/controller.o] Error 127
Failed to run 'make -j2' for 'newsboat': Exited with code 2.
Verify that the part is using the correct parameters and try again.
Run the same command again with --debug to shell into the environment if you wish to introspect this failure.
```