### PR TITLE
Update Russian and Ukrainian translations

### DIFF
--- a/doc/internal/howto-release.md
+++ b/doc/internal/howto-release.md
@@ -92,7 +92,9 @@ master repository and shell access to newsboat.org.
     * Close the current milestone
     * Create a new milestone with a date set to 20-ish of
         March/June/September/December
-12. Prepare the repo for the next release
+12. Add a TaskWarrior reminder to myself to update POT file and ask for updated
+    translations two weeks before the next release
+13. Prepare the repo for the next release
     * Add "Unreleased" section to CHANGELOG and commit
     * Update all the transitive dependencies: `cargo update` and commit
     * Push it: `git push`

--- a/po/ca.po
+++ b/po/ca.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2017-07-19 20:19+0300\n"
 "Last-Translator: Alejandro Gallo <aamsgallo@gmail.com>\n"
 "Language-Team: Alejandro Gallo <aamsgallo@gmail.com>, OmeGa <omega@mailoo."
@@ -57,11 +57,11 @@ msgstr "<arxiu caché>"
 msgid "use <cachefile> as cache file"
 msgstr "utilitzar <arxiu caché> com arxiu de caché"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<arxiu config>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "llegir configuració desde <arxiu config>"
 
@@ -85,19 +85,19 @@ msgstr "inicio silencioso"
 msgid "get version information"
 msgstr "mostrar informació de la versió"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<nivell log>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "escriure un registre amb un determinat nivell (valors vàlids: 1 a 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<arxiu log>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "utilitzar <arxiu log> com arxiu de salida per el registre"
 
@@ -109,7 +109,7 @@ msgstr "exportar llista d'articles llegits a <arxiu>"
 msgid "import list of read articles from <file>"
 msgstr "importar llista d'articles llegits desde <arxiu>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "esta ajuda"
 
@@ -176,23 +176,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' no és un color vàlid"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' no és un atribut vàlid"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' no és un element de configuració vàlid"
@@ -204,56 +204,56 @@ msgstr ""
 "newsboat: recàrrega finalitzada, %f fonts no llegides (%n total d'articles "
 "no llegits)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N %V - Articles a la font «%T» (%u no llegits, %t en total) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Diàlegs"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - Les teves fonts (%u no llegides, %t en total)%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Obrir Fitxter&Guardar Fitxer? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Obrir Fitxter&Guardar Fitxer? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Ajuda"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Articles a la font «%T» (%u no llegits, %t en total) - %U"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Resultat de la búsqueda (%u no llegits, %t en total)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Seleccionar filtre"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Seleccionar etiqueta"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
@@ -294,38 +294,43 @@ msgstr "no es va poder obrir l'arxiu."
 msgid "unknown error (bug)."
 msgstr "error desconegut (error de software)."
 
-#: src/configparser.cpp:112
-#, fuzzy, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Error al processar el comando `%s' (%s línea %u): %s"
+#: src/configparser.cpp:98
+#, c-format
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "comando invàlid `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Error al processar el comando `%s' (%s línea %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Iniciant %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Error: una instància de %s ja s'està executant (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Carregant configuració..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "fet."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Obrint caché..."
 
@@ -343,23 +348,33 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Carregant URLs desde %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -368,7 +383,7 @@ msgstr ""
 "Error: no hi ha URLs configurades. Per favor omple l'arxiu %s amb URLs de "
 "fonts RSS, o importa un arxiu OPML."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -376,7 +391,7 @@ msgstr ""
 "Sembla que la font OPML a la cual et vas subscriure no conté fonts. Por "
 "favor llénala amb fonts, e intenta-ho de nou."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -385,7 +400,7 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de The Old Reader. Si "
 "us plau fes-ho i intenta-ho de nou."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -394,7 +409,7 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de Tiny Tiny RSS. Si "
 "us plau fes-ho e intenta-ho de nou."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -403,7 +418,7 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de NewsBlur Reader. "
 "Si us plau fes-ho e intenta-ho de nou."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -412,69 +427,78 @@ msgstr ""
 "Sembla que no has configurat cap font en el teu compte de The Old Reader. Si "
 "us plau fes-ho i intenta-ho de nou."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Sembla que no has configurat cap font en el teu compte de NewsBlur Reader. "
+"Si us plau fes-ho e intenta-ho de nou."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Carregant articles des del caché..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Netejant el caché totalment..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Error al carregar les fonts desde la base de dades: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Error al carregar la font «%s»: %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Omplint les fonts de consulta..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Important la llista d'articles llegits..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Exportant la llista d'articles llegits..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Netejant el caché..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "va fallar: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Error: no es van poder marcar com llegides totes les fonts: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, fuzzy, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ocurrió un error al processar %s."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importació de %s finalitzada."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u articles no llegits"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "comando invàlid `%s'"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: no es va poder obrir l'arxiu de configuració `%s'!"
@@ -495,26 +519,26 @@ msgstr "Tancar diàleg"
 msgid "Error: you can't remove the feed list!"
 msgstr "Error: no es pot eliminar la llista de fonts!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Posició invàlida!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Guardar"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Guardar arxiu - %s"
@@ -559,10 +583,6 @@ msgstr "reproduït"
 msgid "unknown (bug)."
 msgstr "desconegut (error de software)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "índex de fonts invàlid (error de software)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Gent a la que segueixes"
@@ -576,21 +596,21 @@ msgstr "Elements destacats"
 msgid "Shared items"
 msgstr "Elements compartits"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Ninguna font seleccionada!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 #, fuzzy
 msgid "ftauln"
 msgstr "ptaln"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -599,7 +619,7 @@ msgstr ""
 "¿Ordenar per (p)rimera etiqueta/(t)ítulo/número de (a)rtículos/número de "
 "articles no (l)eídos/(n)ada?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -608,158 +628,174 @@ msgstr ""
 "¿Ordenar inversament per (p)rimera etiqueta/(t)ítulo/número de (a)rtículos/"
 "número d'articles no (l)eídos/(n)ada?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Obrir article en el navegador"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Marcant font com llegida..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Error: no es va poder marcar la font com llegida: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "No hi ha fonts amb elements no llegits."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Ja estàs en la última font."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Ja estàs en la primera font."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "¿Realment desitjes sobrescriure `%s' (s:Sí n:No)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "sn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "s"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Marcant totes les fonts com llegides..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Error: no es va poder processar el comando de filtre `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "No hi ha filtres definits."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Buscar: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "¿Realment desitjes sortir (s:Sí n:No)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "sn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "s"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Sortir"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Obrir"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Següent no llegit"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Actualitzar"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Actualitzar tot"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Marcar com llegit"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Marcar tot com llegit"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Buscar"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Ajuda"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Error: no es va poder processar el comando de filtre!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Buscant..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Error al buscar `%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "No hi ha resultats."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "La posició no és visible!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Llista de fonts - %u no llegides, %u en total"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "¿Realment desitjes sobrescriure `%s' (s:Sí n:No)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Arxiu: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Guardar arxiu - %s"
@@ -854,35 +890,35 @@ msgstr "Funcions no definides:"
 msgid "Clear"
 msgstr "Borrar"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "flash incrustado:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "imatge"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Enllaços: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "enllaç"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "flash incrustrat"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "desconegut (error de software)"
 
@@ -900,146 +936,146 @@ msgstr "Elements compartits"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Cap element seleccionat!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Cambiant l'estat de lectura per l'article..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Error al cambiar l'estat de lectura: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "llista de URLs vacía."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Indicadors: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Error: cap element seleccionat!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Error: no es pot recarregar resultats de búsqueda."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "No hi ha elements no llegits."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Ja estàs en el último element."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Ja estàs en el primer element."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "No hi ha fonts no llegides."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Marcant totes les fonts com llegides..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Encadenar article al comando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "ftmaeg"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 #, fuzzy
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "¿Ordenar per (f)echa/(t)ítulo/(i)ndicadors/(a)utor/(e)nlace/(g)uid?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 #, fuzzy
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "¿Ordenar inversament per (f)echa/(t)ítulo/(i)ndicadors/(a)utor/(e)nlace/"
 "(g)uid?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Indicadors actualizats."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: va fallar aplicar el filtre: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Guardat abortat."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Guardar article com %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: no es va poder guardar l'article com %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado de la búsqueda - «%s»"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Consultar font - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Llista d'articles - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1070,15 +1106,15 @@ msgstr "URL de descàrrega del podcast: "
 msgid "type: "
 msgstr "tipus: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Adalt"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Desota"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar l'article com llegit: %s"
@@ -1103,35 +1139,35 @@ msgstr "Article guardat com %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no es va poder escriure l'article en l'arxiu %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Iniciant el navegador..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar l'article com no llegit: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Anar a URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Obrir en el navegador"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Agregar a la cua"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Article - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Error: expressió regular invàlida!"
 
@@ -1183,12 +1219,14 @@ msgid "Save articles"
 msgstr "Guardar article"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Anar al següent article"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Anar a al entrada anterior"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Anar al article anterior"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Anar a la entrada següent"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1498,7 +1536,7 @@ msgstr "`%s' no és un context vàlid"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' no és un comando de tecla vàlid"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' no és un context vàlid"
@@ -1513,16 +1551,16 @@ msgstr "l'atribut `%s' no està disponible."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "l'expressió regular «%s» és invàlida: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Error fatal: no es va poder determinar el directori d'inici!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1530,21 +1568,21 @@ msgstr ""
 "Per favor defineix la variable d'entorn HOME, o afegeix un usuari vàlid per "
 "la UID %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Error: no es va poder obrir l'arxiu de configuració `%s'!"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: valor de loglevel invàlid"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Netejant cua..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1554,31 +1592,31 @@ msgstr ""
 "uso: %s [-i <arxiu>|-e] [-u <arxiu url>] [-c <arxiu caché>] [-x "
 "<comando> ...] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<arxiu caché>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "utilitzar <arxiu caché> com arxiu de caché"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "començar descàrrega en començar el programa"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u descàrregues paral.leles"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Cua (%u descàrregues en procés, %u en total) - %.2f kb/s total%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Error: no es pot sortir: descàrrega en progrés."
 
@@ -1587,7 +1625,7 @@ msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Error: la descàrrega deu finalizar abans de que es pugui reproduir l'arxiu."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Error: no es pot executar l'operació: descàrrega(s) en progrés."
 
@@ -1646,43 +1684,43 @@ msgstr "`%s' és un tipus de diàleg invàlid"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' no és una expressió regular vàlida: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sCarregant %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Error al obtenir %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Error: font invàlida!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "insuficients arguments"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' no és una expressió regular vàlida: %s"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr ""
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Error: URL no soportada: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Seleccionar etiqueta"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Seleccionar filtre"
 
@@ -1694,28 +1732,32 @@ msgstr "atribut no trobat"
 msgid "EOF found while reading XML tag"
 msgstr "EOF trobat al llegir l'etiqueta XML"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Cap enllaç seleccionat!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Guardar marcador"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Error: la font no conté elements!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "No hi ha etiquetes definides."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Actualitzant consulta de font..."
 
@@ -1765,7 +1807,7 @@ msgstr "format de font no suportat"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: valor de loglevel invàlid"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 #, fuzzy
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -1774,26 +1816,49 @@ msgstr ""
 "Per favor defineix la variable d'entorn HOME, o afegeix un usuari vàlid per "
 "la UID %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Error: l'apertura de l'arxiu de caché `%s' va fallar: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "índex de fonts invàlid (error de software)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Anar al següent article"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Anar al article anterior"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/de.po
+++ b/po/de.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2020-06-17 20:03+0200\n"
 "Last-Translator: Lysander Trischler <github@lyse.isobeef.org>\n"
 "Language-Team: Andreas Krennmair <ak@newsbeuter.org>, Simon Nagl "
@@ -58,11 +58,11 @@ msgstr "<cachedatei>"
 msgid "use <cachefile> as cache file"
 msgstr "<cachedatei> als Zwischenspeicherdatei verwenden"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<configdatei>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "Konfiguration aus <configdatei> lesen"
 
@@ -87,20 +87,20 @@ msgstr "ruhiger Start"
 msgid "get version information"
 msgstr "Versionsinformation anzeigen"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<loglevel>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 "Logdatei mit einem bestimmten Loglevel (gültige Werte: 1 bis 6) schreiben"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<logdatei>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "Logs nach <logdatei> schreiben"
 
@@ -112,7 +112,7 @@ msgstr "Liste von gelesenen Artikeln nach <datei> exportieren"
 msgid "import list of read articles from <file>"
 msgstr "Liste von gelesenen Artikeln aus <datei> importieren"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "diese Hilfe anzeigen"
 
@@ -161,16 +161,16 @@ msgid ""
 "- optional-lite library, licensed under the Boost Software License: https://"
 "github.com/martinmoene/optional-lite"
 msgstr ""
-"- optional-lite, unter der Boost-Software-Lizenz stehende Bibliothek: https://"
-"github.com/martinmoene/optional-lite"
+"- optional-lite, unter der Boost-Software-Lizenz stehende Bibliothek: "
+"https://github.com/martinmoene/optional-lite"
 
 #: newsboat.cpp:170
 msgid ""
 "- expected-lite library, licensed under the Boost Software License: https://"
 "github.com/martinmoene/expected-lite"
 msgstr ""
-"- expected-lite, unter der Boost-Software-Lizenz stehende Bibliothek: https://"
-"github.com/martinmoene/expected-lite"
+"- expected-lite, unter der Boost-Software-Lizenz stehende Bibliothek: "
+"https://github.com/martinmoene/expected-lite"
 
 #: newsboat.cpp:243
 #, c-format
@@ -182,23 +182,23 @@ msgstr "newsboat::DbException gefangen mit Nachricht: %s"
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "newsboat::MatcherException gefangen mit Nachricht: %s"
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "newsboat::Exception gefangen mit Nachricht: %s"
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' ist keine gültige Farbe"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' ist kein gültiges Attribut"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' ist kein gültiges Konfigurationselement"
@@ -210,19 +210,19 @@ msgstr ""
 "newsboat: Neuladen beendet, %f ungelesene Feeds (%n ungelesene Artikel "
 "insgesamt)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr ""
-"%N %V - Artikel im Feed '%T' (%u ungelesen, %t gesamt)%?F? passend "
-"auf Filter „%F“&? - %U"
+"%N %V - Artikel im Feed '%T' (%u ungelesen, %t gesamt)%?F? passend auf "
+"Filter „%F“&? - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialoge"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
@@ -230,37 +230,37 @@ msgstr ""
 "%N %V - %?F?Feeds&Ihre Feeds? (%u ungelesen, %t gesamt)%?F? passend auf "
 "Filter „%F“&?%?T? - Tag `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Datei öffnen&Datei speichern? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Verzeichnis öffnen&Datei speichern? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Hilfe"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artikel '%T' (%u ungelesen, %t gesamt)"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr ""
 "%N %V - Suchergebnisse (%u ungelesen, %t gesamt)%?F? passend auf Filter "
 "„%F“&?"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Filter auswählen"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Tag auswählen"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
@@ -299,38 +299,43 @@ msgstr "Datei konnte nicht geöffnet werden."
 msgid "unknown error (bug)."
 msgstr "Unbekannter Fehler (Bug)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Fehler beim Verarbeiten von Befehl `%s' (%s Zeile %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "unbekannter Befehl `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Fehler beim Verarbeiten von Befehl `%s' (%s Zeile %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Starte %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Fehler: Eine Instanz von %s läuft bereits (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Lade Konfiguration..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "Fertig."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Öffne Zwischenspeicher..."
 
@@ -349,7 +354,19 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr "Die Datei %s kann weder gelesen noch erstellt werden\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+#, fuzzy
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+"Fehler: Sie müssen „cookie-cache“ setzen, um NewsBlur verwenden zu können.\n"
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
@@ -357,17 +374,17 @@ msgstr ""
 "Fehler: Sie müssen *sowohl* „inoreader-app-id“ als auch „inoreader-app-key“ "
 "setzen, um Inoreader zu verwenden.\n"
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr "Fehler: Unbekannte urls-source „%s“"
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Lade URLs von %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -376,7 +393,7 @@ msgstr ""
 "Fehler: keine URLs konfiguriert. Bitte füllen Sie die Datei %s mit RSS-Feed-"
 "URLs oder importieren Sie eine OPML-Datei."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -384,7 +401,7 @@ msgstr ""
 "Es sieht so aus als würde die konfigurierte OPML-Datei keine Feeds "
 "enthalten. Bitte füllen Sie diese mit Feeds, und probieren Sie es erneut."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -392,7 +409,7 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem The-Old-Reader-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -400,7 +417,7 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem Tiny-Tiny-RSS-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -408,7 +425,7 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem NewsBlur-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -416,69 +433,78 @@ msgstr ""
 "Es sieht so aus als hätten Sie keine Feeds in Ihrem Inoreader-Account "
 "konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Es sieht so aus als hätten Sie keine Feeds in Ihrem NewsBlur-Account "
+"konfiguriert. Bitte tun Sie das, und probieren Sie es erneut."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Lade Artikel aus dem Zwischenspeicher..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Bereinige Zwischenspeicher gründlich..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Fehler beim Laden der Feeds aus der Datenbank: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Fehler beim Laden von Feed `%s': %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Query-Feed vorbefüllen..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Importiere Liste von gelesenen Artikeln..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Exportierte Liste von gelesenen Artikeln..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Bereinige Zwischenspeicher..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "Fehlgeschlagen: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Fehler: Konnte nicht alle Feeds als gelesen markieren: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ein Fehler ist beim Parsen von %s aufgetreten."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Import von %s fertig."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u ungelesene Artikel"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: unbekannter Befehl"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fehler: Konnte Konfigurationsdatei `%s' nicht öffnen!"
@@ -499,26 +525,26 @@ msgstr "Dialog schließen"
 msgid "Error: you can't remove the feed list!"
 msgstr "Fehler: Sie können die Feedliste nicht entfernen!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Ungültige Position!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr "Verzeichnis: "
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Speichern"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, c-format
 msgid "Save Files - %s"
 msgstr "Dateien speichern - %s"
@@ -563,10 +589,6 @@ msgstr "abgespielt"
 msgid "unknown (bug)."
 msgstr "Unbekannt (Bug)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "ungültiger Feed-Index (Bug)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Personen, deren regelmäßiger Leser Sie sind"
@@ -580,20 +602,20 @@ msgstr "markierte Artikel"
 msgid "Shared items"
 msgstr "empfohlene Artikel"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Kein Feed ausgewählt!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr "etauzn"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -601,7 +623,7 @@ msgstr ""
 "Sortieren nach (e)rstemtag/(t)itel/(a)rtikelzahl/(u)ngeleseneartikel/"
 "(z)uletztaktualisiert/(n)ichts?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -609,158 +631,174 @@ msgstr ""
 "Umgekehrt sortieren nach (e)rstemtag/(t)itel/(a)rtikelzahl/"
 "(u)ngeleseneartikel/(z)uletztaktualisiert/(n)ichts?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Artikel im Browser öffnen"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "Browser brach mit Rückgabestatus %i ab"
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "Query-Feeds können nicht im Browser geöffnet werden!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Markiere Feed als gelesen..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Fehler: Konnte Feed nicht als gelesen markieren: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Keine Feeds mit ungelesenen Artikeln."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Bereits beim letzten Feed."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Bereits beim ersten Feed."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Wollen Sie wirklich `%s' überschreiben (y:Ja n:Nein)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "jn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "j"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Markiere alle Feeds als gelesen..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Fehler: Konnte Filterkommando `%s' nicht parsen: %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Keine Filter definiert."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Suche nach: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Wollen Sie wirklich beenden (j:Ja n:Nein)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "jn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "j"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Beenden"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "nächster Ungelesener"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "neu laden"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "alle neu laden"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "gelesen markieren"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "alle gelesen markieren"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Suchen"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Hilfe"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Fehler: Konnte Filterkommando nicht parsen!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Suche..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Fehler beim Suchen nach `%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Keine Ergebnisse."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Position nicht sichtbar!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Feedliste - %u ungelesen, %u gesamt"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Wollen Sie wirklich `%s' überschreiben (y:Ja n:Nein)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Datei: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Datei speichern - %s"
@@ -852,35 +890,35 @@ msgstr "Unbelegte Funktionen:"
 msgid "Clear"
 msgstr "Löschen"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "Eingebettetes Flash: "
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "Bild"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Links: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "Link"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "eingebettetes Flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr "Video"
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr "Audio"
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "unbekannt (Bug)"
 
@@ -896,136 +934,136 @@ msgstr "für gut befundene Artikel"
 msgid "Saved web pages"
 msgstr "gespeicherte Webseiten"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Kein Element ausgewählt!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Schalte Gelesen-Flag für Artikel um..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Fehler beim Umschalten des Gelesen-Flags: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "URL-Liste leer."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Flags: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Fehler: Keinen Artikel ausgewählt!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Fehler: Sie können Suchergebnisse nicht neu laden."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Keine ungelesenen Artikel."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Bereits beim letzten Artikel."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Bereits beim ersten Artikel."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Keine ungelesenen Feeds."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr "Markiere alle obenstehenden Artikel als gelesen..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Artikel zu Befehl umleiten: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 msgid "dtfalgr"
 msgstr "dtfalgz"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sortieren nach (d)atum/(t)itel/(f)lags/(a)utor/(l)ink/(g)uid/(z)ufällig?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Umgekehrt sortieren nach (d)atum/(t)itel/(f)lags/(a)utor/(l)ink/(g)uid/"
 "(z)ufällig?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Flags aktualisiert."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Fehler: Anwenden des Filters fehlgeschlagen: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Speichern abgebrochen."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artikel nach %s gespeichert"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fehler: Konnte Artikel nicht nach %s speichern"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Suchergebnis - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Query-Feed - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikelliste - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "„%s“ in „%s“ überschreiben (j:Ja n:Nein)"
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr "jank"
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -1034,7 +1072,7 @@ msgstr ""
 "„%s“ in „%s“ überschreiben? Es gibt %d weitere Konflikte (j:Ja a:Alle "
 "überschreiben n:Nein k:Keine überschreiben)"
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1067,15 +1105,15 @@ msgstr "Podcast-Download-URL: "
 msgid "type: "
 msgstr "Typ: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Anfang"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Ende"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fehler beim Markieren des Artikels als gelesen: %s"
@@ -1100,35 +1138,35 @@ msgstr "Artikel nach %s gespeichert."
 msgid "Error: couldn't write article to file %s"
 msgstr "Fehler: Konnte Artikel nicht nach %s speichern"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Starte Browser..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Fehler beim Markieren des Artikels als ungelesen: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Gehe zu URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "im Browser öffnen"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "in Warteschlange"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Fehler: Ungültiger regulärer Ausdruck!"
 
@@ -1177,12 +1215,14 @@ msgid "Save articles"
 msgstr "Artikel speichern"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "zum nächsten Artikel gehen"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "zum nächsten Eintrag gehen"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "zum vorhergehenden Artikel gehen"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "zum vorhergehenden Eintrag gehen"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1492,7 +1532,7 @@ msgstr "`%s' ist kein gültiger Kontext"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' ist kein gültiges Tastenkommando"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, c-format
 msgid "`%s' is not a valid operation"
 msgstr "„%s“ ist keine gültige Operation"
@@ -1507,18 +1547,18 @@ msgstr "Attribut `%s' ist nicht verfügbar."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "Regulärer Ausdruck '%s' ist ungültig: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: Konfigurationsverzeichnis '%s' nicht zugänglich, benutze stattdessen "
 "'%s'."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Schwerer Fehler: Konnte das Home-Verzeichnis nicht feststellen!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1526,22 +1566,22 @@ msgstr ""
 "Bitte setzen Sie die Umgebungsvariable HOME oder fügen Sie einen gültigen "
 "Benutzer für UID %u hinzu!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Fataler Fehler: Konnte Konfigurationsverzeichnis „%s“ nicht anlegen: (%i) %s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: ungültiger Loglevel-Wert"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Bereinige Warteschlange..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1550,30 +1590,30 @@ msgstr ""
 "%s %s\n"
 "Verwendung: %s [-C <configdatei>] [-q <warteschlangendatei>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<warteschlangendatei>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "<warteschlangendatei> als Warteschlangendatei verwenden"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "beim Programmstart automatisch herunterladen"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u parallele Downloads"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr ""
 "Warteschlange (%u Downloads im Gange, %u insgesamt) - %.2f %s insgesamt%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Fehler: Kann nicht beenden: Download(s) im Gange."
 
@@ -1583,7 +1623,7 @@ msgstr ""
 "Fehler: Download muss abgeschlossen sein bevor die Datei abgespielt werden "
 "kann."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Fehler: Kann Vorgang nicht durchführen: Download(s) im Gange."
 
@@ -1644,43 +1684,43 @@ msgstr "`%s' ist ein ungültiger Dialogtyp"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' is kein gültiger regulärer Ausdruck: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sLade %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Fehler beim Abholen von %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Fehler: Ungültiger Feed!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "zu wenige Parameter"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' ist kein gültiger Filterausdruck"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Fehler: Nicht unterstützte URL: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Tag auswählen"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Filter auswählen"
 
@@ -1692,27 +1732,31 @@ msgstr "Attribut nicht gefunden"
 msgid "EOF found while reading XML tag"
 msgstr "Ende der Datei gefunden beim Lesen eines XML-Tags"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 msgid "No links available!"
 msgstr "Keine Links verfügbar!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Lesezeichen speichern"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Fehler: Feed enthält keine Elemente!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Keine Tags definiert."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Aktualisiere Query-Feed..."
 
@@ -1761,7 +1805,7 @@ msgstr "nicht unterstütztes Feed-Format"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %s: ungültiger Loglevel-Wert"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1770,25 +1814,48 @@ msgstr ""
 "Bitte setzen Sie die Umgebungsvariable HOME oder fügen Sie einen gültigen "
 "Benutzer für UID %u hinzu!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 "Migriere Konfigurationen und Daten aus Newsbeuters XDG-Verzeichnissen..."
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr "Migriere Konfigurationen und Daten aus „~/.newsbeuter/“..."
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr ""
 "Abbruch der Migration aufgrund eines Fehlers beim Anlegen des Verzeichnisses "
 "„%s“: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr "regcomp brach mit Rückgabestatus %i ab"
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr "regexec brach mit Rückgabestatus %i ab"
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "ungültiger Feed-Index (Bug)"
+
+#~ msgid "Go to next article"
+#~ msgstr "zum nächsten Artikel gehen"
+
+#~ msgid "Go to previous article"
+#~ msgstr "zum vorhergehenden Artikel gehen"

--- a/po/es.po
+++ b/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2020-04-21 23:43+0200\n"
 "Last-Translator: Marcos Cruz <github@programandala.net>\n"
 "Language-Team: ROOT <epsilon@correoe.no-ip.org>, OmeGa <omega@mailoo.org>, "
@@ -56,11 +56,11 @@ msgstr "<archivo>"
 msgid "use <cachefile> as cache file"
 msgstr "usar <archivo> como archivo de caché"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<archivo>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "leer configuración desde <archivo>"
 
@@ -84,19 +84,19 @@ msgstr "no mostrar mensajes al arrancar"
 msgid "get version information"
 msgstr "mostrar información de la versión"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<nivel>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "nivel de detalle para el archivo de registro (rango: 1 a 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<archivo>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "usar <archivo> como archivo de salida del registro"
 
@@ -108,7 +108,7 @@ msgstr "exportar lista de artículos leídos a <archivo>"
 msgid "import list of read articles from <file>"
 msgstr "importar lista de artículos leídos desde <archivo>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "esta ayuda"
 
@@ -183,23 +183,23 @@ msgstr "Se atrapó newsboat::DbException con el mensaje: %s"
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Se atrapó newsboat::MatcherException con el mensaje: %s"
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Se atrapó newsboat::Exception con el mensaje: %s"
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' no es un color válido"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' no es un atributo válido"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' no es un elemento de configuración válido"
@@ -211,55 +211,55 @@ msgstr ""
 "newsboat: recarga finalizada, %f fuentes no leídas (%n artículos no leídos "
 "en total)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N %V - Artículos en la fuente «%T» (%u no leídos, %t en total) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Diálogos"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - Tus fuentes (%u no leídas, %t en total)%?T? - etiqueta «%T»&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Abrir archivo&Guardar archivo? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Abrir directorio&Guardar archivo? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Ayuda"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artículo «%T» (%u no leídos, %t en total)"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Resultado de la búsqueda (%u no leídos, %t en total)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Seleccionar filtro"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Seleccionar etiqueta"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URL"
 
@@ -298,38 +298,43 @@ msgstr "no se pudo abrir el archivo."
 msgid "unknown error (bug)."
 msgstr "error desconocido (error de programa)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Error al procesar el comando `%s' (%s línea %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "comando desconocido `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Error al procesar el comando `%s' (%s línea %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Iniciando %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Error: una instancia de %s ya está ejecutándose (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Cargando la configuración..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "hecho."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Abriendo la caché..."
 
@@ -347,23 +352,34 @@ msgstr "ERROR: debe definir `cookie-cache` para usar NewsBlur.\n"
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s es inaccesible y no se puede crear\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+#, fuzzy
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr "ERROR: debe definir `cookie-cache` para usar NewsBlur.\n"
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Cargando las URL desde %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -372,7 +388,7 @@ msgstr ""
 "Error: no hay URL configuradas. Por favor, añade URL de fuentes RSS al "
 "archivo %s,o importa un archivo OPML."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -380,7 +396,7 @@ msgstr ""
 "Parece que la fuente OPML a la que estás suscrito no contiene fuentes. Por "
 "favor, añádelas e inténtalo de nuevo."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -388,7 +404,7 @@ msgstr ""
 "Parece que no has configurado fuentes en tu cuenta de The Old Reader. Por "
 "favor, hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -396,7 +412,7 @@ msgstr ""
 "Parece que no has configurado fuentes en tu cuenta de Tiny Tiny RSS. Por "
 "favor, hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -404,7 +420,7 @@ msgstr ""
 "Parece que no has configurado fuentes en tu cuenta de NewsBlur. Por favor, "
 "hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -412,69 +428,78 @@ msgstr ""
 "Parece que no has configurado fuentes en tu cuenta de Inoreader. Por favor, "
 "hazlo e inténtalo de nuevo."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Parece que no has configurado fuentes en tu cuenta de NewsBlur. Por favor, "
+"hazlo e inténtalo de nuevo."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Cargando artículos desde la caché..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Limpiando completamente la caché..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Error al cargar las fuentes desde la base de datos: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Error al cargar la fuente «%s»: %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Prerrellenando las fuentes de consulta..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Importando la lista de artículos leídos..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Exportando la lista de artículos leídos..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Limpiando la caché..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "falló: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Error: no se pudo marcar todas las fuentes como leídas: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ocurrió un error al procesar %s."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importación de %s finalizada."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u artículos no leídos"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: comando desconocido"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Error: no se pudo abrir el archivo de configuración `%s'."
@@ -495,26 +520,26 @@ msgstr "Cerrar el diálogo"
 msgid "Error: you can't remove the feed list!"
 msgstr "Error: no puedes eliminar la lista de fuentes."
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Posición incorrecta."
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr "Directorio: "
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Guardar"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, c-format
 msgid "Save Files - %s"
 msgstr "Guardar archivos - %s"
@@ -559,10 +584,6 @@ msgstr "reproducido"
 msgid "unknown (bug)."
 msgstr "desconocido (error de programa)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "índice de fuentes incorrecto (error de programa)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Gente que sigues"
@@ -576,20 +597,20 @@ msgstr "Elementos destacados"
 msgid "Shared items"
 msgstr "Elementos compartidos"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "No hay fuentes seleccionadas."
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr "ptasln"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -597,7 +618,7 @@ msgstr ""
 "¿Ordenar por (p)rimera etiqueta/(t)ítulo/número de (a)rtículos/número de "
 "artículos (s)in leer/ú(l)timo actualizado/(n)ada?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -605,158 +626,174 @@ msgstr ""
 "¿Ordenar decrecientemente por (p)rimera etiqueta/(t)ítulo/número de "
 "(a)rtículos/número de artículos (s)in leer/ú(l)timo actualizado/(n)ada?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Abrir artículo en el navegador"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "El navegador devolvió el código de error %i"
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "No se pudo abrir las fuentes de consulta en el navegador."
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Marcando la fuente como leída..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Error: no se pudo marcar la fuente como leída: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "No hay fuentes con elementos no leídos."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Ya estás en la última fuente."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Ya estás en la primera fuente."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "¿Realmente quieres sobreescribir `%s'? (s:Sí n:No) "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "sn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "s"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Marcando todas las fuentes como leídas..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Error: no se pudo procesar el comando de filtrado `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "No hay filtros creados."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Buscar: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "¿Realmente quieres salir? (s:Sí n:No)"
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "sn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "s"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Salir"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Abrir"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Siguiente no leído"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Recargar"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Recargar todo"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Marcar como leído"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Marcar todo como leído"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Buscar"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Ayuda"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Error: no se pudo procesar el comando de filtrado."
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Buscando..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Error al buscar «%s»: %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Sin resultados."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Posición no visible."
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista de fuentes - %u no leídas, %u en total"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "¿Realmente quieres sobreescribir `%s'? (s:Sí n:No) "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Archivo: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Guardar archivo - %s"
@@ -849,35 +886,35 @@ msgstr "Funciones sin atajo de teclado:"
 msgid "Clear"
 msgstr "Limpiar"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "flash incrustado:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "imagen"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Enlaces: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "enlace"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "flash incrustado"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr "vídeo"
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr "audio"
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "desconocido (error de programa)"
 
@@ -894,133 +931,133 @@ msgstr "Elementos favoritos"
 msgid "Saved web pages"
 msgstr "Páginas web guardadas"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "No hay elementos seleccionados."
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Cambiando la marca de lectura del artículo..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Error cambiando la marca de lectura: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "Lista de las URL vacía."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Marcas: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Error: ningún elemento seleccionado."
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Error: no puedes recargar los resultados de la búsqueda."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "No hay elementos por leer."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Ya estás en el último elemento."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Ya estás en el primer elemento."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "No hay fuentes por leer."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr "Marcando todo lo de arriba como leído..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Enviar artículo a comando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 msgid "dtfalgr"
 msgstr ""
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Marcas actualizadas."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Error: la aplicación del filtro falló: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Abortada la operación de guardar."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artículo guardado en %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Error: no se pudo guardar el artículo como %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado de la búsqueda - «%s»"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Consultar fuente - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista de artículos - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "Sobreescribir `%s' en `%s'? (s:Sí n:No)"
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr "stng"
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -1029,7 +1066,7 @@ msgstr ""
 "¿Sobreescribir `%s' en `%s'? Hay %d conflictos más como este (s:Sí t:Todos n:"
 "No g:Ninguno)"
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1062,15 +1099,15 @@ msgstr "URL de descarga del pódcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Arriba"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Abajo"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Error al marcar el artículo como leído: %s"
@@ -1095,35 +1132,35 @@ msgstr "Artículo guardado como %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Error: no se pudo escribir el artículo en el archivo %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Iniciando el navegador..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar el artículo como no leído: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Ir a URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Abrir en el navegador"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Añadir a la cola"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Artículo - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Error: expresión regular incorrecta."
 
