### PR TITLE
Stop using `pos_name` attribute in stfl

### DIFF
--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -4,8 +4,6 @@
 #include <sys/stat.h>
 #include <grp.h>
 
-#include "3rd-party/optional.hpp"
-
 #include "configcontainer.h"
 #include "listformatter.h"
 #include "listwidget.h"
@@ -38,7 +36,8 @@ private:
 		std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);
 
-	nonstd::optional<std::string> add_directory(ListFormatter& listfmt,
+	void add_directory(ListFormatter& listfmt,
+		std::vector<std::string>& id_at_position,
 		std::string dirname);
 	std::string get_rwx(unsigned short val);
 	std::vector<std::string> id_at_position;

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -4,6 +4,8 @@
 #include <sys/stat.h>
 #include <grp.h>
 
+#include "3rd-party/optional.hpp"
+
 #include "configcontainer.h"
 #include "listformatter.h"
 #include "listwidget.h"
@@ -36,8 +38,10 @@ private:
 		std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);
 
-	void add_directory(ListFormatter& listfmt, std::string dirname);
+	nonstd::optional<std::string> add_directory(ListFormatter& listfmt,
+		std::string dirname);
 	std::string get_rwx(unsigned short val);
+	std::vector<std::string> id_at_position;
 
 	std::string get_owner(uid_t uid);
 	std::string get_group(gid_t gid);

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -4,6 +4,8 @@
 #include <sys/stat.h>
 #include <grp.h>
 
+#include "3rd-party/optional.hpp"
+
 #include "configcontainer.h"
 #include "listformatter.h"
 #include "listwidget.h"
@@ -40,9 +42,11 @@ private:
 		std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);
 
-	void add_file(ListFormatter& listfmt, std::string filename);
+	nonstd::optional<std::string> add_file(ListFormatter& listfmt,
+		std::string filename);
 	std::string get_filename_suggestion(const std::string& s);
 	std::string get_rwx(unsigned short val);
+	std::vector<std::string> id_at_position;
 
 	char get_filetype(mode_t mode);
 	std::string get_owner(uid_t uid);

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -4,8 +4,6 @@
 #include <sys/stat.h>
 #include <grp.h>
 
-#include "3rd-party/optional.hpp"
-
 #include "configcontainer.h"
 #include "listformatter.h"
 #include "listwidget.h"
@@ -42,7 +40,8 @@ private:
 		std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);
 
