### PR TITLE
Improve docs for `save` and `save-all`

### DIFF
--- a/doc/cmdline-commands.dsv
+++ b/doc/cmdline-commands.dsv
@@ -1,6 +1,6 @@
 quit||||Quit newsboat.||quit
 q||||Alias for quit.||quit
-save||<filename>||Save the currently select article to disk. This works in the article list and in the article view.||save ~/important.txt
+save||<filename>||Export the currently selected article to a plain text file. This works in the article list and in the article view.||save ~/important.txt
 set||<variable>[=<value>|&|!]||Set configuration variable <variable> to <value>. If no value is specified, the current value is printed out. Specifying a _!_ after the name of boolean configuration variables toggles their values, a _&_ directly after the name of a configuration variable of any type resets its value to the documented default value.||set reload-time=15
 tag||<tagname>||Only display feeds with the tag <tagname>.||tag news
 goto||<case-insensitive substring>||Search for a feed whose name contains the case-insensitive substring.||goto foo

--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -7,7 +7,7 @@ mark-feed-read||A||Mark all articles in the currently selected feed read.
 mark-all-feeds-read||C||Mark articles in all feeds read.
 mark-all-above-as-read||n/a||Mark all above as read.
 save||s||Export the currently selected article to a plain text file.
-save-all||n/a||Export all articles from currently selected feed to plain text files.
+save-all||n/a||Export all articles from the currently selected feed to plain text files.
 next-unread||n||Jump to the next unread article.
 prev-unread||p||Jump to the previous unread article.
 next||J||Jump to next list entry.

--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -6,8 +6,8 @@ reload-all||R||Reload all feeds.
 mark-feed-read||A||Mark all articles in the currently selected feed read.
 mark-all-feeds-read||C||Mark articles in all feeds read.
 mark-all-above-as-read||n/a||Mark all above as read.
-save||s||Save the currently selected article to a file.
-save-all||n/a||Save all articles from currently selected feed.
+save||s||Export the currently selected article to a plain text file.
+save-all||n/a||Export all articles from currently selected feed to plain text files.
 next-unread||n||Jump to the next unread article.
 prev-unread||p||Jump to the previous unread article.
 next||J||Jump to next list entry.


### PR DESCRIPTION
This commit fixes a couple issues:

1. it doesn't use the name of the operation to describe it. This
   helps searchability, as there are now two keywords in the text
   ("save" and "export");

2. it mentions that the output format is plain text. Commandline doc
   already hinted at that via ".txt" extension, but I made it clear in
   the text as well.

Inspired by #1210.

Comments are welcome! As usual, @der-lyse can merge this if he approves, or I'll merge this in three days myself.