@@ -1173,12 +1210,14 @@ msgid "Save articles"
 msgstr "Guardar artículos"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Ir al siguiente artículo"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Ir a al entrada siguiente"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Ir al artículo anterior"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Ir a la entrada anterior"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1489,7 +1528,7 @@ msgstr "`%s' no es un contexto válido"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' no es un atajo de teclado válido"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' no es un contexto válido"
@@ -1504,18 +1543,18 @@ msgstr "el atributo `%s' no está disponible."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "la expresión regular '%s' es incorrecta: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: el directorio de configuración '%s' no es accesible; se usará '%s' en "
 "su lugar."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Error fatal: no se pudo encontrar el directorio de usuario."
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1523,22 +1562,22 @@ msgstr ""
 "Por favor, define la variable de entorno HOME o añade un usuario válido para "
 "UID %u."
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Error fatal: no se pudo crear el archivo de configuración `%s': (%i) %s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: nivel de registro incorrecto"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Limpiando la cola..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1547,29 +1586,29 @@ msgstr ""
 "%s %s\n"
 "uso: %s [-C <file>] [-q <file>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<archivo>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "usar <archivo> como archivo de cola"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "iniciar descarga al inicio"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u descargas paralelas"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Cola (%u descargas en proceso, %u en total) - %.2f %s en total%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Error: no se puede salir: descarga(s) en proceso."
 
@@ -1577,7 +1616,7 @@ msgstr "Error: no se puede salir: descarga(s) en proceso."
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Error: la descarga debe terminar antes de poder reproducir el archivo."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Error: no se puede ejecutar la operación: hay descarga(s) en proceso."
 
@@ -1638,43 +1677,43 @@ msgstr "`%s' es un tipo incorrecto de diálogo"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' no es una expresión regular válida: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sCargando %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Error al descargar %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Error: fuente incorrecta."
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "pocos parámetros"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' no es una expresión de filtrado válida"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%F %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Error: URL no soportada: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Seleccionar etiqueta"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Seleccionar filtro"
 
@@ -1686,28 +1725,32 @@ msgstr "atributo no encontrado"
 msgid "EOF found while reading XML tag"
 msgstr "Fin de archivo (EOF) encontrado al leer una etiqueta XML"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Ningún enlace seleccionado."
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Guardar marcador"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URL"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Error: la fuente no contiene elementos."
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "No hay etiquetas definidas."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Actualizando la fuente de consulta..."
 
@@ -1756,7 +1799,7 @@ msgstr "formato de fuente no admitido"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %s: nivel de registro incorrecto"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1765,29 +1808,52 @@ msgstr ""
 "Por favor, define la variable de entorno HOME o añade un usuario válido para "
 "UID %u."
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 "Convirtiendo la configuración y los datos de los directorios XDG de "
 "Newsbeuter..."
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr "Convirtiendo la configuración y los datos de ~/.newsbeuter/..."
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Se detiene la conversión porque mkdir ha fallado en `%s': %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 #, fuzzy
 msgid "regcomp returned code %i"
 msgstr "El navegador devolvió el código de error %i"
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 #, fuzzy
 msgid "regexec returned code %i"
 msgstr "El navegador devolvió el código de error %i"
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "índice de fuentes incorrecto (error de programa)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Ir al siguiente artículo"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Ir al artículo anterior"
 
 #~ msgid "config"
 #~ msgstr "Configuración"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2017-07-11 10:22+0200\n"
 "Last-Translator: rugie <fliehen@posteo.net>\n"
 "Language-Team: Nicolas Martyanoff <khaelin@gmail.com>\n"
@@ -59,11 +59,11 @@ msgstr "<fichier_cache>"
 msgid "use <cachefile> as cache file"
 msgstr "utiliser <fichier_cache> comme fichier de cache"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<fichier_configuration>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "lire la configuration depuis <fichier_configuration>"
 
@@ -87,21 +87,21 @@ msgstr "démarrage silencieux (sans sortie d'affichage)"
 msgid "get version information"
 msgstr "obtenir des informations sur la version"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<verbosité_journal>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 "écrire un fichier de journal, à un certain degré de verbosité (valeurs "
 "acceptées : de 1 à 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<fichier_journal>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "utiliser <fichier_journal> pour écrire le journal"
 
@@ -113,7 +113,7 @@ msgstr "exporter la liste des articles lus vers <fichier>"
 msgid "import list of read articles from <file>"
 msgstr "importer une liste d'articles lus depuis <fichier>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "ce texte d'aide"
 
@@ -190,23 +190,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' n'est pas une valeur de couleur valide"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "'%s' n'est pas un attribut valide"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' n'est pas un élément de configuration valide"
@@ -217,55 +217,55 @@ msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr ""
 "newsboat : rechargement terminé, %f fils à lire (%n articles à lire au total)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N %V - Articles dans le fil '%T' (%u à lire, %t au total) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Vues"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - Vos fils (%u à lire, %t au total)%?T? - étiquette `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Ouvrir un fichier&Enregistrer le fichier? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Ouvrir un fichier&Enregistrer le fichier? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Aide"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Article '%T' (%u à lire, %t au total) - %U"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Résultat de la recherche (%u à lire, %t au total)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Choisir un filtre"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Choisir une étiquette"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - Liens"
 
@@ -304,38 +304,43 @@ msgstr "le fichier n'a pu être ouvert."
 msgid "unknown error (bug)."
 msgstr "erreur inconnue (bug)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Erreur lors du traitement de la commande `%s' (%s ligne %u) : %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "commande inconnue `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Erreur lors du traitement de la commande `%s' (%s ligne %u) : %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Démarrage de %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Erreur : %s est déjà en cours d'exécution (PID : %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Chargement de la configuration..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "fait."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Ouverture du cache..."
 
@@ -353,23 +358,33 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s est inaccessible et ne peut être créé\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Chargement des liens depuis %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -378,7 +393,7 @@ msgstr ""
 "Erreur : aucun lien renseigné. Veuillez remplir le fichier %s avec des liens "
 "de fils RSS ou importer un fichier OPML."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -386,7 +401,7 @@ msgstr ""
 "Il semble que le fichier OPML que vous avez ajouté ne contient aucun fil. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -394,7 +409,7 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte The Old Reader. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -402,7 +417,7 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte Tiny Tiny RSS. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -410,7 +425,7 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte NewsBlur. Ajoutez-"
 "en puis réessayez."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -418,69 +433,78 @@ msgstr ""
 "Il semble qu'aucun fil ne soit configuré dans votre compte Inoreader. "
 "Ajoutez-en puis réessayez."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Il semble qu'aucun fil ne soit configuré dans votre compte NewsBlur. Ajoutez-"
+"en puis réessayez."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Chargement des articles depuis le cache..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Nettoyage en profondeur du cache..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Erreur lors du chargement des fils depuis la base de données : "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Erreur lors du chargement du fil '%s' : %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Pré-remplissage des fils de requête ..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Importation de la liste d'articles lus..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Exportation de la liste d'articles lus..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Nettoyage du cache..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "échoué : "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Erreur : Tous les fils n'ont pu être marqués comme lus : %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Une erreur est survenue lors de l'analyse de %s."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importation de %s terminée."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u articles à lire"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s : %s : commande inconnue"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Erreur : échec de l'ouverture du fichier de configuration `%s' !"
@@ -501,26 +525,26 @@ msgstr "Fermer la vue"
 msgid "Error: you can't remove the feed list!"
 msgstr "Erreur : la liste de fils ne peut être supprimée !"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Position invalide !"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Enregistrer"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Enregistrer le fichier - %s"
@@ -565,10 +589,6 @@ msgstr "lu"
 msgid "unknown (bug)."
 msgstr "inconnu (bug)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "Index de fil invalide (bug)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Personnes que vous suivez"
@@ -582,21 +602,21 @@ msgstr "Éléments favoris"
 msgid "Shared items"
 msgstr "Éléments partagés"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Aucun fil sélectionné !"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 #, fuzzy
 msgid "ftauln"
 msgstr "ptnia"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -605,7 +625,7 @@ msgstr ""
 "Trier par (p)remière étiquette/(t)itre/(n)ombre d'articles/nombre d'articles "
 "à l(i)re/(a)ucun ?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -614,159 +634,175 @@ msgstr ""
 "Trier en sens inverse par (p)remier tag/(t)itre/(n)nombre d'articles/nombre "
 "d'articles à l(i)re/(a)ucun ?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Ouvrir l'article dans le navigateur"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 "Les fils de requête ne sont pas faits pour être ouverts dans un navigateur !"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Fil marqué comme étant lu..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Erreur : Le fil n'a pu être marqué comme étant lu : %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Aucun fil ne possède des éléments à lire"
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Vous êtes déjà au dernier fil."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Vous êtes déjà au premier fil."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Souhaitez-vous réellement écraser `%s' (y : Oui n : No)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "on"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "o"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Tous les fils sont marqués comme lus..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Erreur : échec lors de l'analyse de l'expression de filtrage `%s' : %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Aucun filtre défini."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Rechercher : "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filtre : "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Souhaitez-vous réellement quitter (o : Oui n : Non) ? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "on"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "o"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Quitter"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Ouvrir"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Suivant"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Recharger"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Tout recharger"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Marquer comme lu"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Tout marquer comme lu"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Rechercher"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Aide"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Erreur : l'analyse de l'expression de filtrage a échoué !"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Recherche en cours..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Erreur lors de la recherche de '%s' : %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Aucun résultat."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Position non visible !"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Liste de fils - %u à lire, %u au total"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Souhaitez-vous réellement écraser `%s' (y : Oui n : No)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Fichier : "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Enregistrer le fichier - %s"
@@ -859,35 +895,35 @@ msgstr "Fonctions non attribuées :"
 msgid "Clear"
 msgstr "Effacer"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "flash embarqué :"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "image"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Liens : "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "lien"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "flash embarqué"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "inconnu (bug)"
 
@@ -903,145 +939,145 @@ msgstr "Éléments favoris"
 msgid "Saved web pages"
 msgstr "Pages web sauvegardées"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Aucun élément sélectionné !"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Basculement de l'état de lecture de l'article..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Erreur lors du basculement de l'état de lecture : %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "L'article ne contient aucun lien."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Signaux : "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Erreur : aucun élément sélectionné !"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Erreur : les résultats de recherche ne peuvent être rechargés."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Aucun élément à lire."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Déjà au dernier élément."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Déjà au premier élément."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Aucun fil ne contient d'éléments à lire."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Tous les fils sont marqués comme lus..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Passer l'article à la commande : "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "dtxalg"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 #, fuzzy
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Trier par (d)ate/(t)itre/signau(x)/(a)uteur/(l)ien/(g)uid ?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 #, fuzzy
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Trier en sens inverse par (d)ate/(t)itre/signau(x)/(a)uteur/(l)ien/(g)uid ?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Signaux actualisés."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Erreur : l'application du filtre a échoué : %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Enregistrement annulé."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Article enregistré dans %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Erreur : l'article n'a pu être enregistré dans %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Résultats de la recherche - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Fil de requête - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Articles - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1072,15 +1108,15 @@ msgstr "Lien de téléchargement du podcast : "
 msgid "type: "
 msgstr "type : "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Début"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Fin"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Erreur lors du passage de l'article à l'état lu : %s"
@@ -1105,35 +1141,35 @@ msgstr "Article enregistré dans %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Erreur : échec lors de l'enregistrement vers %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Lancement du navigateur..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Erreur en marquant l'article comme lu : %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Aller à l'addresse #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Ouvrir dans le navigateur"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Ajouter à la file d'attente"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Article - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Erreur : expression régulière incorrecte !"
 
@@ -1184,12 +1220,14 @@ msgid "Save articles"
 msgstr "Enregistrer article"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Passer à l'article suivant"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Passer au prochain élément"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Passer à l'article précédent"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Passer à l'élément précédent"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1500,7 +1538,7 @@ msgstr "`%s' n'est pas un contexte valide"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' n'est pas un raccourci correct"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' n'est pas un contexte valide"
@@ -1515,19 +1553,19 @@ msgstr "l'attribut '%s' n'est pas disponible."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "l'expression régulière '%s' est invalide : %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG : le répertoire de configuration '%s' n'est pas accessible, '%s' sera "
 "utilisé."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr ""
 "Erreur fatale : l'emplacement du répertoire personnel n'a pu être déterminé !"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1535,21 +1573,21 @@ msgstr ""
 "Veuillez définir la variable d'environnement HOME ou ajouter un utilisateur "
 "valide pour l'UID %u !"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Erreur : échec de l'ouverture du fichier de configuration `%s' !"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s : %d : la valeur du degré de verbosité du journal est incorrecte"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Nettoyage de la file d'attente..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1559,31 +1597,31 @@ msgstr ""
 "utilisation : %s [-i <fichier>|-e] [-u <fichier_url>] [-c <fichier_cache>] [-"
 "x <commande> ...] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<fichier_liste>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "utiliser le fichier <fichier_liste> comme file d'attente"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "commencer le téléchargement au démarrage"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u téléchargements en parallèle"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr ""
 "File d'attente (%u téléchargements en cours, %u au total) - %.2f kb/s au "
 "total%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Erreur : impossible de quitter : téléchargement en cours"
 
@@ -1592,7 +1630,7 @@ msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Erreur : le téléchargement doit se terminer avant de pouvoir lire le fichier."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Erreur : impossible d'effectuer l'opération : téléchargement en cours."
 
@@ -1650,43 +1688,43 @@ msgstr "`%s' n'est pas un type de vue valide"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' n'est pas une expression régulière correcte : %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sChargement de %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Erreur lors de la récupération de %s : %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Erreur : fil invalide !"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "paramètres insuffisants"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' n'est pas une expression de filtrage correcte"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Erreur : le format du lien n'est pas pris en charge : %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Choisir une étiquette"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Choisir un filtre"
 
@@ -1698,28 +1736,32 @@ msgstr "attribut non trouvé"
 msgid "EOF found while reading XML tag"
 msgstr "EOF rencontré durant la lecture d'une balise XML"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Aucun lien sélectionné !"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Créer un signet"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "Liens"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Erreur : le fil est vide !"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Aucune étiquette définie."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Mise à jour du fil de requête..."
 
@@ -1769,7 +1811,7 @@ msgstr "le format du fil n'est pas supporté"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s : %d : la valeur du degré de verbosité du journal est incorrecte"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 #, fuzzy
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -1778,26 +1820,49 @@ msgstr ""
 "Veuillez définir la variable d'environnement HOME ou ajouter un utilisateur "
 "valide pour l'UID %u !"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Erreur : l'ouverture du fichier de cache `%s' a échoué : %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "Index de fil invalide (bug)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Passer à l'article suivant"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Passer à l'article précédent"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2008-01-28 10:00+0100\n"
 "Last-Translator: Zsolt Udvari <udvzsolt@gmail.com>\n"
 "Language-Team: \n"
@@ -56,11 +56,11 @@ msgstr "<cachefile>"
 msgid "use <cachefile> as cache file"
 msgstr "<cachefile> használata cache fájlként"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<configfile>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "beállítások olvasása <configfile>-ból"
 
@@ -84,19 +84,19 @@ msgstr ""
 msgid "get version information"
 msgstr "verzió információ"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<loglevel>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "log írása az adott szinten (érvényes értékek: 1-től 6-ig)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<logfile>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "<logfile> használata naplófájlként"
 
@@ -108,7 +108,7 @@ msgstr "olvasott cikkek listájának exportálása <file>-ba"
 msgid "import list of read articles from <file>"
 msgstr "olvasott cikkek listájának importálása <file>-ból"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "ez a súgó"
 
@@ -175,23 +175,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' nem érvényes szín"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' nem érvényes attríbútum"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' nem érvényes konfigurációs elem"
@@ -202,56 +202,56 @@ msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr ""
 "newsboat: újratöltés befejezve, %f olvasatlan üzenet (%n olvasatlan összesen)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N %V - Cikkek '%T'-ben (%u olvasatlan, %t összesen) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialógusok"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - Hírek (%u olvasatlan, %t összesen)%?T? - cimke `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?File megnyitása&Menti a fájlt? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?File megnyitása&Menti a fájlt? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Súgó"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Cikkek '%T'-ben (%u olvasatlan, %t összesen) - %U"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Keresési eredmény (%u olvasatlan, %t összesen)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Szűrő kiválasztása"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Cimke kiválasztása"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URL"
 
@@ -290,38 +290,43 @@ msgstr "a file-t nem tudtam megnyitni."
 msgid "unknown error (bug)."
 msgstr "ismeretlen hiba (bug)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Hiba a `%s' (%s line %u) parancs végrehajtása közben: %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "ismeretlen parancs: `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Hiba a `%s' (%s line %u) parancs végrehajtása közben: %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "%s %s indítása..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Hiba: egy példány már fut %s-ből (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Konfiguráció betöltése..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "kész."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Cache megnyitása..."
 
@@ -339,23 +344,33 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "URL-ek betöltése %s-ből..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -364,7 +379,7 @@ msgstr ""
 "Hiba: nincs URL beállítva. Kérlek töltsd fel a(z) %s file-t RSS URL-ekkel "
 "vagy importálj egy OPML file-ból."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -372,7 +387,7 @@ msgstr ""
 "Úgy tűnik, az OPML, amit betöltöttél, nem tartalmaz hírforrásokat. Töltsd "
 "fel forrásokkal és próbáld újra!"
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -381,7 +396,7 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -390,7 +405,7 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -399,7 +414,7 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -408,69 +423,78 @@ msgstr ""
 "Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
 "fiókodban. Tedd meg, és próbáld újra!"
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Úgy tűnik, még nem konfiguráltál semmilyen forrást a Google Reader "
+"fiókodban. Tedd meg, és próbáld újra!"
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Cikkek töltése a cache-bõl..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "A cache teljes ürítése..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Nem sikerült betölteni a forrásokat az adatbázisból: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Hiba a `%s' forrás betöltése közben: %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "A lekérdezési mezők kezdeti feltöltése..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Olvasott cikkek listájának importálása..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Olvasott cikkek listájának exportálása..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "A cache takarítása..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "nem sikerült: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Hiba: nem tudtam olvasottnak megjelölni: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Egy hiba lépett fel, miközben %s-t elemeztem."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s importálása befejeződött."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u olvasatlan hír"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "ismeretlen parancs: `%s'"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Hiba: nem tudtam megnyitni a(z) `%s' konfigurációs fájlt!"
@@ -491,26 +515,26 @@ msgstr "Bezár Dialógus"
 msgid "Error: you can't remove the feed list!"
 msgstr "Hiba: nem törölheted a cikk listát!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Érvénytelen pozíció!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Mentés"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "File mentése - %s"
@@ -555,10 +579,6 @@ msgstr "lejátszott"
 msgid "unknown (bug)."
 msgstr "ismeretlen (bug)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "érvénytelen hírforrás index (bug)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Akik téged követnek"
@@ -572,21 +592,21 @@ msgstr "Csillagozott elemek"
 msgid "Shared items"
 msgstr "Megosztott elemek"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Nincs forrás kijelölve"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 #, fuzzy
 msgid "ftauln"
 msgstr "ecson"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -595,7 +615,7 @@ msgstr ""
 "Rendezés (e)lső cimke/(c)ím/cikk(s)zám/(o)olvasatlan források száma/semmi "
 "szeri(n)t?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -604,158 +624,174 @@ msgstr ""
 "Visszafele rendezés (e)lső cimke/(c)ím/cikk(s)zám/(o)olvasatlan források "
 "száma/semmi szeri(n)t?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Cikk megnyitása böngészőben"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Forrás olvasottá tétele..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Hiba: nem tudtam olvasottnak megjelölni: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Nincs forrás olvasatlan elemekkel."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Biztos felülírod `%s'-t (y:Yes n:No)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "in"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "i"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Az összes forrás olvasottként jelölése..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Hiba: nem tudtam feldolgozni a filter parancsot: `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Nincs szűrő (filter) definiálva."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Keresés: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Biztos kilépsz (i:Igen n:Nem)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "in"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "i"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Kilép"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Megnyit"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Köv. olvasatlan"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Újratölt"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Mind újratölt"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Olvasottnak megjelöl"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Mindet olvasottnak"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Keres"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Súgó"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Hiba: nem tudtam feldolgozni a filter parancsot!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Keresés..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Hiba `%s' keresése közben: %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Nincs találat."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "A pozíció nem látható!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Forrás lista - %u olvasatlan, %u összesen"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Biztos felülírod `%s'-t (y:Yes n:No)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "File: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "File mentése - %s"
@@ -850,35 +886,35 @@ msgstr "Kötetlen funkciók:"
 msgid "Clear"
 msgstr "Vissza"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "beágyazott flash: "
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "kép"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Linkek: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "link"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "beágyazott flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "ismeretlen (bug)"
 
@@ -895,145 +931,145 @@ msgstr "Megosztott elemek"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Nincs elem kijelölve!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Az olvasott jelző ki/beállítása a cikkre..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Hiba az olvasott jelző állítása közben: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "URL lista üres."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Jelzõk: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Hiba: nincs elem kijelölve!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Hiba: nem töltheted újra a keresési eredményt."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Nincs olvasatlan elem."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Nincs olvasatlan forrás."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Az összes forrás olvasottként jelölése..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "A cikk pipe-olása a parancsnak: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "dcjslg"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 #, fuzzy
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Rendezés (d)átum/(c)ím/(j)elzők/(s)zerző/(l)ink/(g)uid alapján?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 #, fuzzy
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Fordított rendezés (d)átum/(c)ím/(j)elzők/(s)zerző/(l)ink/(g)uid alapján?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Jelzők frissítve."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Hiba: szűrő alkalmazása nem sikerült: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Mentés megszakítva."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Cikk mentése %s-be"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Hiba: nem tudtam a cikket %s fájlba menteni"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Keresés eredménye . '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Lekérdezési lista - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Cikk lista - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1064,15 +1100,15 @@ msgstr "Podcast letöltés URL: "
 msgid "type: "
 msgstr "típus: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Fent"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Lent"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Hiba a cikk olvasottá tétele közben: %s "
@@ -1097,35 +1133,35 @@ msgstr "Cikk mentve %s-be."
 msgid "Error: couldn't write article to file %s"
 msgstr "Hiba: nem tudtam a cikket a(z) %s file-ba menteni"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Böngésző indítása..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Hiba a cikk olvasatlanná tétele közben: %s "
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Ugrás: URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Megnyitás böngészőben"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Lista"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Cikk %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Hiba: érvénytelen reguláris kifejezés!"
 
@@ -1177,13 +1213,13 @@ msgstr "Cikk mentése"
 
 #: src/keymap.cpp:87
 #, fuzzy
-msgid "Go to next article"
-msgstr "Következő olvasatlan cikk"
+msgid "Go to next entry"
+msgstr "Következő bejegyzés"
 
 #: src/keymap.cpp:94
 #, fuzzy
-msgid "Go to previous article"
-msgstr "Elõző olvasatlan cikk"
+msgid "Go to previous entry"
+msgstr "Előző bejegyzés"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1496,7 +1532,7 @@ msgstr "`%s' nem valódi környezet"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' nem érvényes billentyűparancs"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' nem valódi környezet"
@@ -1511,16 +1547,16 @@ msgstr "%s argumentum nem elérhető."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "'%s' reguláris kifejezés érvénytelen: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Végzetes hiba: nem tudtam meghatározni a home-könyvtárat!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1528,21 +1564,21 @@ msgstr ""
 "Kérlek, állítsd be a HOME változót vagy adj valódi felhasználót a(z) %u UID-"
 "hoz!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Hiba: nem tudtam megnyitni a(z) `%s' konfigurációs fájlt!"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Lista törlése..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1552,31 +1588,31 @@ msgstr ""
 "használat: %s [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x "
 "<command> ...] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<file>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "<cachefile> használata cache fájlként"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr ""
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u párhuzamos letöltés"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Lista (%u letöltés folyamatban, %u összesen) - %.2f kb/s összesen%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Hiba: nem léphetsz ki: letöltés(ek) folyamatban."
 
@@ -1584,7 +1620,7 @@ msgstr "Hiba: nem léphetsz ki: letöltés(ek) folyamatban."
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Hiba: a letöltésnek be kell fejeződnie, mielőtt lejátszhatnád."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Hiba: nem hajthatom végre: letöltés(ek) folyamatban."
 
@@ -1643,43 +1679,43 @@ msgstr "`%s' érvénytelen dialógus típus"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' nem valódi reguláris kifejezés: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sTöltés %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Hiba letöltés közben: %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Hiba: érvénytelen hírforrás!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "túl kevés paraméter"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' nem valódi reguláris kifejezés: %s"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr ""
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Hiba: nem támogatott URL: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Cimke kijelölése"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Szűrő kijelölése"
 
@@ -1691,28 +1727,32 @@ msgstr "argumentumot nem találom"
 msgid "EOF found while reading XML tag"
 msgstr "EOF-t találtam XML cimke olvasása közben"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Nincs link kijelölve!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Könyvjelző mentése"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URL-ek: "
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Hiba: a forrás nem tartalmaz elemeket!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Nincs cimke definiálva."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Források lekérdezése..."
 
@@ -1762,7 +1802,7 @@ msgstr "nem támogatott forrás formátum"
 msgid "%s: %s: invalid loglevel value"
 msgstr "`%s' érvénytelen dialógus típus"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 #, fuzzy
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -1771,26 +1811,51 @@ msgstr ""
 "Kérlek, állítsd be a HOME változót vagy adj valódi felhasználót a(z) %u UID-"
 "hoz!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Hiba `%s' cache-file megnyitása közben: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "érvénytelen hírforrás index (bug)"
+
+#, fuzzy
+#~ msgid "Go to next article"
+#~ msgstr "Következő olvasatlan cikk"
+
+#, fuzzy
+#~ msgid "Go to previous article"
+#~ msgstr "Elõző olvasatlan cikk"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/it.po
+++ b/po/it.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2019-08-26 23:02+0200\n"
 "Last-Translator: Leandro Noferini <leandro@noferini.org>\n"
 "Language-Team: Claudio M. Alessi <somppy@gmail.com>\n"
@@ -58,11 +58,11 @@ msgstr "<cachefile>"
 msgid "use <cachefile> as cache file"
 msgstr "usa <cachefile> come file cache"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<configfile>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "leggi la configurazione da <configfile>"
 
@@ -86,19 +86,19 @@ msgstr "avvio silenzioso"
 msgid "get version information"
 msgstr "ottieni informazioni sulla versione"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<loglevel>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "scrivi un log con un certo loglevel (valori validi: da 1 a 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<logfile>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "usa <logfile> come log file di output"
 
@@ -110,7 +110,7 @@ msgstr "esporta lista articoli letti su <file>"
 msgid "import list of read articles from <file>"
 msgstr "importa lista articoli letti da <file>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "questo aiuto"
 
@@ -187,23 +187,23 @@ msgstr "Ricevuto newsboat::DbException con messaggio: %s"
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Ricevuto newsboat::MatcherException con messaggio: %s"
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Ricevuto newsboat::Exception con messaggio: %s"
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' non è un colore valido"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' non è un attributo valido"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' non è un elemento di configurazione valido"
@@ -215,54 +215,54 @@ msgstr ""
 "newsboat: caricamento terminato, %f feed non letti (%n totale articoli non "
 "letti)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N %V - Articoli nel feed '%T' (%u non letti, %t totali) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Schermate"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - I tuoi feed (%u non letti, %t totali)%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Apri File&Salva File? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Apri File&Salva File? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Aiuto"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Articolo '%T' (%u non letti, %t in totale) - %U"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Risultati della ricerca (%u non letti, %t totali) "
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Seleziona Filtro"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Seleziona Tag"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URL"
 
@@ -301,38 +301,43 @@ msgstr "Il file non può essere aperto."
 msgid "unknown error (bug)."
 msgstr "errore sconosciuto (bug)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Errore elaborando il comando `%s' (%s linea %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "comando sconosciuto `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Errore elaborando il comando `%s' (%s linea %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Sto avviando %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Errore: un'istanza di %s è già in esecuzione (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Sto caricando la configurazione..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "fatto."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Sto aprendo la cache..."
 
@@ -350,23 +355,34 @@ msgstr "ERRORE: Devi impostare `cookie-cache` per usare NewsBlur.\n"
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s è inaccessibile e non può essere creato\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+#, fuzzy
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr "ERRORE: Devi impostare `cookie-cache` per usare NewsBlur.\n"
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Sto caricando gli URL da %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -375,7 +391,7 @@ msgstr ""
 "Errore: nessun URL configurato. Per favore, inserisci i feed RSS nel file %s "
 "o importa un file OPML."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -383,7 +399,7 @@ msgstr ""
 "Sembra che il feed OPML di cui hai chiesto la sottoscrizione non contenga "
 "feed. Per favore, inserisci i feed e riprova."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -391,7 +407,7 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account The Old "
 "Reader. Per favore, fallo e riprova."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -399,7 +415,7 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account Tiny Tiny "
 "RSS. Per favore, fallo e riprova."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -407,7 +423,7 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account NewsBlur. Per "
 "favore, fallo e riprova."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -415,69 +431,78 @@ msgstr ""
 "Sembra che tu non abbia configurato alcun feed nel tuo account Inoreader. "
 "Per favore, fallo e riprova."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Sembra che tu non abbia configurato alcun feed nel tuo account NewsBlur. Per "
+"favore, fallo e riprova."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Sto caricando gli articoli dalla cache..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Sto pulendo accuratamente la cache..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Errore durante il caricamento dei feed dal database: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Errore durante il caricamento del feed `%s': %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Sto precompilando l'interrogazione dei feed..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Sto importando la lista degli articoli letti..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Sto esportando la lista degli articoli letti..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Sto pulendo la cache..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "fallito: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Errore: impossibile contrassegnare tutti i feed letti: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Si è verificato un errore analizzando %s."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importazione di %s finita."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u articoli non letti"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: comando sconosciuto"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Errore: impossibile aprire il file di configurazione `%s'!"
@@ -498,26 +523,26 @@ msgstr "Chiudi schermata"
 msgid "Error: you can't remove the feed list!"
 msgstr "Errore: non puoi rimuovere la lista dei feed!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Posizione non valida!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr "Directory: "
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Cancella"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Salva"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, c-format
 msgid "Save Files - %s"
 msgstr "Salva File - %s"
@@ -562,10 +587,6 @@ msgstr "iniziato"
 msgid "unknown (bug)."
 msgstr "sconosciuto (bug)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "indice del feed non valido (bug)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Persone che segui"
@@ -579,20 +600,20 @@ msgstr "Item selezionati"
 msgid "Shared items"
 msgstr "Item condivisi"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Nessun feed selezionato!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr "ptuman"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -600,7 +621,7 @@ msgstr ""
 "Ordina per (p)rimotag/(t)itolo/n(u)meroarticolo/nu(m)eroarticolononletto/"
 "ultimo(a)ggiornamento/(n)iente?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -608,158 +629,174 @@ msgstr ""
 "Ordina al contrario per (p)rimotag/(t)itolo/n(u)meroarticolo/"
 "nu(m)eroarticolononletto/ultimo(a)ggiornamento/(n)iente?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Apri l'articolo nel browser"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "Non posso aprire i query feed nel browser!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Sto contrassegnando il feed come letto..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Errore: impossibile contrassegnare il feed come letto: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Nessun feed con voci non lette."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Già all'ultimo feed."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Già al primo feed."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Vuoi veramente sovrascrivere `%s' (s:Sì n:No)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "sn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "s"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Sto segnando tutti i feed come letti..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Errore: impossibile analizzare il comando di filtro `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Nessun filtro definito."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Ricerca: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Vuoi veramente uscire (s:Sì n:No)?"
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "sn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "s"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Esci"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Apri"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Prossimo non letto"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Ricarica"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Ricarica tutti"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Segna come letto"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Marca tutti come letti"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Cerca"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Aiuto"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Errore: impossibile analizzare il comando di filtro!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Sto cercando..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Errore durante la ricerca di `%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Nessun risultato."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Posizione non visibile!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista feed - %u non letti, %u totali"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Vuoi veramente sovrascrivere `%s' (s:Sì n:No)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "File: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Salva File - %s"
@@ -852,35 +889,35 @@ msgstr "Funzioni non associate:"
 msgid "Clear"
 msgstr "Pulisci"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "flash integrato:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "immagine"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Collegamenti: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "collegamento"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "flash integrato"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "sconosciuto (bug)"
 
@@ -896,136 +933,136 @@ msgstr "Elementi preferiti"
 msgid "Saved web pages"
 msgstr "Pagine web salvate"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Nessuna voce selezionata!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Cambiando la flag \"letto\" per l'articolo..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Errore cambiando la flag \"letto\": %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "Lista URL vuota."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Flag: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Errore: nessuna voce selezionata!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Errore: non puoi ricaricare i risultati della ricerca."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Nessuna voce non letta."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Già all'ultimo elemento."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Già al primo elemento."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Nessun feed non letto."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr "Contrassegno i feed al di sopra come letti..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Metti in pipe l'articolo col comando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 msgid "dtfalgr"
 msgstr "dtfacgr"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Ordina per (d)ata/(t)itolo/(f)lag/(a)utore/(c)ollegamento/(g)uid/(r)andom?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Ordina al contrario per (d)ata/(t)itolo/(f)lag/(a)utore/(c)ollegamento/"
 "(g)uid/(r)andom?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Flag aggiornate."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Errore: applicazione del filtro fallita: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Salvataggio annullato."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Articolo salvato su %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Errore: impossibile salvare l'articolo su %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Risultati della ricerca - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Feed interrogati - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista articoli - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, fuzzy, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "Sovrascrivere `%s` in `%s`? (s:Sì n:No)"
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr "sanq"
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -1034,7 +1071,7 @@ msgstr ""
 "Sovrascrivere `%s` in `%s`? Ci sono ancora %d conflitti come il presente (s:"
 "Sì a:Sì a tutti n:No q:No a tutti)"
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1067,15 +1104,15 @@ msgstr "URL scaricamento podcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Su"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Giù"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Errore contrassegnando l'articolo come letto: %s"
@@ -1100,35 +1137,35 @@ msgstr "Articolo salvato su %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Errore: impossibile scrivere l'articolo sul file %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Sto avviando il browser..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Errore contrassegnando l'articolo come non letto: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Vai a URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Apri nel browser"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Accoda"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Articolo - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Errore: espressione regolare non valida!"
 
@@ -1177,12 +1214,14 @@ msgid "Save articles"
 msgstr "Salva articolo"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Vai al prossimo articolo"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Spostati alla voce successiva"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Vai all'articolo non letto precedente"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Spostati alla voce precedente"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1490,7 +1529,7 @@ msgstr "`%s' non è un contesto valido"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' non è una tasto di comando valido"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' non è un contesto valido"
@@ -1505,17 +1544,17 @@ msgstr "l'attributo `%s' non è disponibile."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "l'espressione regolare `%s' non è valida: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: directory di configurazione '%s' non accessibile, uso '%s' al suo posto."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Errore fatale: impossibile determinare la directory home!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1523,23 +1562,23 @@ msgstr ""
 "Per favore, imposta la variabile d'ambiente HOME o aggiungi un utente valido "
 "per l'UID %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Errore fatale: impossibile creare la directory di configurazione `%s': (%i) "
 "%s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: livello loglevel non valido"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Sto pulendo la coda..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1548,29 +1587,29 @@ msgstr ""
 "%s %s\n"
 "uso %s [-C <file>] [-q <file>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<queuefile>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "usa <queuefile> come file cache"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "inizia download all'avvio"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u download paralleli"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Coda (%u download in corso, %u totali) - %.2f kb/s totale%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Errore: impossibile uscire: ci sono download in esecuzione."
 
@@ -1579,7 +1618,7 @@ msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Errore: il download deve finire prima che il file possa essere richiamato."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Errore: impossibile effettuare l'operazione: ci sono download incorso."
 
@@ -1640,43 +1679,43 @@ msgstr "`%s' non è un tipo di schermata valida"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' non è un'espressione regolare valida: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sSto caricando %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Errore durante il recupero di %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Errore: feed non valido!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "parametri insufficienti"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' non è un'espressione regolare valida"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Errore: URL non supportato: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Seleziona Tag"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Seleziona Filtro"
 
@@ -1688,28 +1727,32 @@ msgstr "attributo non trovato"
 msgid "EOF found while reading XML tag"
 msgstr "EOF trovato durante la lettura del tag XML"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Nessun collegamento selezionato!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Salva Segnalibro"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URL"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Errore: il feed non contiene voci!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Nessun tag definito."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Aggiornamento interrogazione feed..."
 
@@ -1759,7 +1802,7 @@ msgstr "formato feed non supportato"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: livello loglevel non valido"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1768,26 +1811,49 @@ msgstr ""
 "Per favore, imposta la variabile d'ambiente HOME o aggiungi un utente valido "
 "per l'UID %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Errore: apertura del file cache `%s' fallita: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "indice del feed non valido (bug)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Vai al prossimo articolo"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Vai all'articolo non letto precedente"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.9\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2015-04-26 05:55+0900\n"
 "Last-Translator: Grady Martin <GradyMartin@gmail.com>\n"
 "Language-Team: \n"
@@ -54,11 +54,11 @@ msgstr "<キャッシュ>"
 msgid "use <cachefile> as cache file"
 msgstr "キャッシュの指定"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<設定>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "設定ファイルの指定"
 
@@ -82,19 +82,19 @@ msgstr "出力を制御する"
 msgid "get version information"
 msgstr "バージョン情報を表示する"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<ログレベル>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "1から6までの範囲でログレベルを指定する"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<ログ>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "ログの指定"
 
@@ -106,7 +106,7 @@ msgstr "既読記事のリストを<ファイル>に書き込む"
 msgid "import list of read articles from <file>"
 msgstr "既読記事の指定を<ファイル>から読み込む"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "読んでるよ"
 
@@ -172,23 +172,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "「%s」は無効な色です。"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "「%s」は無効な書体です。"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr ""
@@ -198,54 +198,54 @@ msgstr ""
 msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr "newsboat: 同期完了 更新されたフィード%f部 新規記事%n件"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N%V %T %u/%t 未読 %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr ""
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N%V 全フィード %u/%t 未読%?T? %T?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr ""
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr ""
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr ""
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N%V %T %u/%t 未読"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N%V 全フィード %u/%t 未読%?T? %T?"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr ""
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr ""
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr ""
 
@@ -284,38 +284,43 @@ msgstr ""
 msgid "unknown error (bug)."
 msgstr ""
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
+msgid "%s line %u"
 msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr ""
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr ""
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "%s%sを起動中…"
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "エラー：%sは既に起動中です（PID: %u）"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "設定を読み込み中…"
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "完了しました。"
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "キャッシュを読み込み中…"
 
@@ -333,122 +338,138 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "%sからURLを読み込み中…"
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr ""
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr ""
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "キャッシュから記事を読み込み中…"
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "キャッシュをより細かく整理中…"
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr ""
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr ""
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr ""
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "キャッシュを整理中…"
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr ""
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr ""
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr ""
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr ""
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr ""
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr ""
@@ -469,26 +490,26 @@ msgstr ""
 msgid "Error: you can't remove the feed list!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "保存"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, c-format
 msgid "Save Files - %s"
 msgstr ""
@@ -533,10 +554,6 @@ msgstr ""
 msgid "unknown (bug)."
 msgstr ""
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr ""
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr ""
@@ -550,183 +567,198 @@ msgstr ""
 msgid "Shared items"
 msgstr ""
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr ""
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+msgid "Failed to spawn browser"
+msgstr ""
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr ""
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "%sを上書きしてもよろしいですか（y/n）"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr ""
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr ""
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr ""
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "終了してもよろしいですか（y/n）"
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr ""
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr ""
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "閉じる"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "開く"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "次"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "同期"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "全フィードを同期"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "既読にする"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "全件を既読にする"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "検索"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "ヘルプ"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "検索中…"
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "検索結果がありませんでした。"
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr ""
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "%sを上書きしてもよろしいですか（y/n）"
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr ""
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr ""
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr ""
@@ -817,35 +849,35 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr ""
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr ""
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr ""
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr ""
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr ""
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr ""
 
@@ -861,140 +893,140 @@ msgstr ""
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr ""
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr ""
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr ""
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr ""
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr ""
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr ""
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 msgid "dtfalgr"
 msgstr ""
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr ""
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1025,15 +1057,15 @@ msgstr "コンテンツ："
 msgid "type: "
 msgstr ""
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr ""
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr ""
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
@@ -1058,35 +1090,35 @@ msgstr ""
 msgid "Error: couldn't write article to file %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "ブラウザーを起動中…"
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "ブラウザーで開く"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "コンテンツをダウンロード"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr ""
 
@@ -1136,11 +1168,11 @@ msgid "Save articles"
 msgstr ""
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
+msgid "Go to next entry"
 msgstr ""
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
+msgid "Go to previous entry"
 msgstr ""
 
 #: src/keymap.cpp:101
@@ -1449,7 +1481,7 @@ msgstr ""
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "「%s」は無効な色です。"
@@ -1464,36 +1496,36 @@ msgstr ""
 msgid "regular expression '%s' is invalid: %s"
 msgstr ""
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG設定ディレクトリ%sを読み込めませんでした。%sを使用します。"
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr ""
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr ""
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr ""
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1503,31 +1535,31 @@ msgstr ""
 "%s [-i <ファイル>|-e] [-u <URLファイル>] [-c <キャッシュ>] [-x <コマンド>…] "
 "[-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<ファイル>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "キャッシュの指定"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr ""
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr ""
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr ""
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr ""
 
@@ -1535,7 +1567,7 @@ msgstr ""
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr ""
 
@@ -1593,43 +1625,43 @@ msgstr ""
 msgid "`%s' is not a valid regular expression: %s"
 msgstr ""
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%s%sにアクセス中…"
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr ""
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr ""
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr ""
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "「%s」は無効な色です。"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr ""
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr ""
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr ""
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr ""
 
@@ -1641,27 +1673,31 @@ msgstr ""
 msgid "EOF found while reading XML tag"
 msgstr ""
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 msgid "No links available!"
 msgstr ""
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr ""
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr ""
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "記事がありません！"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr ""
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr ""
 
@@ -1710,29 +1746,43 @@ msgstr ""
 msgid "%s: %s: invalid loglevel value"
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2012-08-08 20:07+0100\n"
 "Last-Translator: Daniel Aleksandersen <code@daniel.priv.no>\n"
 "Language-Team: \n"
@@ -58,11 +58,11 @@ msgstr "<mellomlagerfil>"
 msgid "use <cachefile> as cache file"
 msgstr "bruk <mellomlagerfil> som mellomlagerfil"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<oppsettsfil>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "les oppsettsfilen fra <oppsettsfil>"
 
@@ -86,19 +86,19 @@ msgstr "stille oppstart"
 msgid "get version information"
 msgstr "få versjonsinformasjon"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<loggnivå>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "skriv en logg med angitt loggskrivningsnivå mellom 1 og 6"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<loggfil>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "bruk <loggfil> som loggfil"
 
@@ -110,7 +110,7 @@ msgstr "eksporterer en liste med leste artikler til <fil>"
 msgid "import list of read articles from <file>"
 msgstr "importer en liste med leste artikler fra <fil>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "denne hjelpen"
 
@@ -176,23 +176,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' er ikke en gyldig farge"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' er ikke en gyldig attributt"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' er ikke et gyldig oppsettselement"
@@ -204,7 +204,7 @@ msgstr ""
 "newsboat: fullførte oppdateringen, %f uleste nyhetsstrømmer (totalt %n "
 "uleste artikler)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
@@ -212,11 +212,11 @@ msgid ""
 msgstr ""
 "%N %V - Artikler i nyhetsnyhetsstrømmen '%T' (%u ulest, %t totalt) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialoger"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
@@ -224,39 +224,39 @@ msgid ""
 msgstr ""
 "%N %V - Nyhetsstrømmene dine (%u uleste, %t totalt)%?T? - etikett `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Åpne fil&Lagre fil? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Åpne fil&Lagre fil? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Hjelp"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr ""
 "%N %V - Artikler i nyhetsnyhetsstrømmen '%T' (%u ulest, %t totalt) - %U"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Søkeresultater (%u ulest, %t totalt)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Velg filter"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Velg etikett"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URLer"
 
@@ -295,38 +295,43 @@ msgstr "filen kunne ikke åpnes."
 msgid "unknown error (bug)."
 msgstr "ukjent feil (programfeil)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Feil under behandling av kommandoen `%s' (%s linje %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "ukjent kommando `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Feil under behandling av kommandoen `%s' (%s linje %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Starter %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Feil: en annen instans av %s kjører allerede (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Leser oppsett..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "utført."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Åpner mellomlager..."
 
@@ -344,23 +349,33 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Laster inn URLer fra %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -369,7 +384,7 @@ msgstr ""
 "Feil: ingen URLer er satt opp. Vennligst fyll inn filen %s med RSS "
 "nyhetsstrømmer, eller importer fra en OPML-fil."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -378,7 +393,7 @@ msgstr ""
 "nyhetsstrømmer. Vennligst sørg for at den inneholder noen nyhetsstrømmer og "
 "prøv igjen."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -387,7 +402,7 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -396,7 +411,7 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -405,7 +420,7 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -414,69 +429,78 @@ msgstr ""
 "Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
 "Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Det ser ikke ut til at du har satt opp noen nyhetsstrømmer i din Google "
+"Reader-konto. Vennligst sørg for å gjøre det og prøv igjen."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Leser artikler fra mellomlageret..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Rydder grundig opp i mellomlageret..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Feil under innlesing av nyhetsstrømmer fra databasen: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Feil under innlastning av nyhetsstrømmen '%s': %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Forhåndsutfyller spørringsstrømmer..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Importerer liste over leste artikler..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Eksporterer liste over leste artikler..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Rydder opp i mellomlageret..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "feilet: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Feil: kunne ikke markere alle nyhetsstrømmene som lest: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "En feil oppsto under tolkningen av %s"
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Fullførte importeringen av %s."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u uleste artikler"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "ukjent kommando `%s'"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Feil: kunne ikke åpne oppsettsfilen `%s'!"
@@ -497,26 +521,26 @@ msgstr "Lukk dialogen"
 msgid "Error: you can't remove the feed list!"
 msgstr "Feil: du kan ikke fjerne nyhetsstrømlisten!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "ugyldig posisjon!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Lagre"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Lagre fil - %s"
@@ -561,10 +585,6 @@ msgstr "avspilt"
 msgid "unknown (bug)."
 msgstr "ukjent (programfeil)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "ugyldig strøminndeks (programfeil)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Folk du følger"
@@ -578,21 +598,21 @@ msgstr "Favorittinnlegg"
 msgid "Shared items"
 msgstr "Delte innlegg"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Ingen nyhetsstrømmer merket!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 #, fuzzy
 msgid "ftauln"
 msgstr "ftaui"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -601,7 +621,7 @@ msgstr ""
 "Sorter stigende etter (f)ørste etikett/(t)ittel/antall (a)artikler/antall "
 "(u)leste artikler/(i)ngen?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -610,158 +630,174 @@ msgstr ""
 "Sorter synkende etter (f)ørste etikett/(t)ittel/antall (a)artikler/antall "
 "(u)leste artikler/(i)ngen?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Åpne artikkel i en nettleser"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Markerer nyhetsstrømmen som lest..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Feil: kunne ikke markere nyhetsstrømmen som lest: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Ingen nyhetsstrømmer med uleste innlegg."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Allerede i den siste nyhetsstrømmen."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Allerede i den første nyhetsstrømmen."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Vil du virkelig overskrive `%s' (j:Ja n:Nei)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "jn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "j"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Markerer alle nyhetsstrømmer som lest..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Feil: kunne ikke tolke filterkommandoen `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Ingen angitte filtere."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Søk etter: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Vil du virkelig avslutte (j:Ja n:Nei)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "jn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "j"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Avslutt"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Åpne"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Neste uleste"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Oppdater"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Oppdater alle"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Merk som lest"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Marker alle som lest"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Søk"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Hjelp"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Feil: kunne ikke  tolke filterkommandoen!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Leter..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Feil under søket etter `%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Ingen resultater."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Posisjonen er ikke synlig!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Nyhetsstrømliste  - %u uleste, %u totalt"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Vil du virkelig overskrive `%s' (j:Ja n:Nei)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "i"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Fil: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Lagre fil - %s"
@@ -856,35 +892,35 @@ msgstr "Utilknyttede funksjoner:"
 msgid "Clear"
 msgstr "Tøm"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "innbakt Flash-tillegg"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "bilde"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Lenker: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "lenke"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "innbakt Flash-tillegg"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "ukjent (programfeil)"
 
@@ -902,145 +938,145 @@ msgstr "Delte innlegg"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Ingen innlegg merket!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Setter lestflagg for artikkelen..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Feil under setting av lestflagg: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "URL-listen er tom."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Flagg: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Feil: ingen markerte innlegg!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Feil: du kan ikke oppdatere søkeresultater."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Ingen uleste innlegg."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Allerede på siste innlegg."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Allerede på første innlegg."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Ingen uleste nyhetsstrømmer."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Markerer alle nyhetsstrømmer som lest..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Send artikkel til kommando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "dtfolg"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 #, fuzzy
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Sorter etter (d)ato)/(t)ittel/(f)lagg/f(o)rfatter/(l)enke/(g)uide?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 #, fuzzy
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sorter synkende etter (d)ato)/(t)ittel/(f)lagg/f(o)rfatter/(l)enke/(g)uide?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Flagg oppdatert."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Feil: bruk av filteret feilet: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Avbrøt lagringen."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Lagret artikkelen til %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Feil: kunne ikke lagre artikkelen til %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Søkeresultater - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Spørringsstrøm - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikkelliste - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1071,15 +1107,15 @@ msgstr "Podkastnedlastings-URL: "
 msgid "type: "
 msgstr "slag: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Toppen"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Bunnen"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Feil mens artikkelen ble markert som lest: %s"
