### PR TITLE
Load article text when trying to match on `content` attribute.

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -74,7 +74,7 @@ public:
 	void mark_items_read_by_guid(const std::vector<std::string>& guids);
 	std::vector<std::string> get_read_item_guids();
 	void fetch_descriptions(RssFeed* feed);
-	void fetch_description(RssItem* item);
+	std::string fetch_description(RssItem* item);
 
 private:
 	SchemaVersion get_schema_version();

--- a/include/cache.h
+++ b/include/cache.h
@@ -74,6 +74,7 @@ public:
 	void mark_items_read_by_guid(const std::vector<std::string>& guids);
 	std::vector<std::string> get_read_item_guids();
 	void fetch_descriptions(RssFeed* feed);
+	void fetch_description(RssItem* item);
 
 private:
 	SchemaVersion get_schema_version();

--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -38,7 +38,7 @@ public:
 
 	std::string description() const
 	{
-		return description_;
+		return description_.value_or("");
 	}
 	void set_description(const std::string& d);
 
@@ -170,14 +170,14 @@ public:
 
 	void unload()
 	{
-		description_.clear();
+		description_.reset();
 	}
 
 private:
 	std::string title_;
 	std::string link_;
 	std::string author_;
-	std::string description_;
+	nonstd::optional<std::string> description_;
 	std::string guid_;
 	std::string feedurl_;
 	Cache* ch;

--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -2,6 +2,7 @@
 #define NEWSBOAT_RSSITEM_H_
 
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "matchable.h"
@@ -38,6 +39,7 @@ public:
 
 	std::string description() const
 	{
+		std::lock_guard<std::mutex> guard(description_mutex);
 		return description_.value_or("");
 	}
 	void set_description(const std::string& d);
@@ -170,6 +172,7 @@ public:
 
 	void unload()
 	{
+		std::lock_guard<std::mutex> guard(description_mutex);
 		description_.reset();
 	}
 
@@ -177,7 +180,6 @@ private:
 	std::string title_;
 	std::string link_;
 	std::string author_;
-	nonstd::optional<std::string> description_;
 	std::string guid_;
 	std::string feedurl_;
 	Cache* ch;
@@ -194,6 +196,9 @@ private:
 	bool enqueued_;
 	bool deleted_;
 	bool override_unread_;
+
+	mutable std::mutex description_mutex;
+	nonstd::optional<std::string> description_;
 };
 
 } // namespace newsboat

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -531,7 +531,8 @@ src/rssitem.o: src/rssitem.cpp include/rssitem.h include/matchable.h \
  include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/dbexception.h include/rssfeed.h \
  include/rssitem.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/strprintf.h include/utils.h
+ include/strprintf.h include/scopemeasure.h include/strprintf.h \
+ include/utils.h
 src/rssparser.o: src/rssparser.cpp include/rssparser.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h rss/feed.h rss/item.h include/cache.h \

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -216,17 +216,6 @@ static int fill_content_callback(void* myfeed,
 	return 0;
 }
 
-static int fill_content_callback_single_item(void* myitem,
-	int argc,
-	char** argv,
-	char** /* azColName */)
-{
-	RssItem* item = static_cast<RssItem*>(myitem);
-	assert(argc == 1);
-	item->set_description(argv[0] ? argv[0] : "");
-	return 0;
-}
-
 static int search_item_callback(void* myfeed,
 	int argc,
 	char** argv,
@@ -1111,7 +1100,7 @@ void Cache::fetch_descriptions(RssFeed* feed)
 	run_sql(query, fill_content_callback, feed);
 }
 
-void Cache::fetch_description(RssItem* item)
+std::string Cache::fetch_description(RssItem* item)
 {
 	std::string in_clause = prepare_query("'%q'", item->guid());
 
@@ -1119,7 +1108,15 @@ void Cache::fetch_description(RssItem* item)
 			"SELECT content FROM rss_item WHERE guid = %s;",
 			in_clause);
 
