### PR TITLE
Display reason of download failure in podboat

### DIFF
--- a/include/download.h
+++ b/include/download.h
@@ -30,9 +30,9 @@ public:
 	{
 		return download_status;
 	}
-	const char* status_msg() const
+	const std::string& status_msg() const
 	{
-		return msg ? msg : "";
+		return msg;
 	}
 	const std::string filename() const;
 	const std::string basename() const;
@@ -40,7 +40,7 @@ public:
 	void set_filename(const std::string& str);
 	void set_url(const std::string& url);
 	void set_progress(double downloaded, double total);
-	void set_status(DlStatus dls, const char* msg_ = nullptr);
+	void set_status(DlStatus dls, const std::string& msg_ = {});
 	void set_kbps(double kbps);
 	double kbps() const;
 	void set_offset(unsigned long offset);
@@ -58,7 +58,7 @@ private:
 	std::string fn;
 	std::string url_;
 	DlStatus download_status;
-	const char* msg;
+	std::string msg;
 	double cursize;
 	double totalsize;
 	double curkbps;

--- a/include/download.h
+++ b/include/download.h
@@ -30,13 +30,17 @@ public:
 	{
 		return download_status;
 	}
+	const char* status_msg() const
+	{
+		return msg ? msg : "";
+	}
 	const std::string filename() const;
 	const std::string basename() const;
 	const std::string url() const;
 	void set_filename(const std::string& str);
 	void set_url(const std::string& url);
 	void set_progress(double downloaded, double total);
-	void set_status(DlStatus dls);
+	void set_status(DlStatus dls, const char* msg_ = nullptr);
 	void set_kbps(double kbps);
 	double kbps() const;
 	void set_offset(unsigned long offset);
@@ -54,6 +58,7 @@ private:
 	std::string fn;
 	std::string url_;
 	DlStatus download_status;
+	const char* msg;
 	double cursize;
 	double totalsize;
 	double curkbps;

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -104,9 +104,7 @@ void Download::set_status(DlStatus dls, const char* msg_)
 	if (download_status != dls) {
 		cb_require_view_update();
 	}
-	if (msg_ != nullptr) {
-		msg = msg_;
-	}
+	msg = msg_;
 	download_status = dls;
 }
 

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -14,7 +14,6 @@ namespace podboat {
 
 Download::Download(std::function<void()> cb_require_view_update_)
 	: download_status(DlStatus::QUEUED)
-	, msg(nullptr)
 	, cursize(0.0)
 	, totalsize(0.0)
 	, curkbps(0.0)
@@ -99,7 +98,7 @@ void Download::set_progress(double downloaded, double total)
 	totalsize = total;
 }
 
-void Download::set_status(DlStatus dls, const char* msg_)
+void Download::set_status(DlStatus dls, const std::string& msg_)
 {
 	if (download_status != dls) {
 		cb_require_view_update();

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -14,6 +14,7 @@ namespace podboat {
 
 Download::Download(std::function<void()> cb_require_view_update_)
 	: download_status(DlStatus::QUEUED)
+	, msg(nullptr)
 	, cursize(0.0)
 	, totalsize(0.0)
 	, curkbps(0.0)
@@ -98,10 +99,13 @@ void Download::set_progress(double downloaded, double total)
 	totalsize = total;
 }
 
-void Download::set_status(DlStatus dls)
+void Download::set_status(DlStatus dls, const char* msg_)
 {
 	if (download_status != dls) {
 		cb_require_view_update();
+	}
+	if (msg_ != nullptr) {
+		msg = msg_;
 	}
 	download_status = dls;
 }

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -102,7 +102,9 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 				i++;
 			}
 
-			if (i >= 1 && dllist_form.get("msg").length() == 0) {
+			// If there's no status message, we know there's no error to show
+			// Thus, it's safe to replace with the download's status
+			if (i >= 1 && dllist_form.get("msg").empty()) {
 				const auto idx = downloads_list.get_position();
 				dllist_form.set("msg", ctrl->downloads()[idx].status_msg());
 			}

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -261,7 +261,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			break;
 		}
 
-		if (dllist_form.get("msg").length() == 0) {
+		if (ctrl->downloads().size() >= 1 && dllist_form.get("msg").length() == 0) {
 			const auto idx = downloads_list.get_position();
 			dllist_form.set("msg", ctrl->downloads()[idx].status_msg());
 		}

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -261,6 +261,11 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			break;
 		}
 
+		if (dllist_form.get("msg").length() == 0) {
+			const auto idx = downloads_list.get_position();
+			dllist_form.set("msg", ctrl->downloads()[idx].status_msg());
+		}
+
 	} while (!quit);
 }
 

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -102,6 +102,11 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 				i++;
 			}
 
+			if (i >= 1 && dllist_form.get("msg").length() == 0) {
+				const auto idx = downloads_list.get_position();
+				dllist_form.set("msg", ctrl->downloads()[idx].status_msg());
+			}
+
 			downloads_list.stfl_replace_lines(listfmt);
 
 			ctrl->set_view_update_necessary(false);
@@ -139,22 +144,28 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		case OP_PREV:
 		case OP_SK_UP:
 			downloads_list.move_up(wrap_scroll);
+			ctrl->set_view_update_necessary(true);
 			break;
 		case OP_NEXT:
 		case OP_SK_DOWN:
 			downloads_list.move_down(wrap_scroll);
+			ctrl->set_view_update_necessary(true);
 			break;
 		case OP_SK_HOME:
 			downloads_list.move_to_first();
+			ctrl->set_view_update_necessary(true);
 			break;
 		case OP_SK_END:
 			downloads_list.move_to_last();
+			ctrl->set_view_update_necessary(true);
 			break;
 		case OP_SK_PGUP:
 			downloads_list.move_page_up(wrap_scroll);
+			ctrl->set_view_update_necessary(true);
 			break;
 		case OP_SK_PGDOWN:
 			downloads_list.move_page_down(wrap_scroll);
+			ctrl->set_view_update_necessary(true);
 			break;
 		case OP_PB_TOGGLE_DLALL:
 			auto_download = !auto_download;
@@ -259,11 +270,6 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			break;
 		default:
 			break;
-		}
-
-		if (ctrl->downloads().size() >= 1 && dllist_form.get("msg").length() == 0) {
-			const auto idx = downloads_list.get_position();
-			dllist_form.set("msg", ctrl->downloads()[idx].status_msg());
 		}
 
 	} while (!quit);

--- a/src/poddlthread.cpp
+++ b/src/poddlthread.cpp
@@ -1,5 +1,6 @@
 #include "poddlthread.h"
 
+#include <cstring>
 #include <cinttypes>
 #include <curl/curl.h>
 #include <iostream>
@@ -127,12 +128,12 @@ void PodDlThread::run()
 				::unlink(filename.c_str());
 				this->run();
 			} else {
-				dl->set_status(DlStatus::FAILED);
+				dl->set_status(DlStatus::FAILED, curl_easy_strerror(success));
 				::unlink(filename.c_str());
 			}
 		}
 	} else {
-		dl->set_status(DlStatus::FAILED);
+		dl->set_status(DlStatus::FAILED, strerror(errno));
 	}
 
 	curl_easy_cleanup(easyhandle);


### PR DESCRIPTION
When the user is highlighting a failed download, the reason will now be
reported in the status line. #1209