### PR TITLE
Explain where to send vulnerability reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Support
 * Check out our
   [documentation](https://newsboat.org/releases/2.20.1/docs/newsboat.html) and
   [FAQ](https://newsboat.org/releases/2.20.1/docs/faq.html)
-* Report vulnerabilities to security@newsboat.org. Please encrypt your emails to
+* Report security vulnerabilities to security@newsboat.org. Please encrypt your emails to
   [PGP key 4ED6CD61932B9EBE](https://newsboat.org/newsboat.pgp) if you can.
 * Report bugs and ask questions on
   [the issue tracker](https://github.com/newsboat/newsboat/issues) and

--- a/README.md
+++ b/README.md
@@ -118,10 +118,11 @@ Support
 * Check out our
   [documentation](https://newsboat.org/releases/2.20.1/docs/newsboat.html) and
   [FAQ](https://newsboat.org/releases/2.20.1/docs/faq.html)
-* Bugs and whatnot should be reported to the
-  [issue tracker](https://github.com/newsboat/newsboat/issues)
-* Drop us a line at
-  [newsboat mailing list](https://groups.google.com/group/newsboat)
+* Report vulnerabilities to security@newsboat.org. Please encrypt your emails to
+  [PGP key 4ED6CD61932B9EBE](https://newsboat.org/newsboat.pgp) if you can.
+* Report bugs and ask questions on
+  [the issue tracker](https://github.com/newsboat/newsboat/issues) and
+  [the mailing list](https://groups.google.com/group/newsboat)
   (newsboat@googlegroups.com)
 * Chat with developers and fellow users on #newsboat at
   [Freenode](https://freenode.net) ([webchat

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1434,16 +1434,19 @@ just works.
 
 include::chapter-environment-variables.asciidoc[]
 
-== Feedback
+== Feedback and security
 
-If you want to tell us something related to newsboat, don't hesitate to send
-an email to our mailing list: newsboat@googlegroups.com
+Please report vulnerabilities to security@newsboat.org, encrypting your
+emails to https://newsboat.org/newsboat.pgp[PGP key 4ED6CD61932B9EBE] if at all
+possible.
 
-Alternatively, you can reach the newsboat developers on IRC: channel
-#newsboat on irc.freenode.net.
+Non-security issues and general questions can be discussed on
+https://github.com/newsboat/newsboat/issues/[the issue tracker] and
+mailto:newsboat@googlegroups.com[the mailing list].
 
-If you want to report newsboat bugs, please use this issue tracker:
-https://github.com/newsboat/newsboat/issues/[]
+You can also chat with developers and fellow users on #newsboat at Freenode
+(irc.freenode.net or https://webchat.freenode.net/?channels=newsboat[via
+webchat]).
 
 == License
 

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1436,7 +1436,7 @@ include::chapter-environment-variables.asciidoc[]
 
 == Feedback and security
 
-Please report vulnerabilities to security@newsboat.org, encrypting your
+Please report security vulnerabilities to security@newsboat.org, encrypting your
 emails to https://newsboat.org/newsboat.pgp[PGP key 4ED6CD61932B9EBE] if at all
 possible.
 


### PR DESCRIPTION
I added an email forward from security@newsboat.org to my email, and would like to encourage people to report vulnerabilities there.

In addition to these changes to the docs, I added the following paragraph to [the website](https://newsboat.org/):

> If you have found a vulnerability, please email security@newsboat.org, and use the aforementioned PGP key if at all possible.

I'm open to suggestions on how to better phrase this, where to put it etc. Also open to feedback on the overall process. (I requested a review from @der-lyse because I run all the docs PR by him, and because I want to make sure at least one other person took a look at this.)

Will merge in three days if this is approved by @der-lyse and no-one else raised any issues.