### PR TITLE
Fix SIGSEGV when running `newsboat -r`

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -51,7 +51,7 @@ public:
 		const std::string& feedurl);
 	void update_rssitem_unread_and_enqueued(RssItem* item,
 		const std::string& feedurl);
-	void cleanup_cache(std::vector<std::shared_ptr<RssFeed>>& feeds);
+	void cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds);
 	void do_vacuum();
 	std::vector<std::shared_ptr<RssItem>> search_for_items(
 			const std::string& querystr,

--- a/include/controller.h
+++ b/include/controller.h
@@ -128,7 +128,6 @@ private:
 	ColorManager colorman;
 	RegexManager rxman;
 	RemoteApi* api;
-	std::mutex feeds_mutex;
 
 	std::unique_ptr<FsLock> fslock;
 

--- a/include/feedcontainer.h
+++ b/include/feedcontainer.h
@@ -36,7 +36,6 @@ public:
 	void reset_feeds_status();
 	void set_feeds(const std::vector<std::shared_ptr<RssFeed>> new_feeds);
 	std::vector<std::shared_ptr<RssFeed>> get_all_feeds();
-	void clear_feeds_items();
 	unsigned int unread_feed_count() const;
 	unsigned int unread_item_count() const;
 

--- a/include/feedcontainer.h
+++ b/include/feedcontainer.h
@@ -35,7 +35,7 @@ public:
 	unsigned int feeds_size();
 	void reset_feeds_status();
 	void set_feeds(const std::vector<std::shared_ptr<RssFeed>> new_feeds);
-	std::vector<std::shared_ptr<RssFeed>> get_all_feeds();
+	std::vector<std::shared_ptr<RssFeed>> get_all_feeds() const;
 	unsigned int unread_feed_count() const;
 	unsigned int unread_item_count() const;
 

--- a/include/feedcontainer.h
+++ b/include/feedcontainer.h
@@ -39,6 +39,8 @@ public:
 	unsigned int unread_feed_count() const;
 	unsigned int unread_item_count() const;
 
+	void replace_feed(unsigned int pos, std::shared_ptr<RssFeed> feed);
+
 	std::vector<std::shared_ptr<RssFeed>> feeds;
 
 private:

--- a/include/feedcontainer.h
+++ b/include/feedcontainer.h
@@ -41,9 +41,8 @@ public:
 
 	void replace_feed(unsigned int pos, std::shared_ptr<RssFeed> feed);
 
-	std::vector<std::shared_ptr<RssFeed>> feeds;
-
 private:
+	std::vector<std::shared_ptr<RssFeed>> feeds;
 	mutable std::mutex feeds_mutex;
 };
 } // namespace newsboat

--- a/include/feedcontainer.h
+++ b/include/feedcontainer.h
@@ -19,7 +19,7 @@ public:
 	void sort_feeds(const FeedSortStrategy& sort_strategy);
 	std::shared_ptr<RssFeed> get_feed(const unsigned int pos);
 	void add_feed(const std::shared_ptr<RssFeed> feed);
-	void mark_all_feed_items_read(const unsigned int feed_pos);
+	void mark_all_feed_items_read(std::shared_ptr<RssFeed> feed);
 	void mark_all_feeds_read();
 	unsigned int get_feed_count_per_tag(const std::string& tag);
 

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -84,13 +84,6 @@ public:
 		add_items(items);
 	}
 
-	void clear_items()
-	{
-		LOG(Level::DEBUG, "RssFeed: clearing items");
-		items_.clear();
-		items_guid_map.clear();
-	}
-
 	void erase_items(std::vector<std::shared_ptr<RssItem>>::iterator begin,
 		std::vector<std::shared_ptr<RssItem>>::iterator end)
 	{

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -737,7 +737,7 @@ void Cache::do_vacuum()
 	run_sql("VACUUM;");
 }
 
