### PR TITLE
Add Clang 11 to CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -192,13 +192,13 @@ linux_task:
           env: &extra_warnings_and_checks_env
             CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
             PROFILE: 0
-        - name: Clang 10, more warnings and checks (Ubuntu 20.04)
+        - name: Clang 11, more warnings and checks (Ubuntu 20.10)
           container:
-            dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
+            dockerfile: docker/ubuntu_20.10-build-tools.dockerfile
             docker_arguments:
-                cxx_package: clang-10
-                cc: clang-10
-                cxx: clang++-10
+                cxx_package: clang-11
+                cc: clang-11
+                cxx: clang++-11
           env: *extra_warnings_and_checks_env
 
         - name: Rust 1.47.0, GCC 4.9 (Ubuntu 16.04)
@@ -299,6 +299,13 @@ linux_task:
                 cxx_package: clang-10
                 cc: clang-10
                 cxx: clang++-10
+        - name: Rust 1.47.0, Clang 11 (Ubuntu 20.10)
+          container:
+            dockerfile: docker/ubuntu_20.10-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: clang-11
+                cc: clang-11
+                cxx: clang++-11
 
     cargo_cache: *cargo_cache
 
@@ -314,16 +321,16 @@ linux_task:
     before_cache_script: *before_cache_script
 
 address_sanitizer_task:
-    name: AddressSanitizer (Clang 10, Ubuntu 20.04)
+    name: AddressSanitizer (Clang 11, Ubuntu 20.10)
 
     container:
-      dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
+      dockerfile: docker/ubuntu_20.10-build-tools.dockerfile
       docker_arguments:
           # We need llvm-symbolizer from llvm-10-tools to demangle symbols in
           # sanitizer's reports
-          cxx_package: "clang-10 llvm-10"
-          cc: clang-10
-          cxx: clang++-10
+          cxx_package: "clang-11 llvm-11"
+          cc: clang-11
+          cxx: clang++-11
 
     env:
       CXXFLAGS: "-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-optimize-sibling-calls -g"
@@ -359,16 +366,16 @@ depslist_task:
         - git diff --exit-code || (echo 'WARNING: the above diff is produced by GCC. Copy it if you only have Clang installed; otherwise just run `make depslist` and commit the result'; false)
 
 undefined_behavior_sanitizer_task:
-    name: UB Sanitizer (Clang 10, Ubuntu 20.04)
+    name: UB Sanitizer (Clang 11, Ubuntu 20.10)
 
     container:
-      dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
+      dockerfile: docker/ubuntu_20.10-build-tools.dockerfile
       docker_arguments:
           # We need llvm-symbolizer from llvm-10-tools to demangle symbols in
           # sanitizer's reports
-          cxx_package: "clang-10 llvm-10"
-          cc: clang-10
-          cxx: clang++-10
+          cxx_package: "clang-11 llvm-11"
+          cc: clang-11
+          cxx: clang++-11
 
     env:
       CXXFLAGS: "-fsanitize=undefined -g -fno-omit-frame-pointer"

--- a/docker/ubuntu_20.10-build-tools.dockerfile
+++ b/docker/ubuntu_20.10-build-tools.dockerfile
@@ -1,0 +1,107 @@
+# All the programs and libraries necessary to build Newsboat with newer
+# compilers. Contains GCC 10 and Rust 1.47.0 by default.
+#
+# Configurable via build-args:
+#
+# - cxx_package -- additional Ubuntu packages to install. Default: g++-10
+# - rust_version -- Rust version to install. Default: 1.47.0
+# - cc -- C compiler to use. This gets copied into CC environment variable.
+#       Default: gcc-10
+# - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
+#       Default: g++-10
+#
+# Build with defaults:
+#
+#   docker build \
+#       --tag=newsboat-build-tools \
+#       --file=docker/ubuntu_20.10-build-tools.dockerfile \
+#       docker
+#
+# Build with non-default compiler and Rust version:
+#
+#   docker build \
+#       --tag=newsboat-build-tools \
+#       --file=docker/ubuntu_20.10-build-tools.dockerfile \
+#       --build-arg cxx_package=clang-10 \
+#       --build-arg cc=clang-11 \
+#       --build-arg cxx=clang++-11 \
+#       --build-arg rust_version=1.40.0 \
+#       docker
+#
+# Before building in a container, run this to remove any binaries that you
+# might've compiled on your host system (or in another container):
+#
+#   make distclean
+#
+# Run on your local files:
+#
+#   docker run \
+#       --rm \
+#       --mount type=bind,source=$(pwd),target=/home/builder/src \
+#       --user $(id -u):$(id -g) \
+#       newsboat-build-tools \
+#       make
+#
+# To save on bandwidth, and speed up the build slightly, share the host's Cargo
+# cache with the container:
+#
+#   mkdir -p ~/.cargo/registry
+#   docker run \
+#       --mount type=bind,source=$HOME/.cargo/registry,target=/home/builder/.cargo/registry \
+#       ... # the rest of the options
+#
+# If you want to build on the host again, run this to remove binary files
+# compiled in the container:
+#
+#   make distclean
+
+FROM ubuntu:20.10
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PATH /home/builder/.cargo/bin:$PATH
+
+RUN apt-get update \
+    && apt-get upgrade --assume-yes
+
+ARG cxx_package=g++-10
+
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends \
+        build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
+        libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
+        pkg-config zlib1g-dev asciidoctor wget \
+    && apt-get autoremove \
+    && apt-get clean
+
+RUN addgroup --gid 1000 builder \
+    && adduser --home /home/builder --uid 1000 --ingroup builder \
+        --disabled-password --shell /bin/bash builder \
+    && mkdir -p /home/builder/src \
+    && chown -R builder:builder /home/builder
+
+RUN apt-get install locales \
+    && echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
+    && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+USER builder
+WORKDIR /home/builder/src
+
+ARG rust_version=1.47.0
+
+RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
+    && chmod +x $HOME/rustup.sh \
+    && $HOME/rustup.sh -y \
+        --default-host x86_64-unknown-linux-gnu \
+        --default-toolchain $rust_version \
+    && chmod a+w $HOME/.cargo
+
+ENV HOME /home/builder
+
+ARG cc=gcc-10
+ARG cxx=g++-10
+
+ENV CC=$cc
+ENV CXX=$cxx


### PR DESCRIPTION
Also migrate the "more checks" and "sanitizer" jobs to Clang 11, since it makes sense to run those with the latest-and-greatest compiler.

Reviews are welcome! I'll merge this in three days if no issues are raised.