### PR TITLE
Refactor ColorManager

### DIFF
--- a/include/colormanager.h
+++ b/include/colormanager.h
@@ -29,8 +29,8 @@ public:
 	void handle_action(const std::string& action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) override;
-	void apply_colors(Stfl::Form& form);
-	std::map<std::string, TextStyle> get_styles()
+	void apply_colors(Stfl::Form& form) const;
+	std::map<std::string, TextStyle> get_styles() const
 	{
 		return element_styles;
 	}

--- a/include/colormanager.h
+++ b/include/colormanager.h
@@ -22,10 +22,6 @@ public:
 	void handle_action(const std::string& action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) override;
-	bool colors_loaded()
-	{
-		return colors_loaded_;
-	}
 	void set_pb_colors(podboat::PbView* v);
 	std::map<std::string, std::string>& get_fgcolors()
 	{
@@ -41,7 +37,6 @@ public:
 	}
 
 private:
-	bool colors_loaded_;
 	std::map<std::string, std::string> fg_colors;
 	std::map<std::string, std::string> bg_colors;
 	std::map<std::string, std::vector<std::string>> attributes;

--- a/include/colormanager.h
+++ b/include/colormanager.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "configparser.h"
+#include "stflpp.h"
 
 namespace podboat {
 class PbView;
@@ -28,7 +29,7 @@ public:
 	void handle_action(const std::string& action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) override;
-	void set_pb_colors(podboat::PbView* v);
+	void apply_colors(Stfl::Form& form);
 	std::map<std::string, TextStyle> get_styles()
 	{
 		return element_styles;

--- a/include/colormanager.h
+++ b/include/colormanager.h
@@ -14,6 +14,12 @@ class View;
 
 namespace newsboat {
 
+struct TextStyle {
+	std::string fg_color;
+	std::string bg_color;
+	std::vector<std::string> attributes;
+};
+
 class ColorManager : public ConfigActionHandler {
 public:
 	ColorManager();
@@ -23,23 +29,13 @@ public:
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) override;
 	void set_pb_colors(podboat::PbView* v);
-	std::map<std::string, std::string>& get_fgcolors()
+	std::map<std::string, TextStyle> get_styles()
 	{
-		return fg_colors;
-	}
-	std::map<std::string, std::string>& get_bgcolors()
-	{
-		return bg_colors;
-	}
-	std::map<std::string, std::vector<std::string>>& get_attributes()
-	{
-		return attributes;
+		return element_styles;
 	}
 
 private:
-	std::map<std::string, std::string> fg_colors;
-	std::map<std::string, std::string> bg_colors;
-	std::map<std::string, std::vector<std::string>> attributes;
+	std::map<std::string, TextStyle> element_styles;
 };
 
 } // namespace newsboat

--- a/include/controller.h
+++ b/include/controller.h
@@ -106,6 +106,11 @@ public:
 		return filters;
 	}
 
+	ColorManager& get_colormanager()
+	{
+		return colorman;
+	}
+
 private:
 	void import_opml(const std::string& opmlFile, const std::string& urlFile);
 	void export_opml();

--- a/include/controller.h
+++ b/include/controller.h
@@ -106,7 +106,7 @@ public:
 		return filters;
 	}
 
-	ColorManager& get_colormanager()
+	const ColorManager& get_colormanager()
 	{
 		return colorman;
 	}

--- a/include/pbcontroller.h
+++ b/include/pbcontroller.h
@@ -62,6 +62,11 @@ public:
 		return cfg;
 	}
 
+	newsboat::ColorManager& get_colormanager()
+	{
+		return colorman;
+	}
+
 private:
 	void print_usage(const char* argv0);
 	bool setup_dirs_xdg(const char* env_home);

--- a/include/pbcontroller.h
+++ b/include/pbcontroller.h
@@ -62,7 +62,7 @@ public:
 		return cfg;
 	}
 
