### PR TITLE
contrib: change feedgrabber.rb cachedir from newsbeuter to newsboat

### DIFF
--- a/contrib/feedgrabber.rb
+++ b/contrib/feedgrabber.rb
@@ -25,7 +25,7 @@ require 'gdbm'
     # create a FeedGrabber instance
     def initialize(uniqueName, path = nil, retries = 4, depth = 5, timeout = 15)
       path = File.expand_path("~") if path.nil?
-      @dbCacheName = "#{path}/.newsbeuter/#{uniqueName}.db"       # generate db cache filename
+      @dbCacheName = "#{path}/.newsboat/#{uniqueName}.db"       # generate db cache filename
       @maxRetries = retries
       @maxDepth = depth
       @timeout = timeout


### PR DESCRIPTION
The feedgrabber.rb script was using ~/.newsbeuter/ as directory to store
the cache file. Change it to ~/.newsboat.