### PR TITLE
Bump Rust to 1.46.0 on CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -138,12 +138,12 @@ macos_task:
           env:
               CC: clang
               CXX: clang++
-              RUST: 1.45.0
+              RUST: 1.46.0
         - name: macOS GCC Rust stable
           env:
               CC: gcc
               CXX: g++
-              RUST: 1.45.0
+              RUST: 1.46.0
         # This job tests our minimum supported Rust version, so only bump on
         # Newsboat release day
         - name: macOS GCC Rust 1.42.0

--- a/docker/ubuntu_16.04-build-tools.dockerfile
+++ b/docker/ubuntu_16.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with an older
-# C++ compiler. Contains GCC 4.9 and Rust 1.45.0 by default.
+# C++ compiler. Contains GCC 4.9 and Rust 1.46.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-4.9
-# - rust_version -- Rust version to install. Default: 1.45.0
+# - rust_version -- Rust version to install. Default: 1.46.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-4.9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -89,7 +89,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.45.0
+ARG rust_version=1.46.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.45.0 by default.
+# and Rust 1.46.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-8
-# - rust_version -- Rust version to install. Default: 1.45.0
+# - rust_version -- Rust version to install. Default: 1.46.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-8
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -89,7 +89,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.45.0
+ARG rust_version=1.46.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -80,7 +80,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain 1.45.0 \
+        --default-toolchain 1.46.0 \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 9 and Rust 1.45.0 by default.
+# compilers. Contains GCC 9 and Rust 1.46.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.45.0
+# - rust_version -- Rust version to install. Default: 1.46.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -89,7 +89,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.45.0
+ARG rust_version=1.46.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \


### PR DESCRIPTION
This is nothing fancy, just mundane updates, so I'll merge this once CI builds pass.