-	newsboat::ColorManager& get_colormanager()
+	const newsboat::ColorManager& get_colormanager()
 	{
 		return colorman;
 	}

--- a/include/pbview.h
+++ b/include/pbview.h
@@ -25,6 +25,7 @@ public:
 	{
 		keys = k;
 	}
+	void apply_colors_to_all_formactions();
 
 private:
 	friend class newsboat::ColorManager;
@@ -48,6 +49,7 @@ private:
 	newsboat::Stfl::Form dllist_form;
 	newsboat::Stfl::Form help_form;
 	newsboat::KeyMap* keys;
+	newsboat::ColorManager& colorman;
 
 	ListWidget downloads_list;
 	TextviewWidget help_textview;

--- a/include/pbview.h
+++ b/include/pbview.h
@@ -25,11 +25,9 @@ public:
 	{
 		keys = k;
 	}
-	void apply_colors_to_all_formactions();
+	void apply_colors_to_all_forms();
 
 private:
-	friend class newsboat::ColorManager;
-
 	struct KeyMapHintEntry {
 		Operation op;
 		char* text;

--- a/include/pbview.h
+++ b/include/pbview.h
@@ -47,7 +47,7 @@ private:
 	newsboat::Stfl::Form dllist_form;
 	newsboat::Stfl::Form help_form;
 	newsboat::KeyMap* keys;
-	newsboat::ColorManager& colorman;
+	const newsboat::ColorManager& colorman;
 
 	ListWidget downloads_list;
 	TextviewWidget help_textview;

--- a/include/view.h
+++ b/include/view.h
@@ -169,7 +169,7 @@ protected:
 	unsigned int tab_count;
 	Cache* rsscache;
 	FilterContainer& filters;
-	ColorManager& colorman;
+	const ColorManager& colorman;
 	std::vector<std::string> suggestions;
 };
 

--- a/include/view.h
+++ b/include/view.h
@@ -108,8 +108,6 @@ public:
 
 	void force_redraw();
 
-	void set_text_styles(std::map<std::string, TextStyle> styles);
-
 	void notify_itemlist_change(std::shared_ptr<RssFeed> feed);
 
 	void feedlist_mark_pos_if_visible(unsigned int pos);
@@ -154,8 +152,6 @@ protected:
 	KeyMap* keys;
 	std::mutex mtx;
 
-	friend class ColorManager;
-
 	std::vector<std::shared_ptr<FormAction>> formaction_stack;
 	unsigned int current_formaction;
 	std::shared_ptr<FeedListFormAction> feedlist_form;
@@ -173,6 +169,7 @@ protected:
 	unsigned int tab_count;
 	Cache* rsscache;
 	FilterContainer& filters;
+	ColorManager& colorman;
 	std::vector<std::string> suggestions;
 };
 

--- a/include/view.h
+++ b/include/view.h
@@ -108,9 +108,7 @@ public:
 
 	void force_redraw();
 
-	void set_colors(std::map<std::string, std::string>& fg_colors,
-		std::map<std::string, std::string>& bg_colors,
-		std::map<std::string, std::vector<std::string>>& attributes);
+	void set_text_styles(std::map<std::string, TextStyle> styles);
 
 	void notify_itemlist_change(std::shared_ptr<RssFeed> feed);
 
@@ -166,9 +164,7 @@ protected:
 
 	RegexManager& rxman;
 
-	std::map<std::string, std::string> fg_colors;
-	std::map<std::string, std::string> bg_colors;
-	std::map<std::string, std::vector<std::string>> attributes;
+	std::map<std::string, TextStyle> text_styles;
 
 	bool is_inside_qna;
 	bool is_inside_cmdline;

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -40,32 +40,32 @@ rss/rssparserfactory.o: rss/rssparserfactory.cpp rss/rssparserfactory.h \
 src/cache.o: src/cache.cpp include/cache.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h config.h \
  include/configcontainer.h include/controller.h include/cache.h \