@@ -1104,35 +1140,35 @@ msgstr "Lagret artikkel til %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Feil: kunne ikke skrive artikkelen til filen %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Åpner nettleseren..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Feil mens artikkelen ble markert som lest: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Gå til URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Åpne i nettleseren"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Legg til i køen"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Artikkel - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Feil: ugyldig regulært uttrykk!"
 
@@ -1183,12 +1219,14 @@ msgid "Save articles"
 msgstr "Lagre artikkel"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Gå til neste artikkel"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Gå til neste innlegg"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Gå til forrige artikkel"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Gå til forrige innlegg"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1498,7 +1536,7 @@ msgstr "`%s' er ikke en gyldig kontekst"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' er en ugyldig nøkkelkommando"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' er ikke en gyldig kontekst"
@@ -1513,16 +1551,16 @@ msgstr "attributten `%s' er ikke tilgjengelig."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "det regulære uttrykket '%s' er ugyldig: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Kraftig feil: kunne ikke finne hjemmemappen!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1530,21 +1568,21 @@ msgstr ""
 "Vennligst sett miljøvariablen HOME eller legg til en gyldig bruker for UID "
 "%u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Feil: kunne ikke åpne oppsettsfilen `%s'!"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Rydder opp i køen..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1554,31 +1592,31 @@ msgstr ""
 "bruk: %s [-i <fil>|-e] [-u <URL fil>] [-c <mellomlagerfil>] [-x "
 "<kommando> ...] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<fil>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "bruk <mellomlagerfil> som mellomlagerfil"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr ""
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u samtidige nedlastinger"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Kø (%u nedlastinger pågår, %u totalt) - %.2f kb/s totalt%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Feil: kan ikke avslutte: nedlasting(er) pågår."
 
@@ -1586,7 +1624,7 @@ msgstr "Feil: kan ikke avslutte: nedlasting(er) pågår."
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Feil: nedlastinger må fullføres før filen kan spilles av."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Feil: klarte ikke å utføre oppgaven: nedlasting(er) pågår."
 
@@ -1645,43 +1683,43 @@ msgstr "`%s' er en ugyldig dialogtype"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' er ikke et gyldig regulært utrykk: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sInnlasting%s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Feil under innhenting av %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Feil: ugyldig nyhetsstrøm!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "for få argumenter"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' er ikke et gyldig regulært utrykk: %s"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr ""
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Feil: URLen støttes ikke: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Velg etikett"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Velg filter"
 
@@ -1693,28 +1731,32 @@ msgstr "attributten ble ikke funnet"
 msgid "EOF found while reading XML tag"
 msgstr "fant EOF mens XML-element ble lest inn"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Ingen lenke valgt!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Lagre bokmerke"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URLer"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Feil: nyhetsstrømmen inneholder ingen innlegg!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Ingen etiketter angitt."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Frisker opp spørringsstrømmen..."
 
@@ -1764,7 +1806,7 @@ msgstr "strømformatet støttes ikke"
 msgid "%s: %s: invalid loglevel value"
 msgstr "`%s' er en ugyldig dialogtype"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 #, fuzzy
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -1773,26 +1815,49 @@ msgstr ""
 "Vennligst sett miljøvariablen HOME eller legg til en gyldig bruker for UID "
 "%u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Feil: åpning av mellomlagerfilen `%s' feilet: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "ugyldig strøminndeks (programfeil)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Gå til neste artikkel"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Gå til forrige artikkel"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-07-07 20:53+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,11 +57,11 @@ msgstr ""
 msgid "use <cachefile> as cache file"
 msgstr ""
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr ""
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr ""
 
@@ -85,19 +85,19 @@ msgstr ""
 msgid "get version information"
 msgstr ""
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr ""
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr ""
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr ""
 
@@ -109,7 +109,7 @@ msgstr ""
 msgid "import list of read articles from <file>"
 msgstr ""
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr ""
 
@@ -171,23 +171,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr ""
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr ""
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr ""
@@ -197,51 +197,51 @@ msgstr ""
 msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr ""
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr ""
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr ""
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr ""
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr ""
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr ""
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr ""
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr ""
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr ""
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr ""
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr ""
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr ""
 
@@ -280,38 +280,43 @@ msgstr ""
 msgid "unknown error (bug)."
 msgstr ""
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
+msgid "%s line %u"
 msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr ""
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr ""
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr ""
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr ""
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr ""
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr ""
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr ""
 
@@ -329,122 +334,138 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr ""
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr ""
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr ""
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
 msgstr ""
 
-#: src/controller.cpp:366
-msgid "Loading articles from cache..."
-msgstr ""
-
-#: src/controller.cpp:375
-msgid "Cleaning up cache thoroughly..."
+#: src/controller.cpp:384
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
 msgstr ""
 
 #: src/controller.cpp:395
+msgid "Loading articles from cache..."
+msgstr ""
+
+#: src/controller.cpp:404
+msgid "Cleaning up cache thoroughly..."
+msgstr ""
+
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr ""
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr ""
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr ""
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr ""
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr ""
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr ""
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr ""
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr ""
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr ""
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr ""
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr ""
@@ -465,26 +486,26 @@ msgstr ""
 msgid "Error: you can't remove the feed list!"
 msgstr ""
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:999
-#: src/itemlistformaction.cpp:1274 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1252 src/itemviewformaction.cpp:483
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, c-format
 msgid "Save Files - %s"
 msgstr ""
@@ -529,10 +550,6 @@ msgstr ""
 msgid "unknown (bug)."
 msgstr ""
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr ""
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr ""
@@ -546,191 +563,197 @@ msgstr ""
 msgid "Shared items"
 msgstr ""
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:277 src/feedlistformaction.cpp:302
-#: src/feedlistformaction.cpp:368
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr ""
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:265 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:320 src/itemlistformaction.cpp:157
-#: src/itemlistformaction.cpp:192 src/itemlistformaction.cpp:214
-#: src/itemlistformaction.cpp:231 src/itemviewformaction.cpp:251
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
 #: src/itemviewformaction.cpp:438
 msgid "Failed to spawn browser"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268 src/feedlistformaction.cpp:297
-#: src/feedlistformaction.cpp:323 src/itemlistformaction.cpp:160
-#: src/itemlistformaction.cpp:195 src/itemlistformaction.cpp:217
-#: src/itemlistformaction.cpp:234 src/itemviewformaction.cpp:254
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
 #: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:273
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:352 src/itemlistformaction.cpp:512
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:363 src/itemlistformaction.cpp:559
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:388 src/feedlistformaction.cpp:397
-#: src/feedlistformaction.cpp:423
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr ""
 
-#: src/feedlistformaction.cpp:405 src/itemlistformaction.cpp:502
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:414 src/itemlistformaction.cpp:507
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:429
+#: src/feedlistformaction.cpp:409
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr ""
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr ""
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr ""
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:477 src/itemlistformaction.cpp:653
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:490 src/itemlistformaction.cpp:666
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr ""
 
-#: src/feedlistformaction.cpp:504 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:624 src/itemviewformaction.cpp:283
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:521 src/itemlistformaction.cpp:679
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr ""
 
-#: src/feedlistformaction.cpp:538 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr ""
 
-#: src/feedlistformaction.cpp:539 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1462 src/view.cpp:175
-msgid "yn"
-msgstr ""
-
-#: src/feedlistformaction.cpp:539 src/view.cpp:175
-msgid "y"
-msgstr ""
-
-#: src/feedlistformaction.cpp:612 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1250 src/itemviewformaction.cpp:482
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr ""
 
-#: src/feedlistformaction.cpp:613 src/itemlistformaction.cpp:1251
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr ""
 
-#: src/feedlistformaction.cpp:614 src/itemlistformaction.cpp:1254
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
 #: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr ""
 
-#: src/feedlistformaction.cpp:615 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr ""
 
-#: src/feedlistformaction.cpp:616
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr ""
 
-#: src/feedlistformaction.cpp:617
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr ""
 
-#: src/feedlistformaction.cpp:618 src/itemlistformaction.cpp:1255
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr ""
 
-#: src/feedlistformaction.cpp:619 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1256
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr ""
 
-#: src/feedlistformaction.cpp:620 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1257 src/itemviewformaction.cpp:487
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr ""
 
-#: src/feedlistformaction.cpp:944 src/itemlistformaction.cpp:837
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:961 src/itemlistformaction.cpp:872
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr ""
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:885
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr ""
 
-#: src/feedlistformaction.cpp:983 src/itemlistformaction.cpp:892
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr ""
 
-#: src/feedlistformaction.cpp:994 src/itemlistformaction.cpp:1269
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:1069
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr ""
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr ""
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr ""
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr ""
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr ""
@@ -820,35 +843,35 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr ""
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr ""
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr ""
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr ""
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr ""
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr ""
 
@@ -864,140 +887,140 @@ msgstr ""
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:181 src/itemlistformaction.cpp:202
-#: src/itemlistformaction.cpp:340 src/itemlistformaction.cpp:369
-#: src/itemlistformaction.cpp:395 src/itemlistformaction.cpp:612
-#: src/itemlistformaction.cpp:850
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr ""
 
-#: src/itemlistformaction.cpp:244 src/itemviewformaction.cpp:394
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:286
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:330 src/itemviewformaction.cpp:325
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr ""
 
-#: src/itemlistformaction.cpp:386 src/itemrenderer.cpp:67
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
 #: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr ""
 
-#: src/itemlistformaction.cpp:414 src/itemlistformaction.cpp:1298
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr ""
 
-#: src/itemlistformaction.cpp:432
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr ""
 
-#: src/itemlistformaction.cpp:453 src/itemlistformaction.cpp:462
-#: src/itemlistformaction.cpp:486 src/itemviewformaction.cpp:347
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
 #: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
-#: src/view.cpp:717 src/view.cpp:793
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr ""
 
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:368
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:479 src/itemviewformaction.cpp:378
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:492 src/itemlistformaction.cpp:497
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr ""
 
-#: src/itemlistformaction.cpp:566
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr ""
 
-#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:299
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:693 src/itemlistformaction.cpp:731
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 msgid "dtfalgr"
 msgstr ""
 
-#: src/itemlistformaction.cpp:695
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:733
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:858 src/itemviewformaction.cpp:558
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr ""
 
-#: src/itemlistformaction.cpp:959 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1338 src/itemviewformaction.cpp:230
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
 #: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr ""
 
-#: src/itemlistformaction.cpp:1343 src/itemviewformaction.cpp:534
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1346 src/itemviewformaction.cpp:538
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1421
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1424
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1431
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1464
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1516
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1538
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1545
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1036,7 +1059,7 @@ msgstr ""
 msgid "Bottom"
 msgstr ""
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr ""
@@ -1062,8 +1085,8 @@ msgid "Error: couldn't write article to file %s"
 msgstr ""
 
 #: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
-#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr ""
 
@@ -1076,7 +1099,7 @@ msgstr ""
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr ""
 
@@ -1138,11 +1161,11 @@ msgid "Save articles"
 msgstr ""
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
+msgid "Go to next entry"
 msgstr ""
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
+msgid "Go to previous entry"
 msgstr ""
 
 #: src/keymap.cpp:101
@@ -1451,7 +1474,7 @@ msgstr ""
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, c-format
 msgid "`%s' is not a valid operation"
 msgstr ""
@@ -1466,65 +1489,65 @@ msgstr ""
 msgid "regular expression '%s' is invalid: %s"
 msgstr ""
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr ""
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr ""
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr ""
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
 "usage %s [-C <file>] [-q <file>] [-h]\n"
 msgstr ""
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr ""
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr ""
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr ""
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr ""
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr ""
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr ""
 
@@ -1532,7 +1555,7 @@ msgstr ""
 msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr ""
 
@@ -1590,43 +1613,43 @@ msgstr ""
 msgid "`%s' is not a valid regular expression: %s"
 msgstr ""
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr ""
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr ""
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr ""
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr ""
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr ""
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr ""
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr ""
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr ""
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr ""
 
@@ -1638,27 +1661,31 @@ msgstr ""
 msgid "EOF found while reading XML tag"
 msgstr ""
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 msgid "No links available!"
 msgstr ""
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr ""
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr ""
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr ""
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr ""
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2020-06-17 09:45+0200\n"
 "Last-Translator: Dennis van der Schagt <dennisschagt@gmail.com>\n"
 "Language-Team: Dutch <vertalen@vrijschrift.org>, Erwin Poeze <donnut@outlook."
@@ -59,11 +59,11 @@ msgstr "<bestand>"
 msgid "use <cachefile> as cache file"
 msgstr "gebruik <bestand> als cachebestand"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<bestand>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "configuratie uit <bestand> lezen"
 
@@ -87,19 +87,19 @@ msgstr "opstarten zonder opdrachtregeluitvoer"
 msgid "get version information"
 msgstr "versie-informatie tonen"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<niveau>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "log niveaus 1..<niveau> wegschrijven (geldige waarden: 1 tot 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<bestand>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "<bestand> als logbestand gebruiken"
 
@@ -111,7 +111,7 @@ msgstr "exporteer lijst van gelezen artikelen naar <bestand>"
 msgid "import list of read articles from <file>"
 msgstr "importeer lijst van gelezen artikelen uit <bestand>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "deze hulptekst"
 
@@ -181,23 +181,23 @@ msgstr "Fout (newsboat::DbException): %s"
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Fout (newsboat::MatcherException): %s"
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Fout (newsboat::Exception): %s"
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "kleur ‘%s’ is ongeldig"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "attribuut ‘%s’ is ongeldig"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "configuratie-element ‘%s’ is ongeldig"
@@ -209,7 +209,7 @@ msgstr ""
 "newsboat: klaar met vernieuwen, %f ongelezen feeds (%n ongelezen artikelen "
 "in totaal)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
@@ -217,11 +217,11 @@ msgstr ""
 "%N %V - Artikelen in feed ‘%T’ (%u ongelezen, %t totaal)%?F? gefilterd met `"
 "%F'&? - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialogen"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
@@ -229,36 +229,36 @@ msgstr ""
 "%N %V - %?F?Feeds&Uw feeds? (%u ongelezen, %t totaal)%?F? gefilterd met `"
 "%F'&?%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Open Bestand&Bestand opslaan? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Open Map&Bestand opslaan? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Hulp"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artikel ‘%T’ (%u ongelezen, %t totaal)"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr ""
 "%N %V - Zoekresultaten (%u ongelezen, %t totaal)%?F? gefilterd met `%F'&?"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Filter selecteren"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Tag selecteren"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
@@ -297,38 +297,43 @@ msgstr "bestand openen is mislukt."
 msgid "unknown error (bug)."
 msgstr "onbekende fout (bug)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Fout bij het uitvoeren van opdrachtregel ‘%s’ (%s regel %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "onbekende opdracht ‘%s’"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Fout bij het uitvoeren van opdrachtregel ‘%s’ (%s regel %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Starten van %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Fout: er draait al een instantie van %s (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Laden van de configuratie..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "klaar."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Openen van de cache..."
 
@@ -348,7 +353,20 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s is niet toegangelijk en kan ook niet aangemaakt worden\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+#, fuzzy
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+"Error: `cookie-cache` moet ingesteld worden om NewsBlur te kunnen "
+"gebruiken.\n"
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
@@ -356,17 +374,17 @@ msgstr ""
 "Fout: Om Inoreader te gebruiken moet er een waarde gegeven worden voor "
 "`inoreader-app-id` en `inoreader-app-key`.\n"
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr "Fout: Onbekende waarde voor urls-source: `%s'"
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "URLs laden uit %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -375,7 +393,7 @@ msgstr ""
 "Fout: geen URLs geconfigureerd. Plaats RSS-feed URLs in het bestand %s of "
 "importeer een OPML-bestand."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -383,7 +401,7 @@ msgstr ""
 "Blijkbaar bevat de OPML-feed waar uw zich op heeft geabonneerd geen feeds. "
 "Vul het met feeds en probeer het dan opnieuw."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -391,7 +409,7 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw \"The Old Reader\"-"
 "account. Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -399,7 +417,7 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw Tiny Tiny RSS-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -407,7 +425,7 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw NewsBlur-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -415,69 +433,78 @@ msgstr ""
 "Blijkbaar hebt u nog geen feeds geconfigureerd in uw Inoreader-account. "
 "Configureer enkele feeds en probeer dan opnieuw."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Blijkbaar hebt u nog geen feeds geconfigureerd in uw NewsBlur-account. "
