### PR TITLE
Make reload non-blocking in feedlist

### DIFF
--- a/include/downloadthread.h
+++ b/include/downloadthread.h
@@ -9,13 +9,15 @@ namespace newsboat {
 
 class DownloadThread {
 public:
-	DownloadThread(Reloader& r, const std::vector<int>& idxs = {});
+	DownloadThread(Reloader& r, const std::vector<int>& idxs = {}, bool
+		notify_on_finish_ = false);
 	virtual ~DownloadThread();
 	void operator()();
 
 private:
 	Reloader& reloader;
 	std::vector<int> indexes;
+	const bool notify_on_finish;
 };
 
 } // namespace newsboat

--- a/include/reloader.h
+++ b/include/reloader.h
@@ -26,6 +26,9 @@ public:
 	/// If \a indexes is empty, all feeds will be reloaded.
 	void start_reload_all_thread(const std::vector<int>& indexes = {});
 
+	/// \brief Start a thread that will reload the specified feed
+	void start_reload_thread(int index);
+
 	void unlock_reload_mutex()
 	{
 		reload_mutex.unlock();
@@ -59,7 +62,7 @@ public:
 	/// \brief Reloads all feeds with given indexes in feedlist.
 	///
 	/// Only updates status bar if \a unattended is false.
-	void reload_indexes(const std::vector<int>& indexes,
+	void reload_indexes(const std::vector<int>& indexes, bool notify_on_finish,
 		bool unattended = false);
 
 	/// \brief Reloads feeds occupying positions from \a start to \a end in

--- a/src/downloadthread.cpp
+++ b/src/downloadthread.cpp
@@ -4,8 +4,13 @@
 
 namespace newsboat {
 
-DownloadThread::DownloadThread(Reloader& r, const std::vector<int>& idxs)
-	: reloader(r), indexes(idxs) {}
+DownloadThread::DownloadThread(Reloader& r, const std::vector<int>& idxs,
+	bool notify_on_finish_)
+	: reloader(r)
+	, indexes(idxs)
+	, notify_on_finish(notify_on_finish_)
+{
+}
 
 DownloadThread::~DownloadThread() {}
 
@@ -23,7 +28,7 @@ void DownloadThread::operator()()
 		if (indexes.size() == 0) {
 			reloader.reload_all();
 		} else {
-			reloader.reload_indexes(indexes);
+			reloader.reload_indexes(indexes, notify_on_finish);
 		}
 		reloader.unlock_reload_mutex();
 	}

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -118,7 +118,7 @@ REDO:
 			"FeedListFormAction: reloading feed at position `%s'",
 			feedpos);
 		if (visible_feeds.size() > 0 && feedpos.length() > 0) {
-			v->get_ctrl()->get_reloader()->reload(pos);
+			v->get_ctrl()->get_reloader()->start_reload_thread(pos);
 		} else {
 			v->show_error(
 				_("No feed selected!")); // should not happen

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -408,7 +408,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		if (!show_searchresult) {
 			LOG(Level::INFO,
 				"ItemListFormAction: reloading current feed");
-			v->get_ctrl()->get_reloader()->reload(pos);
+			v->get_ctrl()->get_reloader()->start_reload_thread(pos);
 			invalidate_everything();
 		} else {
 			v->show_error(

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -38,7 +38,14 @@ void Reloader::spawn_reloadthread()
 void Reloader::start_reload_all_thread(const std::vector<int>& indexes)
 {
 	LOG(Level::INFO, "starting reload all thread");
-	std::thread t(DownloadThread(*this, indexes));
+	std::thread t(DownloadThread(*this, indexes, true));
+	t.detach();
+}
+
+void Reloader::start_reload_thread(int index)
+{
+	LOG(Level::INFO, "starting reload all thread");
+	std::thread t(DownloadThread(*this, {index}));
 	t.detach();
 }
 
@@ -195,7 +202,8 @@ void Reloader::reload_all(bool unattended)
 	notify_reload_finished(unread_feeds, unread_articles);
 }
 
-void Reloader::reload_indexes(const std::vector<int>& indexes, bool unattended)
+void Reloader::reload_indexes(const std::vector<int>& indexes,
+	bool notify_on_finish, bool unattended)
 {
 	ScopeMeasure m1("Reloader::reload_indexes");
 	const auto unread_feeds =
@@ -208,7 +216,9 @@ void Reloader::reload_indexes(const std::vector<int>& indexes, bool unattended)
 		reload(idx, size, unattended);
 	}
 
-	notify_reload_finished(unread_feeds, unread_articles);
+	if (notify_on_finish) {
+		notify_reload_finished(unread_feeds, unread_articles);
+	}
 
 	if (!unattended) {
 		ctrl->get_view()->set_status("");


### PR DESCRIPTION
Partial fix for:
- https://github.com/newsboat/newsboat/issues/75
- https://github.com/akrennmair/newsbeuter/issues/606

It is probably possible to apply the same fix to make reload non-blocking in the ItemListFormAction.
However, I still need to verify this does not have unintended consequences.

The current changes have the effect that single-feed reloads will also start sending notifications (related to `notify-program`, before, notifications were only sent when finishing a `reload-all` action). To reproduce, add the following to the config file:
```
notify-program "notify-send"
notify-always yes
```
I think that should not happen, do others agree?

Marking as draft as I need to verify there are no other unintended changes.