- include/colormanager.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- include/dbexception.h include/logger.h include/strprintf.h \
- include/matcherexception.h include/rssfeed.h include/utils.h \
- include/logger.h include/scopemeasure.h include/strprintf.h \
- include/utils.h
+ include/colormanager.h include/stflpp.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ 3rd-party/optional.hpp include/dbexception.h include/logger.h \
+ include/strprintf.h include/matcherexception.h include/rssfeed.h \
+ include/utils.h include/logger.h include/scopemeasure.h \
+ include/strprintf.h include/utils.h
 src/cliargsparser.o: src/cliargsparser.cpp include/cliargsparser.h \
  3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
  include/globals.h include/ruststring.h include/strprintf.h
 src/colormanager.o: src/colormanager.cpp include/colormanager.h \
- include/configparser.h include/configactionhandler.h config.h \
- include/confighandlerexception.h include/feedlistformaction.h \
+ include/configparser.h include/configactionhandler.h include/stflpp.h \
+ config.h include/confighandlerexception.h include/feedlistformaction.h \
  3rd-party/optional.hpp include/configcontainer.h include/history.h \
  include/listformaction.h include/formaction.h include/keymap.h \
- include/stflpp.h include/listwidget.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+ include/listwidget.h include/listformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/view.h include/colormanager.h include/controller.h \
+ include/cache.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h include/opml.h include/fileurlreader.h \
+ include/urlreader.h include/queuemanager.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/dirbrowserformaction.h \
  include/feedlistformaction.h include/filebrowserformaction.h \
  include/htmlrenderer.h include/textformatter.h \
  include/filebrowserformaction.h include/helpformaction.h \
@@ -102,7 +102,7 @@ src/configpaths.o: src/configpaths.cpp include/configpaths.h \
  include/strprintf.h
 src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/colormanager.h \
+ include/configactionhandler.h include/colormanager.h include/stflpp.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
  include/opml.h include/fileurlreader.h include/urlreader.h \
  include/queuemanager.h include/regexmanager.h include/matcher.h \
@@ -126,9 +126,9 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/strprintf.h include/ttrssapi.h include/ttrssurlreader.h \
  include/utils.h include/view.h include/controller.h \
  include/dirbrowserformaction.h include/listformatter.h \
- include/listwidget.h include/stflpp.h include/formaction.h \
- include/history.h include/keymap.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h
+ include/listwidget.h include/formaction.h include/history.h \
+ include/keymap.h include/feedlistformaction.h include/listformaction.h \
+ include/view.h include/filebrowserformaction.h
 src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/dialogsformaction.h include/formaction.h include/history.h \
  include/keymap.h include/configparser.h include/configactionhandler.h \
@@ -165,7 +165,7 @@ src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
  include/pbcontroller.h include/colormanager.h include/configparser.h \
- include/configactionhandler.h include/configcontainer.h \
+ include/configactionhandler.h include/stflpp.h include/configcontainer.h \
  include/download.h include/fslock.h include/keymap.h \
  include/queueloader.h
 src/downloadthread.o: src/downloadthread.cpp include/downloadthread.h \
@@ -441,22 +441,21 @@ src/opmlurlreader.o: src/opmlurlreader.cpp include/opmlurlreader.h \
  3rd-party/optional.hpp include/logger.h config.h include/strprintf.h
 src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
  include/colormanager.h include/configparser.h \
- include/configactionhandler.h include/configcontainer.h \
+ include/configactionhandler.h include/stflpp.h include/configcontainer.h \
  include/download.h include/fslock.h include/keymap.h \
  include/queueloader.h config.h include/configcontainer.h \
  include/configexception.h include/globals.h include/logger.h \
  include/strprintf.h include/matcherexception.h \
  include/nullconfigactionhandler.h include/pbview.h include/listwidget.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/stflpp.h \