-	run_sql(query, fill_content_callback_single_item, item);
+	std::string description;
+	auto store_description = [](void* d, int, char** argv, char**) -> int {
+		auto& desc = *static_cast<std::string*>(d);
+		desc = argv[0] ? argv[0] : "";
+		return 0;
+	};
+
+	run_sql(query, store_description, &description);
+	return description;
 }
 
 SchemaVersion Cache::get_schema_version()

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -216,6 +216,17 @@ static int fill_content_callback(void* myfeed,
 	return 0;
 }
 
+static int fill_content_callback_single_item(void* myitem,
+	int argc,
+	char** argv,
+	char** /* azColName */)
+{
+	RssItem* item = static_cast<RssItem*>(myitem);
+	assert(argc == 1);
+	item->set_description(argv[0] ? argv[0] : "");
+	return 0;
+}
+
 static int search_item_callback(void* myfeed,
 	int argc,
 	char** argv,
@@ -1098,6 +1109,17 @@ void Cache::fetch_descriptions(RssFeed* feed)
 			in_clause);
 
 	run_sql(query, fill_content_callback, feed);
+}
+
+void Cache::fetch_description(RssItem* item)
+{
+	std::string in_clause = prepare_query("'%q'", item->guid());
+
+	std::string query = prepare_query(
+			"SELECT content FROM rss_item WHERE guid = %s;",
+			in_clause);
+
+	run_sql(query, fill_content_callback_single_item, item);
 }
 
 SchemaVersion Cache::get_schema_version()

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -613,6 +613,13 @@ std::shared_ptr<RssFeed> Cache::internalize_rssfeed(std::string rssurl,
 			rssurl);
 	run_sql(query, rssitem_callback, &feed);
 
+	auto feed_weak_ptr = std::weak_ptr<RssFeed>(feed);
+	for (const auto& item : feed->items()) {
+		item->set_cache(this);
+		item->set_feedptr(feed_weak_ptr);
+		item->set_feedurl(feed->rssurl());
+	}
+
 	if (ign != nullptr) {
 		auto& items = feed->items();
 		items.erase(
@@ -632,13 +639,6 @@ std::shared_ptr<RssFeed> Cache::internalize_rssfeed(std::string rssurl,
 			}
 		}),
 		items.end());
-	}
-
-	auto feed_weak_ptr = std::weak_ptr<RssFeed>(feed);
-	for (const auto& item : feed->items()) {
-		item->set_cache(this);
-		item->set_feedptr(feed_weak_ptr);
-		item->set_feedurl(feed->rssurl());
 	}
 
 	unsigned int max_items = cfg->get_configvalue_as_int("max-items");

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -7,6 +7,7 @@
 #include "cache.h"
 #include "dbexception.h"
 #include "rssfeed.h"
+#include "scopemeasure.h"
 #include "strprintf.h"
 #include "utils.h"
 
@@ -145,6 +146,7 @@ nonstd::optional<std::string> RssItem::attribute_value(const std::string&
 	} else if (attribname == "author") {
 		return utils::utf8_to_locale(author());
 	} else if (attribname == "content") {
+		ScopeMeasure sm("RssItem::attribute_value(\"content\")");
 		std::lock_guard<std::mutex> guard(description_mutex);
 		if (description_.has_value()) {
 			return utils::utf8_to_locale(description_.value());

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -144,7 +144,15 @@ nonstd::optional<std::string> RssItem::attribute_value(const std::string&
 	} else if (attribname == "author") {
 		return utils::utf8_to_locale(author());
 	} else if (attribname == "content") {
-		return utils::utf8_to_locale(description());
+		if (description_.has_value()) {
+			return utils::utf8_to_locale(description_.value());
+		} else if (ch) {
+			ch->fetch_description(this);
+			auto result = utils::utf8_to_locale(description_.value());
+			description_.reset();
+			return result;
+		}
+		return "";
 	} else if (attribname == "date") {
 		return pubDate();
 	} else if (attribname == "guid") {


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/111.
Fixes https://github.com/newsboat/newsboat/issues/218.

Still needs some testing, marking as draft for now.
I expect to have time for testing during the weekend.

This loads article content from the sqlite database one at a time.
Performance is relatively bad (when testing with cache containing ~30000 items) but at least matching on `content` can be used.

I'm pretty sure this does not slow down query feeds and ignore-article rules which do not use the `content` attribute.
