### PR TITLE
Revert "Cirrus: Allow FreeBSD 11.4 to fail"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,9 +3,6 @@ freebsd_task:
         - name: FreeBSD 11.4
           freebsd_instance:
             image: freebsd-11-4-release-amd64
-          # We expect this build to fail because "latest" repo for 11.4 is currently missing Rust.
-          allow_failures: true
-          skip_notifications: true
         - name: FreeBSD 12.1
           freebsd_instance:
             image: freebsd-12-1-release-amd64


### PR DESCRIPTION
This reverts commit 25d5ff744b931caf4f4571937be6d1b2bfd5d94c.

The build with FreeBSD 11.4 succeeds now: https://cirrus-ci.com/task/5515721159475200