### PR TITLE
Fix CI builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,6 +3,9 @@ freebsd_task:
         - name: FreeBSD 11.4
           freebsd_instance:
             image: freebsd-11-4-release-amd64
+          # We expect this build to fail because "latest" repo for 11.4 is currently missing Rust.
+          allow_failures: true
+          skip_notifications: true
         - name: FreeBSD 12.1
           freebsd_instance:
             image: freebsd-12-1-release-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,6 @@ cache:
 before_cache:
   - rm -rf $HOME/.cargo/registry/index
 
-addons:
-  apt:
-    packages: &global_deps
-    - libsqlite3-dev
-    - libcurl4-openssl-dev
-    - libxml2-dev
-    - libstfl-dev
-    - libjson-c-dev
-    - libncursesw5-dev
-    - asciidoctor
-addons:
-  apt:
-    packages: &clang_deps
-    - *global_deps
-    - g++ # required for some niceties in C++ standard library
-
 env:
   - CXXFLAGS='-fstack-clash-protection -D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2'
 
@@ -32,20 +16,27 @@ matrix:
   fast_finish: true
   include:
     - name: "Test Coverage"
-      compiler: clang-8
+      compiler: clang-11
       os: linux
       dist: bionic
       rust: nightly
       addons:
         apt:
           sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
+            - sourceline: "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main"
+              key_url: https://apt.llvm.org/llvm-snapshot.gpg.key
+          update: true
           packages:
-            - clang-8
-            - llvm-8
-            - *clang_deps
+            - clang-11
+            - libsqlite3-dev
+            - libcurl4-openssl-dev
+            - libxml2-dev
+            - libstfl-dev
+            - libjson-c-dev
+            - libncursesw5-dev
+            - asciidoctor
       env:
-        - COMPILER=clang++-8
+        - COMPILER=clang++-11
         - REPORT_COVERAGE=yes
       before_install:
         - cargo install grcov


### PR DESCRIPTION
1. FreeBSD 11.4 build is failing because [the "rust" package is missing](https://cirrus-ci.com/task/5392278598451200?command=install#L129). It's present in a "quarterly" repo, but is absent from "latest". I allowed this build to fail for now, and disabled notifications so GitHub doesn't see the failing build at all.

2. Code coverage build on Travis [fails because the C++ test suite segfaults](https://travis-ci.com/github/newsboat/newsboat/jobs/379049336#L957). This appears to be caused by Rust Nightly migrating to LLVM 11 (https://github.com/rust-lang/rust/issues/76085). Everything works fine if I build the C++ part with Clang 11 (which also uses LLVM 11), so that's the fix I apply here.

I intend to merge this as soon as the builds finished, to get "master" back to green. But if you have any comments, please leave them even after the merge.