-	nonstd::optional<std::string> add_file(ListFormatter& listfmt,
+	void add_file(ListFormatter& listfmt,
+		std::vector<std::string>& id_at_position,
 		std::string filename);
 	std::string get_filename_suggestion(const std::string& s);
 	std::string get_rwx(unsigned short val);

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -14,7 +14,7 @@ class ListFormatter {
 public:
 	ListFormatter(RegexManager* r = nullptr, const std::string& loc = "");
 	~ListFormatter();
-	void add_line(const std::string& text, unsigned int width = 0);
+	void add_line(const std::string& text);
 	void set_line(const unsigned int itempos,
 		const std::string& text,
 		unsigned int width = 0);

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -11,8 +11,6 @@
 namespace newsboat {
 
 class ListFormatter {
-	typedef std::pair<std::string, std::string> LineIdPair;
-
 public:
 	ListFormatter(RegexManager* r = nullptr, const std::string& loc = "");
 	~ListFormatter();
@@ -33,7 +31,7 @@ public:
 	}
 
 private:
-	std::vector<LineIdPair> lines;
+	std::vector<std::string> lines;
 	RegexManager* rxman;
 	std::string location;
 };

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -15,8 +15,6 @@ public:
 	ListFormatter(RegexManager* r = nullptr, const std::string& loc = "");
 	~ListFormatter();
 	void add_line(const std::string& text, unsigned int width = 0);
-	void add_lines(const std::vector<std::string>& lines,
-		unsigned int width = 0);
 	void set_line(const unsigned int itempos,
 		const std::string& text,
 		unsigned int width = 0);

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -16,8 +16,7 @@ public:
 	~ListFormatter();
 	void add_line(const std::string& text);
 	void set_line(const unsigned int itempos,
-		const std::string& text,
-		unsigned int width = 0);
+		const std::string& text);
 	void clear()
 	{
 		lines.clear();

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -16,9 +16,7 @@ class ListFormatter {
 public:
 	ListFormatter(RegexManager* r = nullptr, const std::string& loc = "");
 	~ListFormatter();
-	void add_line(const std::string& text,
-		const std::string& id = "",
-		unsigned int width = 0);
+	void add_line(const std::string& text, unsigned int width = 0);
 	void add_lines(const std::vector<std::string>& lines,
 		unsigned int width = 0);
 	void set_line(const unsigned int itempos,

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -21,7 +21,6 @@ public:
 		unsigned int width = 0);
 	void set_line(const unsigned int itempos,
 		const std::string& text,
-		const std::string& id = "",
 		unsigned int width = 0);
 	void clear()
 	{

--- a/include/utils.h
+++ b/include/utils.h
@@ -79,7 +79,6 @@ std::string get_useragent(ConfigContainer* cfgcont);
 
 size_t strwidth(const std::string& s);
 size_t strwidth_stfl(const std::string& str);
-size_t wcswidth_stfl(const std::wstring& str, size_t size);
 
 std::string substr_with_width(const std::string& str,
 	const size_t max_width);

--- a/include/utils.h
+++ b/include/utils.h
@@ -35,9 +35,6 @@ nonstd::optional<std::string> extract_token_quoted(std::string& str,
 
 std::string consolidate_whitespace(const std::string& str);
 
-std::vector<std::wstring> wtokenize(const std::wstring& str,
-	std::wstring delimiters = L" \r\n\t");
-
 std::string translit(const std::string& tocode,
 	const std::string& fromcode);
 std::string convert_text(const std::string& text,

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -147,22 +147,22 @@ src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/filebrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h
 src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
- include/dirbrowserformaction.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/listwidget.h include/stflpp.h \
- include/formaction.h include/history.h include/keymap.h config.h \
- include/fmtstrformatter.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h include/logger.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/dirbrowserformaction.h include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/listwidget.h \
+ include/stflpp.h include/formaction.h include/history.h include/keymap.h \
+ config.h include/fmtstrformatter.h include/logger.h include/strprintf.h \
+ include/strprintf.h include/utils.h 3rd-party/optional.hpp \
+ include/logger.h include/view.h include/colormanager.h \
+ include/controller.h include/cache.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
  include/pbcontroller.h include/colormanager.h include/configparser.h \
  include/configactionhandler.h include/configcontainer.h \
@@ -211,23 +211,22 @@ src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/scopemeasure.h include/strprintf.h include/utils.h \
  include/view.h
 src/filebrowserformaction.o: src/filebrowserformaction.cpp \
- include/filebrowserformaction.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/listwidget.h include/stflpp.h \
- include/formaction.h include/history.h include/keymap.h config.h \
- include/fmtstrformatter.h include/listformatter.h include/logger.h \
- include/strprintf.h include/strprintf.h include/utils.h include/logger.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/filebrowserformaction.h include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/listwidget.h \
+ include/stflpp.h include/formaction.h include/history.h include/keymap.h \
+ config.h include/fmtstrformatter.h include/listformatter.h \
+ include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
+ 3rd-party/optional.hpp include/logger.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/fileurlreader.o: src/fileurlreader.cpp include/fileurlreader.h \
  include/urlreader.h include/utils.h 3rd-party/optional.hpp \
  include/configcontainer.h include/configparser.h \

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -147,22 +147,22 @@ src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/filebrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h
 src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
- include/dirbrowserformaction.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/listwidget.h \
- include/stflpp.h include/formaction.h include/history.h include/keymap.h \
- config.h include/fmtstrformatter.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/dirbrowserformaction.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/listformatter.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/listwidget.h include/stflpp.h \
+ include/formaction.h include/history.h include/keymap.h config.h \
+ include/fmtstrformatter.h include/logger.h include/strprintf.h \
+ include/strprintf.h include/utils.h include/logger.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
  include/pbcontroller.h include/colormanager.h include/configparser.h \
  include/configactionhandler.h include/configcontainer.h \
@@ -211,22 +211,23 @@ src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/scopemeasure.h include/strprintf.h include/utils.h \
  include/view.h
 src/filebrowserformaction.o: src/filebrowserformaction.cpp \
- include/filebrowserformaction.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/listwidget.h \
- include/stflpp.h include/formaction.h include/history.h include/keymap.h \
- config.h include/fmtstrformatter.h include/listformatter.h \
- include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/filebrowserformaction.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/listformatter.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/listwidget.h include/stflpp.h \
+ include/formaction.h include/history.h include/keymap.h config.h \
+ include/fmtstrformatter.h include/listformatter.h include/logger.h \
+ include/strprintf.h include/strprintf.h include/utils.h include/logger.h \
+ include/view.h include/colormanager.h include/controller.h \
+ include/cache.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/dirbrowserformaction.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/fileurlreader.o: src/fileurlreader.cpp include/fileurlreader.h \
  include/urlreader.h include/utils.h 3rd-party/optional.hpp \
  include/configcontainer.h include/configparser.h \

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -57,8 +57,7 @@ void DialogsFormAction::prepare()
 							get_parent_formaction().get())
 						? "*"
 						: " ",
-						fa.second)),
-				std::to_string(fa.first));
+						fa.second)));
 			i++;
 		}
 

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -271,10 +271,7 @@ void DirBrowserFormAction::prepare()
 
 		id_at_position.clear();
 		for (std::string directory : directories) {
-			const auto id = add_directory(listfmt, directory);
-			if (id.has_value()) {
-				id_at_position.push_back(id.value());
-			}
+			add_directory(listfmt, id_at_position, directory);
 		}
 
 		files_list.stfl_replace_lines(listfmt);
