### PR TITLE
External APIs: Only mark unread items as read

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -610,12 +610,14 @@ void Controller::mark_all_read(unsigned int pos)
 	}
 
 	if (feed->is_query_feed()) {
-		rsscache->mark_all_read(feed);
 		if (api) {
 			for (const auto& item : feed->items()) {
-				api->mark_article_read(item->guid(), true);
+				if (item->unread()) {
+					api->mark_article_read(item->guid(), true);
+				}
 			}
 		}
+		rsscache->mark_all_read(feed);
 	} else {
 		rsscache->mark_all_read(feed->rssurl());
 		if (api) {


### PR DESCRIPTION
@arjan-s at https://github.com/newsboat/newsboat/issues/220#issuecomment-725632690:
> There is one bug in the current code: it also performs the API call for articles that were already marked read. Changing this to only mark unread articles as read would improve the performance a lot.

Good idea, implemented in this PR.