+"Configureer enkele feeds en probeer dan opnieuw."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Laden van artikelen uit de cache..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Grondig opruimen van de cache..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Fout bij het laden van feeds uit de database: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Fout tijdens het laden van ‘%s’: %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Feedzoekopdrachten voorinvullen..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Importeren van lijst van gelezen artikelen..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Exporteren van lijst van gelezen artikelen..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Opruimen van de cache..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "fout: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Fout: alle feeds als gelezen markeren is mislukt: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Het ontleden van %s is mislukt."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Klaar met importeren van %s."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u ongelezen artikelen"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: onbekende opdracht"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fout: configuratiebestand ‘%s’ openen is mislukt!"
@@ -498,26 +525,26 @@ msgstr "Sluit dialoogvenster"
 msgid "Error: you can't remove the feed list!"
 msgstr "Fout: feedlijst verwijderen is mislukt!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Ongeldige positie!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr "Map: "
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Opslaan"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, c-format
 msgid "Save Files - %s"
 msgstr "Bestanden opslaan - %s"
@@ -562,10 +589,6 @@ msgstr "afgespeeld"
 msgid "unknown (bug)."
 msgstr "onbekend (bug)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "ongeldige feed-index (bug)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Mensen die u volgt"
@@ -579,20 +602,20 @@ msgstr "Favoriete items"
 msgid "Shared items"
 msgstr "Gedeelde items"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Geen feeds geselecteerd!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr "etaoln"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -600,7 +623,7 @@ msgstr ""
 "Sorteren op (e)erste tag/(t)itel/(a)antal artikelen/aantal (o)ngelezen "
 "artikelen/(l)aatst aangepast/(n)iets?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -608,158 +631,174 @@ msgstr ""
 "Omgekeerd sorteren op (e)erste tag/(t)itel/(a)antal artikelen/aantal "
 "(o)ngelezen artikelen/(l)aatst aangepast/(n)iets?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Open artikel in browser"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "Browser gaf error code %i terug"
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "Feed-zoekopdrachten kunnen niet in een browser geopend worden!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Bezig met feed als gelezen te markeren..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Fout: feed als gelezen markeren is mislukt: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Geen feeds met ongelezen items."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Dit is reeds de laatste feed."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Dit is reeds de eerste feed."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Bent u zeker dat u ‘%s’ wilt overschrijven (j:ja n:nee)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "jn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "j"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Bezig met alle feeds als gelezen te markeren..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Fout: filteropdracht ‘%s’ ontleden is mislukt: %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Geen filters gedefinieerd."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Zoeken naar: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Zeker dat u wilt afsluiten (j:ja n:nee)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "jn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "j"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Afsluiten"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Openen"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Volgende Ongelezen"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Vernieuwen"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Alles vernieuwen"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Markeer als gelezen"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Alles als gelezen markeren"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Zoeken"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Hulp"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Fout: filteropdracht ontleden is mislukt!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Bezig met zoeken..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Fout tijdens het zoeken naar ‘%s’: %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Geen resultaten."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Positie niet zichtbaar!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Feedlijst - %u ongelezen, %u totaal"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Bent u zeker dat u ‘%s’ wilt overschrijven (j:ja n:nee)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Bestand: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Bestand opslaan - %s"
@@ -851,35 +890,35 @@ msgstr "Ongekoppelde functies:"
 msgid "Clear"
 msgstr "Wissen"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "ingebedde flash:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "afbeelding"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Koppelingen: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "koppeling"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "ingebedde flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr "video"
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr "audio"
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "onbekend (bug)"
 
@@ -895,137 +934,137 @@ msgstr "Liked items"
 msgid "Saved web pages"
 msgstr "Opgeslagen webpagina's"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Geen item geselecteerd!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Gelezen-vlag van artikel omschakelen..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Gelezen-vlag omschakelen is mislukt: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "URL-lijst is leeg."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Vlaggen: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Fout: geen item geselecteerd!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Fout: zoekresultaten vernieuwen is mislukt."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Er zijn geen ongelezen items."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Dit is reeds het laatste item."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Dit is reeds het eerste item."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Geen ongelezen feeds."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr "Bezig met alle voorgaande feeds als gelezen te markeren..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Pipe artikel naar commando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 msgid "dtfalgr"
 msgstr "dtvakgw"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sorteren op (d)atum/(t)itel/(v)laggen/(a)uteur/(k)oppeling/(g)uid/"
 "(w)illekeurig?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Omgekeerd sorteren op (d)atum/(t)itel/(v)laggen/(a)uteur/(k)oppeling/(g)uid/"
 "(w)illekeurig?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Vlaggen zijn bijgewerkt."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Fout: toepassen van filter is mislukt: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Opslaan afgebroken."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artikel opgeslagen in %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fout: opslaan artikel in %s is mislukt"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Zoekresultaat - ‘%s’"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Feed-zoekopdracht - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikellijst - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "Wilt u `%s' in `%s' overschrijven? (y:Ja n:No)"
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr "janq"
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -1034,7 +1073,7 @@ msgstr ""
 "Wilt u `%s' in `%s' overschrijven? Er zijn %d vergelijkbare conflicten (j:Ja "
 "a:Alles overschrijven n:Nee q:Niks overschrijven)"
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1067,15 +1106,15 @@ msgstr "Download-URL podcast: "
 msgid "type: "
 msgstr "type: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Boven"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Onder"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fout bij het als gelezen markeren van het artikel: %s"
@@ -1100,35 +1139,35 @@ msgstr "Artikel opgeslagen in %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Fout: artikel opslaan in bestand ‘%s’ is mislukt"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Bezig met starten van browser..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Het als ongelezen markeren van het artikel ‘%s’ is mislukt"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Ga naar URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Openen in browser"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Aan downloadlijst toevoegen"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Fout: ongeldige reguliere expressie!"
 
@@ -1177,12 +1216,14 @@ msgid "Save articles"
 msgstr "Artikelen opslaan"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Ga naar volgend artikel"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Ga naar volgend ongelezen element"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Ga naar vorig artikel"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Ga naar vorig ongelezen element"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1490,7 +1531,7 @@ msgstr "‘%s’ is een ongeldige context"
 msgid "`%s' is not a valid key command"
 msgstr "‘%s’ is een ongeldige toetsopdracht"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, c-format
 msgid "`%s' is not a valid operation"
 msgstr "‘%s’ is een ongeldige opdracht"
@@ -1505,17 +1546,17 @@ msgstr "attribuut ‘%s’ is niet beschikbaar."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "reguliere expressie ‘%s’ is ongeldig: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: configuratiemap ‘%s’ is niet toegankelijk, daarom wordt ‘%s’ gebruikt."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Fatale fout: bepalen van de persoonlijke map is mislukt!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1523,21 +1564,21 @@ msgstr ""
 "Stel de omgevingsvariabele HOME in of voeg een geldige gebruiker toe voor "
 "UID %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Fout: aanmaken van configuratie-map ‘%s’ is mislukt: (%i) %s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: logniveau is ongeldig"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Wachtrij opruimen..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1546,29 +1587,29 @@ msgstr ""
 "%s %s\n"
 "gebruik: %s [-C <bestand>] [-q <bestand>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<bestand>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "gebruik <bestand> als downloadlijst"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "start automatisch met downloaden"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u gelijktijdige downloads"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Wachtrij (%u downloads bezig, %u totaal) - %.2f %s totaal%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Fout: afsluiten is mislukt: download(s) zijn bezig."
 
@@ -1577,7 +1618,7 @@ msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Fout: download moet klaar zijn voordat het bestand afgespeeld kan worden."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Fout: opdracht uitvoeren is mislukt: download(s) zijn bezig."
 
@@ -1638,43 +1679,43 @@ msgstr "‘%s’ is een ongelidg dialoogvenstertype"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "‘%s’ is ongeldige reguliere expressie: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sLaden van %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Ophalen van ‘%s’ is mislukt: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Fout: ongeldige feed!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "te weinig argumenten"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "‘%s’ is een ongeldige filterexpressie"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Fout: niet ondersteunde URL: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Tag selecteren"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Filter selecteren"
 
@@ -1686,27 +1727,31 @@ msgstr "attribuut niet gevonden"
 msgid "EOF found while reading XML tag"
 msgstr "EOF gevonden tijdens het lezen van XML-tag"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 msgid "No links available!"
 msgstr "Geen koppelingen beschikbaar!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Bladwijzer opslaan"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Fout: feed bevat geen items!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Geen tags gedefinieerd."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Feed-zoekopdracht bijwerken..."
 
@@ -1755,7 +1800,7 @@ msgstr "feed-type wordt niet ondersteund"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %s: logniveau is ongeldig"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1764,28 +1809,51 @@ msgstr ""
 "Stel de omgevingsvariabele HOME in of voeg een geldige gebruiker toe voor "
 "UID %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 "Bezig met migreren van configuratiebestanden en data vanaf Newsbeuter XDG "
 "mappen..."
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 "Bezig met migreren van configuratiebestanden en data vanaf ~/.newsbeuter/..."
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Migratie is afgebroken omdat mkdir mislukte voor map `%s': %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr "regcomp gaf error code %i terug"
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr "regexec gaf error code %i terug"
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "ongeldige feed-index (bug)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Ga naar volgend artikel"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Ga naar vorig artikel"
 
 #~ msgid "config"
 #~ msgstr "configuratie"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2019-01-09 20:42+0100\n"
 "Last-Translator: Michal Siemek <carnophage@dobramama.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -58,11 +58,11 @@ msgstr "<plik pamięci podręcznej>"
 msgid "use <cachefile> as cache file"
 msgstr "użyj <plik pamięci podręcznej> jako pliku pamięci podręcznej"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<plik konfiguracyjny>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "wczytaj konfiguracje z <plik konfiguracyjny>"
 
@@ -86,20 +86,20 @@ msgstr "cichy start"
 msgid "get version information"
 msgstr "pobierz informacje o wersji"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<poziom logowania>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 "utwórz log używając wybranego poziomu logowania (poprawne wartości: 1 do 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<plik z logami>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "użyj <plik z logami> jako wyjściowy plik z logami"
 
@@ -111,7 +111,7 @@ msgstr "eksport listy przeczytanych artykułów do <plik>"
 msgid "import list of read articles from <file>"
 msgstr "import listy przeczytanych artykułów z <plik>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "ta strona pomocy"
 
@@ -188,23 +188,23 @@ msgstr "Złapano wyjątek newsboat::dbexception o treści: %s"
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Złapano wyjątek newsboat::matcherexception o treści: %s"
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, fuzzy, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Złapano wyjątek newsboat::dbexception o treści: %s"
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' nie jest poprawnym kolorem"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' nie jest poprawnym atrybutem"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' nie jest poprawnym elementem konfiguracji"
@@ -216,7 +216,7 @@ msgstr ""
 "newsboat: odświeżanie zakończone, %f nieprzeczytanych kanałów(%n "
 "nieprzeczytanych artykułów)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
@@ -224,11 +224,11 @@ msgid ""
 msgstr ""
 "%N %V - Artykuły w kanale '%T' (%u nieprzeczytanych, %t wszystkich) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Okna dialogowe"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
@@ -236,37 +236,37 @@ msgid ""
 msgstr ""
 "%N %V - Twoje kanały (%u nieprzeczytanych, %t wszystkich)%?T? - tag '%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Otwórz plik&Zapisz plik? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Otwórz plik&Zapisz plik? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Pomoc"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artykuł '%T' (%u nieprzeczytanych, %t wszystkich)"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Wynik wyszukiwania (%u nieprzeczytanych, %t wszystkich)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Wybierz filtr"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Wybierz tag"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - Odnośniki"
 
@@ -305,38 +305,43 @@ msgstr "nie udało się otworzyć pliku."
 msgid "unknown error (bug)."
 msgstr "nieznany błąd (bug)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Błąd podczas przetwarzania komendy '%s' (%s linia %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "nieznana komenda '%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Błąd podczas przetwarzania komendy '%s' (%s linia %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Uruchamianie %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Błąd: inny proces %s jest już uruchomiony (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Czytanie konfiguracji..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "gotowe."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Otwieranie pamięci podręcznej..."
 
@@ -354,23 +359,34 @@ msgstr "BŁĄD: Musisz ustawić `cookie-cache` aby korzystać z NewsBlur.\n"
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s jest niedostępny i nie może zostać utworzony\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+#, fuzzy
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr "BŁĄD: Musisz ustawić `cookie-cache` aby korzystać z NewsBlur.\n"
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Czytanie odnośników z %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -379,7 +395,7 @@ msgstr ""
 "Błąd: brak skonfigurowanych odnośników. Dodaj do pliku %s kilka odnośników "
 "do kanałów RSS lub zaimportuj plik OPML."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -387,7 +403,7 @@ msgstr ""
 "Wygląda na to, że kanał OPML który subskrybujesz nie posiada żadnych kanałów."
 "Wypełnij go źródłami RSS i spróbuj ponownie."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -395,7 +411,7 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie The "
 "Old Reader. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -403,7 +419,7 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie Tiny "
 "Tiny RSS. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -411,7 +427,7 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie "
 "NewsBlur. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -419,69 +435,78 @@ msgstr ""
 "Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie "
 "Inoreader. Wykonaj to proszę i spróbuj ponownie."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Wygląda na to, że nie skonfigurowałeś żadnych kanałów na swoim koncie "
+"NewsBlur. Wykonaj to proszę i spróbuj ponownie."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Wczytywanie artykułów z pamięci podręcznej..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Dokładne czyszczenie pamięci podręcznej..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Błąd podczas wczytywania kanałów z bazy danych: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Błąd podczas ładowania kanału: '%s': %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Wstępne wypełnianie kanałów zapytań..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Importowanie listy przeczytanych artykułów..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Eksportowanie listy przeczytanych artykułów..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Czyszczenie pamięci podręcznej..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "nieudane: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Błąd: nie można zaznaczyć wszystkich kanałów jako przeczytanych: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Wystąpił błąd podczas przetwarzania %s."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Import z %s zakończony."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u nieprzeczytanych artykułów"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: nieznana komenda"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Błąd: nie można otworzyć pliku konfiguracyjnego `%s'!"
@@ -502,26 +527,26 @@ msgstr "Zamknij okno"
 msgid "Error: you can't remove the feed list!"
 msgstr "Błąd: nie możesz usunąć listy kanałów!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Błędna pozycja!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Zapisz"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Zapisz plik - %s"
@@ -566,10 +591,6 @@ msgstr "odtworzony"
 msgid "unknown (bug)."
 msgstr "nieznany (bug)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "nieprawidłowy indeks kanału (bug)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Obserwowane osoby"
@@ -583,20 +604,20 @@ msgstr "Pozycje oznaczone gwiazdką"
 msgid "Shared items"
 msgstr "Pozycje współdzielone"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Nie wybrano żadnego kanału!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr "ptlnob"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -604,7 +625,7 @@ msgstr ""
 "Sortuj wg (p)ierwszego taga/(t)ytułu/(l)iczby artykułów/liczby "
 "(n)ieprzeczytanych artykułów/(o)statnio aktualizowane/(b)rak?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -612,158 +633,174 @@ msgstr ""
 "Sortuj odwrotnie wg (p)ierwszego taga/(t)ytułu/(l)iczby artykułów/liczby "
 "(n)ieprzeczytanych artykułów/(o)statnio aktualizowane/(b)rak?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Otwórz artykuł w przeglądarce"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "Nie można otworzyć wybranych kanałów w przeglądarce!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Oznaczam kanał jako przeczytany..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Błąd: nie udało się oznaczyć kanału jako przeczytanego: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Brak kanałów z nieprzeczytanymi artykułami."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "To już ostatni kanał."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "To już pierwszy kanał."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Czy na pewno chcesz nadpisać `%s' (t:Tak n:Nie)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "tn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "t"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Oznaczam wszystkie kanały jako przeczytane..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Błąd składniowy komendy filtra `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Brak zdefiniowanych filtrów."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Szukaj: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filtr: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Czy na pewno chcesz wyjść (t:Tak n:Nie)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "tn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "t"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Wyjście"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Otwórz"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Następny nieprzeczytany"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Odśwież"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Odśwież wszystkie"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Oznacz jako przeczytane"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Oznacz wszystkie jako przeczytane"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Szukaj"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Pomoc"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Błąd składniowy komendy filtra!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Wyszukiwanie..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Błąd podczas wyszukiwania `%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Brak wyników."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Pozycja niewidoczna!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista kanałów - %u nieprzeczytanych, %u wszystkich"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Czy na pewno chcesz nadpisać `%s' (t:Tak n:Nie)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Plik: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Zapisz plik - %s"
@@ -856,35 +893,35 @@ msgstr "Nieprzypisane funkcje:"
 msgid "Clear"
 msgstr "Wyczyść"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "osadzony flash:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "obraz"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Odsyłacze: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "odsyłacz"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "osadzony flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "nieznany (bug)"
 
@@ -900,144 +937,144 @@ msgstr "Polubione pozycje"
 msgid "Saved web pages"
 msgstr "Zapisane strony internetowe"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Nie wybrano żadnej pozycji!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Przełączam znacznik przeczytania dla artykułu..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Błąd podczas przełączania znacznika przeczytania: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "Lista adresów jest pusta."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Flagi: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Błąd: nie wybrano żadnej pozycji!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Błąd: nie możesz odświeżyć wyników wyszukiwania."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Brak nieprzeczytanych pozycji."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "To już ostatnia pozycja."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "To już pierwsza pozycja."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Brak nieprzeczytanych kanałów."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr "Oznaczam powyższe jako przeczytane..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Prześlij artykuł do polecenia: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "dtfaog"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 #, fuzzy
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Sortuj wg (d)aty/(t)ytułu/(f)lag/(a)utora/(o)dnośnika/(g)uid?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 #, fuzzy
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sortuj odwrotnie wg (d)aty/(t)ytułu/(f)lag/(a)utora/(o)dnośnika/(g)uid?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Znaczniki uaktualnione."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Błąd: użycie filtra nie powiodło się: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Zapisywanie przerwane."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Zapisano artykuł do %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Błąd: nie można zapisać artykułu do %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Wyniki wyszukiwania - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Kanał zapytania - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista artykułów - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1068,15 +1105,15 @@ msgstr "Adres podcastu: "
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Góra"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Dół"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Błąd podczas oznaczania artykułu jako przeczytanego: %s"
@@ -1101,35 +1138,35 @@ msgstr "Zapisano artykuł do %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Błąd: nie można zapisać artykułu do pliku %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Uruchamiam przeglądarkę..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Błąd podczas oznaczania artykułu jako nieprzeczytanego: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Idź do adresu URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Otwórz w przeglądarce"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Zakolejkuj"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Artykuł - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Błąd: nieprawidłowe wyrażenie regularne!"
 
@@ -1179,12 +1216,14 @@ msgid "Save articles"
 msgstr "Zapisz artykuł"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Przejdź do następnego artykułu"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Przejdź do następnego wpisu"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Przejdź do poprzedniego artykułu"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Idź do poprzedniego wpisu"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1494,7 +1533,7 @@ msgstr "`%s' nie jest dopuszczalnym kontekstem"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' nie jest dopuszczalnym poleceniem"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' nie jest dopuszczalnym kontekstem"
@@ -1509,16 +1548,16 @@ msgstr "atrybut '%s' nie jest dostępny."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "wyrażenie regularne: '%s' jest nieprawidłowe: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: folder z konfiguracją '%s' niedostępny, zostanie użyty '%s'."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Błąd krytyczny: nie mogę znaleźć katalogu domowego!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1526,22 +1565,22 @@ msgstr ""
 "Proszę ustawić zmienną środowiskową HOME lub dodać prawidłowego użytkownika "
 "o UID %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr ""
 "Błąd krytyczny: nie można otworzyć pliku konfiguracyjnego `%s': (%i) %s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: nieprawidłowy poziom logowania"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Czyszczenie kolejki..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1550,29 +1589,29 @@ msgstr ""
 "%s %s\n"
 "Składnia: %s [-C <plik>] [-q <plik>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<plik kolejki>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "użyj <plik kolejki> jako pliku kolejki"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "rozpocznij pobieranie przy starcie"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u równoległych pobrań"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Kolejka (%u pobieranych plików, %u wszystkich) - %.2f kb/s całość%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Błąd: nie można wyjść, pobieranie w toku."
 
@@ -1581,7 +1620,7 @@ msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Błąd: pobieranie musi być zakończone zanim plik będzie mógł być odtworzony."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Błąd: nie można wykonać operacji: pobieranie w toku."
 
@@ -1639,43 +1678,43 @@ msgstr "`%s' nie jest dopuszczalnym typem dialogu"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' nie jest poprawnym wyrażeniem regularnym: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sWczytywanie %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Błąd podczas pobierania %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Błąd: nieprawidłowy kanał!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "zbyt mało parametrów"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' nie jest poprawnym filtrem"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Błąd: nieobsługiwany adres: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Wybierz tag"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Wybierz filtr"
 
@@ -1687,28 +1726,32 @@ msgstr "atrybut nie znaleziony"
 msgid "EOF found while reading XML tag"
 msgstr "Trafiono na koniec pliku podczas odczytu tagu XML"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Brak wybranego odnośnika!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Zapisz zakładkę"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "Adresy URL"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Błąd: kanał jest pusty!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Brak zdefiniowanych tagów."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Odświeżam kanał kolejki..."
 
@@ -1758,7 +1801,7 @@ msgstr "niewspierany format kanału"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: nieprawidłowy poziom logowania"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1767,26 +1810,49 @@ msgstr ""
 "Proszę ustawić zmienną środowiskową HOME lub dodać prawidłowego użytkownika "
 "o UID %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Błąd: otwarcie pliku pamięci podręcznej '%s' nieudane: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "nieprawidłowy indeks kanału (bug)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Przejdź do następnego artykułu"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Przejdź do poprzedniego artykułu"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.8\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2018-03-06 20:35-0300\n"
 "Last-Translator: Alexandre Erwin Ittner <alexandre@ittner.com.br>\n"
 "Language-Team: \n"
@@ -59,11 +59,11 @@ msgstr "<arquivocache>"
 msgid "use <cachefile> as cache file"
 msgstr "usar <arquivocache> como arquivo de cache"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<arquivoconfig>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "ler configurações de <arquivoconfig>"
 
@@ -87,21 +87,21 @@ msgstr "início silencioso"
 msgid "get version information"
 msgstr "obter informações sobre a versão"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<nívellog>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr ""
 "escrever arquivo de log com um determinado nível de log (valores válidos: 1 "
 "a 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<arquivolog>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "usar <arquivolog> como arquivo de log"
 
@@ -113,7 +113,7 @@ msgstr "exportar lista de artigos lidos para <arquivo>"
 msgid "import list of read articles from <file>"
 msgstr "importar lista de artigos lidos de <arquivo>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "esta ajuda"
 
@@ -190,23 +190,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "'%s' não é uma cor válida"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "'%s' não é um atributo válido"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "'%s' não é um elemento de configuração válido"
@@ -218,55 +218,55 @@ msgstr ""
 "newsboat: recarregamento terminado, %f fontes não lidos (%n artigos não "
 "lidos no total)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N %V - Artigos na fonte '%T' (%u não lidos, %t no total) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Telas"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - Suas fontes (%u não lidas, %t no total)%?T? - etiqueta '%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Abrir Arquivo&Salvar arquivo? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Abrir Arquivo&Salvar arquivo? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Ajuda"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artigo '%T' (%u não lidos, %t no total)"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Resultado da busca (%u não lidos, %t no total)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Selecione o Filtro"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Selecione a etiqueta"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
@@ -305,38 +305,43 @@ msgstr "o arquivo não pôde ser aberto."
 msgid "unknown error (bug)."
 msgstr "erro desconhecido (erro de software)"
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Erro ao processar o comando '%s' (%s linha %u). %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "comando desconhecido '%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Erro ao processar o comando '%s' (%s linha %u). %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Iniciando o %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Erro: uma instância de %s já está sendo executada (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Carregando configuração..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "pronto."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Abrindo o cache..."
 
@@ -354,23 +359,33 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s não está acessível e não pode ser criado\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Carregando URLS a partir de %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -379,7 +394,7 @@ msgstr ""
 "Erro: nenhuma URL configurada. Por favor preencha o arquivo %s com URLs de "
 "fontes RSS ou importe um arquivo OPML."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -387,7 +402,7 @@ msgstr ""
 "Parece que a fonte OPML especificada não tem fontes RSS. Por favor, preencha-"
 "a com fontes RSS e tente novamente."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -395,7 +410,7 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta em The Old Reader. "
 "Faça isso, e tente novamente."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -403,7 +418,7 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta do Tiny Tiny RSS."
 "Faça isso, e tente novamente."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -411,7 +426,7 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta do NewsBlur. Faça "
 "isso, e tente novamente."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -419,69 +434,78 @@ msgstr ""
 "Parece que você não configurou nenhuma fonte na sua conta em Inoreader. Faça "
 "isso, e tente novamente."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Parece que você não configurou nenhuma fonte na sua conta do NewsBlur. Faça "
+"isso, e tente novamente."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Carregando artigos do cache..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Limpando o cache completamente..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Erro carregando as fontes do banco de dados: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Erro carregando fonte '%s': %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Pré-povoando fontes de consulta..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Importando lista de artigos lidos..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Exportando lista de artigos lidos..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Limpando o cache..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "falha: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Erro: não foi possível marcar todos artigos como lidos: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Um erro ocorreu durante a análise de %s."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importação de %s concluída."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u artigos não lidos"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: comando desconhecido"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Erro: não foi possível abrir o arquivo de configuração '%s'!"
@@ -502,26 +526,26 @@ msgstr "Fechar Tela"
 msgid "Error: you can't remove the feed list!"
 msgstr "Erro: você não pode remover a lista de fontes!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Posição inválida!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Salvar"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Salvar Arquivo - %s"
@@ -566,10 +590,6 @@ msgstr "tocado"
 msgid "unknown (bug)."
 msgstr "desconhecido (erro de software)"
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "índice de fonte inválido (erro de software)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Pessoas que você segue"
@@ -583,21 +603,21 @@ msgstr "Itens com estrela"
 msgid "Shared items"
 msgstr "Itens compartilhados"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Nenhuma fonte RSS selecionada!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 #, fuzzy
 msgid "ftauln"
 msgstr "ptqnm"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -606,7 +626,7 @@ msgstr ""
 "Classificar por (p)rimeiraetiqueta/(t)ítulo/(q)uantidadeartigos/"
 "quantidadeartigos(n)ãolidos/nenhu(m)?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -615,158 +635,174 @@ msgstr ""
 "Classificar inversamente por (p)rimeiraetiqueta/(t)ítulo/(q)uantidadeartigos/"
 "quantidadeartigos(n)ãolidos/nenhu(m)?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Abrir artigo no navegador"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "Não é possível abrir fontes de consulta no navegador!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Marcando fonte como lida..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Erro: não foi possível marcar fonte como lida: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Nenhuma fonte RSS com artigos não lidos."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Já na última fonte"
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Já na primeira fonte"
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Tem certeza que deseja sobrescrever '%s' (s: Sim n:Não)?"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "sn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "s"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Marcando todas fontes RSS como lidas..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Erro: não foi possível analisar o comando de filtro '%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Nenhum filtro definido."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Procurar por: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filtro: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Tem certeza que deseja sair (s: Sim n: Não)?"
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "sn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "s"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Sair"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Abrir"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Próxima Não Lida"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Recarregar"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Recarregar Todas"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Marcar como Lida"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Marcar Todos como Lidos"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Procurar"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Ajuda"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Erro: não foi possível analisar o comando de filtro!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Procurando..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Erro procurando por '%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Nenhum resultado."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "A posição não está visível!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista de Fontes - %u não lidas, %u no total"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Tem certeza que deseja sobrescrever '%s' (s: Sim n:Não)?"
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "m"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Arquivo: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Salvar Arquivo - %s"
@@ -859,35 +895,35 @@ msgstr "Funções sem ligações:"
 msgid "Clear"
 msgstr "Limpar"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "flash embutido:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "imagem"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Links: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "link"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "flash embutido"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "desconhecido (erro de software)"
 
@@ -903,146 +939,146 @@ msgstr "Itens gostados"
 msgid "Saved web pages"
 msgstr "Páginas web salvas"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Nenhum item selecionado!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Alternando estado lido/não lido do artigo..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Erro ao alternar estado lido/não lido do artigo: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "A lista de URLs está vazia."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Sinalizações: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Erro: nenhum item selecionado!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Erro: você não pode recarregar os resultados da busca."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Nenhum artigo não lido."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Já no último item"
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Já no primeiro item"
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Nenhuma fonte não lida."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Marcando todas fontes RSS como lidas..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Passar o artigo por pipe ao comando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "dtsalg"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 #, fuzzy
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Classificar por (d)ata/(t)ítulo/(s)inalizações/(a)utor/(l)ink/(g)uid?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 #, fuzzy
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Classificar inversamente por (d)ata/(t)ítulo/(s)inalizações/(a)utor/(l)ink/"
 "(g)uid?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Sinalizações atualizadas."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Erro: aplicação do filtro falhou: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Salvamento cancelado."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Artigo salvo em %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Erro: não foi possível salvar artigo em %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Resultado da Busca - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Fonte de Consulta - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Lista de Artigos - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1073,15 +1109,15 @@ msgstr "URL para baixar Podcast: "
 msgid "type: "
 msgstr "tipo: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Início"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Fim"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Erro marcando artigo como lido: %s"
@@ -1106,35 +1142,35 @@ msgstr "Artigo salvo em %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Erro: não foi possível gravar o artigo no arquivo %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Iniciando navegador..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Erro marcando artigo como não lido: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Ir para a URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Abrir no Navegador"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Pôr na Fila"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Artigo - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Erro: expressão regular inválida!"
 
@@ -1185,12 +1221,14 @@ msgid "Save articles"
 msgstr "Salvar artigo"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Ir para o próximo artigo"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Ir para o próximo item"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Ir para o artigo anterior"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Ir para o item anterior "
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1501,7 +1539,7 @@ msgstr "'%s' não é um contexto válido"
 msgid "`%s' is not a valid key command"
 msgstr "'%s' não é um comando de tecla válido"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "'%s' não é um contexto válido"
@@ -1516,16 +1554,16 @@ msgstr "atributo '%s' não está disponível."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "a expressão regular '%s' é inválida: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: diretório de configuração '%s' inacessível, usando '%s' no lugar."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Erro fatal: não foi possível determinar o diretório do usuário!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1533,21 +1571,21 @@ msgstr ""
 "Por favor defina a variável de ambiente HOME ou adicione um usuário válido "
 "para o UID %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Erro: não foi possível abrir o arquivo de configuração '%s'!"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: nível de log inválido"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Limpando fila..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1556,29 +1594,29 @@ msgstr ""
 "%s %s\n"
 "uso: %s [-C <arquivo>] [-q <arquivo>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<arquivofila>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "usar <arquivofila> como arquivo de fila"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "iniciar download ao abrir"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u transferências simultâneas"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Fila (%u transferências em progresso, %u no total) - %.2f kb/s total%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Erro: não é possível sair: transferência(s) em progresso"
 
@@ -1587,7 +1625,7 @@ msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Erro: a transferência precisa ser concluída antes de o arquivo ser tocado."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr ""
 "Erro: não foi possível realizar a operação: transferência(s) em progresso."
@@ -1646,43 +1684,43 @@ msgstr "'%s' é um tipo inválido de tela"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "'%s' não é uma expressão regular válida: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sCarregando %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Erro ao tentar obter %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Erro: fonte RSS inválida!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "poucos parâmetros"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' não é uma expressão de filtro válida"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Erro: URL não suportada: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Selecionar Etiqueta"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Selecionar Filtro"
 
@@ -1694,28 +1732,32 @@ msgstr "atributo não encontrado"
 msgid "EOF found while reading XML tag"
 msgstr "Fim de arquivo encontrado ao ler etiqueta XML"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Nenhum link selecionado!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Salvar Marcador"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Erro: fonte não possui nenhum item!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Nenhuma etiqueta definida."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Atualizando fonte de consulta..."
 
@@ -1765,7 +1807,7 @@ msgstr "formato de fonte não suportado"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: nível de log inválido"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 #, fuzzy
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -1774,26 +1816,49 @@ msgstr ""
 "Por favor defina a variável de ambiente HOME ou adicione um usuário válido "
 "para o UID %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Erro: falha ao abrir o arquivo de cache '%s': %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "índice de fonte inválido (erro de software)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Ir para o próximo artigo"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Ir para o artigo anterior"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/ru.po
+++ b/po/ru.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
 "POT-Creation-Date: 2020-09-17 16:02+0300\n"
-"PO-Revision-Date: 2020-06-16 19:52+0300\n"
+"PO-Revision-Date: 2020-09-17 16:14+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Konstantin Shakhnov <kastian@mail.ru>, Alexander Batischev "
 "<eual.jp@gmail.com>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-SourceCharset: utf-8\n"
-"X-Generator: Poedit 2.3.1\n"
+"X-Generator: Poedit 2.4.1\n"
 
 #: newsboat.cpp:31
 #, c-format
@@ -302,7 +302,7 @@ msgstr "неизвестная ошибка (сбой)."
 #: src/configparser.cpp:98
 #, c-format
 msgid "%s line %u"
-msgstr ""
+msgstr "%s строка %u"
 
 #: src/configparser.cpp:118
 #, c-format
@@ -310,9 +310,9 @@ msgid "unknown command `%s'"
 msgstr "неизвестная команда `%s'"
 
 #: src/configparser.cpp:125
-#, fuzzy, c-format
+#, c-format
 msgid "Error while processing command `%s' (%s): %s"
-msgstr "Ошибка во время выполнения команды `%s' (%s строка %u): %s"
+msgstr "Ошибка во время выполнения команды `%s' (%s): %s"
 
 #: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
@@ -354,15 +354,16 @@ msgid "%s is inaccessible and can't be created\n"
 msgstr "%s недоступен и не может быть создан\n"
 
 #: src/controller.cpp:295
-#, fuzzy
 msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
-msgstr "Ошибка: для пользования NewsBlur нужно задать `cookie-cache`.\n"
+msgstr "Ошибка: для пользования Miniflux нужно задать `miniflux-url`\n"
 
 #: src/controller.cpp:307
 msgid ""
 "ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
 "`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
 msgstr ""
