### PR TITLE
Added support info in --help output

### DIFF
--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -136,6 +136,13 @@ void print_usage(const std::string& argv0, const std::string& config_path,
 	print_filepath(tr_config, config_path);
 	print_filepath(tr_urls, urls_path);
 	print_filepath(tr_cache, cache_path);
+
+	std::cout << std::endl
+		<< _("Support at #newsboat at https://freenode.net or on our mailing "
+			"list https://groups.google.com/g/newsboat")
+		<< std::endl
+		<< _("For more information, check out https://newsboat.org/")
+		<< std::endl;
 }
 
 void print_version(const std::string& argv0, unsigned int level)

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -374,6 +374,13 @@ void PbController::print_usage(const char* argv0)
 		}
 		std::cout << a.desc << std::endl;
 	}
+
+	std::cout << std::endl
+		<< _("Support at #newsboat at https://freenode.net or on our mailing "
+			"list https://groups.google.com/g/newsboat")
+		<< std::endl
+		<< _("For more information, check out https://newsboat.org/")
+		<< std::endl;
 }
 
 std::string PbController::get_formatstr()


### PR DESCRIPTION
The `--help` option to both `newsboat` and `podboat` executables will now display support information along will their usage.

This resolves issue #1233