- include/textviewwidget.h include/poddlthread.h include/queueloader.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h
+ filter/FilterParser.h include/regexowner.h include/textviewwidget.h \
+ include/poddlthread.h include/queueloader.h include/strprintf.h \
+ include/utils.h 3rd-party/optional.hpp include/logger.h
 src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
- include/configparser.h include/configactionhandler.h include/keymap.h \
- include/listwidget.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/stflpp.h include/textviewwidget.h config.h \
+ include/configparser.h include/configactionhandler.h include/stflpp.h \
+ include/keymap.h include/listwidget.h include/listformatter.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/textviewwidget.h config.h \
  include/configcontainer.h stfl/dllist.h include/download.h \
  include/fmtstrformatter.h stfl/help.h include/listformatter.h \
  include/logger.h include/strprintf.h include/pbcontroller.h \
@@ -491,36 +490,36 @@ src/regexowner.o: src/regexowner.cpp include/regexowner.h
 src/reloader.o: src/reloader.cpp include/reloader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/controller.h include/cache.h \
- include/colormanager.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- include/curlhandle.h include/dbexception.h include/downloadthread.h \
- include/fmtstrformatter.h include/reloadrangethread.h \
- include/reloadthread.h include/controller.h rss/exception.h \
- include/rssfeed.h include/utils.h include/logger.h config.h \
- include/strprintf.h include/rssparser.h rss/feed.h rss/item.h \
+ include/colormanager.h include/stflpp.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ 3rd-party/optional.hpp include/curlhandle.h include/dbexception.h \
+ include/downloadthread.h include/fmtstrformatter.h \
+ include/reloadrangethread.h include/reloadthread.h include/controller.h \
+ rss/exception.h include/rssfeed.h include/utils.h include/logger.h \
+ config.h include/strprintf.h include/rssparser.h rss/feed.h rss/item.h \
  include/scopemeasure.h include/utils.h include/view.h \
  include/dirbrowserformaction.h include/listformatter.h \
- include/listwidget.h include/stflpp.h include/formaction.h \
- include/history.h include/keymap.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/listwidget.h include/formaction.h include/history.h \
+ include/keymap.h include/feedlistformaction.h include/listformaction.h \
+ include/view.h include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/reloadrangethread.o: src/reloadrangethread.cpp \
  include/reloadrangethread.h include/reloader.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h
 src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/controller.h include/cache.h \
- include/colormanager.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- include/logger.h config.h include/strprintf.h
+ include/colormanager.h include/stflpp.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h
 src/remoteapi.o: src/remoteapi.cpp include/remoteapi.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/utils.h 3rd-party/optional.hpp \
@@ -642,7 +641,7 @@ src/utils.o: src/utils.cpp include/utils.h 3rd-party/optional.hpp \
  include/strprintf.h include/rs_utils.h
 src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
  include/colormanager.h include/configparser.h \
- include/configactionhandler.h include/configcontainer.h \
+ include/configactionhandler.h include/stflpp.h include/configcontainer.h \
  include/controller.h include/cache.h include/feedcontainer.h \
  include/filtercontainer.h include/fslock.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
@@ -650,21 +649,20 @@ src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
  include/regexowner.h include/reloader.h include/remoteapi.h \
  include/rssignores.h include/rssitem.h include/matchable.h \
  include/dirbrowserformaction.h include/listformatter.h \
