### PR TITLE
Display correct type of numbers in nested list's items

### DIFF
--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -99,7 +99,8 @@ void HtmlRenderer::render(std::istream& input,
 	unsigned int source_count = 0;
 	std::string curline;
 	int indent_level = 0;
-	bool inside_li = false, is_ol = false, inside_pre = false;
+	std::vector<HtmlTag> list_elements_stack;
+	bool is_ol = false, inside_pre = false;
 	bool itunes_hack = false;
 	size_t inside_script = 0;
 	size_t inside_style = 0;
@@ -360,7 +361,9 @@ void HtmlRenderer::render(std::istream& input,
 				break;
 
 			case HtmlTag::LI:
-				if (inside_li) {
+				if (list_elements_stack.size() >= 1
+					&& list_elements_stack.back() == HtmlTag::LI) {
+					list_elements_stack.pop_back();
 					indent_level -= 2;
 					if (indent_level < 0) {
 						indent_level = 0;
@@ -371,7 +374,7 @@ void HtmlRenderer::render(std::istream& input,
 						tables.size() ? 0
 						: indent_level);
 				}
-				inside_li = true;
+				list_elements_stack.push_back(HtmlTag::LI);
 				add_nonempty_line(curline, tables, lines);
 				prepare_new_line(curline,
 					tables.size() ? 0 : indent_level);
@@ -611,7 +614,9 @@ void HtmlRenderer::render(std::istream& input,
 				}
 			// fall-through
 			case HtmlTag::UL:
-				if (inside_li) {
+				if (list_elements_stack.size() >= 1
+					&& list_elements_stack.back() == HtmlTag::LI) {
+					list_elements_stack.pop_back();
 					indent_level -= 2;
 					if (indent_level < 0) {
 						indent_level = 0;
@@ -655,7 +660,10 @@ void HtmlRenderer::render(std::istream& input,
 				if (indent_level < 0) {
 					indent_level = 0;
 				}
-				inside_li = false;
+				if (list_elements_stack.size() >= 1
+					&& list_elements_stack.back() == HtmlTag::LI) {
+					list_elements_stack.pop_back();
+				}
 				add_nonempty_line(curline, tables, lines);
 				prepare_new_line(curline,
 					tables.size() ? 0 : indent_level);

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -1452,14 +1452,14 @@ TEST_CASE("Ordered list can contain unordered list in its items",
 	REQUIRE(lines[0] == p(LineType::wrappable, ""));
 	REQUIRE(lines[1] == p(LineType::wrappable, " 1.  "));
 	REQUIRE(lines[2] == p(LineType::wrappable, ""));
-	REQUIRE(lines[3] == p(LineType::wrappable, "  * first item of sublist A"));
-	REQUIRE(lines[4] == p(LineType::wrappable, "  * second item of sublist A"));
+	REQUIRE(lines[3] == p(LineType::wrappable, "      * first item of sublist A"));
+	REQUIRE(lines[4] == p(LineType::wrappable, "      * second item of sublist A"));
 	REQUIRE(lines[5] == p(LineType::wrappable, ""));
 	REQUIRE(lines[6] == p(LineType::wrappable, " 2.  "));
 	REQUIRE(lines[7] == p(LineType::wrappable, ""));
-	REQUIRE(lines[8] == p(LineType::wrappable, "  * first item of sublist B"));
-	REQUIRE(lines[9] == p(LineType::wrappable, "  * second item of sublist B"));
-	REQUIRE(lines[10] == p(LineType::wrappable, "  * third item of sublist B"));
+	REQUIRE(lines[8] == p(LineType::wrappable, "      * first item of sublist B"));
+	REQUIRE(lines[9] == p(LineType::wrappable, "      * second item of sublist B"));
+	REQUIRE(lines[10] == p(LineType::wrappable, "      * third item of sublist B"));
 	REQUIRE(lines[11] == p(LineType::wrappable, ""));
 	REQUIRE(lines[12] == p(LineType::wrappable, ""));
 

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -1422,3 +1422,46 @@ TEST_CASE("Empty <source> tags do not increase the link count. Media elements"
 	REQUIRE(links[3].first == "http://example.com/audio.oga");
 	REQUIRE(links[3].second == LinkType::AUDIO);
 }
+
+TEST_CASE("Ordered list can contain unordered list in its items",
+	"[HtmlRenderer]")
+{
+	HtmlRenderer rnd;
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	const auto input = std::string(
+			"<ol>"
+			"	<li>"
+			"		<ul>"
+			"			<li>first item of sublist A</li>"
+			"			<li>second item of sublist A</li>"
+			"		</ul>"
+			"	</li>"
+			"	<li>"
+			"		<ul>"
+			"			<li>first item of sublist B</li>"
+			"			<li>second item of sublist B</li>"
+			"			<li>third item of sublist B</li>"
+			"		</ul>"
+			"	</li>"
+			"</ol>");
+	rnd.render(input, lines, links, "");
+
+	REQUIRE(lines.size() == 13);
+	REQUIRE(lines[0] == p(LineType::wrappable, ""));
+	REQUIRE(lines[1] == p(LineType::wrappable, " 1.  "));
+	REQUIRE(lines[2] == p(LineType::wrappable, ""));
+	REQUIRE(lines[3] == p(LineType::wrappable, "  * first item of sublist A"));
+	REQUIRE(lines[4] == p(LineType::wrappable, "  * second item of sublist A"));
+	REQUIRE(lines[5] == p(LineType::wrappable, ""));
+	REQUIRE(lines[6] == p(LineType::wrappable, " 2.  "));
+	REQUIRE(lines[7] == p(LineType::wrappable, ""));
+	REQUIRE(lines[8] == p(LineType::wrappable, "  * first item of sublist B"));
+	REQUIRE(lines[9] == p(LineType::wrappable, "  * second item of sublist B"));
+	REQUIRE(lines[10] == p(LineType::wrappable, "  * third item of sublist B"));
+	REQUIRE(lines[11] == p(LineType::wrappable, ""));
+	REQUIRE(lines[12] == p(LineType::wrappable, ""));
+
+	REQUIRE(links.size() == 0);
+}


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1158.

Resulting output of item mentioned in that issue:
![image](https://user-images.githubusercontent.com/4629607/91670183-6c30c000-eb1b-11ea-92b9-8c5788b01533.png)