-void Cache::cleanup_cache(std::vector<std::shared_ptr<RssFeed>>& feeds)
+void Cache::cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds)
 {
 	// we don't use the std::lock_guard<> here... see comments below
 	mtx.lock();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -604,7 +604,7 @@ void Controller::mark_all_read(unsigned int pos)
 			"after rsscache->mark_all_read, before iteration over "
 			"items");
 
-		feedcontainer.mark_all_feed_items_read(pos);
+		feedcontainer.mark_all_feed_items_read(feed);
 	}
 }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -92,9 +92,6 @@ Controller::~Controller()
 	delete rsscache;
 	delete urlcfg;
 	delete api;
-
-	feedcontainer.clear_feeds_items();
-	feedcontainer.feeds.clear();
 }
 
 void Controller::set_view(View* vv)
@@ -643,8 +640,6 @@ void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
 	for (const auto& item : feed->items()) {
 		rsscache->update_rssitem_unread_and_enqueued(item, feed->rssurl());
 	}
-
-	oldfeed->clear_items();
 
 	v->notify_itemlist_change(feedcontainer.feeds[pos]);
 	if (!unattended) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -524,7 +524,7 @@ int Controller::run(const CliArgsParser& args)
 	}
 	try {
 		std::lock_guard<std::mutex> feedslock(feeds_mutex);
-		rsscache->cleanup_cache(feedcontainer.feeds);
+		rsscache->cleanup_cache(feedcontainer.get_all_feeds());
 		if (!args.silent()) {
 			std::cout << _("done.") << std::endl;
 		}
@@ -542,13 +542,13 @@ int Controller::run(const CliArgsParser& args)
 void Controller::update_feedlist()
 {
 	std::lock_guard<std::mutex> feedslock(feeds_mutex);
-	v->set_feedlist(feedcontainer.feeds);
+	v->set_feedlist(feedcontainer.get_all_feeds());
 }
 
 void Controller::update_visible_feeds()
 {
 	std::lock_guard<std::mutex> feedslock(feeds_mutex);
-	v->update_visible_feeds(feedcontainer.feeds);
+	v->update_visible_feeds(feedcontainer.get_all_feeds());
 }
 
 void Controller::mark_all_read(const std::string& feedurl)
@@ -565,7 +565,7 @@ void Controller::mark_all_read(const std::string& feedurl)
 	if (feedurl.empty()) { // Mark all feeds as read
 		if (api) {
 			std::lock_guard<std::mutex> feedslock(feeds_mutex);
-			for (const auto& feed : feedcontainer.feeds) {
+			for (const auto& feed : feedcontainer.get_all_feeds()) {
 				api->mark_all_read(feed->rssurl());
 			}
 		}
@@ -594,7 +594,7 @@ void Controller::mark_article_read(const std::string& guid, bool read)
 
 void Controller::mark_all_read(unsigned int pos)
 {
-	if (pos < feedcontainer.feeds.size()) {
+	if (pos < feedcontainer.feeds_size()) {
 		ScopeMeasure m("Controller::mark_all_read");
 		std::lock_guard<std::mutex> feedslock(feeds_mutex);
 		const auto feed = feedcontainer.get_feed(pos);
@@ -641,9 +641,9 @@ void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
 		rsscache->update_rssitem_unread_and_enqueued(item, feed->rssurl());
 	}
 
-	v->notify_itemlist_change(feedcontainer.feeds[pos]);
+	v->notify_itemlist_change(feed);
 	if (!unattended) {
-		v->set_feedlist(feedcontainer.feeds);
+		v->set_feedlist(feedcontainer.get_all_feeds());
 	}
 }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -635,7 +635,7 @@ void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
 
 	feed->set_tags(urlcfg->get_tags(oldfeed->rssurl()));
 	feed->set_order(oldfeed->get_order());
-	feedcontainer.feeds[pos] = feed;
+	feedcontainer.replace_feed(pos, feed);
 	queueManager.autoenqueue(feed);
 	for (const auto& item : feed->items()) {
 		rsscache->update_rssitem_unread_and_enqueued(item, feed->rssurl());

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -589,23 +589,25 @@ void Controller::mark_article_read(const std::string& guid, bool read)
 
 void Controller::mark_all_read(unsigned int pos)
 {
-	if (pos < feedcontainer.feeds_size()) {
-		ScopeMeasure m("Controller::mark_all_read");
-		const auto feed = feedcontainer.get_feed(pos);
-		if (feed->is_query_feed()) {
-			rsscache->mark_all_read(feed);
-		} else {
-			rsscache->mark_all_read(feed->rssurl());
-			if (api) {
-				api->mark_all_read(feed->rssurl());
-			}
-		}
-		m.stopover(
-			"after rsscache->mark_all_read, before iteration over "
-			"items");
-
-		feedcontainer.mark_all_feed_items_read(feed);
+	ScopeMeasure m("Controller::mark_all_read");
+	const auto feed = feedcontainer.get_feed(pos);
+	if (feed == nullptr) {
+		return;
 	}
+
+	if (feed->is_query_feed()) {
+		rsscache->mark_all_read(feed);
+	} else {
+		rsscache->mark_all_read(feed->rssurl());
+		if (api) {
+			api->mark_all_read(feed->rssurl());
+		}
+	}
+	m.stopover(
+		"after rsscache->mark_all_read, before iteration over "
+		"items");
+
+	feedcontainer.mark_all_feed_items_read(feed);
 }
 
 void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -523,7 +523,6 @@ int Controller::run(const CliArgsParser& args)
 		std::cout.flush();
 	}
 	try {
-		std::lock_guard<std::mutex> feedslock(feeds_mutex);
 		rsscache->cleanup_cache(feedcontainer.get_all_feeds());
 		if (!args.silent()) {
 			std::cout << _("done.") << std::endl;
@@ -541,13 +540,11 @@ int Controller::run(const CliArgsParser& args)
 
 void Controller::update_feedlist()
 {
-	std::lock_guard<std::mutex> feedslock(feeds_mutex);
 	v->set_feedlist(feedcontainer.get_all_feeds());
 }
 
 void Controller::update_visible_feeds()
 {
-	std::lock_guard<std::mutex> feedslock(feeds_mutex);
 	v->update_visible_feeds(feedcontainer.get_all_feeds());
 }
 
@@ -564,14 +561,12 @@ void Controller::mark_all_read(const std::string& feedurl)
 
 	if (feedurl.empty()) { // Mark all feeds as read
 		if (api) {
-			std::lock_guard<std::mutex> feedslock(feeds_mutex);
 			for (const auto& feed : feedcontainer.get_all_feeds()) {
 				api->mark_all_read(feed->rssurl());
 			}
 		}
 		feedcontainer.mark_all_feeds_read();
 	} else { // Mark a specific feed as read
-		std::lock_guard<std::mutex> feedslock(feeds_mutex);
 		const auto feed = feedcontainer.get_feed_by_url(feedurl);
 		if (!feed) {
 			return;
@@ -596,7 +591,6 @@ void Controller::mark_all_read(unsigned int pos)
 {
 	if (pos < feedcontainer.feeds_size()) {
 		ScopeMeasure m("Controller::mark_all_read");
-		std::lock_guard<std::mutex> feedslock(feeds_mutex);
 		const auto feed = feedcontainer.get_feed(pos);
 		if (feed->is_query_feed()) {
 			rsscache->mark_all_read(feed);
@@ -619,8 +613,6 @@ void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
 	unsigned int pos,
 	bool unattended)
 {
-	std::lock_guard<std::mutex> feedslock(feeds_mutex);
-
 	LOG(Level::DEBUG, "Controller::replace_feed: saving");
 	rsscache->externalize_rssfeed(
 		newfeed, ign.matches_resetunread(newfeed->rssurl()));

--- a/src/feedcontainer.cpp
+++ b/src/feedcontainer.cpp
@@ -248,15 +248,6 @@ std::vector<std::shared_ptr<RssFeed>> FeedContainer::get_all_feeds()
 	return tmpfeeds;
 }
 
-void FeedContainer::clear_feeds_items()
-{
-	std::lock_guard<std::mutex> feedslock(feeds_mutex);
-	for (const auto& feed : feeds) {
-		std::lock_guard<std::mutex> lock(feed->item_mutex);
-		feed->clear_items();
-	}
-}
-
 unsigned int FeedContainer::unread_feed_count() const
 {
 	std::lock_guard<std::mutex> feedslock(feeds_mutex);

--- a/src/feedcontainer.cpp
+++ b/src/feedcontainer.cpp
@@ -103,16 +103,19 @@ void FeedContainer::sort_feeds(const FeedSortStrategy& sort_strategy)
 std::shared_ptr<RssFeed> FeedContainer::get_feed(const unsigned int pos)
 {
 	std::lock_guard<std::mutex> feedslock(feeds_mutex);
-	if (pos >= feeds.size()) {
-		throw std::out_of_range(_("invalid feed index (bug)"));
+	if (pos < feeds.size()) {
+		return feeds[pos];
 	}
-	std::shared_ptr<RssFeed> feed = feeds[pos];
-	return feed;
+	return nullptr;
 }
 
 void FeedContainer::mark_all_feed_items_read(const unsigned int feed_pos)
 {
 	const auto feed = get_feed(feed_pos);
+	if (feed == nullptr) {
+		return;
+	}
+
 	std::lock_guard<std::mutex> lock(feed->item_mutex);
 	std::vector<std::shared_ptr<RssItem>>& items = feed->items();
 	if (items.size() > 0) {

--- a/src/feedcontainer.cpp
+++ b/src/feedcontainer.cpp
@@ -238,14 +238,10 @@ void FeedContainer::set_feeds(
 	feeds = new_feeds;
 }
 
-std::vector<std::shared_ptr<RssFeed>> FeedContainer::get_all_feeds()
+std::vector<std::shared_ptr<RssFeed>> FeedContainer::get_all_feeds() const
 {
-	std::vector<std::shared_ptr<RssFeed>> tmpfeeds;
-	{
-		std::lock_guard<std::mutex> feedslock(feeds_mutex);
-		tmpfeeds = feeds;
-	}
-	return tmpfeeds;
+	std::lock_guard<std::mutex> feedslock(feeds_mutex);
+	return feeds;
 }
 
 unsigned int FeedContainer::unread_feed_count() const

--- a/src/feedcontainer.cpp
+++ b/src/feedcontainer.cpp
@@ -289,4 +289,12 @@ unsigned int FeedContainer::unread_item_count() const
 	return unread_guids.size();
 }
 
+void FeedContainer::replace_feed(unsigned int pos,
+	std::shared_ptr<RssFeed> feed)
+{
+	std::lock_guard<std::mutex> feedslock(feeds_mutex);
+	assert(pos < feeds.size());
+	feeds[pos] = feed;
+}
+
 } // namespace newsboat

--- a/src/feedcontainer.cpp
+++ b/src/feedcontainer.cpp
@@ -109,13 +109,8 @@ std::shared_ptr<RssFeed> FeedContainer::get_feed(const unsigned int pos)
 	return nullptr;
 }
 
-void FeedContainer::mark_all_feed_items_read(const unsigned int feed_pos)
+void FeedContainer::mark_all_feed_items_read(std::shared_ptr<RssFeed> feed)
 {
-	const auto feed = get_feed(feed_pos);
-	if (feed == nullptr) {
-		return;
-	}
-
 	std::lock_guard<std::mutex> lock(feed->item_mutex);
 	std::vector<std::shared_ptr<RssItem>>& items = feed->items();
 	if (items.size() > 0) {

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -216,8 +216,7 @@ REDO:
 	case OP_OPENINBROWSER:
 		if (visible_feeds.size() > 0 && feedpos.length() > 0) {
 			std::shared_ptr<RssFeed> feed =
-				v->get_ctrl()->get_feedcontainer()->get_feed(
-					pos);
+				v->get_ctrl()->get_feedcontainer()->get_feed(pos);
 			if (feed) {
 				if (!feed->is_query_feed()) {
 					LOG(Level::INFO,
@@ -264,8 +263,7 @@ REDO:
 	case OP_OPENALLUNREADINBROWSER:
 		if (visible_feeds.size() > 0 && feedpos.length() > 0) {
 			std::shared_ptr<RssFeed> feed =
-				v->get_ctrl()->get_feedcontainer()->get_feed(
-					pos);
+				v->get_ctrl()->get_feedcontainer()->get_feed(pos);
 			if (feed) {
 				LOG(Level::INFO,
 					"FeedListFormAction: opening all "
@@ -289,8 +287,7 @@ REDO:
 	case OP_OPENALLUNREADINBROWSER_AND_MARK:
 		if (visible_feeds.size() > 0 && feedpos.length() > 0) {
 			std::shared_ptr<RssFeed> feed =
-				v->get_ctrl()->get_feedcontainer()->get_feed(
-					pos);
+				v->get_ctrl()->get_feedcontainer()->get_feed(pos);
 			if (feed) {
 				LOG(Level::INFO,
 					"FeedListFormAction: opening all "

--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -25,7 +25,7 @@ xmlDocPtr opml::generate(const FeedContainer& feedcontainer)
 	xmlNodePtr body = xmlNewTextChild(
 			opml_node, nullptr, (const xmlChar*)"body", nullptr);
 
-	for (const auto& feed : feedcontainer.feeds) {
+	for (const auto& feed : feedcontainer.get_all_feeds()) {
 		if (!utils::is_special_url(feed->rssurl())) {
 			std::string rssurl = feed->rssurl();
 			std::string link = feed->link();

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -58,10 +58,8 @@ void Reloader::reload(unsigned int pos,
 	CurlHandle* easyhandle)
 {
 	LOG(Level::DEBUG, "Reloader::reload: pos = %u max = %u", pos, max);
-	if (pos < ctrl->get_feedcontainer()->feeds_size()) {
-		std::shared_ptr<RssFeed> oldfeed =
-			ctrl->get_feedcontainer()->get_feed(pos);
-
+	std::shared_ptr<RssFeed> oldfeed = ctrl->get_feedcontainer()->get_feed(pos);
+	if (oldfeed) {
 		// Query feed reloading should be handled by the calling functions
 		// (e.g.  Reloader::reload_all() calling View::prepare_query_feed())
 		if (oldfeed->is_query_feed()) {

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -58,9 +58,9 @@ void Reloader::reload(unsigned int pos,
 	CurlHandle* easyhandle)
 {
 	LOG(Level::DEBUG, "Reloader::reload: pos = %u max = %u", pos, max);
-	if (pos < ctrl->get_feedcontainer()->feeds.size()) {
+	if (pos < ctrl->get_feedcontainer()->feeds_size()) {
 		std::shared_ptr<RssFeed> oldfeed =
-			ctrl->get_feedcontainer()->feeds[pos];
+			ctrl->get_feedcontainer()->get_feed(pos);
 
 		// Query feed reloading should be handled by the calling functions
 		// (e.g.  Reloader::reload_all() calling View::prepare_query_feed())
@@ -183,7 +183,7 @@ void Reloader::reload_all(bool unattended)
 
 	// refresh query feeds (update and sort)
 	LOG(Level::DEBUG, "Reloader::reload_all: refresh query feeds");
-	for (const auto& feed : ctrl->get_feedcontainer()->feeds) {
+	for (const auto& feed : ctrl->get_feedcontainer()->get_all_feeds()) {
 		if (feed->is_query_feed()) {
 			ctrl->get_view()->prepare_query_feed(feed);
 			feed->set_status(DlStatus::SUCCESS);
@@ -235,10 +235,12 @@ void Reloader::reload_range(unsigned int start,
 		s = suff.substr(0, p);
 	};
 
+	const auto feeds = ctrl->get_feedcontainer()->get_all_feeds();
+
 	std::sort(v.begin(), v.end(), [&](unsigned int a, unsigned int b) {
 		std::string domain1, domain2;
-		extract(domain1, ctrl->get_feedcontainer()->feeds[a]->rssurl());
-		extract(domain2, ctrl->get_feedcontainer()->feeds[b]->rssurl());
+		extract(domain1, feeds[a]->rssurl());
+		extract(domain2, feeds[b]->rssurl());
 		std::reverse(domain1.begin(), domain1.end());
 		std::reverse(domain2.begin(), domain2.end());
 		return domain1 < domain2;

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -40,7 +40,6 @@ RssFeed::RssFeed(Cache* c)
 
 RssFeed::~RssFeed()
 {
-	clear_items();
 }
 
 unsigned int RssFeed::unread_item_count()

--- a/test/feedcontainer.cpp
+++ b/test/feedcontainer.cpp
@@ -620,7 +620,7 @@ TEST_CASE("mark_all_feed_items_read() marks all of feed's items as read",
 	}
 	feedcontainer.set_feeds(feeds);
 
-	feedcontainer.mark_all_feed_items_read(0);
+	feedcontainer.mark_all_feed_items_read(feed);
 
 	for (const auto& item : feed->items()) {
 		REQUIRE_FALSE(item->unread());

--- a/test/feedcontainer.cpp
+++ b/test/feedcontainer.cpp
@@ -149,7 +149,8 @@ TEST_CASE(
 	REQUIRE(feed == nullptr);
 }
 
-TEST_CASE("Throws on get_feed() with pos out of range", "[FeedContainer]")
+TEST_CASE("get_feed() returns nullptr if pos is out of range",
+	"[FeedContainer]")
 {
 	FeedContainer feedcontainer;
 	ConfigContainer cfg;
@@ -157,8 +158,8 @@ TEST_CASE("Throws on get_feed() with pos out of range", "[FeedContainer]")
 	feedcontainer.set_feeds(get_five_empty_feeds(&rsscache));
 
 	REQUIRE_NOTHROW(feedcontainer.get_feed(4));
-	CHECK_THROWS_AS(feedcontainer.get_feed(5), std::out_of_range);
-	CHECK_THROWS_AS(feedcontainer.get_feed(-1), std::out_of_range);
+	REQUIRE(feedcontainer.get_feed(5) == nullptr);
+	REQUIRE(feedcontainer.get_feed(-1) == nullptr);
 }
 
 TEST_CASE("Returns correct number using get_feed_count_by_tag()",

--- a/test/feedcontainer.cpp
+++ b/test/feedcontainer.cpp
@@ -674,24 +674,6 @@ TEST_CASE(
 	}
 }
 
-TEST_CASE("clear_feeds_items() removes all items from all feeds",
-	"[FeedContainer]")
-{
-	FeedContainer feedcontainer;
-	ConfigContainer cfg;
-	Cache rsscache(":memory:", &cfg);
-	feedcontainer.set_feeds({});
-	const auto feed = std::make_shared<RssFeed>(&rsscache);
-	for (int j = 0; j < 5; ++j) {
-		feed->add_item(std::make_shared<RssItem>(&rsscache));
-	}
-	feedcontainer.add_feed(feed);
-
-	REQUIRE(feed->items().size() == 5);
-	feedcontainer.clear_feeds_items();
-	REQUIRE(feed->items().size() == 0);
-}
-
 TEST_CASE(
 	"unread_feed_count() returns number of feeds that have unread items in "
 	"them",

--- a/test/feedcontainer.cpp
+++ b/test/feedcontainer.cpp
@@ -105,7 +105,7 @@ TEST_CASE("set_feeds() sets FeedContainer's feed vector to the given one",
 
 	feedcontainer.set_feeds(feeds);
 
-	REQUIRE(feedcontainer.feeds == feeds);
+	REQUIRE(feedcontainer.get_all_feeds() == feeds);
 }
 
 TEST_CASE("get_feed_by_url() returns feed by its URL", "[FeedContainer]")

--- a/test/feedcontainer.cpp
+++ b/test/feedcontainer.cpp
@@ -1101,3 +1101,29 @@ TEST_CASE("get_unread_item_count_per_tag returns the number of unread items "
 			== 24);
 	}
 }
+
+TEST_CASE("replace_feed() puts given feed into the specified position",
+	"[FeedContainer]")
+{
+	FeedContainer feedcontainer;
+
+	ConfigContainer cfg;
+	Cache rsscache(":memory:", &cfg);
+	const auto feeds = get_five_empty_feeds(&rsscache);
+
+	const auto first_feed = *feeds.begin();
+	const auto four_feeds = std::vector<std::shared_ptr<RssFeed>>(feeds.begin() + 1,
+			feeds.end());
+
+	feedcontainer.set_feeds(four_feeds);
+
+	const auto position = 2;
+	const auto feed_before_replacement = feedcontainer.get_feed(position);
+	REQUIRE(feed_before_replacement != first_feed);
+
+	feedcontainer.replace_feed(position, first_feed);
+	const auto feed_after_replacement = feedcontainer.get_feed(position);
+
+	REQUIRE(feed_before_replacement != feed_after_replacement);
+	REQUIRE(feed_after_replacement == first_feed);
+}


### PR DESCRIPTION
While investigating #1163, I found that `newsboat -r` segfaults for me with the following backtrace:

```
#0  0x000056442a4a8976 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::size (this=0x98) at /usr/include/c++/10/bits/basic_string.h:2833
#1  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_check (__s=0x56442a705270 "basic_string::substr", __pos=0, this=0x98) at /usr/include/c++/10/bits/basic_string.h:312
#2  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::substr (__n=6, __pos=0, this=0x98) at /usr/include/c++/10/bits/basic_string.h:2835
#3  newsboat::RssFeed::is_query_feed (this=0x0) at include/rssfeed.h:142
#4  newsboat::Reloader::reload (this=0x56442bd73690, pos=1, max=567, unattended=<optimized out>, easyhandle=0x7f031bffe978) at src/reloader.cpp:67
#5  0x000056442a4a994b in newsboat::Reloader::reload_range (this=0x56442bd73690, start=<optimized out>, end=<optimized out>, size=567, unattended=false) at src/reloader.cpp:253
#6  0x00007f03249a7c60 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007f0324ecfea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
#8  0x00007f03246b1eaf in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Note that `this` pointer is zero in frame 3.

I failed to create a sufficiently small reproducible example; looks like one needs my cache file to trigger this, and also use more than one reload thread.

I also failed to pinpoint the exact reason for the segfault. However, while reading the code I noticed that:

1. `FeedContainer` stores a vector of feeds, and that vector *is public*;
2. the vector is protected by a private `FeedContainer::feeds_mutex`, which is used in all relevant methods of `FeedContainer`;
3. `Controller` has its own `feeds_mutex` and uses it every time it accesses `FeedContainer::feeds`.

I guess this is a leftover from a refactoring we made a few years back, when we split `Controller` into smaller classes — that's when we introduced `FeedContainer` (https://github.com/newsboat/newsboat/pull/216).

This fixes the segfault for me. If `newsboat -r` segfaults for someone else, please check out these changes and see if they fix it for you, too.

Reviews welcome! I'll merge this in three days, provided the CI is green and no issues are raised.