### PR TITLE
Fix query feeds with colons in quoted regex

### DIFF
--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -208,8 +208,7 @@ void RssFeed::set_rssurl(const std::string& u)
 		 * query:Title:unread = "yes" and age between 0:7
 		 *
 		 * So we split by colons to get title and the query itself. */
-		std::vector<std::string> tokens =
-			utils::tokenize_quoted(u, ":");
+		const auto tokens = utils::tokenize(u, ":");
 
 		if (tokens.size() < 3) {
 			throw _s("too few arguments");

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -26,6 +26,8 @@ TEST_CASE("RssFeed::set_rssurl() checks if query feed has a valid query",
 		REQUIRE_NOTHROW(f.set_rssurl("query:a title:unread = \"yes\""));
 		REQUIRE_NOTHROW(f.set_rssurl(
 				"query:Title:unread = \"yes\" and age between 0:7"));
+
+		REQUIRE_NOTHROW(f.set_rssurl(R"_(query:a title:title =~ "media:")_"));
 	}
 }
 


### PR DESCRIPTION
This bugfix is inspired by https://github.com/newsboat/newsboat/issues/1167. While trying to reproduce that issue, I created the following query feed:

    "query:only interest:title =~ \"vivid:\""

To my surprise, Newsboat then failed to start:

> Error while loading feed 'query:only interest:title =~ "vivid:"': `title =~ "vivid:' is not a valid filter expression

Note how the closing quote is missing at the end of the filter expression.

The problem was in RssFeed::set_rssurl(), which splits the query line into three components: "query:" prefix, the title, and the filter expression. set_rssurl() used utils::tokenize_quoted() for that, with colon as a delimiter.

If we just split the query on a colon, we get four tokens:

1. query
2. only interest
3. title =~ "vivid
4. "

But "_quoted" means that the method "understands" double quotes: their contents are treated as a single token. That method also has an interesting property of implicitly closing the quotes. All of that combined means that the fourth token above is treated as an empty string, *not* as a stand-alone double quote. Combining the third token with an (empty) fourth token, we then get a filter expression where the quotes are not balanced, leading to an error.

This was trivial to fix by replacing utils::tokenize_quoted() with utils::tokenize(), which doesn't "understand" double quotes.

Reviews are very much welcome! Otherwise I'll merge this in three days.