### PR TITLE
Remove duplicate whiespace from item titles when displaying in list/head

### DIFF
--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -31,7 +31,7 @@ RssItem::~RssItem() {}
 
 void RssItem::set_title(const std::string& t)
 {
-	title_ = t;
+	title_ = utils::consolidate_whitespace(t);
 	utils::trim(title_);
 }
 

--- a/test/rssitem.cpp
+++ b/test/rssitem.cpp
@@ -274,3 +274,28 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		}
 	}
 }
+
+TEST_CASE("set_title() removes superfluous whitespace", "[RssItem]")
+{
+	ConfigContainer cfg;
+	Cache rsscache(":memory:", &cfg);
+	RssItem item(&rsscache);
+
+	SECTION("duplicate whitespace") {
+		item.set_title("lorem        ipsum");
+		REQUIRE(item.title() == "lorem ipsum");
+
+		item.set_title("abc\n\r \tdef");
+		REQUIRE(item.title() == "abc def");
+	}
+
+	SECTION("leading whitespace") {
+		item.set_title("\n\r\t lorem ipsum");
+		REQUIRE(item.title() == "lorem ipsum");
+	}
+
+	SECTION("trailing whitespace") {
+		item.set_title("lorem ipsum\n\r\t ");
+		REQUIRE(item.title() == "lorem ipsum");
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1227.

This only removes duplicate spaces when displaying titles.
It might make sense to remove duplicate whitespaces on a lower level (e.g. in getters like `title()`/`get_title()` or even when retrieving titles in `Cache`) but I'm not sure it is a good idea.