### PR TITLE
Fix Rust version in CI task names

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -201,98 +201,98 @@ linux_task:
                 cxx: clang++-10
           env: *extra_warnings_and_checks_env
 
-        - name: Rust 1.45, GCC 4.9 (Ubuntu 16.04)
+        - name: Rust 1.46.0, GCC 4.9 (Ubuntu 16.04)
           container:
             dockerfile: docker/ubuntu_16.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-4.9
                 cc: gcc-4.9
                 cxx: g++-4.9
-        - name: Rust 1.45, GCC 5 (Ubuntu 18.04)
+        - name: Rust 1.46.0, GCC 5 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-5
                 cc: gcc-5
                 cxx: g++-5
-        - name: Rust 1.45, GCC 6 (Ubuntu 18.04)
+        - name: Rust 1.46.0, GCC 6 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-6
                 cc: gcc-6
                 cxx: g++-6
-        - name: Rust 1.45, GCC 7 (Ubuntu 18.04)
+        - name: Rust 1.46.0, GCC 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-7
                 cc: gcc-7
                 cxx: g++-7
-        - name: Rust 1.45, GCC 8 (Ubuntu 18.04)
+        - name: Rust 1.46.0, GCC 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-8
                 cc: gcc-8
                 cxx: g++-8
-        - name: Rust 1.45, GCC 9 (Ubuntu 20.04)
+        - name: Rust 1.46.0, GCC 9 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-9
                 cc: gcc-9
                 cxx: g++-9
-        - name: Rust 1.45, GCC 10 (Ubuntu 20.04)
+        - name: Rust 1.46.0, GCC 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-10
                 cc: gcc-10
                 cxx: g++-10
-        - name: Rust 1.45, Clang 4.0 (Ubuntu 18.04)
+        - name: Rust 1.46.0, Clang 4.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-4.0
                 cc: clang-4.0
                 cxx: clang++-4.0
-        - name: Rust 1.45, Clang 5.0 (Ubuntu 18.04)
+        - name: Rust 1.46.0, Clang 5.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-5.0
                 cc: clang-5.0
                 cxx: clang++-5.0
-        - name: Rust 1.45, Clang 6.0 (Ubuntu 18.04)
+        - name: Rust 1.46.0, Clang 6.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-6.0
                 cc: clang-6.0
                 cxx: clang++-6.0
-        - name: Rust 1.45, Clang 7 (Ubuntu 18.04)
+        - name: Rust 1.46.0, Clang 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-7
                 cc: clang-7
                 cxx: clang++-7
-        - name: Rust 1.45, Clang 8 (Ubuntu 18.04)
+        - name: Rust 1.46.0, Clang 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-8
                 cc: clang-8
                 cxx: clang++-8
-        - name: Rust 1.45, Clang 9 (Ubuntu 18.04)
+        - name: Rust 1.46.0, Clang 9 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-9
                 cc: clang-9
                 cxx: clang++-9
-        - name: Rust 1.45, Clang 10 (Ubuntu 20.04)
+        - name: Rust 1.46.0, Clang 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:


### PR DESCRIPTION
The names said we're using Rust 1.45, whereas in reality we are using
1.46.0. I think they got out of sync because the names use MAJOR.MINOR
numbers, while Dockerfiles use the full MAJOR.MINOR.PATCH numbers. When
I update the version, I usually just grep for the previous one and
replace all occurrences. Since "1.45" didn't match "1.45.0", I didn't
replace it, leading to the discrepancy.

This patch changes all the numbers to the full version, so I shouldn't
fall into the same trap ever again.

(This shouldn't break CI, but I'll still wait for it to pass before merging.)