### PR TITLE
Mark items read on remote service when using mark-feed-read in query feed

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -611,6 +611,11 @@ void Controller::mark_all_read(unsigned int pos)
 
 	if (feed->is_query_feed()) {
 		rsscache->mark_all_read(feed);
+		if (api) {
+			for (const auto& item : feed->items()) {
+				api->mark_article_read(item->guid(), true);
+			}
+		}
 	} else {
 		rsscache->mark_all_read(feed->rssurl());
 		if (api) {


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/220.