### PR TITLE
Nextcloud: Allow marking multiple articles as read in single request

### DIFF
--- a/include/ocnewsapi.h
+++ b/include/ocnewsapi.h
@@ -23,7 +23,13 @@ public:
 	void add_custom_headers(curl_slist**) override;
 	rsspp::Feed fetch_feed(const std::string& feed_id);
 
+	void start_batch_operation() override;
+	bool finish_batch_operation() override;
+
 private:
+	bool mark_article_read_single(const std::string& id, bool read);
+	bool mark_article_read_multiple(const std::vector<std::string>& ids);
+
 	typedef std::map<std::string, std::pair<rsspp::Feed, long>> FeedMap;
 	std::string retrieve_auth();
 	bool query(const std::string& query,
@@ -33,6 +39,9 @@ private:
 	std::string auth;
 	std::string server;
 	FeedMap known_feeds;
+
+	bool batch_active;
+	std::vector<std::string> mark_read_queue; // IDs
 };
 
 } // namespace newsboat

--- a/include/remoteapi.h
+++ b/include/remoteapi.h
@@ -32,6 +32,18 @@ public:
 	virtual bool update_article_flags(const std::string& oldflags,
 		const std::string& newflags,
 		const std::string& guid) = 0;
+
+	// start_batch_operation() and finish_batch_operation() can be used to combine multiple mutation requests.
+	// For example, to mark multiple articles as read in a single HTTP request instead of sending separate requests for each item.
+	// Remote APIs are free to ignore the {start,finish}_batch_operation() calls and send requests immediately.
+	virtual void start_batch_operation()
+	{
+	};
+	virtual bool finish_batch_operation()
+	{
+		return true;
+	};
+
 	static const std::string read_password(const std::string& file);
 	static const std::string eval_password(const std::string& cmd);
 	// TODO

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -420,8 +420,9 @@ src/newsblururlreader.o: src/newsblururlreader.cpp \
  include/logger.h
 src/ocnewsapi.o: src/ocnewsapi.cpp include/ocnewsapi.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h
+ include/configactionhandler.h rss/feed.h rss/item.h include/strprintf.h \
+ include/utils.h 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h
 src/ocnewsurlreader.o: src/ocnewsurlreader.cpp include/ocnewsurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/fileurlreader.h \
  include/logger.h config.h include/strprintf.h include/remoteapi.h \

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -611,11 +611,13 @@ void Controller::mark_all_read(unsigned int pos)
 
 	if (feed->is_query_feed()) {
 		if (api) {
+			api->start_batch_operation();
 			for (const auto& item : feed->items()) {
 				if (item->unread()) {
 					api->mark_article_read(item->guid(), true);
 				}
 			}
+			api->finish_batch_operation();
 		}
 		rsscache->mark_all_read(feed);
 	} else {


### PR DESCRIPTION
@arjan-s had another idea for improving performance (https://github.com/newsboat/newsboat/issues/220#issuecomment-725632690):
> Then there is a higher level performance question: is marking every article individually the way to go? Performance-wise it would be much better to use the single API call to mark an entire feed read, like when marking a single feed read.

This PR introduces a way to batch process "mark article read" operations, which is now used when marking query feeds as read.

It uses the `/items/read/multiple` endpoint: [doc](https://github.com/nextcloud/news/blob/05598a7f36a7d4bfc7afb473cc7969ca5d14b55c/docs/externalapi/Legacy.md#user-content-mark-multiple-items-as-read).