### PR TITLE
Continue execution, even when loading urls file fails

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -343,9 +343,7 @@ int Controller::run(const CliArgsParser& args)
 	const auto error_message = urlcfg->reload();
 	if (error_message.has_value()) {
 		std::cout << error_message.value() << std::endl;
-		return EXIT_FAILURE;
-	}
-	if (!args.do_export() && !args.silent()) {
+	} else if (!args.do_export() && !args.silent()) {
 		std::cout << _("done.") << std::endl;
 	}
 


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/newsboat/newsboat/pull/1245.

Before the regression, the `urls` file could be omitted when importing an OPML file or when using an online service (e.g. miniflux).
This commit restores that behaviour.
It still prints the error message to help users diagnose issues in case of missing urls or if there are still 0 urls configured.

Relevant file/change in which I introduced the regression:
https://github.com/newsboat/newsboat/pull/1245/files?file-filters%5B%5D=.cpp#diff-53fc727c3acacc0c0b7c531be394c8074b1211826f68cff4e8217b65c536ab8f