### PR TITLE
Fix for "Make Inoreader 'sort by firsttag' useful" #1128

### DIFF
--- a/doc/chapter-tagging.asciidoc
+++ b/doc/chapter-tagging.asciidoc
@@ -20,6 +20,7 @@ and again shows all RSS feeds, regardless of their assigned tags.
 
 A special type of tag are tags that start with the tilde character (`~`). When such
 a tag is found, the feed title is set to the tag name (excluding the `~` character).
+These type of tags are ignored when any kind of "first tag" property is used.
 With this feature, you can give feeds any title you want in your feed list:
 
 	https://rss.orf.at/news.xml "~ORF News"

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -63,7 +63,12 @@ bool RssFeed::matches_tag(const std::string& tag)
 
 std::string RssFeed::get_firsttag()
 {
-	return tags_.empty() ? "" : tags_.front();
+	for (const auto& t : tags_) {
+		if (t.substr(0, 1) != "~") {
+			return t;
+		}
+	}
+	return "";
 }
 
 std::string RssFeed::get_tags()

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -261,23 +261,29 @@ TEST_CASE("RssFeed::get_firsttag() returns first tag", "[RssFeed]")
 	Cache rsscache(":memory:", &cfg);
 	RssFeed f(&rsscache);
 
-	REQUIRE(f.get_firsttag() == "");
+	SECTION("Empty tag array") {
+		REQUIRE(f.get_firsttag() == "");
+	}
 
-	std::vector<std::string> tags = {"One", "Two", "Three", "Four"};
-	f.set_tags(tags);
-	REQUIRE(f.get_firsttag() == "One");
+	SECTION("Ordinary tags") {
+		f.set_tags({"One", "Two", "Three", "Four"});
+		REQUIRE(f.get_firsttag() == "One");
+	}
 
-	tags = {"Five", "Six", "Seven", "Eight"};
-	f.set_tags(tags);
-	REQUIRE(f.get_firsttag() == "Five");
+	SECTION("Title tag exclusion") {
+		f.set_tags({"~Five", "Six", "Seven", "Eight"});
+		REQUIRE(f.get_firsttag() == "Six");
+	}
 
-	tags = {"Nine", "Ten", "Eleven", "Twelve"};
-	f.set_tags(tags);
-	REQUIRE(f.get_firsttag() == "Nine");
+	SECTION("Non exclusion of tag prefixed by a special character other than tilde") {
+		f.set_tags({"~Nine", "!Ten", "Eleven", "Twelve"});
+		REQUIRE(f.get_firsttag() == "!Ten");
+	}
 
-	tags = {"Orange", "Apple", "Kiwi", "Banana"};
-	f.set_tags(tags);
-	REQUIRE(f.get_firsttag() == "Orange");
+	SECTION("Array with only title tags") {
+		f.set_tags({"~Orange", "~Apple", "~Kiwi", "~Banana"});
+		REQUIRE(f.get_firsttag() == "");
+	}
 }
 
 TEST_CASE(


### PR DESCRIPTION
Fixes #1128 

Please check the commit messages for all the needed information.