+"Ошибка: Для использования Miniflux нужно задать `miniflux-login` и одно из: "
+"`miniflux-password`, `miniflux-passwordfile`, `miniflux-passwordeval`\n"
 
 #: src/controller.cpp:320
 msgid ""
@@ -432,13 +433,12 @@ msgstr ""
 "Inoreader. Сделайте это и попробуйте еще раз."
 
 #: src/controller.cpp:384
-#, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Miniflux account. "
 "Please do so, and try again."
 msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
-"NewsBlur. Сделайте это и попробуйте еще раз."
+"Miniflux. Сделайте это и попробуйте еще раз."
 
 #: src/controller.cpp:395
 msgid "Loading articles from cache..."
@@ -634,9 +634,8 @@ msgstr ""
 #: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
 #: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
 #: src/itemviewformaction.cpp:438
-#, fuzzy
 msgid "Failed to spawn browser"
-msgstr "Открыть заметку в браузере"
+msgstr "Не удалось запустить браузер"
 
 #: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
 #: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
@@ -674,9 +673,8 @@ msgid "Already on first feed."
 msgstr "Уже на первой ленте."
 
 #: src/feedlistformaction.cpp:409
-#, fuzzy
 msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
-msgstr "Вы правда хотите перезаписать `%s' (y:Да n:Нет)? "
+msgstr "Вы правда хотите отметить все ленты прочитанными (y:Да n:Нет)? "
 
 #: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
 #: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
@@ -1214,12 +1212,10 @@ msgid "Save articles"
 msgstr "Сохранить заметки"
 
 #: src/keymap.cpp:87
-#, fuzzy
 msgid "Go to next entry"
 msgstr "Перейти к следующей заметке"
 
 #: src/keymap.cpp:94
-#, fuzzy
 msgid "Go to previous entry"
 msgstr "Перейти к предыдущей заметке"
 
@@ -1740,7 +1736,7 @@ msgstr "Источники"
 
 #: src/view.cpp:156
 msgid "Error: Failed to execute startup commands"
-msgstr ""
+msgstr "Ошибка: Не удалось выполнить стартовые команды"
 
 #: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
@@ -1823,16 +1819,16 @@ msgstr "Отменяю миграцию, потому что mkdir для `%s' �
 #. The "%{}" thing is a number, a zero-based offset into a string.
 #: rust/libnewsboat/src/filterparser.rs:263
 msgid "Parse error: trailing characters after position %{}: %s"
-msgstr ""
+msgstr "Ошибка разбора: лишние символы после позиции %{}: %s"
 
 #. The "%{}" thing is a number, a zero-based offset into a string.
 #: rust/libnewsboat/src/filterparser.rs:270
 msgid "Parse error at position %{}: expected %s"
-msgstr ""
+msgstr "Ошибка разбора в позиции %{}: ожидалось %s"
 
 #: rust/libnewsboat/src/filterparser.rs:275
 msgid "Internal parse error"
-msgstr ""
+msgstr "Внутренняя ошибка парсера"
 
 #: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2020-06-16 19:52+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Konstantin Shakhnov <kastian@mail.ru>, Alexander Batischev "
@@ -60,11 +60,11 @@ msgstr "<файл кэша>"
 msgid "use <cachefile> as cache file"
 msgstr "использовать <файл кэша> как файл для кэша"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<файл настроек>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "считать настройки из <файла настроек>"
 
@@ -88,19 +88,19 @@ msgstr "тихий запуск"
 msgid "get version information"
 msgstr "получить информацию о версии"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<уровень>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "записывать в журнал сообщения определенного уровня (от 1 до 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<файл журнала>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "использовать <файл журнала> как файл вывода для журнала"
 
@@ -112,7 +112,7 @@ msgstr "экспорт прочитанных заметок в <файл>"
 msgid "import list of read articles from <file>"
 msgstr "импорт списка прочитанных заметок из <файла>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "эта помощь"
 
@@ -182,23 +182,23 @@ msgstr "Поймали newsboat::DbException с сообщением: %s"
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Поймали newsboat::MatcherException с сообщением: %s"
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Поймали newsboat::Exception с сообщением: %s"
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "цвета `%s' не существует"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "атрибута `%s' не существует"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "элемента конфигурации `%s' не существует"
@@ -210,7 +210,7 @@ msgstr ""
 "newsboat: обновление завершено, %f не прочитанных лент (всего %n заметок не "
 "прочитано)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
@@ -218,11 +218,11 @@ msgstr ""
 "%N %V - Заметки в ленте '%T' (непрочитанно %u, всего %t)%?F? соответствующие "
 "фильтру `%F'&? - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Ссылки"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
@@ -230,37 +230,37 @@ msgstr ""
 "%N %V - %?F?Ленты&Ваши ленты? (непрочитанно %u, всего %t)%?F? "
 "соответствующие фильтру `%F'&?%?T? - метка `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Открыть файл&Сохранить файл? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Открыть директорию&Сохранить файл? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Помощь"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Заметок в ленте '%T' (непрочитанно %u, всего %t)"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr ""
 "%N %V - Результаты поиска (непрочитанно %u, всего %t)%?F? соответствующие "
 "фильтру `%F'&?"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Выбрать Фильтр"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Выбрать Метку"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - Ссылки"
 
@@ -299,38 +299,43 @@ msgstr "файл невозможно открыть."
 msgid "unknown error (bug)."
 msgstr "неизвестная ошибка (сбой)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Ошибка во время выполнения команды `%s' (%s строка %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "неизвестная команда `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Ошибка во время выполнения команды `%s' (%s строка %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Запускаю %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Ошибка: уже запущена копия %s (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Загружаю настройки..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "сделано."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Открываю кэш..."
 
@@ -348,7 +353,18 @@ msgstr "Ошибка: для пользования NewsBlur нужно зада
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s недоступен и не может быть создан\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+#, fuzzy
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr "Ошибка: для пользования NewsBlur нужно задать `cookie-cache`.\n"
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
@@ -356,17 +372,17 @@ msgstr ""
 "ОШИБКА: для использования Inoreader нужно задать `inoreader-app-id` и "
 "`inoreader-app-key`.\n"
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr "ОШИБКА: неизвестный источник URL: `%s'"
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Загружаю ссылки из %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -375,7 +391,7 @@ msgstr ""
 "Ошибка: не найдено ни одной ссылки. Пожалуйста, занесите в файл %s ссылки на "
 "RSS ленты или импортируйте файл OPML."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -383,7 +399,7 @@ msgstr ""
 "Похоже что лента OPML, на которую вы подписались, не содержит лент новостей."
 "Пожалуйста заполните её лентами и попробуйте еще раз."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -391,7 +407,7 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "The Old Reader. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -399,7 +415,7 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "Tiny Tiny RSS. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -407,7 +423,7 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "NewsBlur. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -415,69 +431,78 @@ msgstr ""
 "Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
 "Inoreader. Сделайте это и попробуйте еще раз."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Похоже что вы не настроили ни одной ленты новостей в своей учётной записи в "
+"NewsBlur. Сделайте это и попробуйте еще раз."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Загружаю заметки из кэша..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Тщательно очищаю кэш..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Ошибка во время загрузки лент новостей из базы: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Ошибка во время загрузки ленты '%s': %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Заполняю динамические ленты..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Импортирую список прочитанных заметок..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Экспортирую список прочитанных заметок..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Очищаю кэш..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "не получилось: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Ошибка: невозможно отметить все ленты как прочитанные: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "При обработке %s возникла ошибка."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Импорт %s завершён."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u непрочитанных заметок"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: неизвестная команда"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Ошибка: невозможно открыть конфигурационный файл `%s'!"
@@ -498,26 +523,26 @@ msgstr "Закрыть диалог"
 msgid "Error: you can't remove the feed list!"
 msgstr "Ошибка: невозможно убрать список лент!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Неверная позиция!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr "Директория: "
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Сохранить"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, c-format
 msgid "Save Files - %s"
 msgstr "Сохранить файлы - %s"
@@ -562,10 +587,6 @@ msgstr "проиграно"
 msgid "unknown (bug)."
 msgstr "неизвестно (сбой)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "неверный индекс ленты (сбой)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Люди, которых Вы читаете"
@@ -579,20 +600,20 @@ msgstr "Избранные элементы"
 msgid "Shared items"
 msgstr "Опубликованные элементы"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Не выбрано ни одной ленты!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr "ftauln"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -600,7 +621,7 @@ msgstr ""
 "Сортировать по первой метке (f)/заголовку (t)/количеству записей (a)/"
 "непрочитанным (u)/времени последнего обновления (l)/никак (n)?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -608,158 +629,174 @@ msgstr ""
 "Сортировать в обратном порядке по первой метке (f)/заголовку (t)/количеству "
 "записей (a)/непрочитанным (u)/времени последнего обновления (l)/никак (n)?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Открыть заметку в браузере"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "Браузер вернул код ошибки %i"
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "Динамические ленты нельзя открывать в браузере!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Отмечаю ленту как прочитанную..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Ошибка: невозможно отметить ленту как прочитанную: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Нет лент с непрочитанными элементами."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Уже на последней ленте."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Уже на первой ленте."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Вы правда хотите перезаписать `%s' (y:Да n:Нет)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "yn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "y"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Отмечаю все ленты как прочитанные..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Ошибка: невозможно разобрать команду фильтрации `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Не определено ни одного фильтра."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Искать: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Фильтр: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Вы правда хотите выйти (y:Да n:Нет)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "yn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "y"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Выход"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Открыть"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Следующая непрочитанная"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Обновить"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Обновить все"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Отметить как прочитанную"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Отметить все как прочитанные"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Искать"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Помощь"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Ошибка: невозможно разобрать команду фильтрации!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Ищу..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Ошибка во время поиска `%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Нет результатов."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Позицию не видно!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Список лент - %u непрочитанных, %u всего"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Вы правда хотите перезаписать `%s' (y:Да n:Нет)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Файл: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Сохранить файл - %s"
@@ -851,35 +888,35 @@ msgstr "Отвязанные функции:"
 msgid "Clear"
 msgstr "Чистый"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "встроенный flash:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "изображение"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Ссылки: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "ссылка"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "встроенный flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr "видео"
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr "аудио"
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "неизвестно (сбой)"
 
@@ -895,137 +932,137 @@ msgstr "Понравившиеся статьи"
 msgid "Saved web pages"
 msgstr "Сохранённые веб-страницы"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Не выбранно ни одного элемента!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Переключение флага прочтения у заметки..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Ошибка во время переключения флага прочтения: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "Список ссылок пуст."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Флаги: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Ошибка: не выбранно ни одного элемента!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Ошибка: вы не можете обновить результаты поиска."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Непрочитанных элементов нет."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Уже на последней записи."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Уже на первой записи."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Непрочитанных лент нет."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr "Отмечаю все, что выше, как прочитанные..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Обработать заметку командой: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 msgid "dtfalgr"
 msgstr "dtfalgr"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Сортировать по дате (d)/заголовку (t)/флагам (f)/автору (a)/ссылке (l)/"
 "(g)uid/(r)случайно?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Сортировать в обратном порядке по дате (d)/заголовку (t)/флагам (f)/автору "
 "(a)/ссылке (l)/(g)uid/(r)случайно?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Флаги обновлены."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Ошибка: применение фильтра завершилось неудачей: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Прерванное сохранение."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Заметка сохранена в %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Ошибка: невозможно сохранить заметку в %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Результат поиска - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Динамическая лента - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Список заметок - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "Перезаписать `%s' в `%s'? (y:Да n:Нет)"
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr "yanq"
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -1034,7 +1071,7 @@ msgstr ""
 "Перезаписать `%s' в `%s'? Осталось таких конфликтов: %d (y:Да a:Да для всех "
 "n:Нет q:Нет для всех)"
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1067,15 +1104,15 @@ msgstr "Ссылка загрузки подкаста: "
 msgid "type: "
 msgstr "тип: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Верх"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Низ"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Ошибка во время пометки заметки как прочитанной: %s"
@@ -1100,35 +1137,35 @@ msgstr "Заметка сохранена в %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Ошибка: невозможно записать заметку в файл %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Запускаю браузер..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Ошибка во время пометки заметки как непрочитанной: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Открыть ссылку №"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Открыть в браузере"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Поставить в очередь"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Заметка - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Ошибка: неправильное регулярное выражение!"
 
@@ -1177,11 +1214,13 @@ msgid "Save articles"
 msgstr "Сохранить заметки"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
+#, fuzzy
+msgid "Go to next entry"
 msgstr "Перейти к следующей заметке"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
+#, fuzzy
+msgid "Go to previous entry"
 msgstr "Перейти к предыдущей заметке"
 
 #: src/keymap.cpp:101
@@ -1492,7 +1531,7 @@ msgstr "контекста `%s' не существует"
 msgid "`%s' is not a valid key command"
 msgstr "команда `%s' не поддерживается"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, c-format
 msgid "`%s' is not a valid operation"
 msgstr "операция `%s' не является валидной"
@@ -1507,16 +1546,16 @@ msgstr "атрибут `%s' недоступен."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "регулярное выражение '%s' неверно: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: конфигурационная директория '%s' недоступна, используем '%s'."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Фатальная ошибка: невозможно определить домашний каталог!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1524,21 +1563,21 @@ msgstr ""
 "Пожалуйста, задайте значение переменной окружения HOME или добавьте "
 "подходящего пользователя для UID %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Ошибка: невозможно создать конфигурационную директорию `%s': (%i) %s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: некорректный уровень логирования"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Очищаю очередь..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1547,29 +1586,29 @@ msgstr ""
 "%s %s\n"
 "использование: %s [-C <файл>] [-q <файл>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<файл очереди>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "использовать <файл очереди> как файл очереди"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "начать загрузку сразу после запуска"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u параллельных загрузок"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Очередь (активных загрузок %u, всего %u) - %.2f %s всего%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Ошибка: не могу выйти: загрузка(и) активна(ы)."
 
@@ -1578,7 +1617,7 @@ msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Ошибка: загрузка должна закончиться прежде чем файл может быть проигран."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Ошибка: невозможно выполнить действие: загрузка(и) активна(ы)."
 
@@ -1639,43 +1678,43 @@ msgstr "`%s' - неверный тип диалога"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' — неверное регулярное выражение:%s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sЗагружается %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Ошибка во время получения %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Ошибка: некорректная лента!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "слишком мало параметров"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' — неверный фильтр"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Ошибка: ссылка не поддерживается: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Выбрать метку"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Выбрать фильтр"
 
@@ -1687,27 +1726,31 @@ msgstr "атрибут не найден"
 msgid "EOF found while reading XML tag"
 msgstr "Во время чтения тега XML обнаружен конец файла"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 msgid "No links available!"
 msgstr "Нет ссылок!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Сохранить закладку"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "Источники"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Ошибка: лента не содержит ни одного элемента!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Не определено ни одной метки."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Обновляю динамическую ленту..."
 
