### PR TITLE
Add a "run-on-startup" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased - expected 2020-09-20
 ### Added
 ### Changed
+- It is now an error if a macro is configured with 0 operations.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -113,6 +113,7 @@ reload-only-visible-feeds||[yes/no]||no||If set to `yes`, then manually reloadin
 reload-threads||<number>||1||The number of parallel reload threads that shall be started when all feeds are reloaded.||reload-threads 3
 reload-time||<number>||60||The number of minutes between automatic reloads.||reload-time 120
 reset-unread-on-update||<url> [<url>...]||n/a||Specifies one or more feed URLs for whose articles the unread flag will be reset if an article has been updated, i.e. its content has been changed. This is especially useful for RSS feeds where single articles are updated after publication, and you want to be notified of the updates. This option can be specified multiple times.||reset-unread-on-update "https://blog.fefe.de/rss.xml?html"
+run-on-startup||<list of operations>||n/a||Specifies one or more operations, separated by semicolons, which are executed on Newsboat startup.||run-on-startup next-unread; open; random-unread; open
 save-path||<path-to-directory>||~/||The default path where articles shall be saved to. If an invalid path is specified, the current directory is used.||save-path "~/Saved Articles"
 scrolloff||<number>||0||Keep the configured number of lines above and below the selected item in lists. Configure a high number to keep the selected item in the center of the screen.||scrolloff 5
 search-highlight-colors||<fgcolor> <bgcolor> [<attribute> ...]||black yellow bold||This configuration command specifies the highlighting colors when searching for text from the article view.||search-highlight-colors white black bold

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -190,6 +190,7 @@ public:
 	std::vector<KeyMapDesc> get_keymap_descriptions(std::string context);
 
 	std::vector<MacroCmd> parse_operation_sequence(const std::string& line);
+	std::vector<MacroCmd> get_startup_operation_sequence();
 
 private:
 	bool is_valid_context(const std::string& context);
@@ -198,6 +199,7 @@ private:
 	std::string getopname(Operation op);
 	std::map<std::string, std::map<std::string, Operation>> keymap_;
 	std::map<std::string, std::vector<MacroCmd>> macros_;
+	std::vector<MacroCmd> startup_operations_sequence;
 };
 
 } // namespace newsboat

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -189,6 +189,8 @@ public:
 	void dump_config(std::vector<std::string>& config_output) override;
 	std::vector<KeyMapDesc> get_keymap_descriptions(std::string context);
 
+	std::vector<MacroCmd> parse_operation_sequence(const std::string& line);
+
 private:
 	bool is_valid_context(const std::string& context);
 	unsigned short get_flag_from_context(const std::string& context);

--- a/include/view.h
+++ b/include/view.h
@@ -140,6 +140,8 @@ public:
 	static void ctrl_c_action(int sig);
 
 protected:
+	bool run_commands(const std::vector<MacroCmd>& commands);
+
 	void apply_colors(std::shared_ptr<FormAction> fa);
 
 	void handle_cmdline_completion(std::shared_ptr<FormAction> fa);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -178,6 +178,7 @@ int Controller::run(const CliArgsParser& args)
 	cfgparser.register_handler("bind-key", keys);
 	cfgparser.register_handler("unbind-key", keys);
 	cfgparser.register_handler("macro", keys);
+	cfgparser.register_handler("run-on-startup", keys);
 
 	cfgparser.register_handler("ignore-article", ign);
 	cfgparser.register_handler("always-download", ign);

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -730,6 +730,8 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 		const std::string macrokey = token.value();
 
 		macros_[macrokey] = cmds;
+	} else if (action == "run-on-startup") {
+		startup_operations_sequence = parse_operation_sequence(params);
 	} else {
 		throw ConfigHandlerException(ActionHandlerStatus::INVALID_PARAMS);
 	}
@@ -759,6 +761,11 @@ std::vector<MacroCmd> KeyMap::parse_operation_sequence(const std::string& line)
 	}
 
 	return cmds;
