### PR TITLE
Internationalize errors in Rust FilterParser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ dependencies = [
  "curl-sys 0.4.36+curl-7.71.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gettext-rs 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gettext-sys 0.19.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.77 (registry+https://github.com/rust-lang/crates.io-index)",
  "natord 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -21,6 +21,7 @@ curl-sys = "0.4.5"
 libc = "0.2"
 gettext-rs = "0.5.0"
 natord = "1.0.9"
+lazy_static = "1.4.0"
 
 [dependencies.clap]
 version = "2.33"


### PR DESCRIPTION
Kudos to @dennisschagt for spotting the missing i18n calls:
https://github.com/newsboat/newsboat/pull/1189#discussion_r490950023