@@ -329,8 +326,9 @@ KeyMapHintEntry* DirBrowserFormAction::get_keymap_hint()
 	return hints;
 }
 
-nonstd::optional<std::string> DirBrowserFormAction::add_directory(
+void DirBrowserFormAction::add_directory(
 	ListFormatter& listfmt,
+	std::vector<std::string>& id_at_position,
 	std::string dirname)
 {
 	struct stat sb;
@@ -358,9 +356,8 @@ nonstd::optional<std::string> DirBrowserFormAction::add_directory(
 				formatteddirname);
 		listfmt.add_line(utils::quote_for_stfl(line));
 		const std::string id = strprintf::fmt("%c%s", ftype, dirname);
-		return id;
+		id_at_position.push_back(id);
 	}
-	return {};
 }
 
 std::string DirBrowserFormAction::get_formatted_dirname(std::string dirname,

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -79,10 +79,11 @@ bool DirBrowserFormAction::process_operation(Operation op,
 		std::string focus = f.get_focus();
 		if (focus.length() > 0) {
 			if (focus == "files") {
-				std::string selection = f.get("listposname");
-				char filetype = selection[0];
+				const auto selected_position = files_list.get_position();
+				std::string selection = id_at_position[selected_position];
+				const char filetype = selection[0];
 				selection.erase(0, 1);
-				std::string filename(selection);
+				const std::string filename(selection);
 				switch (filetype) {
 				case 'd': {
 					int status = ::chdir(filename.c_str());
@@ -268,8 +269,12 @@ void DirBrowserFormAction::prepare()
 
 		ListFormatter listfmt;
 
+		id_at_position.clear();
 		for (std::string directory : directories) {
-			add_directory(listfmt, directory);
+			const auto id = add_directory(listfmt, directory);
+			if (id.has_value()) {
+				id_at_position.push_back(id.value());
+			}
 		}
 
 		files_list.stfl_replace_lines(listfmt);
@@ -324,7 +329,8 @@ KeyMapHintEntry* DirBrowserFormAction::get_keymap_hint()
 	return hints;
 }
 
-void DirBrowserFormAction::add_directory(ListFormatter& listfmt,
+nonstd::optional<std::string> DirBrowserFormAction::add_directory(
+	ListFormatter& listfmt,
 	std::string dirname)
 {
 	struct stat sb;
@@ -350,9 +356,11 @@ void DirBrowserFormAction::add_directory(ListFormatter& listfmt,
 				group,
 				sizestr,
 				formatteddirname);
-		std::string id = strprintf::fmt("%c%s", ftype, Stfl::quote(dirname));
-		listfmt.add_line(utils::quote_for_stfl(line), id);
+		listfmt.add_line(utils::quote_for_stfl(line));
+		const std::string id = strprintf::fmt("%c%s", ftype, dirname);
+		return id;
 	}
+	return {};
 }
 
 std::string DirBrowserFormAction::get_formatted_dirname(std::string dirname,

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -86,8 +86,12 @@ bool FeedListFormAction::process_operation(Operation op,
 	bool automatic,
 	std::vector<std::string>* args)
 {
-	std::string feedpos = f.get("feedposname");
-	unsigned int pos = utils::to_u(feedpos);
+	unsigned int pos = 0;
+	if (visible_feeds.size() >= 1) {
+		const auto selected_pos = list.get_position();
+		pos = visible_feeds[selected_pos].second;
+	}
+	const std::string feedpos = std::to_string(pos);
 	bool quit = false;
 REDO:
 	switch (op) {
@@ -581,8 +585,7 @@ void FeedListFormAction::set_feedlist(
 		listfmt.add_line(format_line(feedlist_format,
 				feed.first,
 				feed.second,
-				width),
-			std::to_string(feed.second));
+				width));
 	}
 
 	list.stfl_replace_lines(listfmt);
@@ -881,7 +884,7 @@ void FeedListFormAction::register_format_styles()
 	const std::string textview = strprintf::fmt(
 			"{!list[feeds] .expand:vh style_normal[listnormal]: "
 			"style_focus[listfocus]:fg=yellow,bg=blue,attr=bold "
-			"pos_name[feedposname]: pos[feeds_pos]:0 offset[feeds_offset]:0 %s richtext:1}",
+			"pos[feeds_pos]:0 offset[feeds_offset]:0 %s richtext:1}",
 			attrstr);
 	list.stfl_replace_list(0, textview);
 }

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -263,10 +263,7 @@ void FileBrowserFormAction::prepare()
 
 		id_at_position.clear();
 		for (std::string filename : files) {
-			const auto id = add_file(listfmt, filename);
-			if (id.has_value()) {
-				id_at_position.push_back(id.value());
-			}
+			add_file(listfmt, id_at_position, filename);
 		}
 
 		files_list.stfl_replace_lines(listfmt);
@@ -320,8 +317,9 @@ KeyMapHintEntry* FileBrowserFormAction::get_keymap_hint()
 	return hints;
 }
 
-nonstd::optional<std::string> FileBrowserFormAction::add_file(
+void FileBrowserFormAction::add_file(
 	ListFormatter& listfmt,
+	std::vector<std::string>& id_at_position,
 	std::string filename)
 {
 	struct stat sb;
@@ -349,9 +347,8 @@ nonstd::optional<std::string> FileBrowserFormAction::add_file(
 				formattedfilename);
 		listfmt.add_line(utils::quote_for_stfl(line));
 		const std::string id = strprintf::fmt("%c%s", ftype, filename);
-		return id;
+		id_at_position.push_back(id);
 	}
-	return {};
 }
 
 std::string FileBrowserFormAction::get_formatted_filename(std::string filename,

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -986,7 +986,7 @@ void ItemListFormAction::prepare()
 					width,
 					itemlist_format,
 					datetime_format);
-			listfmt.set_line(itempos, line, std::to_string(item.second));
+			listfmt.set_line(itempos, line);
 		}
 		break;
 	case InvalidationMode::NONE:

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -975,7 +975,7 @@ void ItemListFormAction::prepare()
 					width,
 					itemlist_format,
 					datetime_format);
-			listfmt.add_line(line, std::to_string(item.second));
+			listfmt.add_line(line);
 		}
 		break;
 

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -16,9 +16,9 @@ ListFormatter::ListFormatter(RegexManager* r, const std::string& loc)
 
 ListFormatter::~ListFormatter() {}
 
-void ListFormatter::add_line(const std::string& text, unsigned int width)
+void ListFormatter::add_line(const std::string& text)
 {
-	set_line(UINT_MAX, text, width);
+	set_line(UINT_MAX, text, 0);
 	LOG(Level::DEBUG, "ListFormatter::add_line: `%s'", text);
 }
 

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -26,7 +26,7 @@ void ListFormatter::set_line(const unsigned int itempos,
 	const std::string& text,
 	unsigned int width)
 {
-	std::vector<LineIdPair> formatted_text;
+	std::vector<std::string> formatted_text;
 
 	if (width > 0 && text.length() > 0) {
 		std::wstring mytext = utils::clean_nonprintable_characters(
@@ -42,14 +42,12 @@ void ListFormatter::set_line(const unsigned int itempos,
 					size--;
 				}
 			}
-			formatted_text.push_back(LineIdPair(
-					utils::wstr2str(mytext.substr(0, size)), ""));
+			formatted_text.push_back(utils::wstr2str(mytext.substr(0, size)));
 			mytext.erase(0, size);
 		}
 	} else {
-		formatted_text.push_back(LineIdPair(
-				utils::wstr2str(utils::clean_nonprintable_characters(
-						utils::str2wstr(text))), ""));
+		formatted_text.push_back(utils::wstr2str(utils::clean_nonprintable_characters(
+					utils::str2wstr(text))));
 	}
 
 	if (itempos == UINT_MAX) {
@@ -72,20 +70,12 @@ void ListFormatter::add_lines(const std::vector<std::string>& thelines,
 std::string ListFormatter::format_list() const
 {
 	std::string format_cache = "{list";
-	for (const auto& line : lines) {
-		std::string str = line.first;
+	for (auto str : lines) {
 		if (rxman) {
 			rxman->quote_and_highlight(str, location);
 		}
-		if (line.second.empty()) {
-			format_cache.append(strprintf::fmt(
-					"{listitem text:%s}", Stfl::quote(str)));
-		} else {
-			format_cache.append(
-				strprintf::fmt("{listitem[%s] text:%s}",
-					line.second,
-					Stfl::quote(str)));
-		}
+		format_cache.append(strprintf::fmt(
+				"{listitem text:%s}", Stfl::quote(str)));
 	}
 	format_cache.push_back('}');
 	return format_cache;

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -16,11 +16,9 @@ ListFormatter::ListFormatter(RegexManager* r, const std::string& loc)
 
 ListFormatter::~ListFormatter() {}
 
-void ListFormatter::add_line(const std::string& text,
-	const std::string& id,
-	unsigned int width)
+void ListFormatter::add_line(const std::string& text, unsigned int width)
 {
-	set_line(UINT_MAX, text, id, width);
+	set_line(UINT_MAX, text, "", width);
 	LOG(Level::DEBUG, "ListFormatter::add_line: `%s'", text);
 }
 
@@ -69,9 +67,7 @@ void ListFormatter::add_lines(const std::vector<std::string>& thelines,
 	unsigned int width)
 {
 	for (const auto& line : thelines) {
-		add_line(utils::replace_all(line, "\t", "        "),
-			"",
-			width);
+		add_line(utils::replace_all(line, "\t", "        "), width);
 	}
 }
 

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -18,37 +18,17 @@ ListFormatter::~ListFormatter() {}
 
 void ListFormatter::add_line(const std::string& text)
 {
-	set_line(UINT_MAX, text, 0);
+	set_line(UINT_MAX, text);
 	LOG(Level::DEBUG, "ListFormatter::add_line: `%s'", text);
 }
 
 void ListFormatter::set_line(const unsigned int itempos,
-	const std::string& text,
-	unsigned int width)
+	const std::string& text)
 {
 	std::vector<std::string> formatted_text;
 
-	if (width > 0 && text.length() > 0) {
-		std::wstring mytext = utils::clean_nonprintable_characters(
-				utils::str2wstr(text));
-
-		while (mytext.length() > 0) {
-			size_t size = mytext.length();
-			size_t w = utils::wcswidth_stfl(mytext, size);
-			if (w > width) {
-				while (size &&
-					(w = utils::wcswidth_stfl(
-								mytext, size)) > width) {
-					size--;
-				}
-			}
-			formatted_text.push_back(utils::wstr2str(mytext.substr(0, size)));
-			mytext.erase(0, size);
-		}
-	} else {
-		formatted_text.push_back(utils::wstr2str(utils::clean_nonprintable_characters(
-					utils::str2wstr(text))));
-	}
+	formatted_text.push_back(utils::wstr2str(utils::clean_nonprintable_characters(
+				utils::str2wstr(text))));
 
 	if (itempos == UINT_MAX) {
 		lines.insert(lines.cend(),

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -18,13 +18,12 @@ ListFormatter::~ListFormatter() {}
 
 void ListFormatter::add_line(const std::string& text, unsigned int width)
 {
-	set_line(UINT_MAX, text, "", width);
+	set_line(UINT_MAX, text, width);
 	LOG(Level::DEBUG, "ListFormatter::add_line: `%s'", text);
 }
 
 void ListFormatter::set_line(const unsigned int itempos,
 	const std::string& text,
-	const std::string& id,
 	unsigned int width)
 {
 	std::vector<LineIdPair> formatted_text;
@@ -44,14 +43,13 @@ void ListFormatter::set_line(const unsigned int itempos,
 				}
 			}
 			formatted_text.push_back(LineIdPair(
-					utils::wstr2str(mytext.substr(0, size)), id));
+					utils::wstr2str(mytext.substr(0, size)), ""));
 			mytext.erase(0, size);
 		}
 	} else {
 		formatted_text.push_back(LineIdPair(
 				utils::wstr2str(utils::clean_nonprintable_characters(
-						utils::str2wstr(text))),
-				id));
+						utils::str2wstr(text))), ""));
 	}
 
 	if (itempos == UINT_MAX) {

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -59,14 +59,6 @@ void ListFormatter::set_line(const unsigned int itempos,
 	}
 }
 
