### PR TITLE
CI: upgrade to FreeBSD 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,9 +3,9 @@ freebsd_task:
         - name: FreeBSD 11.4
           freebsd_instance:
             image: freebsd-11-4-release-amd64
-        - name: FreeBSD 12.1
+        - name: FreeBSD 12.2
           freebsd_instance:
-            image: freebsd-12-1-release-amd64
+            image: freebsd-12-2-release-amd64
 
     cargo_cache: &cargo_cache
         # This works in conjunction with after_cache_script and


### PR DESCRIPTION
FreeBSD 12.2 came out [today](https://www.freebsd.org/releases/12.2R/relnotes.html), let's upgrade!

Will merge once the CI checks pass.