### PR TITLE
Continue loading feeds from external services even when `urls` file can't be opened

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -386,6 +386,11 @@ int Controller::run(const CliArgsParser& args)
 					_("It looks like you haven't configured any "
 						"feeds in your Miniflux account. Please do "
 						"so, and try again."));
+		} else if (type == "ocnews") {
+			msg = strprintf::fmt(
+					_("It looks like you haven't configured any feeds in your "
+						"Owncloud/Nextcloud account. Please do so, and try "
+						"again."));
 		} else {
 			assert(0); // shouldn't happen
 		}

--- a/src/feedhqurlreader.cpp
+++ b/src/feedhqurlreader.cpp
@@ -53,7 +53,8 @@ nonstd::optional<std::string> FeedHqUrlReader::reload()
 	FileUrlReader ur(file);
 	const auto error_message = ur.reload();
 	if (error_message.has_value()) {
-		return error_message;
+		LOG(Level::DEBUG, "Reloading failed: %s", error_message.value());
+		// Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
 	}
 
 	for (const auto& url : ur.get_urls()) {

--- a/src/inoreaderurlreader.cpp
+++ b/src/inoreaderurlreader.cpp
@@ -57,7 +57,8 @@ nonstd::optional<std::string> InoreaderUrlReader::reload()
 	FileUrlReader ur(file);
 	const auto error_message = ur.reload();
 	if (error_message.has_value()) {
-		return error_message;
+		LOG(Level::DEBUG, "Reloading failed: %s", error_message.value());
+		// Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
 	}
 
 	std::vector<std::string>& file_urls(ur.get_urls());

--- a/src/minifluxurlreader.cpp
+++ b/src/minifluxurlreader.cpp
@@ -24,7 +24,8 @@ nonstd::optional<std::string> MinifluxUrlReader::reload()
 	FileUrlReader ur(file);
 	const auto error_message = ur.reload();
 	if (error_message.has_value()) {
-		return error_message;
+		LOG(Level::DEBUG, "Reloading failed: %s", error_message.value());
+		// Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
 	}
 
 	const std::vector<std::string>& file_urls(ur.get_urls());

--- a/src/newsblururlreader.cpp
+++ b/src/newsblururlreader.cpp
@@ -25,7 +25,8 @@ nonstd::optional<std::string> NewsBlurUrlReader::reload()
 	FileUrlReader ur(file);
 	const auto error_message = ur.reload();
 	if (error_message.has_value()) {
-		return error_message;
+		LOG(Level::DEBUG, "Reloading failed: %s", error_message.value());
+		// Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
 	}
 
 	std::vector<std::string>& file_urls(ur.get_urls());

--- a/src/ocnewsurlreader.cpp
+++ b/src/ocnewsurlreader.cpp
@@ -24,7 +24,8 @@ nonstd::optional<std::string> OcNewsUrlReader::reload()
 	FileUrlReader ur(file);
 	const auto error_message = ur.reload();
 	if (error_message.has_value()) {
-		return error_message;
+		LOG(Level::DEBUG, "Reloading failed: %s", error_message.value());
+		// Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
 	}
 
 	std::vector<std::string>& file_urls(ur.get_urls());

--- a/src/oldreaderurlreader.cpp
+++ b/src/oldreaderurlreader.cpp
@@ -54,7 +54,8 @@ nonstd::optional<std::string> OldReaderUrlReader::reload()
 	FileUrlReader ur(file);
 	const auto error_message = ur.reload();
 	if (error_message.has_value()) {
-		return error_message;
+		LOG(Level::DEBUG, "Reloading failed: %s", error_message.value());
+		// Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
 	}
 
 	std::vector<std::string>& file_urls(ur.get_urls());

--- a/src/ttrssurlreader.cpp
+++ b/src/ttrssurlreader.cpp
@@ -24,7 +24,8 @@ nonstd::optional<std::string> TtRssUrlReader::reload()
 	FileUrlReader ur(file);
 	const auto error_message = ur.reload();
 	if (error_message.has_value()) {
-		return error_message;
+		LOG(Level::DEBUG, "Reloading failed: %s", error_message.value());
+		// Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
 	}
 
 	auto& file_urls(ur.get_urls());


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1273.

Tested with a local Nextcloud setup to verify that this actually works (I should have done that before submitting https://github.com/newsboat/newsboat/pull/1269).
