### PR TITLE
Replace string constants with a proper enum in FilterParser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,6 @@ dependencies = [
  "curl-sys",
  "gettext-rs",
  "gettext-sys",
- "lazy_static",
  "libc",
  "natord",
  "nom",

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -21,7 +21,6 @@ curl-sys = "0.4.5"
 libc = "0.2"
 gettext-rs = "0.5.0"
 natord = "1.0.9"
-lazy_static = "1.4.0"
 
 [dependencies.clap]
 version = "2.33"


### PR DESCRIPTION
fixes #1077
I made a new error type for the parser and a combinator called `expect` which resembles the `context` combinator.