### PR TITLE
Fix semicolons in macro operations' arguments breaking parsing

### DIFF
--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -421,7 +421,8 @@ src/keymap.o: src/keymap.cpp include/keymap.h include/configparser.h \
  include/configactionhandler.h config.h include/confighandlerexception.h \
  include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
  3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ target/cxxbridge/libnewsboat-ffi/src/keymap.rs.h
 src/listformaction.o: src/listformaction.cpp include/listformaction.h \
  3rd-party/optional.hpp include/formaction.h include/history.h \
  include/keymap.h include/configparser.h include/configactionhandler.h \

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -7,6 +7,7 @@ fn add_cxxbridge(module: &str) {
 
 fn main() {
     add_cxxbridge("fslock");
+    add_cxxbridge("keymap");
     add_cxxbridge("scopemeasure");
     add_cxxbridge("utils");
 }

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -1,6 +1,10 @@
 fn add_cxxbridge(module: &str) {
     cxx_build::bridge(format!("src/{}.rs", module))
         .flag("-std=c++11")
+        // Disable warnings in generated code, since we can't affect them directly. We have to do
+        // this because these warnings are turned into errors when we pass `-D warnings` to Cargo
+        // on CI.
+        .flag("-w")
         .compile(&format!("libnewsboat-ffi-{}", module));
     println!("cargo:rerun-if-changed=src/{}.rs", module);
 }

--- a/rust/libnewsboat-ffi/src/keymap.rs
+++ b/rust/libnewsboat-ffi/src/keymap.rs
@@ -1,0 +1,48 @@
+#[cxx::bridge(namespace = "newsboat::keymap::bridged")]
+mod ffi {
+    extern "Rust" {
+        // `tokenize_operation_sequence()` returns `Option<Vec<Vec<String>>>`, but cxx doesn't
+        // support `Option` and doesn't allow `Vec<Vec<_>>`. Here's how we work around that:
+        //
+        // 1. C++ doesn't care if the parse failed or just returned no operations, so we drop the
+        //    `Option` and represent both `None` and `Some([])` with an empty vector (see
+        //    `tokenize_operation_sequence()` code further down below);
+        //
+        // 2. we put `Vec<String>` into an opaque type `Operation`, and return `Vec<Operation>`.
+        //    The opaque type is, in fact, a struct holding the `Vec<String>`. C++ extracts the
+        //    vector using a helper function `operation_tokens()`.
+        //
+        // This is not very elegant, but doing the same by hand using `extern "C"` is prohibitively
+        // complex.
+        type Operation;
+        fn tokenize_operation_sequence(input: &str) -> Vec<Operation>;
+        fn operation_tokens(operation: &Operation) -> &Vec<String>;
+    }
+
+    extern "C++" {
+        // cxx uses `std::out_of_range`, but doesn't include the header that defines that
+        // exception. So we do it for them.
+        include!("stdexcept");
+        // Also inject a header that defines ptrdiff_t. Note this is *not* a C++ header, because
+        // cxx uses a non-C++ name of the type.
+        include!("stddef.h");
+    }
+}
+
+struct Operation {
+    tokens: Vec<String>,
+}
+
+fn tokenize_operation_sequence(input: &str) -> Vec<Operation> {
+    match libnewsboat::keymap::tokenize_operation_sequence(input) {
+        Some(operations) => operations
+            .into_iter()
+            .map(|tokens| Operation { tokens })
+            .collect::<Vec<_>>(),
+        None => vec![],
+    }
+}
+
+fn operation_tokens(input: &Operation) -> &Vec<String> {
+    &input.tokens
+}

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -16,6 +16,7 @@ pub mod fmtstrformatter;
 pub mod fslock;
 pub mod history;
 pub mod human_panic;
+pub mod keymap;
 pub mod logger;
 pub mod matchererror;
 pub mod scopemeasure;

--- a/rust/libnewsboat/src/keymap.rs
+++ b/rust/libnewsboat/src/keymap.rs
@@ -1,16 +1,15 @@
 use nom::{
     branch::alt,
     bytes::complete::{escaped_transform, is_not, tag, take},
-    character::complete::{none_of, space0, space1},
+    character::complete::{space0, space1},
     combinator::{complete, eof, map, recognize, value},
     multi::{many0, many1, separated_list0, separated_list1},
-    sequence::{delimited, tuple},
+    sequence::delimited,
     IResult,
 };
 
 fn unquoted_token(input: &str) -> IResult<&str, String> {
-    let parser = tuple((none_of("\";"), is_not(" ;")));
-    let mut parser = map(recognize(parser), String::from);
+    let mut parser = map(recognize(is_not(" ;")), String::from);
 
     parser(input)
 }
@@ -283,6 +282,14 @@ mod tests {
         assert_eq!(
             tokenize_operation_sequence(r#"set "arg 1"#).unwrap(),
             vec![vec!["set", "arg 1"]]
+        );
+    }
+
+    #[test]
+    fn t_tokenize_operation_sequence_allows_single_character_unquoted() {
+        assert_eq!(
+            tokenize_operation_sequence(r#"set a b"#).unwrap(),
+            vec![vec!["set", "a", "b"]]
         );
     }
 }

--- a/rust/libnewsboat/src/keymap.rs
+++ b/rust/libnewsboat/src/keymap.rs
@@ -1,0 +1,288 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{escaped_transform, is_not, tag, take},
+    character::complete::{none_of, space0, space1},
+    combinator::{complete, eof, map, recognize, value},
+    multi::{many0, many1, separated_list0, separated_list1},
+    sequence::{delimited, tuple},
+    IResult,
+};
+
+fn unquoted_token(input: &str) -> IResult<&str, String> {
+    let parser = tuple((none_of("\";"), is_not(" ;")));
+    let mut parser = map(recognize(parser), String::from);
+
+    parser(input)
+}
+
+fn quoted_token<'a>(input: &'a str) -> IResult<&'a str, String> {
+    let parser = escaped_transform(is_not(r#""\"#), '\\', |control_char: &'a str| {
+        alt((
+            value(r#"""#, tag(r#"""#)),
+            value(r#"\"#, tag(r#"\"#)),
+            value("\r", tag("r")),
+            value("\n", tag("n")),
+            value("\t", tag("t")),
+            take(1usize), // all other escaped characters are passed through, unmodified
+        ))(control_char)
+    });
+
+    let double_quote = tag("\"");
+    let mut parser = delimited(&double_quote, parser, alt((&double_quote, eof)));
+
+    parser(input)
+}
+
+fn token(input: &str) -> IResult<&str, String> {
+    let mut parser = alt((quoted_token, unquoted_token));
+    parser(input)
+}
+
+fn operation_with_args(input: &str) -> IResult<&str, Vec<String>> {
+    let mut parser = separated_list1(space1, token);
+    parser(input)
+}
+
+fn semicolon(input: &str) -> IResult<&str, &str> {
+    delimited(space0, tag(";"), space0)(input)
+}
+
+fn operation_sequence(input: &str) -> IResult<&str, Vec<Vec<String>>> {
+    let parser = separated_list0(many1(semicolon), operation_with_args);
+    let parser = delimited(many0(semicolon), parser, many0(semicolon));
+
+    let mut parser = complete(parser);
+
+    parser(input)
+}
+
+/// Split a semicolon-separated list of operations into a vector. Each operation is represented by
+/// a non-empty sub-vector, where the first element is the name of the operation, and the rest of
+/// the elements are operation's arguments.
+///
+/// Tokens can be double-quoted. Such tokens can contain spaces and C-like escaped sequences: `\n`
+/// for newline, `\r` for carriage return, `\t` for tab, `\"` for double quote, `\\` for backslash.
+/// Unsupported sequences are stripped of the escaping, e.g. `\e` turns into `e`.
+///
+/// This function assumes that the input string:
+/// 1. doesn't contain a comment;
+/// 2. doesn't contain backticks that need to be processed.
+///
+/// Returns `None` if the input could not be parsed.
+pub fn tokenize_operation_sequence(input: &str) -> Option<Vec<Vec<String>>> {
+    match operation_sequence(input) {
+        Ok((_leftovers, tokens)) => Some(tokens),
+        Err(_error) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tokenize_operation_sequence;
+
+    #[test]
+    fn t_tokenize_operation_sequence_works_for_all_cpp_inputs() {
+        assert_eq!(
+            tokenize_operation_sequence("").unwrap(),
+            Vec::<Vec<String>>::new()
+        );
+        assert_eq!(
+            tokenize_operation_sequence("open").unwrap(),
+            vec![vec!["open"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence("open-all-unread-in-browser-and-mark-read").unwrap(),
+            vec![vec!["open-all-unread-in-browser-and-mark-read"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence("; ; ; ;").unwrap(),
+            Vec::<Vec<String>>::new()
+        );
+        assert_eq!(
+            tokenize_operation_sequence("open ; next").unwrap(),
+            vec![vec!["open"], vec!["next"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence("open ; next ; prev").unwrap(),
+            vec![vec!["open"], vec!["next"], vec!["prev"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence("open ; next ; prev ; quit").unwrap(),
+            vec![vec!["open"], vec!["next"], vec!["prev"], vec!["quit"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"set "arg 1""#).unwrap(),
+            vec![vec!["set", "arg 1"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"set "arg 1" ; set "arg 2" "arg 3""#).unwrap(),
+            vec![vec!["set", "arg 1"], vec!["set", "arg 2", "arg 3"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"set browser "firefox"; open-in-browser"#).unwrap(),
+            vec![vec!["set", "browser", "firefox"], vec!["open-in-browser"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence("set browser firefox; open-in-browser").unwrap(),
+            vec![vec!["set", "browser", "firefox"], vec!["open-in-browser"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence("open-in-browser; quit").unwrap(),
+            vec![vec!["open-in-browser"], vec!["quit"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"open; set browser "firefox --private-window"; quit"#)
+                .unwrap(),
+            vec![
+                vec!["open"],
+                vec!["set", "browser", "firefox --private-window"],
+                vec!["quit"]
+            ]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"open ;set browser "firefox --private-window" ;quit"#)
+                .unwrap(),
+            vec![
+                vec!["open"],
+                vec!["set", "browser", "firefox --private-window"],
+                vec!["quit"]
+            ]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"open;set browser "firefox --private-window";quit"#)
+                .unwrap(),
+            vec![
+                vec!["open"],
+                vec!["set", "browser", "firefox --private-window"],
+                vec!["quit"]
+            ]
+        );
+        assert_eq!(
+            tokenize_operation_sequence("; ;; ; open",).unwrap(),
+            vec![vec!["open"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(";;; ;; ; open",).unwrap(),
+            vec![vec!["open"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(";;; ;; ; open ;",).unwrap(),
+            vec![vec!["open"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(";;; ;; ; open ;; ;",).unwrap(),
+            vec![vec!["open"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(";;; ;; ; open ; ;;;;",).unwrap(),
+            vec![vec!["open"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(";;; open ; ;;;;",).unwrap(),
+            vec![vec!["open"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence("; open ;; ;; ;",).unwrap(),
+            vec![vec!["open"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence("open ; ;;; ;;",).unwrap(),
+            vec![vec!["open"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(
+                r#"set browser "sleep 3; do-something ; echo hi"; open-in-browser"#
+            )
+            .unwrap(),
+            vec![
+                vec!["set", "browser", "sleep 3; do-something ; echo hi"],
+                vec!["open-in-browser"]
+            ]
+        );
+    }
+
+    #[test]
+    fn t_tokenize_operation_sequence_ignores_escaped_sequences_outside_double_quotes() {
+        assert_eq!(
+            tokenize_operation_sequence(r#"\t"#).unwrap(),
+            vec![vec![r#"\t"#]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"\r"#).unwrap(),
+            vec![vec![r#"\r"#]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"\n"#).unwrap(),
+            vec![vec![r#"\n"#]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"\v"#).unwrap(),
+            vec![vec![r#"\v"#]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"\""#).unwrap(),
+            vec![vec![r#"\""#]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#"\\"#).unwrap(),
+            vec![vec![r#"\\"#]]
+        );
+    }
+
+    #[test]
+    fn t_tokenize_operation_sequence_expands_escaped_sequences_inside_double_quotes() {
+        assert_eq!(
+            tokenize_operation_sequence(r#""\t""#).unwrap(),
+            vec![vec!["\t"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#""\r""#).unwrap(),
+            vec![vec!["\r"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#""\n""#).unwrap(),
+            vec![vec!["\n"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#""\"""#).unwrap(),
+            vec![vec!["\""]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#""\\""#).unwrap(),
+            vec![vec!["\\"]]
+        );
+    }
+
+    #[test]
+    fn t_tokenize_operation_sequence_passes_through_unsupported_escaped_chars_inside_double_quotes()
+    {
+        assert_eq!(
+            tokenize_operation_sequence(r#""\1""#).unwrap(),
+            vec![vec!["1"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#""\W""#).unwrap(),
+            vec![vec!["W"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#""\b""#).unwrap(),
+            vec![vec!["b"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#""\d""#).unwrap(),
+            vec![vec!["d"]]
+        );
+        assert_eq!(
+            tokenize_operation_sequence(r#""\x""#).unwrap(),
+            vec![vec!["x"]]
+        );
+    }
+
+    #[test]
+    fn t_tokenize_operation_sequence_implicitly_closes_double_quotes_at_end_of_input() {
+        assert_eq!(
+            tokenize_operation_sequence(r#"set "arg 1"#).unwrap(),
+            vec![vec!["set", "arg 1"]]
+        );
+    }
+}

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -16,6 +16,7 @@ pub mod fmtstrformatter;
 pub mod fslock;
 pub mod history;
 pub mod htmlrenderer;
+pub mod keymap;
 pub mod matchable;
 pub mod matcher;
 pub mod matchererror;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -107,7 +107,7 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 	 * 	[2]: x
 	 * 	y
 	 *
-	 * 	\", \r, \n, \t and \v are replaced with the literals that you
+	 * 	\", \r, \n, and \t are replaced with the literals that you
 	 * know from C/C++ strings.
 	 *
 	 */

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -592,3 +592,21 @@ TEST_CASE("It's not an error to have no operations before a semicolon in "
 		}
 	}
 }
+
+TEST_CASE("Semicolons in operation's arguments don't break parsing of a macro",
+	"[KeyMap]")
+{
+	// This is a regression test for https://github.com/newsboat/newsboat/issues/1200
+
+	KeyMap k(KM_NEWSBOAT);
+
+	k.handle_action("macro",
+		R"(x set browser "sleep 3; do-something ; echo hi"; open-in-browser)");
+
+	const auto macro = k.get_macro("x");
+	REQUIRE(macro.size() == 2);
+	REQUIRE(macro[0].op == OP_INT_SET);
+	REQUIRE(macro[0].args == std::vector<std::string>({"browser", "sleep 3; do-something ; echo hi"}));
+	REQUIRE(macro[1].op == OP_OPENINBROWSER);
+	REQUIRE(macro[1].args == std::vector<std::string>({}));
+}


### PR DESCRIPTION
That title is a mouthful. This commit fixes #1200, so just read that issue for the reproduction steps.

Reviews are welcome as always. Will merge once @dennisschagt approved this, or in three days if no issues are raised.