@@ -1756,7 +1799,7 @@ msgstr "неизвестный тип ленты"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %s: некорректный уровень логирования"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1765,25 +1808,48 @@ msgstr ""
 "Пожалуйста, задайте значение переменной окружения HOME или добавьте "
 "подходящего пользователя для UID %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr "Переношу конфиги и данные из XDG-директорий Newsbeuter..."
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr "Переношу конфиги и данные из ~/.newsbeuter/..."
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Отменяю миграцию, потому что mkdir для `%s' вернула ошибку: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr "regcomp вернула код %i"
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr "regexec вернула код %i"
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "неверный индекс ленты (сбой)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Перейти к следующей заметке"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Перейти к предыдущей заметке"
 
 #~ msgid "config"
 #~ msgstr "настройки"

--- a/po/sk.po
+++ b/po/sk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.10.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2017-12-25 00:38+0100\n"
 "Last-Translator: František Hájik <ferko.hajik@gmail.com>\n"
 "Language-Team: \n"
@@ -56,11 +56,11 @@ msgstr "<cachefile>"
 msgid "use <cachefile> as cache file"
 msgstr "použiť <cachefile> ako cache súbor"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<configfile>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "načítať konfiguráciu z <configfile>"
 
@@ -84,19 +84,19 @@ msgstr "tichý startup"
 msgid "get version information"
 msgstr "získať informácie o verzii"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<loglevel>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "napísať protokol (log) s určitým loglevelom (platné hodnoty: 1 až 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<logfile>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "použitie <logfile> ako výstupného log súboru"
 
@@ -108,7 +108,7 @@ msgstr "export zoznamu čítaných článkov do súboru <file>"
 msgid "import list of read articles from <file>"
 msgstr "import zoznamu čítaných článkov zo súboru <file>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "tento pomocník"
 
@@ -174,23 +174,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' nie je platná farba"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' nie je platný atribút"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' nie je platný prvok konfigurácie"
@@ -202,7 +202,7 @@ msgstr ""
 "newsboat: načítanie ukončené, %f neprečítaných kanálov s %n neprečítanými "
 "článkami celkom"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
@@ -210,48 +210,48 @@ msgid ""
 msgstr ""
 "%N %V - Články v informačných kanáloch (%u neprečítané, %t celkom) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialógy"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - Tvoje zdroje (%u neprečítané, %t celkom)%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Otvoriť Súbor&Uložiť Súbor? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Otvoriť Súbor&Uložiť Súbor? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Pomoc"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Article '%T' (%u neprečítané, %t celkom)"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Výsledok vyhľadávanie (%u nečítané, %t celkom)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Vyber Filter"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Vybraný Tag"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
@@ -290,38 +290,43 @@ msgstr "súbor nemôže byť otvorený."
 msgid "unknown error (bug)."
 msgstr "neznáma chyba (bug)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Chyba pri spracovaní príkazu `%s' (%s riadok %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "neznámy príkaz `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Chyba pri spracovaní príkazu `%s' (%s riadok %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Spúšťanie %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Chyba: program %s už beží (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Načítanie konfigurácie..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "hotovo."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Otvorenie vyrovnávacej pamäte..."
 
@@ -339,23 +344,33 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s je nedostupný a nemôže byť vytvorený\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Načítanie adries URL z %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -364,7 +379,7 @@ msgstr ""
 "Chyba: nenakonfigurované žiadne URL adresy. Prosím vyplňte súbor% s pomocou "
 "URL adries RSS alebo importujte súbor OPML."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -372,7 +387,7 @@ msgstr ""
 "Vyzerá to tak, že OPML zdroj, neobsahuje žiadne kanály. Vyplňte ho kanálmi a "
 "skúste to znova."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -380,7 +395,7 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte The Old Reader. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -388,7 +403,7 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte Tiny Tiny RSS. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -396,7 +411,7 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte NewsBlur. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -404,69 +419,78 @@ msgstr ""
 "Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte Inoreader. "
 "Urobte tak, a skúste to znova."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Vyzerá to tak, že ste nenakonfigurovali žiadne kanály v účte NewsBlur. "
+"Urobte tak, a skúste to znova."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Načítanie článkov zo súboru \"cache\"..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Dokladné vyčistenie \"cahce\"..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Chyba pri načítavaní informačných kanálov z databázy: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Chyba pri načítaní informačného kanálu '%s': %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Predvolené dopyty kanálov..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Importovať zoznam čítaných článkov..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Exportovať zoznam čítaných článkov..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Vyčistenie \"cache\"..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "zlyhalo: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Chyba: nemožno označiť všetky prečítané informačné kanály: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Vyskytla sa chyba počas \"parsingu\" %s."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Import %s ukončený."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u neprečítaných článkov"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: neznámy príkaz"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Chyba: nemožno otvoriť konfiguračný súbor `%s'!"
@@ -487,26 +511,26 @@ msgstr "Zatvoriť na dialóg"
 msgid "Error: you can't remove the feed list!"
 msgstr "Chyba: nemožno odstrániť zoznam informačných kanálov (feed list)!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Neplatná pozícia!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Uložiť"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Uložiť súbor - %s"
@@ -551,10 +575,6 @@ msgstr "prehrať"
 msgid "unknown (bug)."
 msgstr "neznáma (chyba)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "neplatný index kanála (bug)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Ľudia, ktorých sledujete"
@@ -568,21 +588,21 @@ msgstr "Položky označené hviezdičkou"
 msgid "Shared items"
 msgstr "Zdieľané položky"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Nebol vybraný žiadny kanál!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 #, fuzzy
 msgid "ftauln"
 msgstr "ftpun"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
@@ -591,7 +611,7 @@ msgstr ""
 "Zotriediť podľa (f)prvého_tagu/(t)itulkov/(p)očtu_článkov/"
 "(u)neprečítaných_článkov/(n)etriediť?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
@@ -600,158 +620,174 @@ msgstr ""
 "Zotriediť spätne podľa (f)prvého_tagu/(t)itulkov/(p)očtu_článkov/"
 "(u)neprečítaných_článkov/(n)etriediť?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Otvoriť článok v prehliadači"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "V prehliadači sa nedajú otvoriť požiadavky z kanálov!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Označiť kanál za prečítaný..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Chyba: nemožno označiť čítanie kanála: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Žiaden kanál s neprečítanými položkami."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Celkom posledný kanál."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Celkom prvý kanál."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Naozaj chcete prepísať `%s' (a:Áno n:Nie)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "an"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "a"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Označenie všetkých kanálov za prečítané..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Chyba: príkaz filtra nedá analyzovať `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Neboli definované žiadne filtre."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Vyhľadať: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Skutočne skončiť (a:Áno n:Nie)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "an"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "a"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Ukončiť"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Otvoriť"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Ďalší neprečítaný"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Obnoviť"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Obnoviť všetko"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Označiť ako prečítané"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Označiť všetko ako prečítané"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Hľadať"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Pomocník"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Chyba: nebolo možné analyzovať príkaz filtra!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Vyhľadávanie..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Chyba pri vyhľadávaní `%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Žiadny výsledok."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Pozícia nie je viditeľná!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Zoznam informačných kanálov - %u neprečítané, %u celkom"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Naozaj chcete prepísať `%s' (a:Áno n:Nie)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Súbor: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Uložiť súbor - %s"
@@ -844,35 +880,35 @@ msgstr "Neviazané funkcie:"
 msgid "Clear"
 msgstr "Vyčistiť"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "vstavaný flash:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "obrázok"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Odkazy: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "odkaz"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "vstavaný flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "neznáme (chyba)"
 
@@ -888,148 +924,148 @@ msgstr "Obľúbené položky"
 msgid "Saved web pages"
 msgstr "Web stránka uložená"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Žiadna položka nebola označená!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Prepínanie príznaku čítania článku..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Chyba pri prepínaní príznaku čítania: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "Zoznam URL je prázdny."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Príznaky (flags): "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Chyba: žiadna položka nebola vybratá!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Chyba: nemožno načítať výsledky vyhľadávania."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Všetky položky prečítané."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Celkom posledná položka."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Celkom prvá položka."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Všetko prečítané."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "Označenie všetkých kanálov za prečítané..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Odoslať (Pipe) článok do príkazu: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "dnpaoi"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 #, fuzzy
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Zotriedenie podľa (d)átumu/(n)ázvu/(p)ríznaku/(a)utora/(o)dkazu/"
 "(i)dentifikátora?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 #, fuzzy
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Zotriediť spätne podľa (d)átumu/(n)ázvu/(p)ríznaku/(a)utora/(o)dkazu/"
 "(i)dentifikátora?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Príznaky aktualizované."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Chyba: použitie filtra zlyhalo: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Ukladanie bolo prerušené."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Článok bol uložený do %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Chyba: článok nemožno uložiť do %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Výsledok vyhľadávania - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Dotaz informačného kanála - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Zoznam článkov - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1060,15 +1096,15 @@ msgstr "Podcast Download URL: "
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Vrch"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Spodok"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Chyba pri označovaní článku za prečítaný: %s"
@@ -1093,35 +1129,35 @@ msgstr "Článok uložený do %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Chyba: nemožno zapísať článok do súboru %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Spustenie prehliadača..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Chyba pri označovaní článku ako neprečítaného: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Choď na URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Otvoriť v prehliadači"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Do fronty"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Článok - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Chyba: neplatný regulárny výraz!"
 
@@ -1172,12 +1208,14 @@ msgid "Save articles"
 msgstr "Uložiť článok"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Choď na nasledujúci článok"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Prejsť na ďalšiu položku"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Choď na predchádzajúci článok"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Prejsť na predchádzajúcu položku"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1490,7 +1528,7 @@ msgstr "`%s' nie je platný kontext"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' nie je platný príkaz kľúča"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' nie je platný kontext"
@@ -1505,18 +1543,18 @@ msgstr "atribút `%s' nie je k dispozícii."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "regulárny výraz '%s' je vadný: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 "XDG: konfiguračný adresár '% s' nie je prístupný, namiesto toho používa "
 "'% s'."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Fatálna chyba: nedá sa určiť \"home\" adresár!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1524,21 +1562,21 @@ msgstr ""
 "Prosím nastav premennú prostredia \"HOME\" alebo pridaj platného používateľa "
 "pre UID %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Chyba: nemožno otvoriť konfiguračný súbor `%s'!"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: \"loglevel\" hodnota je neplatná"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Čistenie fronty..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1547,29 +1585,29 @@ msgstr ""
 "%s %s\n"
 "použitie %s [-C <file>] [-q <file>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<queuefile>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "použiť <queuefile> ako \"queue\" súbor"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "spustiť sťahovanie pri štarte"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u paralelné sťahovanie"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Fronta (%u prebieha sťahovanie, %u celkom) - %.2f kb/s celkom%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Chyba: nemožno ukončiť preberanie (sťahovanie)."
 
@@ -1577,7 +1615,7 @@ msgstr "Chyba: nemožno ukončiť preberanie (sťahovanie)."
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Chyba: sťahovanie musí byť dokončené pred prehrávaním súboru."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Chyba: nemožno vykonať operáciu: Prebieha sťahovanie."
 
@@ -1635,43 +1673,43 @@ msgstr "`%s' je chybný dialógový typ"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' nie je platný regulárny výraz: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sNačítanie %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Chyba pri načítaní %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Chyba: vadný kanál!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "príliš málo parametrov"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' nie je platný prvok konfigurácie"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Chyba: nepodporovaná URL: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Vyber Tag"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Vyber Filter"
 
@@ -1683,28 +1721,32 @@ msgstr "atribút nebol nájdený"
 msgid "EOF found while reading XML tag"
 msgstr "Bol nájdený \"EOF\" pri načítaní XML tagu"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Link nebol vybraný!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Uložiť záložku"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Chyba: informačný kanál neobsahuje žiadne položky!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Neboli definované žiadne \"tagy\"."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Aktualizácia dopytu informačného kanála..."
 
@@ -1754,7 +1796,7 @@ msgstr "nepodporovaný \"feed\" formát"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: \"loglevel\" hodnota je neplatná"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 #, fuzzy
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
@@ -1763,26 +1805,49 @@ msgstr ""
 "Prosím nastav premennú prostredia \"HOME\" alebo pridaj platného používateľa "
 "pre UID %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Chyba: otvorenie \"cache\" súboru `%s' zlyhalo: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "neplatný index kanála (bug)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Choď na nasledujúci článok"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Choď na predchádzajúci článok"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat-2.12\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2018-08-08 10:17+0200\n"
 "Last-Translator: Dennis Öberg <contact@dennisoberg.se>\n"
 "Language-Team: Niklas Grahn <terra.unknown@yahoo.com>\n"
@@ -58,11 +58,11 @@ msgstr "<cache-fil>"
 msgid "use <cachefile> as cache file"
 msgstr "använd <cache-fil> som cache-fil"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<konfigurationsfil>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "läs in konfiguration från <konfigurationsfil>"
 
@@ -86,19 +86,19 @@ msgstr "tyst uppstart"
 msgid "get version information"
 msgstr "hämta versionsinformation"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<loggnivå>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "skriv en logg med en särskild loggnivå (giltiga värden: 1 till 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<loggfil>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "använd <loggfil> som loggfil"
 
@@ -110,7 +110,7 @@ msgstr "exportera lista över lästa artiklar till <fil>"
 msgid "import list of read articles from <file>"
 msgstr "importera lista över lästa artiklar till <fil>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "denna hjälp"
 
@@ -187,23 +187,23 @@ msgstr "Fångade newsboat::dbexception med meddelande: %s"
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Fångade newsboat::matcherexception med meddelande: %s"
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, fuzzy, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Fångade newsboat::exception med meddelande: %s"
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' är inte en giltig färg"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' är inte ett giltigt attribut"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' är inte ett giltigt konfigurationselement"
@@ -214,55 +214,55 @@ msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr ""
 "newsboat: omläsning färdig, %f olästa webbflöden (%n olästa artiklar totalt)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N %V - Artiklar i webbflöden '%T' (%u olästa, %t totalt) - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Dialogrutor"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - Dina webbflöden (%u olästa, %t totalt)%?T? - tag `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Öppna fil&Spara fil? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Öppna fil&Spara fil? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Hjälp"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Artikel '%T' (%u olästa, %t totalt)"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - Sökresultat (%u olästa, %t totalt)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Välj filter"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Välj tagg"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URL:er"
 
@@ -301,38 +301,43 @@ msgstr "fil kunde inte öppnas."
 msgid "unknown error (bug)."
 msgstr "okänt fel (bugg)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Fel vid behandling av kommando `%s' (%s rad %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "okänt kommando `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Fel vid behandling av kommando `%s' (%s rad %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Startar %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Fel: en instans av %s körs redan (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Läser in konfiguration..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "färdig."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Öppnar cache..."
 
@@ -350,23 +355,34 @@ msgstr "FEL: Du måste sätta 'cookie-cache' till att använda NewsBlur.\n"
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s är oåtkomlig och kan inte skapas\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+#, fuzzy
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr "FEL: Du måste sätta 'cookie-cache' till att använda NewsBlur.\n"
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Läser in URL:er från %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -375,7 +391,7 @@ msgstr ""
 "Fel: inga URL:er konfigurerade. Var god fyll filen %s med URL:er till RSS-"
 "kanaler eller importera en OPML-fil."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -383,7 +399,7 @@ msgstr ""
 "Det ser ut som om OPML-flödet som du valde att prenumerera på inte "
 "innehåller några webbflöden. Var god fyll den med webbflöden och prova igen."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -391,7 +407,7 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt The Old "
 "Reader-konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -399,7 +415,7 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt Tiny Tiny "
 "RSS-konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -407,7 +423,7 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt NewsBlur-"
 "konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -415,69 +431,78 @@ msgstr ""
 "Det ser ut som om du inte har konfigurerat några webbflöden i ditt Inoreader-"
 "konto. Var god gör det och prova igen."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Det ser ut som om du inte har konfigurerat några webbflöden i ditt NewsBlur-"
+"konto. Var god gör det och prova igen."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Läser in artiklar från cache..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Tömmer noggrant cache..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Fel vid inläsning av webbflöden från databasen: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Fel vid inläsning av webbflöde `%s': %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Förbefolkar förfrågansflöden..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Importerar lista över lästa artiklar..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Exporterar lista över lästa artiklar..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Tömmer cache..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "misslyckades: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Fel: kunde inte markera alla webbflödeer som lästa: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Ett fel inträffade vid tolkning av %s."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Importering av %s färdig."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u olästa artiklar"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: okänt kommando"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Fel: kunde inte öppna konfigurationsfil `%s'!"
@@ -498,26 +523,26 @@ msgstr "Stäng dialogruta"
 msgid "Error: you can't remove the feed list!"
 msgstr "Fel: du kan inte ta bort listan över webbflöden!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Ogiltig position!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Spara"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "Spara fil - %s"
@@ -562,10 +587,6 @@ msgstr "uppspelad"
 msgid "unknown (bug)."
 msgstr "okänt (bugg)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "ogiltigt webbflödesindex (bugg)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Personer du följer"
@@ -579,20 +600,20 @@ msgstr "Stjärnmarkerade poster"
 msgid "Shared items"
 msgstr "Delade poster"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Ingen kanal markerad!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr "ftaosi"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -600,7 +621,7 @@ msgstr ""
 "Sortera utifrån (f)örstatagg/(t)itel/(a)rtikelmängd/(o)lästartikelmängd/"
 "(s)enastuppdaterad/(i)nget?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -608,158 +629,174 @@ msgstr ""
 "Sortera omvänt utifrån (f)örstatagg/(t)itel/(a)rtikelmängd/"
 "(o)lästartikelmängd/(s)enastuppdaterad/(i)nget?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Öppna artikel i webbläsare"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "Kan inte öppna query feeds i webbläsaren!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Markerar webbflöde som läst..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Fel: kunde inte markera webbflöde som läst: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Inga webbflöden med olästa poster."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Redan på sista webbflödet."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Redan på första webbflödet."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Vill du verkligen skriva över %s' (j:Ja n:Nej)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "jn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "j"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Markerar alla webbflöden som lästa..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Fel: kunde inte tolka filterkommando `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Inga filter definierade."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Sök efter: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Filter: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Vill du verkligen avsluta (j:Ja n:Nej)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "jn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "j"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Avsluta"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Öppna"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Nästa olästa"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Läs om"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Läs om alla"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Markera som läst"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Markera alla som lästa"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Sök"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Hjälp"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Fel: kunde inte tolka filterkommando!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Söker..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Fel vid sökning efter `%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Inga resultat."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Position inte synlig!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Lista över webbflöden - %u olästa, %u totalt"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Vill du verkligen skriva över %s' (j:Ja n:Nej)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Fil: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Spara fil - %s"
@@ -852,35 +889,35 @@ msgstr "Icke-bundna funktioner:"
 msgid "Clear"
 msgstr "Töm"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "inbäddat flash:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "bild"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Länkar: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "länk"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "inbäddat flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "okänt (bugg)"
 
@@ -896,144 +933,144 @@ msgstr "Gillade poster"
 msgid "Saved web pages"
 msgstr "Sparade webbsidor"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Ingen post markerad!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Växlar läsflagga för artikel..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Fel vid växling av läsflagga: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "URL-lista tom."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Flaggor: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Fel: ingen post markerad!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Fel: du kan inte läsa om sökresultat."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Inga olästa poster."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Redan på sista posten."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Redan på första posten."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Inga olästa webbflöden."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr "Markerar allt ovanför som läst..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Skicka artikel genom pipe till kommando: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "dtFflg"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 #, fuzzy
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "Sortera utifrån (d)atum/(t)itel/(F)laggor/(f)örfattare/(l)änk/(g)uid?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 #, fuzzy
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Sortera omvänt utifrån (d)atum/(t)itel/(F)laggor/(f)örfattare/(l)änk/(g)uid?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Flaggor uppdaterade."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Fel: verkställande av filtret misslyckades: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Avbröt sparande."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Sparade artikel till %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Fel: kunde inte spara artikel till %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Sökresultat - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Förfrågansflöde - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Artikellista - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1064,15 +1101,15 @@ msgstr "Hämtnings-URL för poddsändning: "
 msgid "type: "
 msgstr "typ: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Överkant"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Nederkant"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Fel vid markering av artikel som läst: %s"
@@ -1097,35 +1134,35 @@ msgstr "Sparade artikel till %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Fel: kunde inte skriva artikel till fil %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Startar webbläsare..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Fel vid markering av artikel som oläst: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Gå till URL #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Öppna i webbläsare"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Kölägg"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Artikel - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Fel: ogiltigt reguljärt uttryck!"
 
@@ -1175,12 +1212,14 @@ msgid "Save articles"
 msgstr "Spara artikel"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Gå till nästa artikel"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Flytta till nästa post"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Gå till föregående artikel"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Flytta till föregående post"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1491,7 +1530,7 @@ msgstr "`%s' är inte en giltig kontext"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' är inte ett giltigt tangentkommando"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' är inte en giltig kontext"
@@ -1506,16 +1545,16 @@ msgstr "attribut `%s' är inte tillgängligt."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "reguljärt uttryck '%s' är ogiltigt: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: konfigurationskatalog '%s' inte åtkomlig, använder '%s' istället."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Fatalt fel: kunde inte fastställa hemkatalog!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1523,21 +1562,21 @@ msgstr ""
 "Var god ställ in HOME-miljövariabeln eller lägg till en giltig användare för "
 "UID %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Fatalt fel: kunde inte skapa konfigurationskatalog `%s': (%i) %s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: ogiltigt loggnivåvärde"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Tömmer kö..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1546,29 +1585,29 @@ msgstr ""
 "%s %s\n"
 "användning: %s [-C <fil>] [-q <fil>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<köfil>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "använd <köfil> som köfil"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "påbörja hämtning vid uppstart"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u parallella hämtningar"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Kölista (%u pågående hämtningar, %u totalt) - %.2f kb/s totalt%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Fel: kan inte avsluta: hämtning(ar) pågår."
 
@@ -1576,7 +1615,7 @@ msgstr "Fel: kan inte avsluta: hämtning(ar) pågår."
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "Fel: hämtning måste vara klar innan filen kan spelas upp."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Fel: kan inte utföra åtgärd: hämtning(ar) pågår."
 
@@ -1634,43 +1673,43 @@ msgstr "`%s' är en ogiltig typ av dialogruta"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' är inte ett giltigt reguljärt uttryck: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sLäser in %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Fel vid hämtning av %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Fel: ogiltigt webbflöde!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "för få parametrar"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' är inte ett giltigt filteruttryck"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Fel: URL stöds inte: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Välj tagg"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Välj filter"
 
@@ -1682,28 +1721,32 @@ msgstr "attribut hittades inte"
 msgid "EOF found while reading XML tag"
 msgstr "EOF hittades vid inläsning av XML-tagg"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "Ingen länk markerad!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Spara bokmärke"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URL:er"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Fel: webbflöde innehåller inga poster!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Inga taggar definierade."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Uppdaterar query feed..."
 
@@ -1753,7 +1796,7 @@ msgstr "format på webbflödet stöds inte"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %d: ogiltigt loggnivåvärde"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1762,26 +1805,49 @@ msgstr ""
 "Var god ställ in HOME-miljövariabeln eller lägg till en giltig användare för "
 "UID %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Fel: öppnande av cache-fil `%s' misslyckades: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "ogiltigt webbflödesindex (bugg)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Gå till nästa artikel"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Gå till föregående artikel"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/tr.po
+++ b/po/tr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.2\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2020-04-03 19:00+0300\n"
 "Last-Translator: Emir SARI <bitigchi@me.com>, 2020\n"
 "Language-Team: H. Gökhan SARI <hsa2@difuzyon.net>\n"
@@ -58,11 +58,11 @@ msgstr "<önbellek_dosyası>"
 msgid "use <cachefile> as cache file"
 msgstr "<önbellek_dosyası>nı önbellek dosyası olarak kullan"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<ayar_dosyası>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "ayarları <ayar_dosyası>ndan oku"
 
@@ -86,19 +86,19 @@ msgstr "sessiz başlangıç"
 msgid "get version information"
 msgstr "sürüm bilgisini al"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<kayıt_düzeyi>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "kayıt tutarken seviye belirle (geçerli seviyeler: 1 - 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<kayıt_dosyası>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "<kayıt_dosyası>nı çıktı kaydı için kullan"
 
@@ -110,7 +110,7 @@ msgstr "okunmuş yazıların listesini <dosya>ya aktar"
 msgid "import list of read articles from <file>"
 msgstr "okunmuş yazıları <dosya>dan aktar"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "bu yardım"
 
@@ -139,8 +139,8 @@ msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
 "see the full text.)"
 msgstr ""
-"Newsboat, MIT Lisansı ile lisanslanmış özgür yazılımdır. (Tüm metni görmek için "
-"`%s -vv' yazın.)"
+"Newsboat, MIT Lisansı ile lisanslanmış özgür yazılımdır. (Tüm metni görmek "
+"için `%s -vv' yazın.)"
 
 #: newsboat.cpp:163
 msgid "It bundles:"
@@ -155,18 +155,21 @@ msgstr ""
 "github.com/nlohmann/json"
 
 #: newsboat.cpp:167
+#, fuzzy
 msgid ""
-"- optional-lite kitaplığı, Boost Software Lisansı ile lisanslanmıştır: https://"
+"- optional-lite library, licensed under the Boost Software License: https://"
 "github.com/martinmoene/optional-lite"
 msgstr ""
+"- expected-lite kitaplığı, Boost Software License ile lisanslanmıştır: "
+"https://github.com/martinmoene/expected-lite"
 
 #: newsboat.cpp:170
 msgid ""
 "- expected-lite library, licensed under the Boost Software License: https://"
 "github.com/martinmoene/expected-lite"
 msgstr ""
-"- expected-lite kitaplığı, Boost Software License ile lisanslanmıştır: https://"
-"github.com/martinmoene/expected-lite"
+"- expected-lite kitaplığı, Boost Software License ile lisanslanmıştır: "
+"https://github.com/martinmoene/expected-lite"
 
 #: newsboat.cpp:243
 #, c-format
@@ -178,23 +181,23 @@ msgstr "newsboat::DbException şu iletiyle yakalandı: %s"
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "newsboat::MatcherException şu iletiyle yakalandı: %s"
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "newsboat::Exception şu iletiyle yakalandı: %s"
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' geçerli bir renk değil"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' geçersiz bir özellik"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' geçerli bir yapılandırma ögesi değil"
@@ -206,7 +209,7 @@ msgstr ""
 "newsboat: yeniden yükleme tamamlandı, %f okunmamış besleme (%n okunmamış "
 "toplam yazı)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
@@ -214,48 +217,49 @@ msgstr ""
 "%N %V - '%T' beslemesindeki yazılar (%u okunmamış, %t toplam)%?F? süzgeçle "
 "eşleşen `%F'&? - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Diyalog"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr ""
-"%N %V - %?F?Besleme&Sizin beslemeleriniz? (%u okunmamış, %t toplam)%?F? süzgeçle "
-"eşleşen `%F'&?%?T? - etiket `%T'&?"
+"%N %V - %?F?Besleme&Sizin beslemeleriniz? (%u okunmamış, %t toplam)%?F? "
+"süzgeçle eşleşen `%F'&?%?T? - etiket `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Aç&Kaydet? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Dizin Aç&Dosyayı Kaydet? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Yardım"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - '%T' yazısı (%u okunmamış, %t toplam) - %U"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
-msgstr "%N %V - Arama sonuçları (%u okunmamış, %t toplam))%?F? süzgeçle eşleşen "
-"`%F'&?"
+msgstr ""
+"%N %V - Arama sonuçları (%u okunmamış, %t toplam))%?F? süzgeçle eşleşen `"
+"%F'&?"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Süzgeç Seç"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Etiket Seç"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - Adres"
 
@@ -294,38 +298,43 @@ msgstr "dosya açılamadı."
 msgid "unknown error (bug)."
 msgstr "bilinmeyen hata (bug)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "`%s' komutu çalıştırılırken hata (%s %u. satır): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "bilinmeyen komut `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "`%s' komutu çalıştırılırken hata (%s %u. satır): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "%s %s başlatılıyor..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Hata: %s zaten çalışıyor (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Ayarlar yükleniyor..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "tamamlandı."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Önbellek açılıyor..."
 
@@ -343,25 +352,36 @@ msgstr "HATA: NewsBlur kullanmak için `cookie-cache`i ayarlamalısınız.\n"
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s erişilemiyor ve oluşturulamaz\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+#, fuzzy
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr "HATA: NewsBlur kullanmak için `cookie-cache`i ayarlamalısınız.\n"
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
-"HATA: Inoreader'i kullanmak için *hem* `inoreader-app-id` *hem* `inoreader-app-key` "
-"ayarlamalısınız.\n"
+"HATA: Inoreader'i kullanmak için *hem* `inoreader-app-id` *hem* `inoreader-"
+"app-key` ayarlamalısınız.\n"
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr "HATA: Bilinmeyen urls-source `%s'"
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "%s kaynağından adresler yükleniyor..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -370,7 +390,7 @@ msgstr ""
 "Hata: hiçbir adres ayarlanmamış. Lütfen %s içine RSS besleme kaynakları "
 "ekleyin ya da bir OPML dosyasını içeri aktarın."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -378,7 +398,7 @@ msgstr ""
 "Belirttiğiniz OPML dosyası herhangi bir kaynak içermiyor. Lütfen besleme "
 "kaynaklarını doğru biçimde bu dosyaya ekleyin ve tekrar deneyin."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -386,7 +406,7 @@ msgstr ""
 "Görünüşe göre The Old Reader hesabınızda herhangi bir besleme "
 "ayarlamamışsınız. Lütfen bir tane ayarlayıp yeniden deneyin."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -394,7 +414,7 @@ msgstr ""
 "Görünüşe göre Tiny Tiny RSS hesabınızda herhangi bir besleme "
 "ayarlamamışsınız. Lütfen bir tane ayarlayıp yeniden deneyin."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -402,7 +422,7 @@ msgstr ""
 "Görünüşe göre NewsBlur hesabınızda herhangi bir besleme ayarlamamışsınız. "
 "Lütfen bir tane ayarlayıp yeniden deneyin."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -410,69 +430,78 @@ msgstr ""
 "Görünüşe göre Inoreader hesabınızda herhangi bir besleme ayarlamamışsınız. "
 "Lütfen bir tane ayarlayıp yeniden deneyin."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Görünüşe göre NewsBlur hesabınızda herhangi bir besleme ayarlamamışsınız. "
+"Lütfen bir tane ayarlayıp yeniden deneyin."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Yazılar önbellekten yükleniyor..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Önbellek boşaltılıyor..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Veritabanından beslemeler alınırken hata oluştu: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "`%s' beslemesi yüklenirken hata: %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Sorgu beslemesi güncelleniyor..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Okunmuş yazıların listesi içe aktarılıyor..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Okunmuş yazıların listesi dışa aktarılıyor..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Önbellek temizleniyor..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "başarız: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Hata: tüm beslemeler okundu olarak imlenemedi: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s'in içeri aktarımı tamamlandı."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u okunmamış yazı"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: Bilinmeyen komut"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Hata: ayar dosyası `%s' kaydedilemedi!"
@@ -493,26 +522,26 @@ msgstr "Diyalogu Kapat"
 msgid "Error: you can't remove the feed list!"
 msgstr "Hata: Besleme listesini silemezsiniz!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Geçersiz konum!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr "Dizin: "
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Kaydet"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, c-format
 msgid "Save Files - %s"
 msgstr "Dosyaları Kaydet - %s"
@@ -557,10 +586,6 @@ msgstr "oynatıldı"
 msgid "unknown (bug)."
 msgstr "bilinmiyor (bug) "
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "geçersiz besleme indeksi (bug)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "İzlediğiniz kişiler"
@@ -574,27 +599,28 @@ msgstr "Yıldızlı ögeler"
 msgid "Shared items"
 msgstr "Paylaşılan ögeler."
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Hiçbir besleme seçilmedi!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr "ibyosh"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
-msgstr "Sırala: (i)lketiket/(b)aşlıksayısı/(y)azısayısı/(o)kunmamışyazısayısı/"
+msgstr ""
+"Sırala: (i)lketiket/(b)aşlıksayısı/(y)azısayısı/(o)kunmamışyazısayısı/"
 "(s)ongüncelleme/(h)içbiri?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -602,158 +628,174 @@ msgstr ""
 "Ters Sırala: (i)lketiket/(b)aşlıksayısı/(y)azısayısı/(o)kunmamışyazısayısı/"
 "(s)ongüncelleme/(h)içbiri?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Yazıyı tarayıcıda aç"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "Tarayıcı %i hata kodunu döndürdü"
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "Sorgu beslemeleri tarayıcıda açılamaz!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Besleme okundu olarak imleniyor..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Hata: Besleme okundu olarak imlenemedi: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Okunmamış besleme yok."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Halihazırda son besleme üzerinde"
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Halihazırda ilk besleme üzerinde"
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "`%s' üzerine yazmak istediğinize emin misiniz (e:Evet h:Hayır)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "eh"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "e"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Tüm beslemeler okundu olarak imleniyor..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Hata: Süzgeç komutu `%s' ayrıştırılamadı: %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Hiçbir süzgeç tanımlanmadı."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Ara: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Süzgeç: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Çıkmak istediğinize emin misiniz (e:Evet h:Hayır)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "eh"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "e"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Çık"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Aç"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Sonraki Okunmamış"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Yenile"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Tümünü Yenile"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Okundu İmle"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Tümünü Okundu İmle"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Ara"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Yardım"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Hata: Süzgeç komutu ayrıştırılamadı!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Aranıyor..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "`%s' aranırken hata: %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Sonuç yok."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Konum görünür değil!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Besleme Listesi - %u okunmamış, %u toplam"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "`%s' üzerine yazmak istediğinize emin misiniz (e:Evet h:Hayır)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "h"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Dosya: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Kaydet - %s"
@@ -845,35 +887,35 @@ msgstr "Bağlı olmayan işlevler:"
 msgid "Clear"
 msgstr "Temizle"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "gömülü flash:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "görsel"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Bağlantılar: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "bağlantı"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "gömülü flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr "video"
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr "ses"
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "bilinmiyor (bug)"
 
@@ -889,149 +931,152 @@ msgstr "Beğenilen ögeler"
 msgid "Saved web pages"
 msgstr "Kayıtlı web sayfaları"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Hiçbiri seçilmedi!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Bayrak okuma açılıyor/kapatılıyor..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Hata: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "Adres listesi boş."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Bayraklar: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Hata: Hiçbiri seçilmedi!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Hata: arama sonuçlarını yeniden yükleyemezsiniz."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Okunmamış yok."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Halihazırda son öge üzerinde."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Halihazırda ilk öge üzerinde."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Okunmamış besleme yok."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr "Yukarıdakilerin tümü okundu olarak imleniyor..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Yazıyı şu komuta kanalla: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 msgid "dtfalgr"
 msgstr "tbaylgr"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
-msgstr "Sırala: (t)arih/(b)aşlık/b(a)yraklar/(y)azar/bağ(l)antı/(g)uid/"
-"(r)astgele?"
+msgstr ""
+"Sırala: (t)arih/(b)aşlık/b(a)yraklar/(y)azar/bağ(l)antı/(g)uid/(r)astgele?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
-msgstr "Ters Sırala: (t)arih/(b)aşlık/b(a)yraklar/(y)azar/bağ(l)antı/(g)uid/"
+msgstr ""
+"Ters Sırala: (t)arih/(b)aşlık/b(a)yraklar/(y)azar/bağ(l)antı/(g)uid/"
 "(r)astgele?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Bayraklar güncellendi."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Hata: Süzgeç uygulanırken hata oluştu: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Kayıt işlemi iptal edildi."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Yazı %s' konumuna kaydedildi"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Hata: Yazı %s' konumuna kaydedilemedi"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Arama Sonucu - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Sorgu Beslemesi - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Yazı Listesi - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "`%s' üzerine yaz (`%s' içinde)? (e:Evet h:Hayır)"
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr "evha"
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
-msgstr "`%s' üzerine yaz (`%s' içinde)? Bunun gibi %d çakışma daha var (e:Evet "
-"v:Tümüne evet h:Hayır a:Tümüne hayır)"
+msgstr ""
+"`%s' üzerine yaz (`%s' içinde)? Bunun gibi %d çakışma daha var (e:Evet v:"
+"Tümüne evet h:Hayır a:Tümüne hayır)"
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
-msgstr "`%s' üzerine yaz (`%s' içinde)? Bunun gibi başka çakışmalar daha var "
-"(e:Evet v:Tümüne evet h:Hayır a:Tümüne hayır)"
+msgstr ""
+"`%s' üzerine yaz (`%s' içinde)? Bunun gibi başka çakışmalar daha var (e:Evet "
+"v:Tümüne evet h:Hayır a:Tümüne hayır)"
 
 #: src/itemrenderer.cpp:60
 msgid "Feed: "
@@ -1057,15 +1102,15 @@ msgstr "Podcast İndirme Adresi: "
 msgid "type: "
 msgstr "biçim: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Yukarı"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Aşağı"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Yazı okundu olarak imlenirken hata oluştu: %s"
@@ -1090,35 +1135,35 @@ msgstr "Yazı %s' konumuna kaydedildi."
 msgid "Error: couldn't write article to file %s"
 msgstr "Hata: Yazı %s' konumuna kaydedilemedi"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Tarayıcı başlatılıyor..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Yazı yeni olarak imlenirken hata oluştu: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "URL'ye git: #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Tarayıcıda Görüntüle"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Kuyruktan Çıkar"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Yazı - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Hata: geçersiz düzenli ifade!"
 
@@ -1167,12 +1212,14 @@ msgid "Save articles"
 msgstr "Yazıları kaydet"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Sonraki yazıya git"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Sonraki girdiye taşı"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Önceki yazıya git"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Önceki girdiye taşı"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1480,7 +1527,7 @@ msgstr "`%s' geçerli bir bağlam değil"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' geçerli bir düğme komutu değil"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' geçerli bir işlem değil"
@@ -1495,16 +1542,16 @@ msgstr "`%s' özelliği mevcut değil."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "düzenli ifade '%s' geçersiz: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: Yapılandırma dizini '%s' erişilemez, yerine '%s' kullanılıyor."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Onulmaz hata: Ev dizini tanımlanamadı!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1512,21 +1559,21 @@ msgstr ""
 "Ev dizini değişkenini ayarlayın ya da %u UID'i için geçerli bir kullanıcı "
 "ekleyin!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Onulmaz hata: `%s' yapılandırma dizini oluşturulamadı: (%i) %s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: Geçersiz loglevel değeri"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Kuyruk temizleniyor..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1535,29 +1582,29 @@ msgstr ""
 "%s %s\n"
 "kullanım %s [-C <dosya>] [-q <dosya>] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<sıra_dosyası>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "<sıra_dosyası>'nı sıra dosyası olarak kullan"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "başlangıçta indirmeyi başlat"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u paralel indirme"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Kuyruk (%u indirme sürüyor, %u toplam) - %.2f %s toplam%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Hata: çıkılamadı: devam eden indirme(ler) var."
 
@@ -1566,7 +1613,7 @@ msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Hata: dosya oynatılmadan önce indirme işleminin tamamlanması gerekiyor."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Hata: işlem gerçekleştirilemedi: devam eden indirme(ler) var."
 
@@ -1627,43 +1674,43 @@ msgstr "`%s' geçersiz bir diyalog türü"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' geçerli bir düzenli ifade değil: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sYükleniyor: %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "%s alınırken hata oluştu: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Hata: Geçersiz besleme!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "çok az değişken"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' geçerli bir düzenli ifade değil"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Hata: Desteklenmeyen adres: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Etiket Seç"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Süzgeç Seç"
 
@@ -1675,27 +1722,31 @@ msgstr "özellik bulunamadı"
 msgid "EOF found while reading XML tag"
 msgstr "XML etiketi okunurken EOF (dosya sonu) bulundu"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 msgid "No links available!"
 msgstr "Kullanılabilir bağlantı yok!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Yer İmlerine Ekle"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "Adresler"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Hata: besleme boş!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Hiçbir etiket tanımlanmadı."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Sorgu beslemesi güncelleniyor..."
 
@@ -1744,7 +1795,7 @@ msgstr "desteklenmeyen besleme biçimi"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %s: Geçersiz loglevel değeri"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1752,22 +1803,45 @@ msgstr ""
 "Onulmaz hata: Ev dizini bulunamadı!\n"
 "HOME değişkenini ayarlayın veya %u UID için geçerli bir kullanıcı ekleyin!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr "Yapılandırmalar ve veriler Newsbeuter'in XDG dizinlerinden alınıyor..."
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr "Yapılandırmalar ve veriler ~/.newsbeuter/'den alınıyor..."
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Göç iptal ediliyor çünkü `%s' üzerinde mkdir başarısız oldu: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr "regcomp %i kodunu döndürdü"
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr "regexec %i kodunu döndürdü"
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "geçersiz besleme indeksi (bug)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Sonraki yazıya git"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Önceki yazıya git"

--- a/po/uk.po
+++ b/po/uk.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
 "POT-Creation-Date: 2020-09-17 16:02+0300\n"
-"PO-Revision-Date: 2020-06-16 19:52+0300\n"
+"PO-Revision-Date: 2020-09-17 16:25+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Ivan Kovnatsky <sevenfourk@gmail.com>, Alexander Batischev "
 "<eual.jp@gmail.com>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3.1\n"
+"X-Generator: Poedit 2.4.1\n"
 
 #: newsboat.cpp:31
 #, c-format
@@ -301,7 +301,7 @@ msgstr "невідома помилка (помилка)."
 #: src/configparser.cpp:98
 #, c-format
 msgid "%s line %u"
-msgstr ""
+msgstr "%s рядок %u"
 
 #: src/configparser.cpp:118
 #, c-format
@@ -309,9 +309,9 @@ msgid "unknown command `%s'"
 msgstr "невідома команда `%s'"
 
 #: src/configparser.cpp:125
-#, fuzzy, c-format
+#, c-format
 msgid "Error while processing command `%s' (%s): %s"
-msgstr "Помилка при виконанні команди `%s' (%s рядок %u): %s"
+msgstr "Помилка при виконанні команди `%s' (%s): %s"
 
 #: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
@@ -346,7 +346,7 @@ msgstr "Помилка: при відкритті файлу кеша `%s' ви�
 #: src/controller.cpp:270
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""
-"Помилка: для выкористання NewsBlur потрібно налаштувати `cookie-cache`.\n"
+"Помилка: для використання NewsBlur потрібно налаштувати `cookie-cache`.\n"
 
 #: src/controller.cpp:278
 #, c-format
@@ -354,16 +354,17 @@ msgid "%s is inaccessible and can't be created\n"
 msgstr "%s недоступний і не може бути створеним\n"
 
 #: src/controller.cpp:295
-#, fuzzy
 msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
 msgstr ""
-"Помилка: для выкористання NewsBlur потрібно налаштувати `cookie-cache`.\n"
+"Помилка: для використання Miniflux потрібно налаштувати `miniflux-url`\n"
 
 #: src/controller.cpp:307
 msgid ""
 "ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
 "`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
 msgstr ""
+"Помилка: для використання Miniflux потрібно задати `miniflux-login` та одне "
+"із: `miniflux-password`, `miniflux-passwordfile` чи `miniflux-passwordeval`\n"
 
 #: src/controller.cpp:320
 msgid ""
@@ -433,12 +434,11 @@ msgstr ""
 "ласка, зробіть це і спробуйте знову."
 
 #: src/controller.cpp:384
-#, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Miniflux account. "
 "Please do so, and try again."
 msgstr ""
-"Схоже не те, що ви не налаштували ні одної теми у аккаунті NewsBlur.Будь "
+"Схоже не те, що ви не налаштували ні одної теми у аккаунті Miniflux.Будь "
 "ласка, зробіть це і спробуйте знову."
 
 #: src/controller.cpp:395
@@ -635,9 +635,8 @@ msgstr ""
 #: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
 #: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
 #: src/itemviewformaction.cpp:438
-#, fuzzy
 msgid "Failed to spawn browser"
-msgstr "Відкрити статтю у браузері"
+msgstr "Не вдалося запустити браузер"
 
 #: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
 #: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
@@ -675,9 +674,8 @@ msgid "Already on first feed."
 msgstr "Вже на першій темі."
 
 #: src/feedlistformaction.cpp:409
-#, fuzzy
 msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
-msgstr "Ви впевнені, що хочете перезаписати `%s' (y:Так n:Ні)? "
+msgstr "Ви впевнені, що хочете відмітити усі теми як прочитані (y:Так n:Ні)? "
 
 #: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
 #: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
@@ -1215,12 +1213,10 @@ msgid "Save articles"
 msgstr "Зберегти статті"
 
 #: src/keymap.cpp:87
-#, fuzzy
 msgid "Go to next entry"
-msgstr "Перемістити до наступного рядка"
+msgstr "Перейти до наступного рядка"
 
 #: src/keymap.cpp:94
-#, fuzzy
 msgid "Go to previous entry"
 msgstr "Перейти до попереднього рядка"
 
@@ -1741,7 +1737,7 @@ msgstr "URLs"
 
 #: src/view.cpp:156
 msgid "Error: Failed to execute startup commands"
-msgstr ""
+msgstr "Помилка: Не вдалося виконати стартові команди"
 
 #: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
@@ -1824,16 +1820,16 @@ msgstr "Міграція відмінена: mkdir для `%s' повернув 
 #. The "%{}" thing is a number, a zero-based offset into a string.
 #: rust/libnewsboat/src/filterparser.rs:263
 msgid "Parse error: trailing characters after position %{}: %s"
-msgstr ""
+msgstr "Помилка парсеру: зайві символи після позиції %{}: %s"
 
 #. The "%{}" thing is a number, a zero-based offset into a string.
 #: rust/libnewsboat/src/filterparser.rs:270
 msgid "Parse error at position %{}: expected %s"
-msgstr ""
+msgstr "Помилка парсеру на позиціїї %{}: очікувалося %s"
 
 #: rust/libnewsboat/src/filterparser.rs:275
 msgid "Internal parse error"
-msgstr ""
+msgstr "Внутрішня помилка парсеру"
 
 #: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2020-06-16 19:52+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Ivan Kovnatsky <sevenfourk@gmail.com>, Alexander Batischev "
@@ -59,11 +59,11 @@ msgstr "<файлкешу>"
 msgid "use <cachefile> as cache file"
 msgstr "використайте <файлкешу> як файл кешу"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<файлналаштування>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "читати налаштування з <файлналаштування>"
 
@@ -87,19 +87,19 @@ msgstr "мовчазний запуск"
 msgid "get version information"
 msgstr "отримати інформацію про версію"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<рівеньлогу>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "записувати лог з визначеним рівнем (дійсні значення: від 1 до 6)"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<файллогу>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "використовуйте <файллогу> як вихідний файл логу"
 
@@ -111,7 +111,7 @@ msgstr "експортувати список прочитаних статей 
 msgid "import list of read articles from <file>"
 msgstr "імпортувати список прочитаних статей з <файл>"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "ця довідка"
 
@@ -181,23 +181,23 @@ msgstr "Впіймали newsboat::DbException із повідомленням: 
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr "Впіймали newsboat::MatcherException із повідомленням: %s"
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr "Впіймали newsboat::Exception із повідомленням: %s"
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s' недійсний колір"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "атрибут `%s' не доступний"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s' недійсний елемент конфігурації"
@@ -209,7 +209,7 @@ msgstr ""
 "newsboat: завантаження завершено, %f непрочитаних тем (%n всього "
 "непрочитаних статей)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
@@ -217,11 +217,11 @@ msgstr ""
 "%N %V - Статті у темі '%T' (%u непрочитано, всього %t)%?F? що відповідають "
 "фільтру `%F'&? - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - Діалоги"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
@@ -229,37 +229,37 @@ msgstr ""
 "%N %V - %?F?Новини&Ваші новини? (%u непрочитано, всього %t)%?F? що "
 "відповідають фільтру `%F'&?%?T? - мітка `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?Відкрити Файл&Зберегти Файл? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?Відкрити директорію&Зберегти файл? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - Довідка"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - Стаття '%T' (%u непрочитано, всього %t)"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr ""
 "%N %V - Результат пошуку (%u непрочитано, всього %t)%?F? що відповідають "
 "фільтру `%F'&?"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - Вибрати Фільтер"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - Вибрати Мітку"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - URLs"
 
@@ -298,38 +298,43 @@ msgstr "файл неможливо відкрити."
 msgid "unknown error (bug)."
 msgstr "невідома помилка (помилка)."
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "Помилка при виконанні команди `%s' (%s рядок %u): %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "невідома команда `%s'"
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "Помилка при виконанні команди `%s' (%s рядок %u): %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "Запускаю %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "Помилка: вже працює копія %s (PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "Завантаження налаштувань..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "готово."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "Відкриваю кеш..."
 
@@ -348,7 +353,19 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr "%s недоступний і не може бути створеним\n"
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+#, fuzzy
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+"Помилка: для выкористання NewsBlur потрібно налаштувати `cookie-cache`.\n"
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
@@ -356,17 +373,17 @@ msgstr ""
 "Помилка: для використання Inoreader потрібно задати `inoreader-app-id` та "
 "`inoreader-app-key`.\n"
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr "Помилка: невідоме джерело адрес: `%s'"
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "Завантажую URLs з %s..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
@@ -375,7 +392,7 @@ msgstr ""
 "Помилка: не вказано URLs. Будь ласка, додайте RSS URLs у файл %s чи "
 "імпортуйте файл OPML."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
@@ -383,7 +400,7 @@ msgstr ""
 "Схоже на те, що OPML тема, на яку ви підписалися не містить тем. Будь ласка, "
 "заповніть її темами та спробуйте знову."
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
 "account. Please do so, and try again."
@@ -391,7 +408,7 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті The Old Reader."
 "Будь ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
 "account. Please do so, and try again."
@@ -399,7 +416,7 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті Tiny Tiny RSS."
 "Будь ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
 "Please do so, and try again."
@@ -407,7 +424,7 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті NewsBlur.Будь "
 "ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
 "Please do so, and try again."
@@ -415,69 +432,78 @@ msgstr ""
 "Схоже не те, що ви не налаштували ні одної теми у аккаунті Inoreader.Будь "
 "ласка, зробіть це і спробуйте знову."
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"Схоже не те, що ви не налаштували ні одної теми у аккаунті NewsBlur.Будь "
+"ласка, зробіть це і спробуйте знову."
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "Завантаження статей з кешу..."
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "Ретельне очищення кешу..."
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "Помилка при завантаженні тем з бази даних: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "Помилка при завантаженні теми `%s': %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "Підготовлюю динамічні теми..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "Імпортую список прочитаних статей..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "Зберігаю список прочитаних статей..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "Очищення кешу..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "невдало: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "Помилка: не вдалось позначити всі теми як прочитані: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "Виникла помилка при розборі %s."
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "Імпорт %s завершено."
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u непрочитаних статей"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, c-format
 msgid "%s: %s: unknown command"
 msgstr "%s: %s: невідома команда"
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "Помилка: не можу відкрити файл конфігурації `%s'!"
@@ -498,26 +524,26 @@ msgstr "Закрити Діалог"
 msgid "Error: you can't remove the feed list!"
 msgstr "Помилка: не можна видаляти список тем!"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "Непрацездатна позиція!"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr "Директорія: "
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "Відміна"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "Зберегти"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, c-format
 msgid "Save Files - %s"
 msgstr "Зберегти файли - %s"
@@ -562,10 +588,6 @@ msgstr "програно"
 msgid "unknown (bug)."
 msgstr "невідомо (помилка)."
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "непрацездатний індекс теми (помилка)"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "Люди, котрих ви читаєте"
@@ -579,20 +601,20 @@ msgstr "Відмічені статті"
 msgid "Shared items"
 msgstr "Розшарені статті"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "Не вибрано тем!"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr "ftauln"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
@@ -600,7 +622,7 @@ msgstr ""
 "Сортувати за (f)першимТаґом/(t)назвою/(a)кількістьСтатей/"
 "(u)кількістьНепрочитанихСтатей/(l)останнімОновленням/(n)ніяк?"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
@@ -608,158 +630,174 @@ msgstr ""
 "Сортувати реверсно за (f)першимТаґом/(t)назвою/(a)кількістьСтатей/"
 "(u)кількістьНепрочитанихСтатей/(l)останнімОновленням/(n)ніяк?"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "Відкрити статтю у браузері"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr "Браузер повернув код помилки %i"
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr "Динамічні теми не можна відкрити у браузері!"
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "Позначаю теми як прочитані..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "Помилка: не можу позначити тему: %s як прочитану"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "Немає тем з непрочитаними статтями."
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr "Вже на останній темі."
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr "Вже на першій темі."
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "Ви впевнені, що хочете перезаписати `%s' (y:Так n:Ні)? "
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "yn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "y"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "Позначаю всі теми як прочитані..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "Помилка: неможливо парсувати команду фільтра `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "Не визначено фільтри."
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "Шукати: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "Фільтр: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "Ви впевнені, що хочете вийти (y:Так n:Ні)? "
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "yn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "y"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "Вихід"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "Відкрити"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "Наступна непрочитана"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "Перезавантажити"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "Перезавантажити усі"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "Позначити як прочитано"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "Позначити всі як прочитані"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "Пошук"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "Довідка"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "Помилка: неможливо розібрати помилку фільтра!"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "Шукаю..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "Помилка при пошуку `%s': %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "Безрезультатно."
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "Не видно позицію!"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "Список Тем - %u непрочитано, загалом - %u"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "Ви впевнені, що хочете перезаписати `%s' (y:Так n:Ні)? "
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "Файл: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "Зберегти Файл - %s"
@@ -851,35 +889,35 @@ msgstr "Незастосовані функції:"
 msgid "Clear"
 msgstr "Очистити"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "вбудований флеш:"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "зображення"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "Посилання: "
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "посилання"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "вбудований флеш"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr "відео"
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr "аудіо"
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "невідомо (помилка)"
 
@@ -895,137 +933,137 @@ msgstr "Вподобані статті"
 msgid "Saved web pages"
 msgstr "Збережені веб-сторінки"
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "Не вибрано нічого!"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "Переключення флагу прочитано для статей..."
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "Помилка при переключенні флагу прочитано: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "Список URL пустий."
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "Флаги: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "Помилка: нічого не вибрано!"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "Помилка: не можна перезавантажувати результати пошуку."
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "Немає непрочитаних статей."
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr "Вже на останній статті."
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr "Вже на першій статті."
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "Немає непрочитаних тем."
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 msgid "Marking all above as read..."
 msgstr "Позначаю все, що вище, як прочитані..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Пайпувати статтю до каманди: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 msgid "dtfalgr"
 msgstr "dtfalgr"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Сортувати за (d)датою/(t)назвою/(f)флагами/(a)автором/(l)посиланням/(g)uid/"
 "(r)випадково?"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 "Сортувати реверсно за (d)датою/(t)назвою/(f)флагами/(a)автором/(l)посиланням/"
 "(g)uid/(r)випадково?"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "Флаги поновлено."
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "Помилка: примінення фільтру невдале: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "Збереження перервано."
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "Стаття збережена у %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "Помилка: не можу зберегти у %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "Результати Пошуку - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "Динамічна тема - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "Список Статей - %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr "Перезаписати `%s' в `%s'? (y:Так n:Ні)"
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr "yanq"
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
@@ -1034,7 +1072,7 @@ msgstr ""
 "Перезаписати `%s' в `%s'? Залишилось таких конфліктів: %d (y:Так a:"
 "Перезаписати усі n:Ні q:Не перезаписувати нічого)"
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1067,15 +1105,15 @@ msgstr "Посилання на завантаження Podcast: "
 msgid "type: "
 msgstr "тип: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "Вершина"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "Низ"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "Помилка при позначенні статті як прочитано: %s"
@@ -1100,35 +1138,35 @@ msgstr "Збережено статтю у %s."
 msgid "Error: couldn't write article to file %s"
 msgstr "Помилка: не можу записати статтю у файл %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "Запускаю браузер..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "Помилка при позначенні статті як непрочитано: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "Перейти за посиланням №"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "Відкрити у браузері"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "Поставити у чергу"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "Стаття - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "Помилка: неправильний вираз!"
 
@@ -1177,12 +1215,14 @@ msgid "Save articles"
 msgstr "Зберегти статті"
 
 #: src/keymap.cpp:87
-msgid "Go to next article"
-msgstr "Перейти до наступної статті"
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Перемістити до наступного рядка"
 
 #: src/keymap.cpp:94
-msgid "Go to previous article"
-msgstr "Перейти до попередньої статті"
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Перейти до попереднього рядка"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1492,7 +1532,7 @@ msgstr "`%s' недійсний контекст"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' недійсна ключова команда"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' недійсна операція"
@@ -1507,16 +1547,16 @@ msgstr "атрибут `%s' не доступний."
 msgid "regular expression '%s' is invalid: %s"
 msgstr "вживаний вираз '%s' неправильний %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr "XDG: конфігураційна директорія '%s' недоступна, використовуємо '%s'."
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "Критична помилка: неможливо визначити домашню директорію!"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1524,21 +1564,21 @@ msgstr ""
 "Будь ласка, налаштуйте змінну HOME, або додайте користувача, що відповідає "
 "UID %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "Помилка: не можу створити конфігураційну директорію `%s': (%i) %s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr "%s: %d: неправильний рівень логування"
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "Очищую чергу..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, c-format
 msgid ""
 "%s %s\n"
@@ -1547,29 +1587,29 @@ msgstr ""
 "%s %s\n"
 "використання: %s [-C <файл>] [-q <файл>|-e] [-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 msgid "<queuefile>"
 msgstr "<файл черги>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 msgid "use <queuefile> as queue file"
 msgstr "використовувати <файл черги> як файл черги"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr "починати завантаження при запуску"
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u паралельних завантажень"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "Черга (%u активних завантажень, всього %u) - %.2f %s всього%s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "Помилка: неможливо вийти: активне(і) завантаження."
 
@@ -1578,7 +1618,7 @@ msgid "Error: download needs to be finished before the file can be played."
 msgstr ""
 "Помилка: для того, щоб програти файл, завантаження повинні бути завершені."
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "Помилка: неможливо виконати операцію: активне(і) завантаження."
 
@@ -1639,43 +1679,43 @@ msgstr "`%s' недійсний тип діалогу"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' не є правильним регулярним виразом: %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%sЗавантаження %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "Помилка при стягненні %s: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "Помилка: непрацездатна тема!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "замало параметрів"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' не є правильним фільтром"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr "%a, %d %b %Y %T %z"
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "Помилка: посилання не підтримується: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "Виберіть мітку"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "Виберіть фільтр"
 
@@ -1687,27 +1727,31 @@ msgstr "атрибут не знайдено"
 msgid "EOF found while reading XML tag"
 msgstr "При читанні мітки з XML був виявлений кінець файлу"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 msgid "No links available!"
 msgstr "Немає посилань!"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "Зберегти закладку"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "URLs"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "Помилка: теми не містять елементів!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "Не визначено жодної мітки."
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "Оновлюю динамічну тему..."
 
@@ -1756,7 +1800,7 @@ msgstr "формат теми не підтримується"
 msgid "%s: %s: invalid loglevel value"
 msgstr "%s: %s: неправильний рівень логування"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
@@ -1765,25 +1809,48 @@ msgstr ""
 "Будь ласка, налаштуйте змінну HOME, або додайте користувача, що відповідає "
 "UID %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr "Переношу конфіги і дані з XDG-директорій Newsbeuter..."
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr "Переношу конфіги і дані з ~/.newsbeuter/..."
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "Міграція відмінена: mkdir для `%s' повернув помилку: %s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr "regcomp повернула код помилки %i"
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr "regexec повернула код помилки %i"
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "непрацездатний індекс теми (помилка)"
+
+#~ msgid "Go to next article"
+#~ msgstr "Перейти до наступної статті"
+
+#~ msgid "Go to previous article"
+#~ msgstr "Перейти до попередньої статті"
 
 #~ msgid "config"
 #~ msgstr "налаштування"

--- a/po/zh.po
+++ b/po/zh.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2007-11-21 22:51+0100\n"
 "Last-Translator: josh yu <joshyupeng@gmail.com>\n"
 "Language-Team: \n"
@@ -54,11 +54,11 @@ msgstr "缓存文件"
 msgid "use <cachefile> as cache file"
 msgstr "使用<cachefile>作为保存缓存数据的文件"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<配置文件>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "从<配置文件>里读取配置信息"
 
@@ -82,19 +82,19 @@ msgstr ""
 msgid "get version information"
 msgstr "获得版本信息"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "记录等级"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "以某一等级做记录（有效值：1 - 6）"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<记录文件>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "使用<记录文件>作为导出记录的文件"
 
@@ -106,7 +106,7 @@ msgstr "将已阅读文章导出到<文件>"
 msgid "import list of read articles from <file>"
 msgstr "从<文件>里导入阅读的文章列表"
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "该帮助"
 
@@ -172,23 +172,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr ""
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, fuzzy, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "无效的属性索引"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr ""
@@ -198,57 +198,57 @@ msgstr ""
 msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr "newsboat:重新加载完毕, %f个种子含未读文章(共有 %n 篇未读文章)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N %V - 种子 '%T' 里的文章（%u 未读, 共有 %t 篇） - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 #, fuzzy
 msgid "%N %V - Dialogs"
 msgstr "%N %V - 链接"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - 你的种子 (%u 篇未读, 共有 %t 篇)%?T? - 标签 `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?打开文件&保存文件? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?打开文件&保存文件? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - 帮助"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - 种子 '%T' 里的文章（%u 未读, 共有 %t 篇） - %U"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - 查找结果 (%u 未读, 共有 %t)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - 选择过滤器"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - 选择标签"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - 链接"
 
@@ -287,38 +287,43 @@ msgstr "无法打开文件"
 msgid "unknown error (bug)."
 msgstr "未知的错误（bug）"
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "当处理命令`%s'(%s 第 %u 行)时出错: %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "未知的命令 `%s' "
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "当处理命令`%s'(%s 第 %u 行)时出错: %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "启动 %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "错误：%s的一个进程已经在运行中（PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "加载配置文件..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "完毕."
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "打开缓存..."
 
@@ -336,36 +341,46 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "从 %s 文件加载链接..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr "错误：没有配置链接。请用RSS种子的链接替换 %s 或者导入一个OPML文件."
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr "看起来你订阅的OPML种子没有包含任何种子请更正之后再尝试一下。"
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -373,7 +388,7 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -381,7 +396,7 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -389,7 +404,7 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -397,70 +412,78 @@ msgid ""
 msgstr ""
 "看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"看起来你还没有在bloglines账户里配置任何种子 请先配置种子，然后再尝试一下。"
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "从缓存中加载文章"
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "彻底清除缓存"
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "当从数据库中加载种子的时候出错: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, fuzzy, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "当调用`%s'的时候出错: %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 #, fuzzy
 msgid "Prepopulating query feeds..."
 msgstr "更新查询种子..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "导入阅读文章列表"
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "导出阅读文章列表"
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "清空缓存..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "失败: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "错误:无法将所有种子都标记为已读: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr ""
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s 导入完毕"
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u 篇未读文章"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "未知的命令 `%s' "
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, fuzzy, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "错误：无法将文章写至 %s"
@@ -482,26 +505,26 @@ msgstr ""
 msgid "Error: you can't remove the feed list!"
 msgstr "错误：你不能重新加载所选项目"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "无效位置！"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "取消"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "保存"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "%s %s - 保存文件 - %s"
@@ -546,10 +569,6 @@ msgstr "已播放"
 msgid "unknown (bug)."
 msgstr "未知（bug）"
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "无效的种子索引(bug）"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr ""
@@ -565,183 +584,199 @@ msgstr "没有未读的文章"
 msgid "Shared items"
 msgstr "没有未读的文章"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "没有选择种子"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 msgid "ftauln"
 msgstr ""
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
 msgstr ""
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "在浏览器里打开文章"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "标记该种子已读"
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "错误：无法将种子标记为已读: %s"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "任何种子里都没有未读的文章"
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "你真的想覆盖 `%s'么(y:是的  n:不是)?"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "yn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "y"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "将所有种子都标记为已读..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, fuzzy, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "错误：无法分析过滤器（filter）命令"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "没有定义任何过滤器（filter）"
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "查找: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "过滤器: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "你真的想离开么（y:是的 n:不是)?"
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "yn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "y"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "放弃"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "打开"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "下一篇未读"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "重新加载当前种子"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "重新加载所有种子"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "标记为已读"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "将所有都标记为已读"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "查找"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "帮助"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "错误：无法分析过滤器（filter）命令"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "查找..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "当查找 `%s'的时候出错: %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "没有结果"
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "找不到这个位置"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, fuzzy, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "%N %V - 查找结果 (%u 未读, 共有 %t)"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "你真的想覆盖 `%s'么(y:是的  n:不是)?"
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "文件: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, fuzzy, c-format
 msgid "Save File - %s"
 msgstr "%s %s - 保存文件 - %s"
@@ -835,35 +870,35 @@ msgstr ""
 msgid "Clear"
 msgstr "清空"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "内嵌flash"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "图片"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "所有链接"
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "链接"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "内嵌flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "未知（bug）"
 
@@ -880,142 +915,142 @@ msgstr "没有未读的文章"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "没有选择任何项目"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "切换文章阅读标记（已读/未读）"
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "当切换阅读标记（已读/未读）时出错: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "空空如也的链接列表"
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "标记: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "错误：没有选择任何项目！"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "错误：你不能重新加载所选项目"
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "没有未读的文章"
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "没有未读的种子"
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "将所有种子都标记为已读..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr ""
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "编辑标记"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr ""
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "标记已更新"
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "错误: 应用过滤器失败: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "放弃保存"
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "错误：无法保存文章到 %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, fuzzy, c-format
 msgid "Article List - %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1046,15 +1081,15 @@ msgstr "播客下载的地址: "
 msgid "type: "
 msgstr "类型: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "顶部"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "底部"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "当标记文章为已读的时候出错: %s"
@@ -1079,35 +1114,35 @@ msgstr "将文章保存至 %s "
 msgid "Error: couldn't write article to file %s"
 msgstr "错误：无法将文章写至 %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "启动浏览器..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "当标记文章为未读的时候出错: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr ""
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "在浏览器里打开"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "加入队列"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, fuzzy, c-format
 msgid "Article - %s"
 msgstr "把文章保存到 %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 #, fuzzy
 msgid "Error: invalid regular expression!"
 msgstr "错误:无效的种子!"
@@ -1160,13 +1195,13 @@ msgstr "保存文章"
 
 #: src/keymap.cpp:87
 #, fuzzy
-msgid "Go to next article"
-msgstr "转到下一篇未读文章"
+msgid "Go to next entry"
+msgstr "转到下一篇未读的种子"
 
 #: src/keymap.cpp:94
 #, fuzzy
-msgid "Go to previous article"
-msgstr "转到前一篇未读文章"
+msgid "Go to previous entry"
+msgstr "转到前一篇未读的种子"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1490,7 +1525,7 @@ msgstr ""
 msgid "`%s' is not a valid key command"
 msgstr ""
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "无效的属性索引"
@@ -1505,36 +1540,36 @@ msgstr "无效属性 `%s'"
 msgid "regular expression '%s' is invalid: %s"
 msgstr ""
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "致命错误:无法确定主目录！"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr "请设置主目录的环境变量，或者添加一个有效的用户其UID为 %u!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "错误：无法将文章写至 %s"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "清空队列..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1544,31 +1579,31 @@ msgstr ""
 "用法: %s [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x <command> ...] [-"
 "h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 #, fuzzy
 msgid "<queuefile>"
 msgstr "文件"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "使用<cachefile>作为保存缓存数据的文件"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr ""
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u 个并行下载"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "队列 (%u 个下载项目在进行，共有 %u 个下载项目) - 总共 %.2f kb/s %s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "错误: 无法取消: 还有项目在下载"
 
@@ -1576,7 +1611,7 @@ msgstr "错误: 无法取消: 还有项目在下载"
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "错误：下载项目必须下载完毕才可以播放"
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "错误：无法执行操作：有项目在下载中"
 
@@ -1635,44 +1670,44 @@ msgstr ""
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "错误:无效的种子!"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%s加载中 %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "当抓取%s的时候出错: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "错误:无效的种子!"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 #, fuzzy
 msgid "too few arguments"
 msgstr "参数太少"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "错误:无效的种子!"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr ""
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "错误：不支持的链接: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "选择标签"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "选择过滤器"
 
@@ -1684,29 +1719,33 @@ msgstr "属性没有发现"
 msgid "EOF found while reading XML tag"
 msgstr "当读取XML标签时遇到EOF标记"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "没有选择任何链接！"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "保存书签"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 #, fuzzy
 msgid "URLs"
 msgstr "链接: "
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "错误: 种子里没有包含任何项目!"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "没有定义任何标签"
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "更新查询种子..."
 
@@ -1758,33 +1797,58 @@ msgstr ""
 msgid "%s: %s: invalid loglevel value"
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 #, fuzzy
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr "请设置主目录的环境变量，或者添加一个有效的用户其UID为 %u!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "错误:打开缓存文件`%s' 失败:%s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "无效的种子索引(bug）"
+
+#, fuzzy
+#~ msgid "Go to next article"
+#~ msgstr "转到下一篇未读文章"
+
+#, fuzzy
+#~ msgid "Go to previous article"
+#~ msgstr "转到前一篇未读文章"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2020-06-16 19:51+0300\n"
+"POT-Creation-Date: 2020-09-17 16:02+0300\n"
 "PO-Revision-Date: 2010-03-03 16:55+0800\n"
 "Last-Translator: Aeglos <aeglos.lin@gmail.com>\n"
 "Language-Team: \n"
@@ -57,11 +57,11 @@ msgstr "<快取檔案>"
 msgid "use <cachefile> as cache file"
 msgstr "使用<快取檔案>作為快取檔案"
 
-#: newsboat.cpp:64 src/pbcontroller.cpp:344
+#: newsboat.cpp:64 src/pbcontroller.cpp:341
 msgid "<configfile>"
 msgstr "<組態檔案>"
 
-#: newsboat.cpp:65 src/pbcontroller.cpp:345
+#: newsboat.cpp:65 src/pbcontroller.cpp:342
 msgid "read configuration from <configfile>"
 msgstr "從<組態檔案>讀取組態"
 
@@ -85,19 +85,19 @@ msgstr ""
 msgid "get version information"
 msgstr "取得版本資訊"
 
-#: newsboat.cpp:79 src/pbcontroller.cpp:357
+#: newsboat.cpp:79 src/pbcontroller.cpp:354
 msgid "<loglevel>"
 msgstr "<記錄層級>"
 
-#: newsboat.cpp:80 src/pbcontroller.cpp:358
+#: newsboat.cpp:80 src/pbcontroller.cpp:355
 msgid "write a log with a certain loglevel (valid values: 1 to 6)"
 msgstr "依記錄層級(有效值：1到6)進行記錄"
 
-#: newsboat.cpp:87 src/pbcontroller.cpp:365
+#: newsboat.cpp:87 src/pbcontroller.cpp:362
 msgid "<logfile>"
 msgstr "<記錄檔案>"
 
-#: newsboat.cpp:88 src/pbcontroller.cpp:366
+#: newsboat.cpp:88 src/pbcontroller.cpp:363
 msgid "use <logfile> as output log file"
 msgstr "使用<記錄檔案>作為輸出的記錄檔"
 
@@ -109,7 +109,7 @@ msgstr "匯出已閱讀文章列表至<檔案>"
 msgid "import list of read articles from <file>"
 msgstr "由<檔案>匯入閱讀文章列表..."
 
-#: newsboat.cpp:102 src/pbcontroller.cpp:368
+#: newsboat.cpp:102 src/pbcontroller.cpp:365
 msgid "this help"
 msgstr "這份說明"
 
@@ -175,23 +175,23 @@ msgstr ""
 msgid "Caught newsboat::MatcherException with message: %s"
 msgstr ""
 
-#: newsboat.cpp:256 podboat.cpp:37
+#: newsboat.cpp:256 podboat.cpp:41
 #, c-format
 msgid "Caught newsboat::Exception with message: %s"
 msgstr ""
 
-#: src/colormanager.cpp:56 src/colormanager.cpp:59 src/regexmanager.cpp:220
+#: src/colormanager.cpp:55 src/colormanager.cpp:58 src/regexmanager.cpp:220
 #: src/regexmanager.cpp:234 src/regexmanager.cpp:305 src/regexmanager.cpp:317
 #, c-format
 msgid "`%s' is not a valid color"
 msgstr "`%s'不是有效的顏色"
 
-#: src/colormanager.cpp:65 src/regexmanager.cpp:250 src/regexmanager.cpp:332
+#: src/colormanager.cpp:64 src/regexmanager.cpp:250 src/regexmanager.cpp:332
 #, c-format
 msgid "`%s' is not a valid attribute"
 msgstr "`%s' 不是有效的屬性"
 
-#: src/colormanager.cpp:83
+#: src/colormanager.cpp:79
 #, c-format
 msgid "`%s' is not a valid configuration element"
 msgstr "`%s'不是一個有效的組態項目"
@@ -201,56 +201,56 @@ msgstr "`%s'不是一個有效的組態項目"
 msgid "newsboat: finished reload, %f unread feeds (%n unread articles total)"
 msgstr "newsboat:重新載入完成, %f個來源含未讀文章(共有 %n 篇未讀文章)"
 
-#: src/configcontainer.cpp:264
+#: src/configcontainer.cpp:271
 #, fuzzy
 msgid ""
 "%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `"
 "%F'&? - %U"
 msgstr "%N %V - 來源 '%T' 裡的文章（%u 未讀, 共有 %t 篇） - %U"
 
-#: src/configcontainer.cpp:270
+#: src/configcontainer.cpp:277
 msgid "%N %V - Dialogs"
 msgstr "%N %V - 對話窗"
 
-#: src/configcontainer.cpp:273
+#: src/configcontainer.cpp:280
 #, fuzzy
 msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr "%N %V - 你的來源 (%u 篇未讀, 共有 %t 篇)%?T? - 標籤 `%T'&?"
 
-#: src/configcontainer.cpp:279
+#: src/configcontainer.cpp:286
 msgid "%N %V - %?O?Open File&Save File? - %f"
 msgstr "%N %V - %?O?打開檔案&儲存檔案? - %f"
 
-#: src/configcontainer.cpp:283
+#: src/configcontainer.cpp:290
 #, fuzzy
 msgid "%N %V - %?O?Open Directory&Save File? - %f"
 msgstr "%N %V - %?O?打開檔案&儲存檔案? - %f"
 
-#: src/configcontainer.cpp:287
+#: src/configcontainer.cpp:294
 msgid "%N %V - Help"
 msgstr "%N %V - 說明"
 
-#: src/configcontainer.cpp:290
+#: src/configcontainer.cpp:297
 #, fuzzy
 msgid "%N %V - Article '%T' (%u unread, %t total)"
 msgstr "%N %V - 來源 '%T' 裡的文章（%u 未讀, 共有 %t 篇） - %U"
 
-#: src/configcontainer.cpp:295
+#: src/configcontainer.cpp:302
 #, fuzzy
 msgid "%N %V - Search results (%u unread, %t total)%?F? matching filter `%F'&?"
 msgstr "%N %V - 搜尋結果 (%u 未讀, 共有 %t)"
 
-#: src/configcontainer.cpp:300
+#: src/configcontainer.cpp:307
 msgid "%N %V - Select Filter"
 msgstr "%N %V - 選擇過濾器"
 
-#: src/configcontainer.cpp:304
+#: src/configcontainer.cpp:311
 msgid "%N %V - Select Tag"
 msgstr "%N %V - 選擇標籤"
 
-#: src/configcontainer.cpp:308
+#: src/configcontainer.cpp:315
 msgid "%N %V - URLs"
 msgstr "%N %V - 網址"
 
@@ -289,38 +289,43 @@ msgstr "無法打開檔案"
 msgid "unknown error (bug)."
 msgstr "未知的錯誤（bug）"
 
-#: src/configparser.cpp:112
+#: src/configparser.cpp:98
 #, c-format
-msgid "Error while processing command `%s' (%s line %u): %s"
-msgstr "在處理命令`%s'(%s 第 %u 行)時發生錯誤: %s"
+msgid "%s line %u"
+msgstr ""
 
-#: src/configparser.cpp:122
+#: src/configparser.cpp:118
 #, c-format
 msgid "unknown command `%s'"
 msgstr "未知的命令 `%s' "
 
-#: src/controller.cpp:148 src/pbcontroller.cpp:248
+#: src/configparser.cpp:125
+#, fuzzy, c-format
+msgid "Error while processing command `%s' (%s): %s"
+msgstr "在處理命令`%s'(%s 第 %u 行)時發生錯誤: %s"
+
+#: src/controller.cpp:147 src/pbcontroller.cpp:246
 #, c-format
 msgid "Starting %s %s..."
 msgstr "啟動 %s %s..."
 
-#: src/controller.cpp:158 src/controller.cpp:214 src/pbcontroller.cpp:255
+#: src/controller.cpp:157 src/controller.cpp:214 src/pbcontroller.cpp:253
 #, c-format
 msgid "Error: an instance of %s is already running (PID: %u)"
 msgstr "錯誤：已有一個%s程序在執行中（PID: %u)"
 
-#: src/controller.cpp:168 src/pbcontroller.cpp:263
+#: src/controller.cpp:167 src/pbcontroller.cpp:261
 msgid "Loading configuration..."
 msgstr "載入設定檔..."
 
-#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:321
-#: src/controller.cpp:374 src/controller.cpp:378 src/controller.cpp:414
-#: src/controller.cpp:428 src/controller.cpp:446 src/controller.cpp:457
-#: src/controller.cpp:500 src/pbcontroller.cpp:301 src/pbcontroller.cpp:319
+#: src/controller.cpp:203 src/controller.cpp:248 src/controller.cpp:345
+#: src/controller.cpp:403 src/controller.cpp:407 src/controller.cpp:443
+#: src/controller.cpp:457 src/controller.cpp:475 src/controller.cpp:486
+#: src/controller.cpp:528 src/pbcontroller.cpp:298 src/pbcontroller.cpp:316
 msgid "done."
 msgstr "完成。"
 
-#: src/controller.cpp:224 src/controller.cpp:369
+#: src/controller.cpp:224 src/controller.cpp:398
 msgid "Opening cache..."
 msgstr "打開快取中..."
 
@@ -338,36 +343,46 @@ msgstr ""
 msgid "%s is inaccessible and can't be created\n"
 msgstr ""
 
-#: src/controller.cpp:296
+#: src/controller.cpp:295
+msgid "ERROR: You must set `miniflux-url` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:307
+msgid ""
+"ERROR: You must set `miniflux-login` and one of `miniflux-password`, "
+"`miniflux-passwordfile` or `miniflux-passwordeval` to use Miniflux\n"
+msgstr ""
+
+#: src/controller.cpp:320
 msgid ""
 "ERROR: You must set *both* `inoreader-app-id` and `inoreader-app-key` to use "
 "Inoreader.\n"
 msgstr ""
 
-#: src/controller.cpp:303
+#: src/controller.cpp:327
 #, c-format
 msgid "ERROR: Unknown urls-source `%s'"
 msgstr ""
 
-#: src/controller.cpp:310
+#: src/controller.cpp:334
 #, c-format
 msgid "Loading URLs from %s..."
 msgstr "從 %s 中載入鏈結..."
 
-#: src/controller.cpp:329
+#: src/controller.cpp:353
 #, c-format
 msgid ""
 "Error: no URLs configured. Please fill the file %s with RSS feed URLs or "
 "import an OPML file."
 msgstr "錯誤：沒有設置鏈結。請用RSS來源的鏈結替換 %s 或者匯入一個OPML檔案"
 
-#: src/controller.cpp:335
+#: src/controller.cpp:359
 msgid ""
 "It looks like the OPML feed you subscribed contains no feeds. Please fill it "
 "with feeds, and try again."
 msgstr "看起來你訂閱的OPML沒有任何來源。請先加入來源，然後再試一次。"
 
-#: src/controller.cpp:340
+#: src/controller.cpp:364
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your The Old Reader "
@@ -375,7 +390,7 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:345
+#: src/controller.cpp:369
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Tiny Tiny RSS "
@@ -383,7 +398,7 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:350
+#: src/controller.cpp:374
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your NewsBlur account. "
@@ -391,7 +406,7 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:355
+#: src/controller.cpp:379
 #, fuzzy
 msgid ""
 "It looks like you haven't configured any feeds in your Inoreader account. "
@@ -399,69 +414,77 @@ msgid ""
 msgstr ""
 "看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
 
-#: src/controller.cpp:366
+#: src/controller.cpp:384
+#, fuzzy
+msgid ""
+"It looks like you haven't configured any feeds in your Miniflux account. "
+"Please do so, and try again."
+msgstr ""
+"看來你還沒有在Google Reader帳號裡配置任何來源。請先配置來源，然後再試一次。"
+
+#: src/controller.cpp:395
 msgid "Loading articles from cache..."
 msgstr "從快取中載入文章"
 
-#: src/controller.cpp:375
+#: src/controller.cpp:404
 msgid "Cleaning up cache thoroughly..."
 msgstr "徹底清空快取"
 
-#: src/controller.cpp:395
+#: src/controller.cpp:424
 msgid "Error while loading feeds from database: "
 msgstr "從資料庫中載入來源時發生錯誤: "
 
-#: src/controller.cpp:401
+#: src/controller.cpp:430
 #, c-format
 msgid "Error while loading feed '%s': %s"
 msgstr "載入 `%s'的時候發生錯誤: %s"
 
-#: src/controller.cpp:421
+#: src/controller.cpp:450
 msgid "Prepopulating query feeds..."
 msgstr "更新查詢來源..."
 
-#: src/controller.cpp:443
+#: src/controller.cpp:472
 msgid "Importing list of read articles..."
 msgstr "匯入已閱讀文章列表..."
 
-#: src/controller.cpp:454
+#: src/controller.cpp:483
 msgid "Exporting list of read articles..."
 msgstr "匯出已閱讀文章列表..."
 
-#: src/controller.cpp:493
+#: src/controller.cpp:522
 msgid "Cleaning up cache..."
 msgstr "清空快取..."
 
-#: src/controller.cpp:505
+#: src/controller.cpp:533
 msgid "failed: "
 msgstr "失敗: "
 
-#: src/controller.cpp:531
+#: src/controller.cpp:557
 #, c-format
 msgid "Error: couldn't mark all feeds read: %s"
 msgstr "錯誤:無法將所有來源標為已讀: %s"
 
-#: src/controller.cpp:631
+#: src/controller.cpp:652
 #, c-format
 msgid "An error occurred while parsing %s."
 msgstr "在分析%s時發生錯誤"
 
-#: src/controller.cpp:636
+#: src/controller.cpp:657
 #, c-format
 msgid "Import of %s finished."
 msgstr "%s 匯入完畢"
 
-#: src/controller.cpp:766
+#: src/controller.cpp:787
 #, c-format
 msgid "%u unread articles"
 msgstr "%u篇未讀文章"
 
-#: src/controller.cpp:771
+#: src/controller.cpp:792
 #, fuzzy, c-format
 msgid "%s: %s: unknown command"
 msgstr "未知的命令 `%s' "
 
-#: src/controller.cpp:881
+#: src/controller.cpp:897
 #, c-format
 msgid "Error: couldn't open configuration file `%s'!"
 msgstr "錯誤：無法開啟組態檔案`%s'！"
@@ -482,26 +505,26 @@ msgstr "關閉對話窗"
 msgid "Error: you can't remove the feed list!"
 msgstr "錯誤：你不能移除來源列表！"
 
-#: src/dialogsformaction.cpp:140 src/feedlistformaction.cpp:987
-#: src/itemlistformaction.cpp:1258 src/urlviewformaction.cpp:169
+#: src/dialogsformaction.cpp:142 src/feedlistformaction.cpp:976
+#: src/itemlistformaction.cpp:1247 src/urlviewformaction.cpp:170
 msgid "Invalid position!"
 msgstr "無效位置！"
 
-#: src/dirbrowserformaction.cpp:289
+#: src/dirbrowserformaction.cpp:293
 msgid "Directory: "
 msgstr ""
 
-#: src/dirbrowserformaction.cpp:317 src/filebrowserformaction.cpp:309
-#: src/pbview.cpp:370 src/selectformaction.cpp:247 src/selectformaction.cpp:251
+#: src/dirbrowserformaction.cpp:321 src/filebrowserformaction.cpp:313
+#: src/pbview.cpp:370 src/selectformaction.cpp:246 src/selectformaction.cpp:250
 msgid "Cancel"
 msgstr "取消"
 
-#: src/dirbrowserformaction.cpp:318 src/filebrowserformaction.cpp:310
-#: src/itemlistformaction.cpp:1236 src/itemviewformaction.cpp:474
+#: src/dirbrowserformaction.cpp:322 src/filebrowserformaction.cpp:314
+#: src/itemlistformaction.cpp:1225 src/itemviewformaction.cpp:483
 msgid "Save"
 msgstr "儲存"
 
-#: src/dirbrowserformaction.cpp:427
+#: src/dirbrowserformaction.cpp:434
 #, fuzzy, c-format
 msgid "Save Files - %s"
 msgstr "儲存檔案 - %s"
@@ -546,10 +569,6 @@ msgstr "已播放"
 msgid "unknown (bug)."
 msgstr "未知（bug）"
 
-#: src/feedcontainer.cpp:106
-msgid "invalid feed index (bug)"
-msgstr "無效的來源索引(bug）"
-
 #: src/feedhqurlreader.cpp:47 src/oldreaderurlreader.cpp:48
 msgid "People you follow"
 msgstr "你追蹤的人"
@@ -563,186 +582,202 @@ msgstr "星號的文章"
 msgid "Shared items"
 msgstr "分享的文章"
 
-#: src/feedlistformaction.cpp:109 src/feedlistformaction.cpp:122
-#: src/feedlistformaction.cpp:273 src/feedlistformaction.cpp:294
-#: src/feedlistformaction.cpp:356
+#: src/feedlistformaction.cpp:111 src/feedlistformaction.cpp:124
+#: src/feedlistformaction.cpp:260 src/feedlistformaction.cpp:284
+#: src/feedlistformaction.cpp:349
 msgid "No feed selected!"
 msgstr "沒有選擇的來源！"
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (f)irsttag/..." and "Reverse Sort by
 #. / (f)irsttag/..." messages
-#: src/feedlistformaction.cpp:154 src/feedlistformaction.cpp:194
+#: src/feedlistformaction.cpp:138 src/feedlistformaction.cpp:178
 #, fuzzy
 msgid "ftauln"
 msgstr "ftaun"
 
-#: src/feedlistformaction.cpp:156
+#: src/feedlistformaction.cpp:140
 #, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "(n)one?"
 msgstr "排序依照：(f)第一項Tag/(t)標題/(a)文章數量/(u)未讀文章數量/(n)無？"
 
-#: src/feedlistformaction.cpp:196
+#: src/feedlistformaction.cpp:180
 #, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/(n)one?"
 msgstr "排序依照：(f)第一項Tag/(t)標題/(a)文章數量/(u)未讀文章數量/(n)無？"
 
-#: src/feedlistformaction.cpp:247 src/feedlistformaction.cpp:252
-#: src/feedlistformaction.cpp:288 src/feedlistformaction.cpp:311
-#: src/itemlistformaction.cpp:156 src/itemlistformaction.cpp:187
-#: src/itemlistformaction.cpp:205 src/itemlistformaction.cpp:218
-#: src/itemviewformaction.cpp:250 src/itemviewformaction.cpp:432
+#: src/feedlistformaction.cpp:248 src/feedlistformaction.cpp:276
+#: src/feedlistformaction.cpp:301 src/itemlistformaction.cpp:140
+#: src/itemlistformaction.cpp:175 src/itemlistformaction.cpp:197
+#: src/itemlistformaction.cpp:214 src/itemviewformaction.cpp:251
+#: src/itemviewformaction.cpp:438
+#, fuzzy
+msgid "Failed to spawn browser"
+msgstr "在瀏覽器裡打開文章"
+
+#: src/feedlistformaction.cpp:251 src/feedlistformaction.cpp:279
+#: src/feedlistformaction.cpp:304 src/itemlistformaction.cpp:143
+#: src/itemlistformaction.cpp:178 src/itemlistformaction.cpp:200
+#: src/itemlistformaction.cpp:217 src/itemviewformaction.cpp:254
+#: src/itemviewformaction.cpp:441
 #, c-format
 msgid "Browser returned error code %i"
 msgstr ""
 
-#: src/feedlistformaction.cpp:268
+#: src/feedlistformaction.cpp:256
 msgid "Cannot open query feeds in the browser!"
 msgstr ""
 
-#: src/feedlistformaction.cpp:340 src/itemlistformaction.cpp:496
+#: src/feedlistformaction.cpp:333 src/itemlistformaction.cpp:495
 msgid "Marking feed read..."
 msgstr "將來源標為已讀..."
 
-#: src/feedlistformaction.cpp:351 src/itemlistformaction.cpp:543
+#: src/feedlistformaction.cpp:344 src/itemlistformaction.cpp:542
 #, c-format
 msgid "Error: couldn't mark feed read: %s"
 msgstr "錯誤：無法將來源%s標記為已讀"
 
-#: src/feedlistformaction.cpp:376 src/feedlistformaction.cpp:385
-#: src/feedlistformaction.cpp:411
+#: src/feedlistformaction.cpp:369 src/feedlistformaction.cpp:378
+#: src/feedlistformaction.cpp:404
 msgid "No feeds with unread items."
 msgstr "沒有含未讀文章的來源"
 
-#: src/feedlistformaction.cpp:393 src/itemlistformaction.cpp:486
+#: src/feedlistformaction.cpp:386 src/itemlistformaction.cpp:485
 msgid "Already on last feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:402 src/itemlistformaction.cpp:491
+#: src/feedlistformaction.cpp:395 src/itemlistformaction.cpp:490
 msgid "Already on first feed."
 msgstr ""
 
-#: src/feedlistformaction.cpp:417
+#: src/feedlistformaction.cpp:409
+#, fuzzy
+msgid "Do you really want to mark all feeds as read (y:Yes n:No)? "
+msgstr "你確定要覆蓋 `%s'嗎(y:是的  n:不是)?"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/filebrowserformaction.cpp:126 src/itemlistformaction.cpp:1435
+#: src/view.cpp:181
+msgid "yn"
+msgstr "yn"
+
+#: src/feedlistformaction.cpp:410 src/feedlistformaction.cpp:523
+#: src/view.cpp:181
+msgid "y"
+msgstr "y"
+
+#: src/feedlistformaction.cpp:412
 msgid "Marking all feeds read..."
 msgstr "將所有來源標為已讀..."
 
-#: src/feedlistformaction.cpp:465 src/itemlistformaction.cpp:637
+#: src/feedlistformaction.cpp:461 src/itemlistformaction.cpp:636
 #, c-format
 msgid "Error: couldn't parse filter command `%s': %s"
 msgstr "錯誤：無法分析過濾的命令 `%s': %s"
 
-#: src/feedlistformaction.cpp:478 src/itemlistformaction.cpp:650
+#: src/feedlistformaction.cpp:474 src/itemlistformaction.cpp:649
 msgid "No filters defined."
 msgstr "沒有定義任何過濾器(filter)"
 
-#: src/feedlistformaction.cpp:492 src/helpformaction.cpp:60
-#: src/itemlistformaction.cpp:608 src/itemviewformaction.cpp:278
+#: src/feedlistformaction.cpp:488 src/helpformaction.cpp:60
+#: src/itemlistformaction.cpp:607 src/itemviewformaction.cpp:283
 msgid "Search for: "
 msgstr "搜尋: "
 
-#: src/feedlistformaction.cpp:509 src/itemlistformaction.cpp:663
+#: src/feedlistformaction.cpp:505 src/itemlistformaction.cpp:662
 msgid "Filter: "
 msgstr "過濾器: "
 
-#: src/feedlistformaction.cpp:526 src/view.cpp:173
+#: src/feedlistformaction.cpp:522 src/view.cpp:179
 msgid "Do you really want to quit (y:Yes n:No)? "
 msgstr "你確定要離開嗎(y:是的 n:不是)？"
 
-#: src/feedlistformaction.cpp:527 src/filebrowserformaction.cpp:125
-#: src/itemlistformaction.cpp:1446 src/view.cpp:175
-msgid "yn"
-msgstr "yn"
-
-#: src/feedlistformaction.cpp:527 src/view.cpp:175
-msgid "y"
-msgstr "y"
-
-#: src/feedlistformaction.cpp:600 src/helpformaction.cpp:241
-#: src/itemlistformaction.cpp:1234 src/itemviewformaction.cpp:473
-#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:156
+#: src/feedlistformaction.cpp:595 src/helpformaction.cpp:241
+#: src/itemlistformaction.cpp:1223 src/itemviewformaction.cpp:482
+#: src/pbview.cpp:361 src/pbview.cpp:368 src/urlviewformaction.cpp:157
 msgid "Quit"
 msgstr "放棄"
 
-#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1235
+#: src/feedlistformaction.cpp:596 src/itemlistformaction.cpp:1224
 msgid "Open"
 msgstr "打開"
 
-#: src/feedlistformaction.cpp:602 src/itemlistformaction.cpp:1238
-#: src/itemviewformaction.cpp:475
+#: src/feedlistformaction.cpp:597 src/itemlistformaction.cpp:1227
+#: src/itemviewformaction.cpp:484
 msgid "Next Unread"
 msgstr "下一篇未讀"
 
-#: src/feedlistformaction.cpp:603 src/itemlistformaction.cpp:1237
+#: src/feedlistformaction.cpp:598 src/itemlistformaction.cpp:1226
 msgid "Reload"
 msgstr "重新載入"
 
-#: src/feedlistformaction.cpp:604
+#: src/feedlistformaction.cpp:599
 msgid "Reload All"
 msgstr "全部重新載入"
 
-#: src/feedlistformaction.cpp:605
+#: src/feedlistformaction.cpp:600
 msgid "Mark Read"
 msgstr "標為已讀"
 
-#: src/feedlistformaction.cpp:606 src/itemlistformaction.cpp:1239
+#: src/feedlistformaction.cpp:601 src/itemlistformaction.cpp:1228
 msgid "Mark All Read"
 msgstr "標記全部為已讀"
 
-#: src/feedlistformaction.cpp:607 src/helpformaction.cpp:242
-#: src/itemlistformaction.cpp:1240
+#: src/feedlistformaction.cpp:602 src/helpformaction.cpp:242
+#: src/itemlistformaction.cpp:1229
 msgid "Search"
 msgstr "搜尋"
 
-#: src/feedlistformaction.cpp:608 src/helpformaction.cpp:273
-#: src/itemlistformaction.cpp:1241 src/itemviewformaction.cpp:478
+#: src/feedlistformaction.cpp:603 src/helpformaction.cpp:273
+#: src/itemlistformaction.cpp:1230 src/itemviewformaction.cpp:487
 #: src/pbview.cpp:283 src/pbview.cpp:376
 msgid "Help"
 msgstr "說明"
 
-#: src/feedlistformaction.cpp:932 src/itemlistformaction.cpp:821
+#: src/feedlistformaction.cpp:922 src/itemlistformaction.cpp:820
 msgid "Error: couldn't parse filter command!"
 msgstr "錯誤：無法分析過濾器(filter)命令"
 
-#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:856
+#: src/feedlistformaction.cpp:939 src/itemlistformaction.cpp:855
 msgid "Searching..."
 msgstr "搜尋中..."
 
-#: src/feedlistformaction.cpp:959 src/itemlistformaction.cpp:869
+#: src/feedlistformaction.cpp:949 src/itemlistformaction.cpp:865
 #, c-format
 msgid "Error while searching for `%s': %s"
 msgstr "在搜尋 `%s'的時候出錯: %s"
 
-#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:876
+#: src/feedlistformaction.cpp:960 src/itemlistformaction.cpp:872
 msgid "No results."
 msgstr "沒有結果"
 
-#: src/feedlistformaction.cpp:982 src/itemlistformaction.cpp:1253
+#: src/feedlistformaction.cpp:971 src/itemlistformaction.cpp:1242
 msgid "Position not visible!"
 msgstr "找不到這個位置"
 
-#: src/feedlistformaction.cpp:1057
+#: src/feedlistformaction.cpp:1046
 #, c-format
 msgid "Feed List - %u unread, %u total"
 msgstr "來源列表 - %u 未讀, 總共 %u"
 
-#: src/filebrowserformaction.cpp:122
+#: src/filebrowserformaction.cpp:123
 #, c-format
 msgid "Do you really want to overwrite `%s' (y:Yes n:No)? "
 msgstr "你確定要覆蓋 `%s'嗎(y:是的  n:不是)?"
 
-#: src/filebrowserformaction.cpp:125
+#: src/filebrowserformaction.cpp:126
 msgid "n"
 msgstr "n"
 
-#: src/filebrowserformaction.cpp:281
+#: src/filebrowserformaction.cpp:285
 msgid "File: "
 msgstr "檔案: "
 
-#: src/filebrowserformaction.cpp:439
+#: src/filebrowserformaction.cpp:446
 #, c-format
 msgid "Save File - %s"
 msgstr "儲存檔案 - %s"
@@ -835,35 +870,35 @@ msgstr "未綁定的功能："
 msgid "Clear"
 msgstr "清除"
 
-#: src/htmlrenderer.cpp:213
+#: src/htmlrenderer.cpp:214
 msgid "embedded flash:"
 msgstr "內嵌的flash"
 
-#: src/htmlrenderer.cpp:271 src/htmlrenderer.cpp:277 src/htmlrenderer.cpp:981
+#: src/htmlrenderer.cpp:272 src/htmlrenderer.cpp:278 src/htmlrenderer.cpp:1000
 msgid "image"
 msgstr "圖片"
 
-#: src/htmlrenderer.cpp:938
+#: src/htmlrenderer.cpp:957
 msgid "Links: "
 msgstr "所有鏈結"
 
-#: src/htmlrenderer.cpp:963 src/htmlrenderer.cpp:979
+#: src/htmlrenderer.cpp:982 src/htmlrenderer.cpp:998
 msgid "link"
 msgstr "鏈結"
 
-#: src/htmlrenderer.cpp:983
+#: src/htmlrenderer.cpp:1002
 msgid "embedded flash"
 msgstr "內嵌的flash"
 
-#: src/htmlrenderer.cpp:985
+#: src/htmlrenderer.cpp:1004
 msgid "video"
 msgstr ""
 
-#: src/htmlrenderer.cpp:987
+#: src/htmlrenderer.cpp:1006
 msgid "audio"
 msgstr ""
 
-#: src/htmlrenderer.cpp:989
+#: src/htmlrenderer.cpp:1008
 msgid "unknown (bug)"
 msgstr "未知（bug）"
 
@@ -880,144 +915,144 @@ msgstr "分享的文章"
 msgid "Saved web pages"
 msgstr ""
 
-#: src/itemlistformaction.cpp:81 src/itemlistformaction.cpp:122
-#: src/itemlistformaction.cpp:177 src/itemlistformaction.cpp:194
-#: src/itemlistformaction.cpp:324 src/itemlistformaction.cpp:353
-#: src/itemlistformaction.cpp:379 src/itemlistformaction.cpp:596
-#: src/itemlistformaction.cpp:834
+#: src/itemlistformaction.cpp:78 src/itemlistformaction.cpp:101
+#: src/itemlistformaction.cpp:164 src/itemlistformaction.cpp:185
+#: src/itemlistformaction.cpp:323 src/itemlistformaction.cpp:352
+#: src/itemlistformaction.cpp:378 src/itemlistformaction.cpp:595
+#: src/itemlistformaction.cpp:833
 msgid "No item selected!"
 msgstr "沒有選擇任何項目"
 
-#: src/itemlistformaction.cpp:228 src/itemviewformaction.cpp:389
+#: src/itemlistformaction.cpp:227 src/itemviewformaction.cpp:394
 msgid "Toggling read flag for article..."
 msgstr "切換文章閱讀標記（已讀/未讀）"
 
-#: src/itemlistformaction.cpp:270
+#: src/itemlistformaction.cpp:269
 #, c-format
 msgid "Error while toggling read flag: %s"
 msgstr "當切換閱讀標記（已讀/未讀）時出錯: %s"
 
-#: src/itemlistformaction.cpp:314 src/itemviewformaction.cpp:320
+#: src/itemlistformaction.cpp:313 src/itemviewformaction.cpp:325
 msgid "URL list empty."
 msgstr "空白的鏈結列表"
 
-#: src/itemlistformaction.cpp:370 src/itemrenderer.cpp:67
-#: src/itemviewformaction.cpp:308
+#: src/itemlistformaction.cpp:369 src/itemrenderer.cpp:67
+#: src/itemviewformaction.cpp:313
 msgid "Flags: "
 msgstr "標記: "
 
-#: src/itemlistformaction.cpp:398 src/itemlistformaction.cpp:1282
+#: src/itemlistformaction.cpp:397 src/itemlistformaction.cpp:1271
 msgid "Error: no item selected!"
 msgstr "錯誤：沒有選擇任何項目！"
 
-#: src/itemlistformaction.cpp:416
+#: src/itemlistformaction.cpp:415
 msgid "Error: you can't reload search results."
 msgstr "錯誤：你不能重新載入所選項目"
 
-#: src/itemlistformaction.cpp:437 src/itemlistformaction.cpp:446
-#: src/itemlistformaction.cpp:470 src/itemviewformaction.cpp:342
-#: src/itemviewformaction.cpp:353 src/itemviewformaction.cpp:383
-#: src/view.cpp:717 src/view.cpp:793
+#: src/itemlistformaction.cpp:436 src/itemlistformaction.cpp:445
+#: src/itemlistformaction.cpp:469 src/itemviewformaction.cpp:347
+#: src/itemviewformaction.cpp:358 src/itemviewformaction.cpp:388
+#: src/view.cpp:710 src/view.cpp:775
 msgid "No unread items."
 msgstr "沒有未讀的文章"
 
-#: src/itemlistformaction.cpp:454 src/itemviewformaction.cpp:363
-#: src/view.cpp:866
+#: src/itemlistformaction.cpp:453 src/itemviewformaction.cpp:368
+#: src/view.cpp:842
 msgid "Already on last item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:463 src/itemviewformaction.cpp:373
-#: src/view.cpp:831
+#: src/itemlistformaction.cpp:462 src/itemviewformaction.cpp:378
+#: src/view.cpp:810
 msgid "Already on first item."
 msgstr ""
 
-#: src/itemlistformaction.cpp:476 src/itemlistformaction.cpp:481
+#: src/itemlistformaction.cpp:475 src/itemlistformaction.cpp:480
 msgid "No unread feeds."
 msgstr "沒有未讀的來源"
 
-#: src/itemlistformaction.cpp:550
+#: src/itemlistformaction.cpp:549
 #, fuzzy
 msgid "Marking all above as read..."
 msgstr "將所有來源標為已讀..."
 
-#: src/itemlistformaction.cpp:591 src/itemviewformaction.cpp:294
+#: src/itemlistformaction.cpp:590 src/itemviewformaction.cpp:299
 msgid "Pipe article to command: "
 msgstr "Pipe article to command: "
 
 #. / This string is related to the letters in parentheses in the
 #. / "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 #. / messages
-#: src/itemlistformaction.cpp:677 src/itemlistformaction.cpp:715
+#: src/itemlistformaction.cpp:676 src/itemlistformaction.cpp:714
 #, fuzzy
 msgid "dtfalgr"
 msgstr "dtfalg"
 
-#: src/itemlistformaction.cpp:679
+#: src/itemlistformaction.cpp:678
 #, fuzzy
 msgid "Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "排序依照：(d)日期/(t)標題/(f)"
 
-#: src/itemlistformaction.cpp:717
+#: src/itemlistformaction.cpp:716
 #, fuzzy
 msgid "Reverse Sort by (d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"
 msgstr "反向排序依(d)日期/(t)標題/(f)標誌/(a)作者/(l)連結/(g)用戶號碼"
 
-#: src/itemlistformaction.cpp:842 src/itemviewformaction.cpp:549
+#: src/itemlistformaction.cpp:841 src/itemviewformaction.cpp:558
 msgid "Flags updated."
 msgstr "標記已更新"
 
-#: src/itemlistformaction.cpp:943 src/view.cpp:370 src/view.cpp:396
+#: src/itemlistformaction.cpp:937 src/view.cpp:374 src/view.cpp:397
 #, c-format
 msgid "Error: applying the filter failed: %s"
 msgstr "錯誤: 套用過濾器失敗: %s"
 
-#: src/itemlistformaction.cpp:1322 src/itemviewformaction.cpp:230
-#: src/itemviewformaction.cpp:519
+#: src/itemlistformaction.cpp:1311 src/itemviewformaction.cpp:230
+#: src/itemviewformaction.cpp:528
 msgid "Aborted saving."
 msgstr "放棄儲存"
 
-#: src/itemlistformaction.cpp:1327 src/itemviewformaction.cpp:525
+#: src/itemlistformaction.cpp:1316 src/itemviewformaction.cpp:534
 #, c-format
 msgid "Saved article to %s"
 msgstr "把文章儲存到 %s"
 
-#: src/itemlistformaction.cpp:1330 src/itemviewformaction.cpp:529
+#: src/itemlistformaction.cpp:1319 src/itemviewformaction.cpp:538
 #, c-format
 msgid "Error: couldn't save article to %s"
 msgstr "錯誤：無法儲存文章到 %s"
 
-#: src/itemlistformaction.cpp:1405
+#: src/itemlistformaction.cpp:1394
 #, c-format
 msgid "Search Result - '%s'"
 msgstr "搜尋結果 - '%s'"
 
-#: src/itemlistformaction.cpp:1408
+#: src/itemlistformaction.cpp:1397
 #, c-format
 msgid "Query Feed - %s"
 msgstr "查詢來源 - %s"
 
-#: src/itemlistformaction.cpp:1415
+#: src/itemlistformaction.cpp:1404
 #, c-format
 msgid "Article List - %s"
 msgstr "文章列表 %s"
 
-#: src/itemlistformaction.cpp:1448
+#: src/itemlistformaction.cpp:1437
 #, c-format
 msgid "Overwrite `%s' in `%s'? (y:Yes n:No)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1500
+#: src/itemlistformaction.cpp:1489
 msgid "yanq"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1522
+#: src/itemlistformaction.cpp:1511
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are %d more conflicts like this (y:Yes a:Yes "
 "to all n:No q:No to all)"
 msgstr ""
 
-#: src/itemlistformaction.cpp:1529
+#: src/itemlistformaction.cpp:1518
 #, c-format
 msgid ""
 "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:Yes "
@@ -1048,15 +1083,15 @@ msgstr "Pocast下載網址: "
 msgid "type: "
 msgstr "類型: "
 
-#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:619
+#: src/itemviewformaction.cpp:61 src/itemviewformaction.cpp:628
 msgid "Top"
 msgstr "頂端"
 
-#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:621
+#: src/itemviewformaction.cpp:62 src/itemviewformaction.cpp:630
 msgid "Bottom"
 msgstr "底端"
 
-#: src/itemviewformaction.cpp:177 src/view.cpp:507
+#: src/itemviewformaction.cpp:177 src/view.cpp:506
 #, c-format
 msgid "Error while marking article as read: %s"
 msgstr "當標記文章為已讀的時候發生錯誤: %s"
@@ -1081,35 +1116,35 @@ msgstr "將文章保存至 %s "
 msgid "Error: couldn't write article to file %s"
 msgstr "錯誤：無法將文章寫至 %s"
 
-#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:429
-#: src/itemviewformaction.cpp:574 src/urlviewformaction.cpp:64
-#: src/urlviewformaction.cpp:94
+#: src/itemviewformaction.cpp:248 src/itemviewformaction.cpp:434
+#: src/itemviewformaction.cpp:583 src/urlviewformaction.cpp:66
+#: src/urlviewformaction.cpp:96
 msgid "Starting browser..."
 msgstr "啟動瀏覽器..."
 
-#: src/itemviewformaction.cpp:395
+#: src/itemviewformaction.cpp:400
 #, c-format
 msgid "Error while marking article as unread: %s"
 msgstr "將文章標為未讀時發生錯誤: %s"
 
-#: src/itemviewformaction.cpp:449 src/keymap.cpp:192
+#: src/itemviewformaction.cpp:458 src/keymap.cpp:192
 msgid "Goto URL #"
 msgstr "前往網址 #"
 
-#: src/itemviewformaction.cpp:476 src/urlviewformaction.cpp:157
+#: src/itemviewformaction.cpp:485 src/urlviewformaction.cpp:158
 msgid "Open in Browser"
 msgstr "在瀏覽器裡打開"
 
-#: src/itemviewformaction.cpp:477
+#: src/itemviewformaction.cpp:486
 msgid "Enqueue"
 msgstr "加入隊列"
 
-#: src/itemviewformaction.cpp:632
+#: src/itemviewformaction.cpp:641
 #, c-format
 msgid "Article - %s"
 msgstr "文章 - %s"
 
-#: src/itemviewformaction.cpp:682
+#: src/itemviewformaction.cpp:691
 msgid "Error: invalid regular expression!"
 msgstr "錯誤:無效的正規表示式！"
 
@@ -1161,13 +1196,13 @@ msgstr "保存文章"
 
 #: src/keymap.cpp:87
 #, fuzzy
-msgid "Go to next article"
-msgstr "轉到下一篇未讀文章"
+msgid "Go to next entry"
+msgstr "跳到下一項"
 
 #: src/keymap.cpp:94
 #, fuzzy
-msgid "Go to previous article"
-msgstr "轉到前一篇未讀文章"
+msgid "Go to previous entry"
+msgstr "跳到前一項"
 
 #: src/keymap.cpp:101
 msgid "Go to next unread article"
@@ -1480,7 +1515,7 @@ msgstr "`%s' 不是有效的內容"
 msgid "`%s' is not a valid key command"
 msgstr "`%s' 不是有效的按鍵命令"
 
-#: src/keymap.cpp:744
+#: src/keymap.cpp:755
 #, fuzzy, c-format
 msgid "`%s' is not a valid operation"
 msgstr "`%s' 不是有效的內容"
@@ -1495,36 +1530,36 @@ msgstr "無效屬性 `%s'"
 msgid "regular expression '%s' is invalid: %s"
 msgstr "正規表示式 '%s' 是無效的: %s"
 
-#: src/pbcontroller.cpp:84
+#: src/pbcontroller.cpp:82
 #, c-format
 msgid "XDG: configuration directory '%s' not accessible, using '%s' instead."
 msgstr ""
 
-#: src/pbcontroller.cpp:145
+#: src/pbcontroller.cpp:144
 msgid "Fatal error: couldn't determine home directory!"
 msgstr "嚴重錯誤:無法確認主目錄！"
 
-#: src/pbcontroller.cpp:149
+#: src/pbcontroller.cpp:148
 #, c-format
 msgid ""
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr "請設定主目錄的環境變數，或者增加一個UID為 %u的有效使用者!"
 
-#: src/pbcontroller.cpp:170
+#: src/pbcontroller.cpp:169
 #, fuzzy, c-format
 msgid "Fatal error: couldn't create configuration directory `%s': (%i) %s"
 msgstr "錯誤：無法開啟組態檔案`%s'！"
 
-#: src/pbcontroller.cpp:232
+#: src/pbcontroller.cpp:230
 #, c-format
 msgid "%s: %d: invalid loglevel value"
 msgstr ""
 
-#: src/pbcontroller.cpp:313
+#: src/pbcontroller.cpp:310
 msgid "Cleaning up queue..."
 msgstr "清空隊列..."
 
-#: src/pbcontroller.cpp:327
+#: src/pbcontroller.cpp:324
 #, fuzzy, c-format
 msgid ""
 "%s %s\n"
@@ -1534,31 +1569,31 @@ msgstr ""
 "使用方法: %s [-i <file>|-e] [-u <網址檔案>] [-c <快取檔案>] [-x <命令> ...] "
 "[-h]\n"
 
-#: src/pbcontroller.cpp:350
+#: src/pbcontroller.cpp:347
 #, fuzzy
 msgid "<queuefile>"
 msgstr "<檔案>"
 
-#: src/pbcontroller.cpp:351
+#: src/pbcontroller.cpp:348
 #, fuzzy
 msgid "use <queuefile> as queue file"
 msgstr "使用<快取檔案>作為快取檔案"
 
-#: src/pbcontroller.cpp:353
+#: src/pbcontroller.cpp:350
 msgid "start download on startup"
 msgstr ""
 
-#: src/pbview.cpp:65
+#: src/pbview.cpp:67
 #, c-format
 msgid " - %u parallel downloads"
 msgstr " - %u 個平行下載"
 
-#: src/pbview.cpp:72
+#: src/pbview.cpp:74
 #, fuzzy, c-format
 msgid "Queue (%u downloads in progress, %u total) - %.2f %s total%s"
 msgstr "隊列 (%u 個下載在進行中，共有 %u 個下載項目) - 總共 %.2f kb/s %s"
 
-#: src/pbview.cpp:157
+#: src/pbview.cpp:161
 msgid "Error: can't quit: download(s) in progress."
 msgstr "錯誤: 無法取消: 還有下載在進行中"
 
@@ -1566,7 +1601,7 @@ msgstr "錯誤: 無法取消: 還有下載在進行中"
 msgid "Error: download needs to be finished before the file can be played."
 msgstr "錯誤：必須下載完畢才可以播放"
 
-#: src/pbview.cpp:251
+#: src/pbview.cpp:245
 msgid "Error: unable to perform operation: download(s) in progress."
 msgstr "錯誤：無法執行操作：還有下載在進行中"
 
@@ -1625,43 +1660,43 @@ msgstr "`%s' 不是有效的對話類別"
 msgid "`%s' is not a valid regular expression: %s"
 msgstr "`%s' 不是一個有效的正規表示式： %s"
 
-#: src/reloader.cpp:75
+#: src/reloader.cpp:73
 #, c-format
 msgid "%sLoading %s..."
 msgstr "%s載入中 %s..."
 
-#: src/reloader.cpp:105 src/reloader.cpp:110 src/reloader.cpp:115
+#: src/reloader.cpp:103 src/reloader.cpp:108 src/reloader.cpp:113
 #, c-format
 msgid "Error while retrieving %s: %s"
 msgstr "在抓取%s的時候發生錯誤: %s"
 
-#: src/reloader.cpp:125
+#: src/reloader.cpp:123
 msgid "Error: invalid feed!"
 msgstr "錯誤:無效的來源！"
 
-#: src/rssfeed.cpp:210
+#: src/rssfeed.cpp:213
 msgid "too few arguments"
 msgstr "參數過少"
 
-#: src/rssfeed.cpp:225
+#: src/rssfeed.cpp:228
 #, fuzzy, c-format
 msgid "`%s' is not a valid filter expression"
 msgstr "`%s' 不是一個有效的正規表示式： %s"
 
-#: src/rssitem.cpp:124
+#: src/rssitem.cpp:126
 msgid "%a, %d %b %Y %T %z"
 msgstr ""
 
-#: src/rssparser.cpp:176
+#: src/rssparser.cpp:180
 #, c-format
 msgid "Error: unsupported URL: %s"
 msgstr "錯誤：不支持的鏈結: %s"
 
-#: src/selectformaction.cpp:248 src/selectformaction.cpp:268
+#: src/selectformaction.cpp:247 src/selectformaction.cpp:267
 msgid "Select Tag"
 msgstr "選擇標籤"
 
-#: src/selectformaction.cpp:252 src/selectformaction.cpp:270
+#: src/selectformaction.cpp:251 src/selectformaction.cpp:269
 msgid "Select Filter"
 msgstr "選擇過濾器"
 
@@ -1673,28 +1708,32 @@ msgstr "未發現屬性"
 msgid "EOF found while reading XML tag"
 msgstr "當讀取XML標籤時遇到EOF標記"
 
-#: src/urlviewformaction.cpp:68 src/urlviewformaction.cpp:77
+#: src/urlviewformaction.cpp:70 src/urlviewformaction.cpp:79
 #, fuzzy
 msgid "No links available!"
 msgstr "沒有選擇任何鏈結！"
 
-#: src/urlviewformaction.cpp:158
+#: src/urlviewformaction.cpp:159
 msgid "Save Bookmark"
 msgstr "儲存書籤"
 
-#: src/urlviewformaction.cpp:180
+#: src/urlviewformaction.cpp:181
 msgid "URLs"
 msgstr "網址"
 
-#: src/view.cpp:424 src/view.cpp:448
+#: src/view.cpp:156
+msgid "Error: Failed to execute startup commands"
+msgstr ""
+
+#: src/view.cpp:425 src/view.cpp:451
 msgid "Error: feed contains no items!"
 msgstr "錯誤: 來源裡沒有任何項目！"
 
-#: src/view.cpp:580
+#: src/view.cpp:579
 msgid "No tags defined."
 msgstr "沒有定義任何標籤"
 
-#: src/view.cpp:926
+#: src/view.cpp:894
 msgid "Updating query feed..."
 msgstr "更新查詢的來源..."
 
@@ -1744,33 +1783,58 @@ msgstr "不支援的來源格式"
 msgid "%s: %s: invalid loglevel value"
 msgstr "`%s' 不是有效的對話類別"
 
-#: rust/libnewsboat/src/configpaths.rs:88
+#: rust/libnewsboat/src/configpaths.rs:85
 #, fuzzy
 msgid ""
 "Fatal error: couldn't determine home directory!\n"
 "Please set the HOME environment variable or add a valid user for UID %u!"
 msgstr "請設定主目錄的環境變數，或者增加一個UID為 %u的有效使用者!"
 
-#: rust/libnewsboat/src/configpaths.rs:149
+#: rust/libnewsboat/src/configpaths.rs:146
 msgid "Migrating configs and data from Newsbeuter's XDG dirs..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:205
+#: rust/libnewsboat/src/configpaths.rs:202
 msgid "Migrating configs and data from ~/.newsbeuter/..."
 msgstr ""
 
-#: rust/libnewsboat/src/configpaths.rs:217
+#: rust/libnewsboat/src/configpaths.rs:214
 #, fuzzy
 msgid "Aborting migration because mkdir on `%s' failed: %s"
 msgstr "錯誤:打開快取檔案`%s' 失敗:%s"
 
-#: rust/regex-rs/src/lib.rs:158 rust/regex-rs/src/lib.rs:163
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:263
+msgid "Parse error: trailing characters after position %{}: %s"
+msgstr ""
+
+#. The "%{}" thing is a number, a zero-based offset into a string.
+#: rust/libnewsboat/src/filterparser.rs:270
+msgid "Parse error at position %{}: expected %s"
+msgstr ""
+
+#: rust/libnewsboat/src/filterparser.rs:275
+msgid "Internal parse error"
+msgstr ""
+
+#: rust/regex-rs/src/lib.rs:161 rust/regex-rs/src/lib.rs:166
 msgid "regcomp returned code %i"
 msgstr ""
 
-#: rust/regex-rs/src/lib.rs:243 rust/regex-rs/src/lib.rs:247
+#: rust/regex-rs/src/lib.rs:246 rust/regex-rs/src/lib.rs:250
 msgid "regexec returned code %i"
 msgstr ""
+
+#~ msgid "invalid feed index (bug)"
+#~ msgstr "無效的來源索引(bug）"
+
+#, fuzzy
+#~ msgid "Go to next article"
+#~ msgstr "轉到下一篇未讀文章"
+
+#, fuzzy
+#~ msgid "Go to previous article"
+#~ msgstr "轉到前一篇未讀文章"
 
 #, fuzzy
 #~ msgid "config"


### PR DESCRIPTION
This updates the POT file, as well as the translations for the two languages that I maintain.

I used to write "Call for translations" emails, but they never resulted in more translations, so I'm trying something new today: I've created @newsboat/translators team and invited everyone who translated something since 2017 onwards. From now on, I'll update the POT file two weeks before the release, and highlight that team. You all will get emails, and will have two weeks to update your translations and submit PRs. I'm open to suggestions on how to improve that, of course.

Since not everyone accepted the invite to the team yet, I'm mentioning everyone directly too: @adiel-mittmann @alejandrogallo @der-lyse @carno @deob83 @bitigchi @programandala-net @esteban123456789 @tkerdonc @dennisschagt 

**If you don't accept the invite, I promise not to bug you about translations anymore.**