### PR TITLE
Remove "none" logging level

### DIFF
--- a/include/logger.h
+++ b/include/logger.h
@@ -27,7 +27,8 @@ void unset_loglevel();
 template<typename... Args>
 void log(Level l, const std::string& format, Args... args)
 {
-	if (static_cast<int64_t>(l) <= rs_get_loglevel()) {
+	if (l == Level::USERERROR
+		|| static_cast<int64_t>(l) <= rs_get_loglevel()) {
 		rs_log(l, strprintf::fmt(format, args...).c_str());
 	}
 }

--- a/include/logger.h
+++ b/include/logger.h
@@ -9,25 +9,25 @@ enum class Level;
 }
 
 extern "C" {
-	uint64_t rs_get_loglevel();
+	int64_t rs_get_loglevel();
 	void rs_log(newsboat::Level level, const char* message);
 }
 
 namespace newsboat {
 
 // This has to be in sync with logger::Level in rust/libnewsboat/src/logger.rs
-enum class Level { NONE = 0, USERERROR, CRITICAL, ERROR, WARN, INFO, DEBUG };
+enum class Level { USERERROR = 1, CRITICAL, ERROR, WARN, INFO, DEBUG };
 
 namespace Logger {
 void set_logfile(const std::string& logfile);
 void set_user_error_logfile(const std::string& logfile);
 void set_loglevel(Level l);
+void unset_loglevel();
 
 template<typename... Args>
 void log(Level l, const std::string& format, Args... args)
 {
-	if (l == Level::USERERROR
-		|| static_cast<uint64_t>(l) <= rs_get_loglevel()) {
+	if (static_cast<int64_t>(l) <= rs_get_loglevel()) {
 		rs_log(l, strprintf::fmt(format, args...).c_str());
 	}
 }

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -262,10 +262,12 @@ pub unsafe extern "C" fn rs_cliargsparser_set_log_level(object: *mut c_void) -> 
 
 #[no_mangle]
 pub unsafe extern "C" fn rs_cliargsparser_log_level(object: *mut c_void) -> i8 {
-    with_cliargsparser(object, |o| {
-        match o.log_level {
+    with_cliargsparser(
+        object,
+        |o| match o.log_level {
             Some(l) => l as i8,
-            None => -1 as i8
-        }
-    }, -1)
+            None => -1 as i8,
+        },
+        -1,
+    )
 }

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -1,7 +1,6 @@
 use crate::abort_on_panic;
 use libc::{c_char, c_void};
 use libnewsboat::cliargsparser::CliArgsParser;
-use libnewsboat::logger::Level;
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::panic::{RefUnwindSafe, UnwindSafe};
@@ -262,6 +261,11 @@ pub unsafe extern "C" fn rs_cliargsparser_set_log_level(object: *mut c_void) -> 
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn rs_cliargsparser_log_level(object: *mut c_void) -> u8 {
-    with_cliargsparser(object, |o| o.log_level.unwrap_or(Level::None) as u8, 0)
+pub unsafe extern "C" fn rs_cliargsparser_log_level(object: *mut c_void) -> i8 {
+    with_cliargsparser(object, |o| {
+        match o.log_level {
+            Some(l) => l as i8,
+            None => -1 as i8
+        }
+    }, -1)
 }

--- a/rust/libnewsboat-ffi/src/logger.rs
+++ b/rust/libnewsboat-ffi/src/logger.rs
@@ -19,6 +19,13 @@ pub unsafe extern "C" fn rs_set_loglevel(level: logger::Level) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn rs_unset_loglevel() {
+    abort_on_panic(|| {
+        logger::get_instance().unset_loglevel();
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn rs_set_logfile(logfile: *const c_char) {
     abort_on_panic(|| {
         let logfile = CStr::from_ptr(logfile);
@@ -41,6 +48,6 @@ pub unsafe extern "C" fn rs_set_user_error_logfile(user_error_logfile: *const c_
 }
 
 #[no_mangle]
-pub extern "C" fn rs_get_loglevel() -> u64 {
-    abort_on_panic(|| logger::get_instance().get_loglevel() as u64)
+pub extern "C" fn rs_get_loglevel() -> i64 {
+    abort_on_panic(|| logger::get_instance().get_loglevel() as i64)
 }

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -270,7 +270,7 @@ impl CliArgsParser {
         }
 
         if let Some(log_level_str) = matches.value_of(LOG_LEVEL) {
-            match log_level_str.parse::<i8>() {
+            match log_level_str.parse::<u8>() {
                 Ok(1) => {
                     args.log_level = Some(Level::UserError);
                 }

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -270,7 +270,7 @@ impl CliArgsParser {
         }
 
         if let Some(log_level_str) = matches.value_of(LOG_LEVEL) {
-            match log_level_str.parse::<u8>() {
+            match log_level_str.parse::<i8>() {
                 Ok(1) => {
                     args.log_level = Some(Level::UserError);
                 }

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicIsize, Ordering};
 use std::sync::Mutex;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -16,12 +16,6 @@ use std::sync::Mutex;
 // TODO: remove repr(C) when we finished porting C++ code to Rust.
 #[repr(C)]
 pub enum Level {
-    /// Not important at all, don't log.
-    ///
-    /// This level is purely for Logger's internal use, and shouldn't be passed to log(). That
-    /// isn't enforced in any way, though.
-    None,
-
     /// An error that can potentially be resolved by the user.
     ///
     /// This level should be used for configuration errors and the like.
@@ -58,7 +52,6 @@ pub enum Level {
 impl fmt::Display for Level {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Level::None => write!(f, "NONE"),
             Level::UserError => write!(f, "USERERROR"),
             Level::Critical => write!(f, "CRITICAL"),
             Level::Error => write!(f, "ERROR"),
@@ -66,12 +59,6 @@ impl fmt::Display for Level {
             Level::Info => write!(f, "INFO"),
             Level::Debug => write!(f, "DEBUG"),
         }
-    }
-}
-
-impl Default for Level {
-    fn default() -> Level {
-        Level::None
     }
 }
 
@@ -83,8 +70,7 @@ struct LogFiles {
     /// The file to which all messages at and above `loglevel` will be written.
     logfile: Option<File>,
 
-    /// The file to which all Level::UserError messages will be written if `loglevel` is not
-    /// Level::None.
+    /// The file to which all Level::UserError messages will be written
     user_error_logfile: Option<File>,
 }
 
@@ -125,7 +111,7 @@ pub struct Logger {
     files: Mutex<LogFiles>,
 
     /// Maximum "importance level" of the messages that will be written to the log.
-    loglevel: AtomicUsize,
+    loglevel: AtomicIsize,
 }
 
 impl Logger {
@@ -138,7 +124,7 @@ impl Logger {
                 logfile: None,
                 user_error_logfile: None,
             }),
-            loglevel: AtomicUsize::new(Level::None as usize),
+            loglevel: AtomicIsize::new(-1 as isize),
         }
     }
 
@@ -166,8 +152,6 @@ impl Logger {
     }
 
     /// Specifies the file to which all Level::UserError messages will be written.
-    ///
-    /// The messages will only be written if Logger's loglevel is not Level::None.
     ///
     /// The file will be created if it doesn't exist yet. It will be opened in the append mode, so
     /// its previous contents will stay unchanged.
@@ -197,7 +181,7 @@ impl Logger {
     ///
     /// This method is a wrapper around `log_raw()`.
     pub fn log(&self, level: Level, message: &str) {
-        if level == Level::UserError || level as usize <= self.get_loglevel() {
+        if level as isize <= self.get_loglevel() {
             self.log_raw(level, message.as_bytes())
         }
     }
@@ -234,7 +218,7 @@ impl Logger {
 
         let mut files = self.files.lock().expect("Someone poisoned logger's mutex");
 
-        if level as usize <= self.get_loglevel() {
+        if level as isize <= self.get_loglevel() {
             if let Some(ref mut logfile) = files.logfile {
                 let level = format!("{}: ", level);
 
@@ -261,18 +245,22 @@ impl Logger {
     /// For example, after the call to set_loglevel(Level::Error), only UserError, Critical, and
     /// Error messages will be written.
     ///
-    /// If new level is Level::None, no logs will be written from now on. Otherwise, at least
-    /// error-logfile will be written.
-    ///
+    /// Regardless of the loglevel, at the minimum, error-logfile will be written
+    /// 
     /// Calling this doesn't close already opened logs.
     pub fn set_loglevel(&self, level: Level) {
-        self.loglevel.store(level as usize, Ordering::SeqCst);
+        self.loglevel.store(level as isize, Ordering::SeqCst);
+    }
+
+    /// No logs will be written from now on.
+    pub fn unset_loglevel(&self) {
+        self.loglevel.store(-1 as isize, Ordering::SeqCst);
     }
 
     /// Returns current maximum "importance level" of the messages that will be written to the log.
     ///
     /// For a more detailed explanation, see `set_loglevel()`.
-    pub fn get_loglevel(&self) -> usize {
+    pub fn get_loglevel(&self) -> isize {
         self.loglevel.load(Ordering::Relaxed)
     }
 }
@@ -564,7 +552,7 @@ mod tests {
     fn t_if_curlevel_is_none_nothing_is_logged() {
         let (_tmp, logfile, _error_logfile, logger) = setup_logger().unwrap();
 
-        logger.set_loglevel(Level::None);
+        logger.unset_loglevel();
 
         let levels = vec![
             (Level::UserError, "USERERROR"),
@@ -591,13 +579,6 @@ mod tests {
     fn t_user_errors_are_logged_at_all_curlevels_beside_none() {
         let message = (Level::UserError, "hello".to_string());
 
-        LogLinesCounter::new()
-            .with_messages(vec![message.clone()])
-            .at_levels(vec![Level::None])
-            .expected_log_lines_count(0)
-            .test()
-            .unwrap();
-
         let levels = vec![
             Level::UserError,
             Level::Critical,
@@ -618,7 +599,7 @@ mod tests {
     fn t_critical_msgs_are_logged_at_curlevels_starting_with_critical() {
         let message = (Level::Critical, "hello".to_string());
 
-        let nolog_levels = vec![Level::None, Level::UserError];
+        let nolog_levels = vec![Level::UserError];
         LogLinesCounter::new()
             .with_messages(vec![message.clone()])
             .at_levels(nolog_levels)
@@ -645,7 +626,7 @@ mod tests {
     fn t_error_msgs_are_logged_at_curlevels_starting_with_error() {
         let message = (Level::Error, "hello".to_string());
 
-        let nolog_levels = vec![Level::None, Level::UserError, Level::Critical];
+        let nolog_levels = vec![Level::UserError, Level::Critical];
         LogLinesCounter::new()
             .with_messages(vec![message.clone()])
             .at_levels(nolog_levels)
@@ -666,7 +647,7 @@ mod tests {
     fn t_warning_msgs_are_logged_at_curlevels_starting_with_warning() {
         let message = (Level::Warn, "hello".to_string());
 
-        let nolog_levels = vec![Level::None, Level::UserError, Level::Critical, Level::Error];
+        let nolog_levels = vec![Level::UserError, Level::Critical, Level::Error];
         LogLinesCounter::new()
             .with_messages(vec![message.clone()])
             .at_levels(nolog_levels)
@@ -688,7 +669,6 @@ mod tests {
         let message = (Level::Info, "hello".to_string());
 
         let nolog_levels = vec![
-            Level::None,
             Level::UserError,
             Level::Critical,
             Level::Error,
@@ -715,7 +695,6 @@ mod tests {
         let message = (Level::Debug, "hello".to_string());
 
         let nolog_levels = vec![
-            Level::None,
             Level::UserError,
             Level::Critical,
             Level::Error,
@@ -748,7 +727,6 @@ mod tests {
         let message = (Level::UserError, "hello".to_string());
 
         let log_levels = vec![
-            Level::None,
             Level::UserError,
             Level::Critical,
             Level::Error,
@@ -775,7 +753,6 @@ mod tests {
         ];
 
         let log_levels = vec![
-            Level::None,
             Level::UserError,
             Level::Critical,
             Level::Error,

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -66,6 +66,9 @@ impl fmt::Display for Level {
 ///
 /// This is part of `Logger` struct. This struct is not thread-safe, but in `Logger`, it will be
 /// behind a `Mutex`.
+///
+/// Log messages will only be written if the loglevel in the `Logger` struct is valid.
+/// That is, the loglevel must be equal to one of the enum variants specified above.
 struct LogFiles {
     /// The file to which all messages at and above `loglevel` will be written.
     logfile: Option<File>,
@@ -111,6 +114,7 @@ pub struct Logger {
     files: Mutex<LogFiles>,
 
     /// Maximum "importance level" of the messages that will be written to the log.
+    /// The value -1 is used to disable logging entirely.
     loglevel: AtomicIsize,
 }
 
@@ -152,6 +156,8 @@ impl Logger {
     }
 
     /// Specifies the file to which all Level::UserError messages will be written.
+    ///
+    /// Messages will only be written if the current loglevel is valid.
     ///
     /// The file will be created if it doesn't exist yet. It will be opened in the append mode, so
     /// its previous contents will stay unchanged.
@@ -245,14 +251,12 @@ impl Logger {
     /// For example, after the call to set_loglevel(Level::Error), only UserError, Critical, and
     /// Error messages will be written.
     ///
-    /// Regardless of the loglevel, at the minimum, error-logfile will be written
-    ///
     /// Calling this doesn't close already opened logs.
     pub fn set_loglevel(&self, level: Level) {
         self.loglevel.store(level as isize, Ordering::SeqCst);
     }
 
-    /// No logs will be written from now on.
+    /// Disables Logging entirely.
     pub fn unset_loglevel(&self) {
         self.loglevel.store(-1 as isize, Ordering::SeqCst);
     }

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -66,14 +66,11 @@ impl fmt::Display for Level {
 ///
 /// This is part of `Logger` struct. This struct is not thread-safe, but in `Logger`, it will be
 /// behind a `Mutex`.
-///
-/// Log messages will only be written if the loglevel in the `Logger` struct is valid.
-/// That is, the loglevel must be equal to one of the enum variants specified above.
 struct LogFiles {
     /// The file to which all messages at and above `loglevel` will be written.
     logfile: Option<File>,
 
-    /// The file to which all Level::UserError messages will be written
+    /// The file to which all Level::UserError messages will be written.
     user_error_logfile: Option<File>,
 }
 
@@ -114,7 +111,6 @@ pub struct Logger {
     files: Mutex<LogFiles>,
 
     /// Maximum "importance level" of the messages that will be written to the log.
-    /// The value -1 is used to disable logging entirely.
     loglevel: AtomicIsize,
 }
 
@@ -157,8 +153,6 @@ impl Logger {
 
     /// Specifies the file to which all Level::UserError messages will be written.
     ///
-    /// Messages will only be written if the current loglevel is valid.
-    ///
     /// The file will be created if it doesn't exist yet. It will be opened in the append mode, so
     /// its previous contents will stay unchanged.
     ///
@@ -187,7 +181,7 @@ impl Logger {
     ///
     /// This method is a wrapper around `log_raw()`.
     pub fn log(&self, level: Level, message: &str) {
-        if level as isize <= self.get_loglevel() {
+        if level == Level::UserError || level as isize <= self.get_loglevel() {
             self.log_raw(level, message.as_bytes())
         }
     }
@@ -256,7 +250,7 @@ impl Logger {
         self.loglevel.store(level as isize, Ordering::SeqCst);
     }
 
-    /// Disables Logging entirely.
+    /// Disables Logging (Except for UserError messages).
     pub fn unset_loglevel(&self) {
         self.loglevel.store(-1 as isize, Ordering::SeqCst);
     }
@@ -393,7 +387,7 @@ mod tests {
 
     struct LogLinesCounter {
         messages: Vec<(Level, String)>,
-        levels: Vec<Level>,
+        levels: Vec<Option<Level>>,
         expected_log_lines: Option<usize>,
         expected_errorlog_lines: Option<usize>,
     }
@@ -413,7 +407,7 @@ mod tests {
             self
         }
 
-        pub fn at_levels(mut self, levels: Vec<Level>) -> Self {
+        pub fn at_levels(mut self, levels: Vec<Option<Level>>) -> Self {
             self.levels = levels;
             self
         }
@@ -435,7 +429,11 @@ mod tests {
 
             for level in &self.levels {
                 let (_tmp, logfile, error_logfile, logger) = setup_logger()?;
-                logger.set_loglevel(*level);
+
+                match *level {
+                    Some(l) => logger.set_loglevel(l),
+                    None => logger.unset_loglevel(),
+                };
 
                 for &(level, ref msg) in &self.messages {
                     logger.log(level, msg);
@@ -583,13 +581,20 @@ mod tests {
     fn t_user_errors_are_logged_at_all_curlevels_beside_none() {
         let message = (Level::UserError, "hello".to_string());
 
+        LogLinesCounter::new()
+            .with_messages(vec![message.clone()])
+            .at_levels(vec![None])
+            .expected_log_lines_count(0)
+            .test()
+            .unwrap();
+
         let levels = vec![
-            Level::UserError,
-            Level::Critical,
-            Level::Error,
-            Level::Warn,
-            Level::Info,
-            Level::Debug,
+            Some(Level::UserError),
+            Some(Level::Critical),
+            Some(Level::Error),
+            Some(Level::Warn),
+            Some(Level::Info),
+            Some(Level::Debug),
         ];
         LogLinesCounter::new()
             .with_messages(vec![message])
@@ -603,7 +608,7 @@ mod tests {
     fn t_critical_msgs_are_logged_at_curlevels_starting_with_critical() {
         let message = (Level::Critical, "hello".to_string());
 
-        let nolog_levels = vec![Level::UserError];
+        let nolog_levels = vec![None, Some(Level::UserError)];
         LogLinesCounter::new()
             .with_messages(vec![message.clone()])
             .at_levels(nolog_levels)
@@ -612,11 +617,11 @@ mod tests {
             .unwrap();
 
         let log_levels = vec![
-            Level::Critical,
-            Level::Error,
-            Level::Warn,
-            Level::Info,
-            Level::Debug,
+            Some(Level::Critical),
+            Some(Level::Error),
+            Some(Level::Warn),
+            Some(Level::Info),
+            Some(Level::Debug),
         ];
         LogLinesCounter::new()
             .with_messages(vec![message])
@@ -630,7 +635,7 @@ mod tests {
     fn t_error_msgs_are_logged_at_curlevels_starting_with_error() {
         let message = (Level::Error, "hello".to_string());
 
-        let nolog_levels = vec![Level::UserError, Level::Critical];
+        let nolog_levels = vec![None, Some(Level::UserError), Some(Level::Critical)];
         LogLinesCounter::new()
             .with_messages(vec![message.clone()])
             .at_levels(nolog_levels)
@@ -638,7 +643,12 @@ mod tests {
             .test()
             .unwrap();
 
-        let log_levels = vec![Level::Error, Level::Warn, Level::Info, Level::Debug];
+        let log_levels = vec![
+            Some(Level::Error),
+            Some(Level::Warn),
+            Some(Level::Info),
+            Some(Level::Debug),
+        ];
         LogLinesCounter::new()
             .with_messages(vec![message])
             .at_levels(log_levels)
@@ -651,7 +661,12 @@ mod tests {
     fn t_warning_msgs_are_logged_at_curlevels_starting_with_warning() {
         let message = (Level::Warn, "hello".to_string());
 
-        let nolog_levels = vec![Level::UserError, Level::Critical, Level::Error];
+        let nolog_levels = vec![
+            None,
+            Some(Level::UserError),
+            Some(Level::Critical),
+            Some(Level::Error),
+        ];
         LogLinesCounter::new()
             .with_messages(vec![message.clone()])
             .at_levels(nolog_levels)
@@ -659,7 +674,7 @@ mod tests {
             .test()
             .unwrap();
 
-        let log_levels = vec![Level::Warn, Level::Info, Level::Debug];
+        let log_levels = vec![Some(Level::Warn), Some(Level::Info), Some(Level::Debug)];
         LogLinesCounter::new()
             .with_messages(vec![message])
             .at_levels(log_levels)
@@ -672,7 +687,13 @@ mod tests {
     fn t_info_msgs_are_logged_at_curlevels_starting_with_info() {
         let message = (Level::Info, "hello".to_string());
 
-        let nolog_levels = vec![Level::UserError, Level::Critical, Level::Error, Level::Warn];
+        let nolog_levels = vec![
+            None,
+            Some(Level::UserError),
+            Some(Level::Critical),
+            Some(Level::Error),
+            Some(Level::Warn),
+        ];
         LogLinesCounter::new()
             .with_messages(vec![message.clone()])
             .at_levels(nolog_levels)
@@ -680,7 +701,7 @@ mod tests {
             .test()
             .unwrap();
 
-        let log_levels = vec![Level::Info, Level::Debug];
+        let log_levels = vec![Some(Level::Info), Some(Level::Debug)];
         LogLinesCounter::new()
             .with_messages(vec![message])
             .at_levels(log_levels)
@@ -694,11 +715,12 @@ mod tests {
         let message = (Level::Debug, "hello".to_string());
 
         let nolog_levels = vec![
-            Level::UserError,
-            Level::Critical,
-            Level::Error,
-            Level::Warn,
-            Level::Info,
+            None,
+            Some(Level::UserError),
+            Some(Level::Critical),
+            Some(Level::Error),
+            Some(Level::Warn),
+            Some(Level::Info),
         ];
         LogLinesCounter::new()
             .with_messages(vec![message.clone()])
@@ -709,7 +731,7 @@ mod tests {
 
         LogLinesCounter::new()
             .with_messages(vec![message])
-            .at_levels(vec![Level::Debug])
+            .at_levels(vec![Some(Level::Debug)])
             .expected_log_lines_count(1)
             .test()
             .unwrap();
@@ -726,12 +748,13 @@ mod tests {
         let message = (Level::UserError, "hello".to_string());
 
         let log_levels = vec![
-            Level::UserError,
-            Level::Critical,
-            Level::Error,
-            Level::Warn,
-            Level::Info,
-            Level::Debug,
+            None,
+            Some(Level::UserError),
+            Some(Level::Critical),
+            Some(Level::Error),
+            Some(Level::Warn),
+            Some(Level::Info),
+            Some(Level::Debug),
         ];
         LogLinesCounter::new()
             .with_messages(vec![message])
@@ -752,12 +775,13 @@ mod tests {
         ];
 
         let log_levels = vec![
-            Level::UserError,
-            Level::Critical,
-            Level::Error,
-            Level::Warn,
-            Level::Info,
-            Level::Debug,
+            None,
+            Some(Level::UserError),
+            Some(Level::Critical),
+            Some(Level::Error),
+            Some(Level::Warn),
+            Some(Level::Info),
+            Some(Level::Debug),
         ];
         LogLinesCounter::new()
             .with_messages(messages)

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -19,7 +19,7 @@ pub enum Level {
     /// An error that can potentially be resolved by the user.
     ///
     /// This level should be used for configuration errors and the like.
-    UserError,
+    UserError = 1,
 
     /// An error that prevents program from working at all.
     ///
@@ -246,7 +246,7 @@ impl Logger {
     /// Error messages will be written.
     ///
     /// Regardless of the loglevel, at the minimum, error-logfile will be written
-    /// 
+    ///
     /// Calling this doesn't close already opened logs.
     pub fn set_loglevel(&self, level: Level) {
         self.loglevel.store(level as isize, Ordering::SeqCst);
@@ -668,12 +668,7 @@ mod tests {
     fn t_info_msgs_are_logged_at_curlevels_starting_with_info() {
         let message = (Level::Info, "hello".to_string());
 
-        let nolog_levels = vec![
-            Level::UserError,
-            Level::Critical,
-            Level::Error,
-            Level::Warn,
-        ];
+        let nolog_levels = vec![Level::UserError, Level::Critical, Level::Error, Level::Warn];
         LogLinesCounter::new()
             .with_messages(vec![message.clone()])
             .at_levels(nolog_levels)

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -75,7 +75,7 @@ extern "C" {
 
 	bool rs_cliargsparser_set_log_level(void* rs_cliargsparser);
 
-	unsigned char rs_cliargsparser_log_level(void* rs_cliargsparser);
+	char rs_cliargsparser_log_level(void* rs_cliargsparser);
 }
 
 #define GET_VALUE(NAME, DEFAULT) \
@@ -259,7 +259,7 @@ nonstd::optional<Level> CliArgsParser::log_level() const
 			return nonstd::nullopt;
 		}
 	} else {
-		return Level::NONE;
+		return nonstd::nullopt;
 	}
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -4,6 +4,7 @@ extern "C" {
 	void rs_set_logfile(const char* logfile);
 	void rs_set_user_error_logfile(const char* logfile);
 	void rs_set_loglevel(newsboat::Level level);
+	void rs_unset_loglevel();
 }
 
 namespace newsboat {
@@ -20,6 +21,11 @@ void Logger::set_user_error_logfile(const std::string& logfile)
 void Logger::set_loglevel(Level l)
 {
 	rs_set_loglevel(l);
+}
+
+void Logger::unset_loglevel()
+{
+	rs_unset_loglevel();
 }
 
 } // namespace newsboat

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -224,7 +224,7 @@ void PbController::initialize(int argc, char* argv[])
 			break;
 		case 'l': {
 			Level l = static_cast<Level>(atoi(optarg));
-			if (l > Level::NONE && l <= Level::DEBUG) {
+			if (l >= Level::USERERROR && l <= Level::DEBUG) {
 				Logger::set_loglevel(l);
 			} else {
 				std::cerr << strprintf::fmt(_("%s: %d: invalid "

--- a/test/test-helpers/loggerresetter.cpp
+++ b/test/test-helpers/loggerresetter.cpp
@@ -8,7 +8,7 @@ void reset_logger()
 {
 	::newsboat::Logger::set_logfile("/dev/null");
 	::newsboat::Logger::set_user_error_logfile("/dev/null");
-	::newsboat::Logger::set_loglevel(newsboat::Level::NONE);
+	::newsboat::Logger::unset_loglevel();
 }
 
 LoggerResetter::LoggerResetter()


### PR DESCRIPTION
This PR removes the NONE/None logging level as those enum constants/variants are never used by the client code.