### PR TITLE
Fix segfault in podboat --help

### DIFF
--- a/include/pbcontroller.h
+++ b/include/pbcontroller.h
@@ -26,7 +26,7 @@ public:
 	{
 		v = vv;
 	}
-	int initialize(int argc, char* argv[]);
+	void initialize(int argc, char* argv[]);
 	int run();
 
 	bool view_update_necessary() const

--- a/podboat.cpp
+++ b/podboat.cpp
@@ -28,10 +28,7 @@ int main(int argc, char* argv[])
 	PbController c;
 
 	try {
-		int ret = c.initialize(argc, argv);
-		if (ret != EXIT_SUCCESS) {
-			return ret;
-		}
+		c.initialize(argc, argv);
 
 		podboat::PbView v(&c);
 		c.set_view(&v);

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -185,7 +185,7 @@ PbController::~PbController()
 	delete cfg;
 }
 
-int PbController::initialize(int argc, char* argv[])
+void PbController::initialize(int argc, char* argv[])
 {
 	int c;
 
@@ -209,7 +209,7 @@ int PbController::initialize(int argc, char* argv[])
 		case ':':
 		case '?':
 			print_usage(argv[0]);
-			return EXIT_FAILURE;
+			exit(EXIT_FAILURE);
 		case 'C':
 			config_file = optarg;
 			break;
@@ -232,13 +232,13 @@ int PbController::initialize(int argc, char* argv[])
 						argv[0],
 						static_cast<int>(l))
 					<< std::endl;
-				return EXIT_FAILURE;
+				exit(EXIT_FAILURE);
 			}
 		}
 		break;
 		case 'h':
 			print_usage(argv[0]);
-			return EXIT_SUCCESS;
+			exit(EXIT_SUCCESS);
 		}
 	};
 
@@ -255,7 +255,7 @@ int PbController::initialize(int argc, char* argv[])
 				"podboat",
 				pid)
 			<< std::endl;
-		return EXIT_FAILURE;
+		exit(EXIT_FAILURE);
 	}
 
 	std::cout << _("Loading configuration...");
@@ -283,10 +283,8 @@ int PbController::initialize(int argc, char* argv[])
 		cfgparser.parse_file(config_file);
 	} catch (const ConfigException& ex) {
 		std::cout << ex.what() << std::endl;
-		return EXIT_FAILURE;
+		exit(EXIT_FAILURE);
 	}
-
-	return EXIT_SUCCESS;
 }
 
 int PbController::run()


### PR DESCRIPTION
9c720413519aa29b1bb1ef3be9fff5e1696bba55 introduced a bug: `podboat
--help` segfaults after printing out the help message.

That commit split out some initialization code from
`PbController::run()` into a new method, `initialize()`. That new method
didn't *always* initialize the object; if --help or an unknown option
was passed into Newsboat, the method would print out the usage message
and return EXIT_SUCCESS.

However, this same EXIT_SUCCESS value was used to indicate that the
initialization was successful. As a result, Podboat proceeded to use
unitialized PbController, and crashed.

To fix this, I changed `PbController::initialize()` to call `exit(3)`
directly when it wanted to quit Podboat.

Requesting a review from @dennisschagt because he's the last one to change that code. Will merge in two or three days, just before the 2.21 release.