-void ListFormatter::add_lines(const std::vector<std::string>& thelines,
-	unsigned int width)
-{
-	for (const auto& line : thelines) {
-		add_line(utils::replace_all(line, "\t", "        "), width);
-	}
-}
-
 std::string ListFormatter::format_list() const
 {
 	std::string format_cache = "{list";

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -97,7 +97,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			unsigned int i = 0;
 			for (const auto& dl : ctrl->downloads()) {
 				auto lbuf = format_line(formatstring, dl, i, width);
-				listfmt.add_line(lbuf, std::to_string(i));
+				listfmt.add_line(lbuf);
 				i++;
 			}
 
@@ -171,10 +171,8 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			ctrl->decrease_parallel_downloads();
 			break;
 		case OP_PB_DOWNLOAD: {
-			std::istringstream os(dllist_form.get("dlposname"));
-			int idx = -1;
-			os >> idx;
-			if (idx != -1) {
+			if (ctrl->downloads().size() >= 1) {
+				const auto idx = downloads_list.get_position();
 				if (ctrl->downloads()[idx].status() !=
 					DlStatus::DOWNLOADING) {
 					std::thread t{PodDlThread(
@@ -186,10 +184,8 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		}
 		break;
 		case OP_PB_PLAY: {
-			std::istringstream os(dllist_form.get("dlposname"));
-			int idx = -1;
-			os >> idx;
-			if (idx != -1) {
+			if (ctrl->downloads().size() >= 1) {
+				const auto idx = downloads_list.get_position();
 				DlStatus status =
 					ctrl->downloads()[idx].status();
 				if (status == DlStatus::FINISHED ||
@@ -209,10 +205,8 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		}
 		break;
 		case OP_PB_MARK_FINISHED: {
-			std::istringstream os(dllist_form.get("dlposname"));
-			int idx = -1;
-			os >> idx;
-			if (idx != -1) {
+			if (ctrl->downloads().size() >= 1) {
+				const auto idx = downloads_list.get_position();
 				DlStatus status =
 					ctrl->downloads()[idx].status();
 				if (status == DlStatus::PLAYED) {
@@ -223,10 +217,8 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		}
 		break;
 		case OP_PB_CANCEL: {
-			std::istringstream os(dllist_form.get("dlposname"));
-			int idx = -1;
-			os >> idx;
-			if (idx != -1) {
+			if (ctrl->downloads().size() >= 1) {
+				const auto idx = downloads_list.get_position();
 				if (ctrl->downloads()[idx].status() ==
 					DlStatus::DOWNLOADING) {
 					ctrl->downloads()[idx].set_status(
@@ -236,10 +228,8 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		}
 		break;
 		case OP_PB_DELETE: {
-			std::istringstream os(dllist_form.get("dlposname"));
-			int idx = -1;
-			os >> idx;
-			if (idx != -1) {
+			if (ctrl->downloads().size() >= 1) {
+				const auto idx = downloads_list.get_position();
 				if (ctrl->downloads()[idx].status() !=
 					DlStatus::DOWNLOADING) {
 					ctrl->downloads()[idx].set_status(

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -109,27 +109,25 @@ bool SelectFormAction::process_operation(Operation op,
 		hardquit = true;
 		break;
 	case OP_OPEN: {
-		std::string tagposname = f.get("tagposname");
-		unsigned int pos = utils::to_u(tagposname);
-		if (tagposname.length() > 0) {
-			switch (type) {
-			case SelectionType::TAG: {
-				if (pos < tags.size()) {
-					value = tags[pos];
-					quit = true;
-				}
+		switch (type) {
+		case SelectionType::TAG: {
+			if (tags.size() >= 1) {
+				const auto pos = tags_list.get_position();
+				value = tags[pos];
+				quit = true;
 			}
-			break;
-			case SelectionType::FILTER: {
-				if (pos < filters.size()) {
-					value = filters[pos].expr;
-					quit = true;
-				}
+		}
+		break;
+		case SelectionType::FILTER: {
+			if (filters.size() >= 1) {
+				const auto pos = tags_list.get_position();
+				value = filters[pos].expr;
+				quit = true;
 			}
-			break;
-			default:
-				assert(0); // should never happen
-			}
+		}
+		break;
+		default:
+			assert(0); // should never happen
 		}
 	}
 	break;
@@ -163,8 +161,7 @@ void SelectFormAction::prepare()
 						format_line(selecttag_format,
 							tag,
 							i + 1,
-							width)),
-					std::to_string(i));
+							width)));
 				i++;
 			}
 			break;
@@ -172,7 +169,7 @@ void SelectFormAction::prepare()
 			for (const auto& filter : filters) {
 				std::string tagstr = strprintf::fmt(
 						"%4u  %s", i + 1, filter.name);
-				listfmt.add_line(utils::quote_for_stfl(tagstr), std::to_string(i));
+				listfmt.add_line(utils::quote_for_stfl(tagstr));
 				i++;
 			}
 			break;

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -124,9 +124,8 @@ void UrlViewFormAction::prepare()
 		ListFormatter listfmt;
 		unsigned int i = 0;
 		for (const auto& link : links) {
-			listfmt.add_line(
-				utils::quote_for_stfl(strprintf::fmt("%2u  %s", i + 1, link.first)),
-				std::to_string(i));
+			listfmt.add_line(utils::quote_for_stfl(strprintf::fmt("%2u  %s", i + 1,
+						link.first)));
 			i++;
 		}
 		urls_list.stfl_replace_lines(listfmt);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -610,28 +610,6 @@ size_t utils::strwidth_stfl(const std::string& str)
 	return rs_strwidth_stfl(str.c_str());
 }
 
-size_t utils::wcswidth_stfl(const std::wstring& str, size_t size)
-{
-	size_t reduce_count = 0;
-	size_t len = std::min(str.length(), size);
-	if (len > 1) {
-		for (size_t idx = 0; idx < len - 1; ++idx) {
-			if (str[idx] == L'<' && str[idx + 1] != L'>') {
-				reduce_count += 3;
-				idx += 3;
-			}
-		}
-	}
-
-	int width = wcswidth(str.c_str(), size);
-	if (width < 0) {
-		LOG(Level::ERROR, "oh, oh, wcswidth just failed");
-		return str.length() - reduce_count;
-	}
-
-	return width - reduce_count;
-}
-
 std::string utils::substr_with_width(const std::string& str,
 	const size_t max_width)
 {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -187,24 +187,6 @@ std::vector<std::string> utils::tokenize(const std::string& str,
 	return tokens;
 }
 
-std::vector<std::wstring> utils::wtokenize(const std::wstring& str,
-	std::wstring delimiters)
-{
-	/*
-	 * This function tokenizes a string by the delimiters. Plain and simple.
-	 */
-	std::vector<std::wstring> tokens;
-	std::wstring::size_type last_pos = str.find_first_not_of(delimiters, 0);
-	std::wstring::size_type pos = str.find_first_of(delimiters, last_pos);
-
-	while (std::string::npos != pos || std::string::npos != last_pos) {
-		tokens.push_back(str.substr(last_pos, pos - last_pos));
-		last_pos = str.find_first_not_of(delimiters, pos);
-		pos = str.find_first_of(delimiters, last_pos);
-	}
-	return tokens;
-}
-
 std::vector<std::string> utils::tokenize_spaced(const std::string& str,
 	std::string delimiters)
 {

--- a/stfl/dialogs.stfl
+++ b/stfl/dialogs.stfl
@@ -17,7 +17,6 @@ vbox
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     .expand:vh
     richtext:1
-    pos_name[dialogposname]:
     pos[dialogs_pos]:0
     offset[dialogs_offset]:0
   vbox[hints]

--- a/stfl/dllist.stfl
+++ b/stfl/dllist.stfl
@@ -17,7 +17,6 @@ vbox
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     .expand:vh
     richtext:1
-    pos_name[dlposname]:
     pos[dls_pos]:0
     offset[dls_offset]:0
   vbox[hints]

--- a/stfl/feedlist.stfl
+++ b/stfl/feedlist.stfl
@@ -19,7 +19,6 @@ vbox
     richtext:1
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
-    pos_name[feedposname]:
     pos[feeds_pos]:0
     offset[feeds_offset]:0
   vbox[hints]

--- a/stfl/filebrowser.stfl
+++ b/stfl/filebrowser.stfl
@@ -18,7 +18,6 @@ vbox
     richtext:1
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
-    pos_name[listposname]:
     pos[files_pos]:0
     offset[files_offset]:0
   hbox[hints]

--- a/stfl/selecttag.stfl
+++ b/stfl/selecttag.stfl
@@ -17,7 +17,6 @@ vbox
     richtext:1
     style_normal[listnormal]:
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
-    pos_name[tagposname]:
     pos[taglist_pos]:0
     offset[taglist_offset]:0
   vbox[hints]

--- a/stfl/urlview.stfl
+++ b/stfl/urlview.stfl
@@ -17,7 +17,6 @@ vbox
     style_focus[listfocus]:fg=yellow,bg=blue,attr=bold
     .expand:vh
     richtext:1
-    pos_name[feedposname]:
     pos[urls_pos]:0
     offset[urls_offset]:0
   vbox[hints]

--- a/test/listformatter.cpp
+++ b/test/listformatter.cpp
@@ -41,7 +41,7 @@ TEST_CASE("set_line() replaces the item in a list", "[ListFormatter]")
 		"}";
 	REQUIRE(fmt.format_list() == expected);
 
-	fmt.set_line(1, "oh", 3);
+	fmt.set_line(1, "oh");
 
 	expected =
 		"{list"

--- a/test/listformatter.cpp
+++ b/test/listformatter.cpp
@@ -4,7 +4,7 @@
 
 using namespace newsboat;
 
-TEST_CASE("add_line(), add_lines(), get_lines_count() and clear()",
+TEST_CASE("add_line(), get_lines_count() and clear()",
 	"[ListFormatter]")
 {
 	ListFormatter fmt;
@@ -18,14 +18,9 @@ TEST_CASE("add_line(), add_lines(), get_lines_count() and clear()",
 		fmt.add_line("two");
 		REQUIRE(fmt.get_lines_count() == 2);
 
-		SECTION("add_lines() adds multiple lines") {
-			fmt.add_lines({"three", "four"});
-			REQUIRE(fmt.get_lines_count() == 4);
-
-			SECTION("clear() removes all lines") {
-				fmt.clear();
-				REQUIRE(fmt.get_lines_count() == 0);
-			}
+		SECTION("clear() removes all lines") {
+			fmt.clear();
+			REQUIRE(fmt.get_lines_count() == 0);
 		}
 	}
 }

--- a/test/listformatter.cpp
+++ b/test/listformatter.cpp
@@ -87,7 +87,7 @@ TEST_CASE("set_line() replaces the item in a list", "[ListFormatter]")
 		"}";
 	REQUIRE(fmt.format_list() == expected);
 
-	fmt.set_line(1, "oh", "3", 3);
+	fmt.set_line(1, "oh", 3);
 
 	expected =
 		"{list"

--- a/test/listformatter.cpp
+++ b/test/listformatter.cpp
@@ -36,10 +36,9 @@ TEST_CASE("add_line() splits overly long sequences to fit width",
 	ListFormatter fmt;
 
 	SECTION("ordinary text") {
-		fmt.add_line("123456789_", "", 10);
-		fmt.add_line("_987654321", "", 10);
+		fmt.add_line("123456789_", 10);
+		fmt.add_line("_987654321", 10);
 		fmt.add_line("ListFormatter doesn't care about word boundaries",
-			"",
 			10);
 		std::string expected =
 			"{list"
@@ -55,20 +54,19 @@ TEST_CASE("add_line() splits overly long sequences to fit width",
 	}
 
 	SECTION("numbered list") {
-		fmt.add_line("123456789_", "1", 10);
-		fmt.add_line("_987654321", "2", 10);
+		fmt.add_line("123456789_", 10);
+		fmt.add_line("_987654321", 10);
 		fmt.add_line("ListFormatter doesn't care about word boundaries",
-			"3",
 			10);
 		std::string expected =
 			"{list"
-			"{listitem[1] text:\"123456789_\"}"
-			"{listitem[2] text:\"_987654321\"}"
-			"{listitem[3] text:\"ListFormat\"}"
-			"{listitem[3] text:\"ter doesn'\"}"
-			"{listitem[3] text:\"t care abo\"}"
-			"{listitem[3] text:\"ut word bo\"}"
-			"{listitem[3] text:\"undaries\"}"
+			"{listitem text:\"123456789_\"}"
+			"{listitem text:\"_987654321\"}"
+			"{listitem text:\"ListFormat\"}"
+			"{listitem text:\"ter doesn'\"}"
+			"{listitem text:\"t care abo\"}"
+			"{listitem text:\"ut word bo\"}"
+			"{listitem text:\"undaries\"}"
 			"}";
 		REQUIRE(fmt.format_list() == expected);
 	}
@@ -78,14 +76,14 @@ TEST_CASE("set_line() replaces the item in a list", "[ListFormatter]")
 {
 	ListFormatter fmt;
 
-	fmt.add_line("hello", "1", 5);
-	fmt.add_line("goodbye", "2", 5);
+	fmt.add_line("hello", 5);
+	fmt.add_line("goodbye", 5);
 
 	std::string expected =
 		"{list"
-		"{listitem[1] text:\"hello\"}"
-		"{listitem[2] text:\"goodb\"}"
-		"{listitem[2] text:\"ye\"}"
+		"{listitem text:\"hello\"}"
+		"{listitem text:\"goodb\"}"
+		"{listitem text:\"ye\"}"
 		"}";
 	REQUIRE(fmt.format_list() == expected);
 
@@ -93,9 +91,9 @@ TEST_CASE("set_line() replaces the item in a list", "[ListFormatter]")
 
 	expected =
 		"{list"
-		"{listitem[1] text:\"hello\"}"
-		"{listitem[3] text:\"oh\"}"
-		"{listitem[2] text:\"ye\"}"
+		"{listitem text:\"hello\"}"
+		"{listitem text:\"oh\"}"
+		"{listitem text:\"ye\"}"
 		"}";
 	REQUIRE(fmt.format_list() == expected);
 }

--- a/test/listformatter.cpp
+++ b/test/listformatter.cpp
@@ -25,54 +25,13 @@ TEST_CASE("add_line(), get_lines_count() and clear()",
 	}
 }
 
-TEST_CASE("add_line() splits overly long sequences to fit width",
-	"[ListFormatter]")
-{
-	ListFormatter fmt;
-
-	SECTION("ordinary text") {
-		fmt.add_line("123456789_", 10);
-		fmt.add_line("_987654321", 10);
-		fmt.add_line("ListFormatter doesn't care about word boundaries",
-			10);
-		std::string expected =
-			"{list"
-			"{listitem text:\"123456789_\"}"
-			"{listitem text:\"_987654321\"}"
-			"{listitem text:\"ListFormat\"}"
-			"{listitem text:\"ter doesn'\"}"
-			"{listitem text:\"t care abo\"}"
-			"{listitem text:\"ut word bo\"}"
-			"{listitem text:\"undaries\"}"
-			"}";
-		REQUIRE(fmt.format_list() == expected);
-	}
-
-	SECTION("numbered list") {
-		fmt.add_line("123456789_", 10);
-		fmt.add_line("_987654321", 10);
-		fmt.add_line("ListFormatter doesn't care about word boundaries",
-			10);
-		std::string expected =
-			"{list"
-			"{listitem text:\"123456789_\"}"
-			"{listitem text:\"_987654321\"}"
-			"{listitem text:\"ListFormat\"}"
-			"{listitem text:\"ter doesn'\"}"
-			"{listitem text:\"t care abo\"}"
-			"{listitem text:\"ut word bo\"}"
-			"{listitem text:\"undaries\"}"
-			"}";
-		REQUIRE(fmt.format_list() == expected);
-	}
-}
-
 TEST_CASE("set_line() replaces the item in a list", "[ListFormatter]")
 {
 	ListFormatter fmt;
 
-	fmt.add_line("hello", 5);
-	fmt.add_line("goodbye", 5);
+	fmt.add_line("hello");
+	fmt.add_line("goodb");
+	fmt.add_line("ye");
 
 	std::string expected =
 		"{list"


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/72.
Fixes https://github.com/newsboat/newsboat/issues/1126.

This works around [an stfl bug](https://github.com/dennisschagt/stfl/issues/3) by just not using the (slightly) broken feature.