- include/listwidget.h include/stflpp.h include/formaction.h \
- include/history.h include/keymap.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h config.h \
- include/dbexception.h stfl/dialogs.h include/dialogsformaction.h \
- include/exception.h stfl/feedlist.h stfl/filebrowser.h \
- include/fmtstrformatter.h include/formaction.h stfl/help.h \
- include/helpformaction.h include/textviewwidget.h include/htmlrenderer.h \
- stfl/itemlist.h include/itemlistformaction.h stfl/itemview.h \
- include/itemviewformaction.h include/keymap.h include/logger.h \
- include/strprintf.h include/matcherexception.h include/regexmanager.h \
- include/reloadthread.h include/rssfeed.h include/utils.h \
- include/logger.h include/selectformaction.h stfl/selecttag.h \
- include/strprintf.h stfl/urlview.h include/urlviewformaction.h \
- include/utils.h
+ include/listwidget.h include/formaction.h include/history.h \
+ include/keymap.h include/feedlistformaction.h include/listformaction.h \
+ include/view.h include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h config.h include/dbexception.h stfl/dialogs.h \
+ include/dialogsformaction.h include/exception.h stfl/feedlist.h \
+ stfl/filebrowser.h include/fmtstrformatter.h include/formaction.h \
+ stfl/help.h include/helpformaction.h include/textviewwidget.h \
+ include/htmlrenderer.h stfl/itemlist.h include/itemlistformaction.h \
+ stfl/itemview.h include/itemviewformaction.h include/keymap.h \
+ include/logger.h include/strprintf.h include/matcherexception.h \
+ include/regexmanager.h include/reloadthread.h include/rssfeed.h \
+ include/utils.h include/logger.h include/selectformaction.h \
+ stfl/selecttag.h include/strprintf.h stfl/urlview.h \
+ include/urlviewformaction.h include/utils.h
 test/cache.o: test/cache.cpp include/cache.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h 3rd-party/catch.hpp \
  include/configcontainer.h include/rssfeed.h include/matchable.h \
@@ -679,8 +677,8 @@ test/cliargsparser.o: test/cliargsparser.cpp 3rd-party/catch.hpp \
  test/test-helpers/stringmaker/optional.h test/test-helpers/tempdir.h \
  test/test-helpers/maintempdir.h
 test/colormanager.o: test/colormanager.cpp include/colormanager.h \
- include/configparser.h include/configactionhandler.h 3rd-party/catch.hpp \
- include/confighandlerexception.h
+ include/configparser.h include/configactionhandler.h include/stflpp.h \
+ 3rd-party/catch.hpp include/confighandlerexception.h
 test/configcontainer.o: test/configcontainer.cpp \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h 3rd-party/catch.hpp include/configdata.h \

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -101,7 +101,7 @@ void ColorManager::dump_config(std::vector<std::string>& config_output)
 	}
 }
 
-void ColorManager::apply_colors(Stfl::Form& form)
+void ColorManager::apply_colors(Stfl::Form& form) const
 {
 	for (const auto& element_style : element_styles) {
 		const std::string& element = element_style.first;

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -101,11 +101,7 @@ void ColorManager::dump_config(std::vector<std::string>& config_output)
 	}
 }
 
-/*
- * this is podboat-specific color management
- * TODO: refactor this
- */
-void ColorManager::set_pb_colors(podboat::PbView* v)
+void ColorManager::apply_colors(Stfl::Form& form)
 {
 	for (const auto& element_style : element_styles) {
 		const std::string& element = element_style.first;
@@ -135,8 +131,7 @@ void ColorManager::set_pb_colors(podboat::PbView* v)
 			element,
 			colorattr);
 
-		v->dllist_form.set(element, colorattr);
-		v->help_form.set(element, colorattr);
+		form.set(element, colorattr);
 	}
 }
 

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -132,6 +132,23 @@ void ColorManager::apply_colors(Stfl::Form& form)
 			colorattr);
 
 		form.set(element, colorattr);