+}
+
+std::vector<MacroCmd> KeyMap::get_startup_operation_sequence()
+{
+	return startup_operations_sequence;
 }
 
 std::vector<std::string> KeyMap::get_keys(Operation op,

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -120,7 +120,7 @@ void View::show_error(const std::string& msg)
 int View::run()
 {
 	bool have_macroprefix = false;
-	std::vector<MacroCmd> macrocmds;
+	std::vector<MacroCmd> macrocmds = keys->get_startup_operation_sequence();
 
 	feedlist_form = std::make_shared<FeedListFormAction>(
 			this, feedlist_str, rsscache, filters, cfg, rxman);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -117,10 +117,23 @@ void View::show_error(const std::string& msg)
 	set_status(msg);
 }
 
+bool View::run_commands(const std::vector<MacroCmd>& commands)
+{
+	for (auto command : commands) {
+		std::shared_ptr<FormAction> fa = get_current_formaction();
+		fa->prepare();
+		fa->get_form().run(-1);
+		if (!fa->process_op(command.op, true, &command.args)) {
+			// Operation failed, abort
+			return false;
+		}
+	}
+	return true;
+}
+
 int View::run()
 {
 	bool have_macroprefix = false;
-	std::vector<MacroCmd> macrocmds = keys->get_startup_operation_sequence();
 
 	feedlist_form = std::make_shared<FeedListFormAction>(
 			this, feedlist_str, rsscache, filters, cfg, rxman);
@@ -134,6 +147,12 @@ int View::run()
 
 	curs_set(0);
 
+	if (!run_commands(keys->get_startup_operation_sequence())) {
+		Stfl::reset();
+		std::cerr << _("Error: Failed to execute startup commands") << std::endl;
+		return EXIT_FAILURE;
+	}
+
 	/*
 	 * This is the main "event" loop of newsboat.
 	 */
@@ -145,90 +164,74 @@ int View::run()
 		// we signal "oh, you will receive an operation soon"
 		fa->prepare();
 
-		if (!macrocmds.empty()) {
-			// if there is any macro command left to process, we do
-			// so
+		// we then receive the event and ignore timeouts.
+		const char* event = fa->get_form().run(60000);
 
-			fa->get_form().run(-1);
-			if (!fa->process_op(
-					macrocmds[0].op, true, &macrocmds[0].args)) {
-
-				// Operation failed, abort
-				macrocmds.clear();
-			} else {
-				// remove first macro command, since it has already been processed
-				macrocmds.erase(macrocmds.begin());
+		if (ctrl_c_hit) {
+			ctrl_c_hit = false;
+			cancel_input(fa);
+			if (!get_cfg()->get_configvalue_as_bool(
+					"confirm-exit") ||
+				confirm(_("Do you really want to quit "
+						"(y:Yes n:No)? "),
+					_("yn")) == *_("y")) {
+				Stfl::reset();
+				return EXIT_FAILURE;
 			}
-		} else {
-			// we then receive the event and ignore timeouts.
-			const char* event = fa->get_form().run(60000);
+		}
 
-			if (ctrl_c_hit) {
-				ctrl_c_hit = false;
-				cancel_input(fa);
-				if (!get_cfg()->get_configvalue_as_bool(
-						"confirm-exit") ||
-					confirm(_("Do you really want to quit "
-							"(y:Yes n:No)? "),
-						_("yn")) == *_("y")) {
-					Stfl::reset();
-					return EXIT_FAILURE;
-				}
-			}
+		if (!event || strcmp(event, "TIMEOUT") == 0) {
+			continue;
+		}
 
-			if (!event || strcmp(event, "TIMEOUT") == 0) {
+		if (is_inside_qna) {
+			LOG(Level::DEBUG,
+				"View::run: we're inside QNA input");
+			if (is_inside_cmdline &&
+				strcmp(event, "TAB") == 0) {
+				handle_cmdline_completion(fa);
 				continue;
 			}
+			if (strcmp(event, "^U") == 0) {
+				clear_line(fa);
+				continue;
+			} else if (strcmp(event, "^K") == 0) {
+				clear_eol(fa);
+				continue;
+			} else if (strcmp(event, "^G") == 0) {
+				cancel_input(fa);
+				continue;
+			} else if (strcmp(event, "^W") == 0) {
+				delete_word(fa);
+				continue;
+			}
+		}
 
-			if (is_inside_qna) {
-				LOG(Level::DEBUG,
-					"View::run: we're inside QNA input");
-				if (is_inside_cmdline &&
-					strcmp(event, "TAB") == 0) {
-					handle_cmdline_completion(fa);
-					continue;
-				}
-				if (strcmp(event, "^U") == 0) {
-					clear_line(fa);
-					continue;
-				} else if (strcmp(event, "^K") == 0) {
-					clear_eol(fa);
-					continue;
-				} else if (strcmp(event, "^G") == 0) {
-					cancel_input(fa);
-					continue;
-				} else if (strcmp(event, "^W") == 0) {
-					delete_word(fa);
-					continue;
-				}
+		LOG(Level::DEBUG, "View::run: event = %s", event);
+
+		if (have_macroprefix) {
+			have_macroprefix = false;
+			LOG(Level::DEBUG,
+				"View::run: running macro `%s'",
+				event);
+			run_commands(keys->get_macro(event));
+			set_status("");
+		} else {
+			const Operation op = keys->get_operation(event, fa->id());
+
+			LOG(Level::DEBUG,
+				"View::run: event = %s op = %u",
+				event,
+				op);
+
+			if (OP_MACROPREFIX == op) {
+				have_macroprefix = true;
+				set_status("macro-");
 			}
 
-			LOG(Level::DEBUG, "View::run: event = %s", event);
-
-			if (have_macroprefix) {
-				have_macroprefix = false;
-				LOG(Level::DEBUG,
-					"View::run: running macro `%s'",
-					event);
-				macrocmds = keys->get_macro(event);
-				set_status("");
-			} else {
-				const Operation op = keys->get_operation(event, fa->id());
-
-				LOG(Level::DEBUG,
-					"View::run: event = %s op = %u",
-					event,
-					op);
-
-				if (OP_MACROPREFIX == op) {
-					have_macroprefix = true;
-					set_status("macro-");
-				}
-
-				// now we handle the operation to the
-				// formaction.
-				fa->process_op(op);
-			}
+			// now we handle the operation to the
+			// formaction.
+			fa->process_op(op);
 		}
 	}
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -120,6 +120,9 @@ void View::show_error(const std::string& msg)
 bool View::run_commands(const std::vector<MacroCmd>& commands)
 {
 	for (auto command : commands) {
+		if (formaction_stack_size() == 0) {
+			return true;
+		}
 		std::shared_ptr<FormAction> fa = get_current_formaction();
 		fa->prepare();
 		fa->get_form().run(-1);

--- a/test/data/test-config.txt
+++ b/test/data/test-config.txt
@@ -9,7 +9,7 @@ cache-file "~/foo" # yet another comment
 
 macro k open ; reload ; reload-all ; mark-feed-read ; save ; next-unread
 macro j open "foo" "bar" baz ; "save" blafasel
-macro l ; ; ; 
+macro l open
 macro m quit ;
 
 # and here's one more comment

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -214,6 +214,12 @@ TEST_CASE("handle_action()", "[KeyMap]")
 		REQUIRE(k.get_keys(OP_SK_PGUP, "feedlist")
 			== std::vector<std::string>({"PPAGE", "p", "u"}));
 	}
+
+	SECTION("macro without commands results in exception") {
+		REQUIRE_NOTHROW(k.handle_action("macro", "r ; ; ; ; open"));
+		REQUIRE_THROWS_AS(k.handle_action("macro", "r ; ; ; ;"),
+			ConfigHandlerException);
+	}
 }
 
 TEST_CASE("verify get_keymap_descriptions() behavior",


### PR DESCRIPTION
Related to (but not necessarily a complete fix for):
- https://github.com/akrennmair/newsbeuter/issues/402
- https://github.com/akrennmair/newsbeuter/issues/41
- https://github.com/newsboat/newsboat/issues/888

Obsoletes https://github.com/newsboat/newsboat/pull/889

- [x] Find a better example than `run-on-startup set-filter "feedtitle =~ \"newsboat\"" ; clear-filter ; open` (preferably a bit more straightforward while still showing that a sequence of multiple commands is an option)
- [x] Look through https://github.com/newsboat/newsboat/pull/889#issuecomment-614161864 (open issues for non-implemented remarks)