### PR TITLE
docs: clarify open-in-browser operation

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -13,7 +13,7 @@ prev-unread||p||Jump to the previous unread article.
 next||J||Jump to next list entry.
 prev||K||Jump to previous list entry.
 random-unread||^K||Jump to a random unread article.
-open-in-browser||o||Open the URL associated with the current article, or selection when in the URL view.
+open-in-browser||o||Open the URL associated with the current feed, article, or selection in the browser.
 open-in-browser-and-mark-read||O||Open the URL associated with the current article, or selection when in the URL view. When used in the article view, it will also mark the article as read.
 open-all-unread-in-browser||n/a||Open all the unread URLs in the current feed.
 open-all-unread-in-browser-and-mark-read||n/a||Open all the unread URLs in the current feed and mark them as read.

--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -13,7 +13,7 @@ prev-unread||p||Jump to the previous unread article.
 next||J||Jump to next list entry.
 prev||K||Jump to previous list entry.
 random-unread||^K||Jump to a random unread article.
-open-in-browser||o||Open the URL associated with the current feed, article, or selection in the browser.
+open-in-browser||o||Open the URL associated with the current feed, article, or selection in the browser (selection applies to many dialogs, including the URL view).
 open-in-browser-and-mark-read||O||Open the URL associated with the current article, or selection when in the URL view. When used in the article view, it will also mark the article as read.
 open-all-unread-in-browser||n/a||Open all the unread URLs in the current feed.
 open-all-unread-in-browser-and-mark-read||n/a||Open all the unread URLs in the current feed and mark them as read.

--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -13,8 +13,8 @@ prev-unread||p||Jump to the previous unread article.
 next||J||Jump to next list entry.
 prev||K||Jump to previous list entry.
 random-unread||^K||Jump to a random unread article.
-open-in-browser||o||Open the URL associated with the current feed, article, or selection in the browser (selection applies to many dialogs, including the URL view).
-open-in-browser-and-mark-read||O||Open the URL associated with the current article, or selection when in the URL view. When used in the article view, it will also mark the article as read.
+open-in-browser||o||Use browser to open the URL associated with the current article, feed, or entry in the URL view.
+open-in-browser-and-mark-read||O||Use browser to open the URL associated with the current article, or entry in the URL view. When used in the article list, it will also mark the article as read.
 open-all-unread-in-browser||n/a||Open all the unread URLs in the current feed.
 open-all-unread-in-browser-and-mark-read||n/a||Open all the unread URLs in the current feed and mark them as read.
 help||?||Run the help screen.

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -119,7 +119,7 @@ static const std::vector<OpDesc> opdescs = {
 		OP_OPENBROWSER_AND_MARK,
 		"open-in-browser-and-mark-read",
 		"O",
-		_("Open article in browser and mark read"),
+		_("Open URL of current article, or entry in URL view. Mark as read in article list"),
 		KM_ARTICLELIST | KM_ARTICLE | KM_URLVIEW
 	},
 	{
@@ -141,7 +141,7 @@ static const std::vector<OpDesc> opdescs = {
 		OP_OPENINBROWSER,
 		"open-in-browser",
 		"o",
-		_("Open URL of the feed, article or selection"),
+		_("Open URL of current article, feed or entry in URL view"),
 		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE | KM_URLVIEW
 	},
 	{

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -119,7 +119,7 @@ static const std::vector<OpDesc> opdescs = {
 		OP_OPENBROWSER_AND_MARK,
 		"open-in-browser-and-mark-read",
 		"O",
-		_("Open URL of current article, or entry in URL view. Mark as read in article list"),
+		_("Open URL of article, or entry in URL view. Mark read."),
 		KM_ARTICLELIST | KM_ARTICLE | KM_URLVIEW
 	},
 	{
@@ -141,7 +141,7 @@ static const std::vector<OpDesc> opdescs = {
 		OP_OPENINBROWSER,
 		"open-in-browser",
 		"o",
-		_("Open URL of current article, feed or entry in URL view"),
+		_("Open URL of article, feed, or entry in URL view"),
 		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE | KM_URLVIEW
 	},
 	{

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -141,7 +141,7 @@ static const std::vector<OpDesc> opdescs = {
 		OP_OPENINBROWSER,
 		"open-in-browser",
 		"o",
-		_("Open article in browser"),
+		_("Open URL of the feed, article or selection"),
 		KM_FEEDLIST | KM_ARTICLELIST | KM_ARTICLE | KM_URLVIEW
 	},
 	{
@@ -387,7 +387,6 @@ static const std::vector<OpDesc> opdescs = {
 		KM_FEEDLIST | KM_ARTICLELIST
 	},
 
-	{OP_OPEN_URL_10, "zero", "0", _("Open URL 10"), KM_URLVIEW | KM_ARTICLE},
 	{OP_OPEN_URL_1, "one", "1", _("Open URL 1"), KM_URLVIEW | KM_ARTICLE},
 	{OP_OPEN_URL_2, "two", "2", _("Open URL 2"), KM_URLVIEW | KM_ARTICLE},
 	{OP_OPEN_URL_3, "three", "3", _("Open URL 3"), KM_URLVIEW | KM_ARTICLE},
@@ -397,6 +396,7 @@ static const std::vector<OpDesc> opdescs = {
 	{OP_OPEN_URL_7, "seven", "7", _("Open URL 7"), KM_URLVIEW | KM_ARTICLE},
 	{OP_OPEN_URL_8, "eight", "8", _("Open URL 8"), KM_URLVIEW | KM_ARTICLE},
 	{OP_OPEN_URL_9, "nine", "9", _("Open URL 9"), KM_URLVIEW | KM_ARTICLE},
+	{OP_OPEN_URL_10, "zero", "0", _("Open URL 10"), KM_URLVIEW | KM_ARTICLE},
 
 	{OP_CMD_START_1, "cmd-one", "1", _("Start cmdline with 1"), KM_FEEDLIST | KM_ARTICLELIST | KM_TAGSELECT | KM_FILTERSELECT},
 	{OP_CMD_START_2, "cmd-two", "2", _("Start cmdline with 2"), KM_FEEDLIST | KM_ARTICLELIST | KM_TAGSELECT | KM_FILTERSELECT},


### PR DESCRIPTION
I understand that:

- From the feed list, `open-in-browser` opens feed link.
- From the article list, `open-in-browser` opens article link.
- From the article view, `open-in-browser` opens article link.
- From the url view, `open-in-browser` opens selected link.

That's why I clarify that `open-in-browser` can be also be used for those tasks.