+
+		if (element == "article") {
+			std::string bold = colorattr;
+			std::string ul = colorattr;
+			if (bold.length() > 0) {
+				bold.append(",");
+			}
+			if (ul.length() > 0) {
+				ul.append(",");
+			}
+			bold.append("attr=bold");
+			ul.append("attr=underline");
+			// STFL will just ignore those in forms which don't have the
+			// `color_bold` and `color_underline` variables.
+			form.set("color_bold", bold.c_str());
+			form.set("color_underline", ul.c_str());
+		}
 	}
 }
 

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -20,7 +20,6 @@ using namespace podboat;
 namespace newsboat {
 
 ColorManager::ColorManager()
-	: colors_loaded_(false)
 {
 }
 
@@ -77,7 +76,6 @@ void ColorManager::handle_action(const std::string& action,
 			fg_colors[element] = fgcolor;
 			bg_colors[element] = bgcolor;
 			attributes[element] = attribs;
-			colors_loaded_ = true;
 		} else
 			throw ConfigHandlerException(strprintf::fmt(
 					_("`%s' is not a valid configuration element"),

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -883,12 +883,10 @@ void Controller::export_read_information(const std::string& readinfofile)
 
 void Controller::update_config()
 {
-	if (colorman.colors_loaded()) {
-		v->set_colors(colorman.get_fgcolors(),
-			colorman.get_bgcolors(),
-			colorman.get_attributes());
-		v->apply_colors_to_all_formactions();
-	}
+	v->set_colors(colorman.get_fgcolors(),
+		colorman.get_bgcolors(),
+		colorman.get_attributes());
+	v->apply_colors_to_all_formactions();
 
 	if (cfg.get_configvalue("error-log").length() > 0) {
 		try {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -883,9 +883,7 @@ void Controller::export_read_information(const std::string& readinfofile)
 
 void Controller::update_config()
 {
-	v->set_colors(colorman.get_fgcolors(),
-		colorman.get_bgcolors(),
-		colorman.get_attributes());
+	v->set_text_styles(colorman.get_styles());
 	v->apply_colors_to_all_formactions();
 
 	if (cfg.get_configvalue("error-log").length() > 0) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -883,7 +883,6 @@ void Controller::export_read_information(const std::string& readinfofile)
 
 void Controller::update_config()
 {
-	v->set_text_styles(colorman.get_styles());
 	v->apply_colors_to_all_formactions();
 
 	if (cfg.get_configvalue("error-log").length() > 0) {

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -291,9 +291,7 @@ int PbController::initialize(int argc, char* argv[])
 
 int PbController::run()
 {
-	if (colorman.colors_loaded()) {
-		colorman.set_pb_colors(v);
-	}
+	colorman.set_pb_colors(v);
 
 	max_dls = cfg->get_configvalue_as_int("max-downloads");
 

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -291,7 +291,7 @@ int PbController::initialize(int argc, char* argv[])
 
 int PbController::run()
 {
-	colorman.set_pb_colors(v);
+	v->apply_colors_to_all_formactions();
 
 	max_dls = cfg->get_configvalue_as_int("max-downloads");
 

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -291,7 +291,7 @@ int PbController::initialize(int argc, char* argv[])
 
 int PbController::run()
 {
-	v->apply_colors_to_all_formactions();
+	v->apply_colors_to_all_forms();
 
 	max_dls = cfg->get_configvalue_as_int("max-downloads");
 

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -29,6 +29,7 @@ PbView::PbView(PbController* c)
 	, dllist_form(dllist_str)
 	, help_form(help_str)
 	, keys(0)
+	, colorman(ctrl->get_colormanager())
 	, downloads_list("dls", dllist_form,
 		  ctrl->get_cfgcont()->get_configvalue_as_int("scrolloff"))
 	, help_textview("helptext", help_form)
@@ -256,6 +257,11 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		}
 
 	} while (!quit);
+}
+
+void PbView::apply_colors_to_all_formactions()
+{
+	colorman.set_pb_colors(this);
 }
 
 std::pair<double, std::string> PbView::get_speed_human_readable(double kbps)

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -259,9 +259,10 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 	} while (!quit);
 }
 
-void PbView::apply_colors_to_all_formactions()
+void PbView::apply_colors_to_all_forms()
 {
-	colorman.set_pb_colors(this);
+	colorman.apply_colors(dllist_form);
+	colorman.apply_colors(help_form);
 }
 
 std::pair<double, std::string> PbView::get_speed_human_readable(double kbps)

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -69,6 +69,7 @@ View::View(Controller* c)
 	, tab_count(0)
 	, rsscache(nullptr)
 	, filters(ctrl->get_filtercontainer())
+	, colorman(ctrl->get_colormanager())
 {
 	if (getenv("ESCDELAY") == nullptr) {
 		set_escdelay(25);
@@ -975,11 +976,6 @@ void View::remove_formaction(unsigned int pos)
 	}
 }
 
-void View::set_text_styles(std::map<std::string, TextStyle> styles)
-{
-	text_styles = styles;
-}
-
 void View::apply_colors_to_all_formactions()
 {
 	for (const auto& form : formaction_stack) {
@@ -996,6 +992,7 @@ void View::apply_colors(std::shared_ptr<FormAction> fa)
 	LOG(Level::DEBUG, "View::apply_colors: fa = %s", fa->id());
 
 	std::string article_colorstr;
+	const auto text_styles = colorman.get_styles();
 
 	for (const auto& text_style : text_styles) {
 		const std::string& element = text_style.first;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -991,59 +991,7 @@ void View::apply_colors(std::shared_ptr<FormAction> fa)
 {
 	LOG(Level::DEBUG, "View::apply_colors: fa = %s", fa->id());
 
-	std::string article_colorstr;
-	const auto text_styles = colorman.get_styles();
-
-	for (const auto& text_style : text_styles) {
-		const std::string& element = text_style.first;
-		const TextStyle& style = text_style.second;
-		std::string colorattr;
-		if (style.fg_color != "default") {
-			colorattr.append("fg=");
-			colorattr.append(style.fg_color);
-		}
-		if (style.bg_color != "default") {
-			if (colorattr.length() > 0) {
-				colorattr.append(",");
-			}
-			colorattr.append("bg=");
-			colorattr.append(style.bg_color);
-		}
-		for (const auto& attr : style.attributes) {
-			if (colorattr.length() > 0) {
-				colorattr.append(",");
-			}
-			colorattr.append("attr=");
-			colorattr.append(attr);
-		}
-
-		if (element == "article") {
-			article_colorstr = colorattr;
-			if (fa->id() == "article") {
-				std::string bold = article_colorstr;
-				std::string ul = article_colorstr;
-				if (bold.length() > 0) {
-					bold.append(",");
-				}
-				if (ul.length() > 0) {
-					ul.append(",");
-				}
-				bold.append("attr=bold");
-				ul.append("attr=underline");
-				fa->get_form().set("color_bold", bold.c_str());
-				fa->get_form().set(
-					"color_underline", ul.c_str());
-			}
-		}
-
-		LOG(Level::DEBUG,
-			"View::apply_colors: %s %s %s\n",
-			fa->id(),
-			element,
-			colorattr);
-
-		fa->get_form().set(element, colorattr);
-	}
+	colorman.apply_colors(fa->get_form());
 }
 
 void View::feedlist_mark_pos_if_visible(unsigned int pos)

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -975,13 +975,9 @@ void View::remove_formaction(unsigned int pos)
 	}
 }
 
-void View::set_colors(std::map<std::string, std::string>& fgc,
-	std::map<std::string, std::string>& bgc,
-	std::map<std::string, std::vector<std::string>>& attribs)
+void View::set_text_styles(std::map<std::string, TextStyle> styles)
 {
-	fg_colors = fgc;
-	bg_colors = bgc;
-	attributes = attribs;
+	text_styles = styles;
 }
 
 void View::apply_colors_to_all_formactions()
@@ -997,28 +993,26 @@ void View::apply_colors_to_all_formactions()
 
 void View::apply_colors(std::shared_ptr<FormAction> fa)
 {
-	auto fgcit = fg_colors.begin();
-	auto bgcit = bg_colors.begin();
-	auto attit = attributes.begin();
-
 	LOG(Level::DEBUG, "View::apply_colors: fa = %s", fa->id());
 
 	std::string article_colorstr;
 
-	for (; fgcit != fg_colors.end(); ++fgcit, ++bgcit, ++attit) {
+	for (const auto& text_style : text_styles) {
+		const std::string& element = text_style.first;
+		const TextStyle& style = text_style.second;
 		std::string colorattr;
-		if (fgcit->second != "default") {
+		if (style.fg_color != "default") {
 			colorattr.append("fg=");
-			colorattr.append(fgcit->second);
+			colorattr.append(style.fg_color);
 		}
-		if (bgcit->second != "default") {
+		if (style.bg_color != "default") {
 			if (colorattr.length() > 0) {
 				colorattr.append(",");
 			}
 			colorattr.append("bg=");
-			colorattr.append(bgcit->second);
+			colorattr.append(style.bg_color);
 		}
-		for (const auto& attr : attit->second) {
+		for (const auto& attr : style.attributes) {
 			if (colorattr.length() > 0) {
 				colorattr.append(",");
 			}
@@ -1026,7 +1020,7 @@ void View::apply_colors(std::shared_ptr<FormAction> fa)
 			colorattr.append(attr);
 		}
 
-		if (fgcit->first == "article") {
+		if (element == "article") {
 			article_colorstr = colorattr;
 			if (fa->id() == "article") {
 				std::string bold = article_colorstr;
@@ -1048,10 +1042,10 @@ void View::apply_colors(std::shared_ptr<FormAction> fa)
 		LOG(Level::DEBUG,
 			"View::apply_colors: %s %s %s\n",
 			fa->id(),
-			fgcit->first,
+			element,
 			colorattr);
 
-		fa->get_form().set(fgcit->first, colorattr);
+		fa->get_form().set(element, colorattr);
 	}
 }
 

--- a/test/colormanager.cpp
+++ b/test/colormanager.cpp
@@ -10,37 +10,6 @@
 using namespace newsboat;
 
 TEST_CASE(
-	"colors_loaded() signals if any \"color\" actions have been processed",
-	"[ColorManager]")
-{
-	ColorManager c;
-
-	{
-		INFO("By default, no colors are loaded");
-
-		REQUIRE_FALSE(c.colors_loaded());
-	}
-
-	{
-		INFO("Processing \"color\" action makes it return `true`");
-
-		c.handle_action("color", {"listnormal", "default", "default"});
-		REQUIRE(c.colors_loaded());
-	}
-
-	{
-		INFO("Processing more \"color\" actions doesn't affect the "
-			"return value");
-
-		c.handle_action("color", {"listfocus", "default", "default"});
-		REQUIRE(c.colors_loaded());
-		c.handle_action(
-			"color", {"listfocus_unread", "default", "cyan"});
-		REQUIRE(c.colors_loaded());
-	}
-}
-
-TEST_CASE(
 	"get_fgcolors() returns foreground colors for each element that "
 	"was processed",
 	"[ColorManager]")
@@ -112,9 +81,15 @@ TEST_CASE("register_commands() registers ColorManager with ConfigParser",
 
 	REQUIRE_NOTHROW(clr.register_commands(cfg));
 
-	REQUIRE_FALSE(clr.colors_loaded());
+	REQUIRE(clr.get_fgcolors().size() == 0);
+	REQUIRE(clr.get_bgcolors().size() == 0);
+	REQUIRE(clr.get_attributes().size() == 0);
+
 	cfg.parse_file("data/config-with-colors");
-	REQUIRE(clr.colors_loaded());
+
+	REQUIRE(clr.get_fgcolors().size() == 2);
+	REQUIRE(clr.get_bgcolors().size() == 2);
+	REQUIRE(clr.get_attributes().size() == 2);
 }
 
 TEST_CASE(


### PR DESCRIPTION
Improvements:
- Don't handle 0 color rules as a special case (related to `colors_loaded`)
- Make it explicit that there are always the same amount of foreground colors, background colors and attribute vectors
- Remove code duplication between `ColorManager::set_pb_colors()` and `View::apply_colors()`