### PR TITLE
Make utils::run_command() test less flaky

### DIFF
--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -621,17 +621,17 @@ TEST_CASE("run_command() doesn't wait for the command to finish",
 {
 	using namespace std::chrono;
 
-	const auto start = high_resolution_clock::now();
+	const auto start = steady_clock::now();
 
-	const std::string argument("5");
-	utils::run_command("sleep", argument);
+	// Using a big timeout value of 60 seconds to overcome any slowdowns that
+	// Cirrus CI sometimes exhibits, e.g. here waiting for `sleep 5` took 19
+	// seconds: https://cirrus-ci.com/task/6641382309756928?command=test#L64
+	utils::run_command("sleep", "60");
 
-	const auto finish = high_resolution_clock::now();
+	const auto finish = steady_clock::now();
 	const auto runtime = duration_cast<milliseconds>(finish - start);
 
-	// run_command finished under a second, meaning it didn't wait for
-	// a five-second sleep to finish
-	REQUIRE(runtime.count() < 1000);
+	REQUIRE(runtime.count() < 60000);
 }
 
 TEST_CASE("resolve_tilde() replaces ~ with the path to the $HOME directory",


### PR DESCRIPTION
PR #1172 changed the implementation of utils::run_command(), which
caused this function to sometimes take more than a second to execute,
failing the test:

    test/utils.cpp:634: FAILED:
      REQUIRE( runtime.count() < 1000 )
    with expansion:
      1087 (0x43f) < 1000 (0x3e8)

I couldn't reproduce this locally even though I ran the tests in a loop
for half an hour. This makes me think that this is a peculiarity of the
CI environment, not an actual bug in utils::run_command().

Since the test spawns `sleep 5`, it should be sufficient to check that
the function's runtime didn't exceed five seconds. Anything under that
guarantees that the function *didn't* wait for the `sleep` to finish.

I intend to merge this once the CI passes, but feel free to leave any comments you have even once this is merged — we can always work on this some more!