### PR TITLE
Store mime-type together with each article's content

### DIFF
--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -13,6 +13,11 @@ namespace newsboat {
 class Cache;
 class RssFeed;
 
+struct Description {
+	std::string text;
+	std::string mime;
+};
+
 class RssItem : public Matchable {
 public:
 	explicit RssItem(Cache* c);
@@ -37,12 +42,15 @@ public:
 	}
 	void set_author(const std::string& a);
 
-	std::string description() const
+	Description description() const
 	{
 		std::lock_guard<std::mutex> guard(description_mutex);
-		return description_.value_or("");
+		if (description_.has_value()) {
+			return description_.value();
+		}
+		return {"", ""};
 	}
-	void set_description(const std::string& d);
+	void set_description(const std::string& content, const std::string& mime_type);
 
 	unsigned int size() const
 	{
@@ -199,7 +207,7 @@ private:
 	bool override_unread_;
 
 	mutable std::mutex description_mutex;
-	nonstd::optional<std::string> description_;
+	nonstd::optional<Description> description_;
 };
 
 } // namespace newsboat

--- a/rss/atomparser.h
+++ b/rss/atomparser.h
@@ -21,6 +21,7 @@ struct AtomParser : public RssParser {
 
 private:
 	Item parse_entry(xmlNode* itemNode);
+	static std::string content_type_to_mime(const std::string& type);
 	const char* ns;
 };
 

--- a/rss/item.h
+++ b/rss/item.h
@@ -19,7 +19,7 @@ public:
 	std::string title_type;
 	std::string link;
 	std::string description;
-	std::string description_type;
+	std::string description_mime_type;
 
 	std::string author;
 	std::string author_email;

--- a/rss/medianamespace.cpp
+++ b/rss/medianamespace.cpp
@@ -36,9 +36,9 @@ void parse_media_node(xmlNode* node, Item& it)
 		if (it.description.empty()) {
 			it.description = get_content(node);
 			if (type == "html") {
-				it.description_type = "html";
+				it.description_mime_type = "text/html";
 			} else {
-				it.description_type = "text";
+				it.description_mime_type = "text/plain";
 			}
 		}
 	} else if (node_is(node, "title", MEDIA_RSS_URI)) {

--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -76,6 +76,7 @@ Item Rss09xParser::parse_item(xmlNode* itemNode)
 				it.base = base;
 			}
 			it.description = get_content(node);
+			it.description_mime_type = "";
 		} else if (node_is(node, "encoded", CONTENT_URI)) {
 			it.content_encoded = get_content(node);
 		} else if (node_is(node, "summary", ITUNES_URI)) {

--- a/rss/rss10parser.cpp
+++ b/rss/rss10parser.cpp
@@ -58,6 +58,7 @@ void Rss10Parser::parse_feed(Feed& f, xmlNode* rootNode)
 						"description",
 						RSS_1_0_NS)) {
 					it.description = get_content(itnode);
+					it.description_mime_type = "";
 				} else if (node_is(itnode, "date", DC_URI)) {
 					it.pubDate = w3cdtf_to_rfc822(
 							get_content(itnode));

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -387,7 +387,10 @@ static const schema_patches schemaPatches{
 
 			"ALTER TABLE rss_item ADD COLUMN content_mime_type VARCHAR(255) NOT NULL DEFAULT \"\";"
 		}
-	}};
+	}
+
+	// Note: schema changes should use the version number of the release that introduced them.
+};
 
 void Cache::populate_tables()
 {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -380,6 +380,13 @@ static const schema_patches schemaPatches{
 
 			"INSERT INTO metadata VALUES ( 2, 11 );"
 		}
+	},
+	{	{2, 22},
+		{
+			"UPDATE metadata SET db_schema_version_major = 2, db_schema_version_minor = 22;",
+
+			"ALTER TABLE rss_item ADD COLUMN content_mime_type VARCHAR(255) NOT NULL DEFAULT \"\";"
+		}
 	}};
 
 void Cache::populate_tables()

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -207,11 +207,11 @@ static int fill_content_callback(void* myfeed,
 	char** /* azColName */)
 {
 	RssFeed* feed = static_cast<RssFeed*>(myfeed);
-	assert(argc == 2);
+	assert(argc == 3);
 	if (argv[0]) {
 		std::shared_ptr<RssItem> item =
 			feed->get_item_by_guid_unlocked(argv[0]);
-		item->set_description(argv[1] ? argv[1] : "");
+		item->set_description(argv[1] ? argv[1] : "", argv[2] ? argv[2] : "");
 	}
 	return 0;
 }
@@ -376,7 +376,7 @@ static const schema_patches schemaPatches{
 		{
 			"CREATE TABLE metadata ( "
 			" db_schema_version_major INTEGER NOT NULL, "
-			" db_schema_version_minor INTEGER NOT NULL );"
+			" db_schema_version_minor INTEGER NOT NULL );",
 
 			"INSERT INTO metadata VALUES ( 2, 11 );"
 		}
@@ -812,6 +812,7 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 			item->guid());
 	CbHandler count_cbh;
 	run_sql(query, count_callback, &count_cbh);
+	const auto description = item->description();
 	if (count_cbh.count() > 0) {
 		if (reset_unread) {
 			std::string content;
@@ -820,13 +821,13 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 					"'%q';",
 					item->guid());
 			run_sql(query, single_string_callback, &content);
-			if (content != item->description()) {
+			if (content != description.text) {
 				LOG(Level::DEBUG,
 					"Cache::update_rssitem_unlocked: '%s' "
 					"is "
 					"different from '%s'",
 					content,
-					item->description());
+					description.text);
 				query = prepare_query(
 						"UPDATE rss_item SET unread = 1 WHERE "
 						"guid = '%q';",
@@ -840,7 +841,7 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 					"UPDATE rss_item "
 					"SET title = '%q', author = '%q', url = '%q', "
 					"feedurl = '%q', "
-					"content = '%q', enclosure_url = '%q', "
+					"content = '%q', content_mime_type = '%q', enclosure_url = '%q', "
 					"enclosure_type = '%q', base = '%q', unread = "
 					"'%d' "
 					"WHERE guid = '%q'",
@@ -848,7 +849,8 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 					item->author(),
 					item->link(),
 					feedurl,
-					item->description(),
+					description.text,
+					description.mime,
 					item->enclosure_url(),
 					item->enclosure_type(),
 					item->get_base(),
@@ -859,14 +861,15 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 					"UPDATE rss_item "
 					"SET title = '%q', author = '%q', url = '%q', "
 					"feedurl = '%q', "
-					"content = '%q', enclosure_url = '%q', "
+					"content = '%q', content_mime_type = '%q', enclosure_url = '%q', "
 					"enclosure_type = '%q', base = '%q' "
 					"WHERE guid = '%q'",
 					item->title(),
 					item->author(),
 					item->link(),
 					feedurl,
-					item->description(),
+					description.text,
+					description.mime,
 					item->enclosure_url(),
 					item->enclosure_type(),
 					item->get_base(),
@@ -877,10 +880,10 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 		std::string insert = prepare_query(
 				"INSERT INTO rss_item (guid, title, author, url, "
 				"feedurl, "
-				"pubDate, content, unread, enclosure_url, "
+				"pubDate, content, content_mime_type, unread, enclosure_url, "
 				"enclosure_type, enqueued, base) "
 				"VALUES "
-				"('%q','%q','%q','%q','%q','%u','%q','%d','%q','%q',%d,"
+				"('%q','%q','%q','%q','%q','%u','%q','%q','%d','%q','%q',%d,"
 				" "
 				"'%q')",
 				item->guid(),
@@ -889,7 +892,8 @@ void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,
 				item->link(),
 				feedurl,
 				item->pubDate_timestamp(),
-				item->description(),
+				description.text,
+				description.mime,
 				(item->unread() ? 1 : 0),
 				item->enclosure_url(),
 				item->enclosure_type(),
@@ -1102,7 +1106,7 @@ void Cache::fetch_descriptions(RssFeed* feed)
 	const std::string in_clause = utils::join(guids, ", ");
 
 	const std::string query = prepare_query(
-			"SELECT guid, content FROM rss_item WHERE guid IN (%s);",
+			"SELECT guid, content, content_mime_type FROM rss_item WHERE guid IN (%s);",
 			in_clause);
 
 	run_sql(query, fill_content_callback, feed);

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -302,7 +302,8 @@ bool ItemListFormAction::process_operation(Operation op,
 						: visible_items[itempos]
 						.first->feedurl();
 					rnd.render(
-						utils::utf8_to_locale(visible_items[itempos].first->description()),
+						// TODO: Take mime-type into account
+						utils::utf8_to_locale(visible_items[itempos].first->description().text),
 						lines,
 						links,
 						baseurl);

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -302,7 +302,6 @@ bool ItemListFormAction::process_operation(Operation op,
 						: visible_items[itempos]
 						.first->feedurl();
 					rnd.render(
-						// TODO: Take mime-type into account
 						utils::utf8_to_locale(visible_items[itempos].first->description().text),
 						lines,
 						links,

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -139,7 +139,8 @@ std::string item_renderer::to_plain_text(
 
 	prepare_header(item, lines, links, true);
 	const auto base = get_item_base_link(item);
-	render_html(cfg, utils::utf8_to_locale(item->description()), lines, links,
+	// TODO: Take mime-type into account
+	render_html(cfg, utils::utf8_to_locale(item->description().text), lines, links,
 		base, true);
 
 	TextFormatter txtfmt;
@@ -166,7 +167,8 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 
 	prepare_header(item, lines, links);
 	const std::string baseurl = get_item_base_link(item);
-	const auto body = utils::utf8_to_locale(item->description());
+	// TODO: Take mime-type into account
+	const auto body = utils::utf8_to_locale(item->description().text);
 	render_html(cfg, body, lines, links, baseurl, false);
 
 	TextFormatter txtfmt;
@@ -209,7 +211,7 @@ std::pair<std::string, size_t> item_renderer::source_to_stfl_list(
 
 	prepare_header(item, lines, links);
 	render_source(lines, utils::quote_for_stfl(utils::utf8_to_locale(
-				item->description())));
+				item->description().text)));
 
 	TextFormatter txtfmt;
 	txtfmt.add_lines(lines);

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -139,7 +139,6 @@ std::string item_renderer::to_plain_text(
 
 	prepare_header(item, lines, links, true);
 	const auto base = get_item_base_link(item);
-	// TODO: Take mime-type into account
 	render_html(cfg, utils::utf8_to_locale(item->description().text), lines, links,
 		base, true);
 
@@ -167,7 +166,6 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 
 	prepare_header(item, lines, links);
 	const std::string baseurl = get_item_base_link(item);
-	// TODO: Take mime-type into account
 	const auto body = utils::utf8_to_locale(item->description().text);
 	render_html(cfg, body, lines, links, baseurl, false);
 

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -46,10 +46,11 @@ void RssItem::set_author(const std::string& a)
 	author_ = a;
 }
 
-void RssItem::set_description(const std::string& d)
+void RssItem::set_description(const std::string& content,
+	const std::string& mime_type)
 {
 	std::lock_guard<std::mutex> guard(description_mutex);
-	description_ = d;
+	description_ = {content, mime_type};
 }
 
 void RssItem::set_size(unsigned int size)
@@ -149,7 +150,8 @@ nonstd::optional<std::string> RssItem::attribute_value(const std::string&
 		ScopeMeasure sm("RssItem::attribute_value(\"content\")");
 		std::lock_guard<std::mutex> guard(description_mutex);
 		if (description_.has_value()) {
-			return utils::utf8_to_locale(description_.value());
+			const std::string content = description_.value().text;
+			return utils::utf8_to_locale(content);
 		} else if (ch) {
 			std::string description = ch->fetch_description(*this);
 			return utils::utf8_to_locale(description);

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -518,7 +518,9 @@ void RssParser::set_item_content(std::shared_ptr<RssItem> x,
 				HTTPMethod::GET, easyhandle);
 		std::string content_mime_type;
 
-		// Determine mime-type
+		// Determine mime-type based on Content-type header:
+		// Content-type: https://tools.ietf.org/html/rfc7231#section-3.1.1.5
+		// Format: https://tools.ietf.org/html/rfc7231#section-3.1.1.1
 		char* value = nullptr;
 		curl_easy_getinfo(easyhandle, CURLINFO_CONTENT_TYPE, &value);
 		if (value != nullptr) {

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -51,7 +51,7 @@ TEST_CASE("Cleaning old articles works", "[Cache]")
 	item->set_link("http://example.com/item");
 	item->set_guid("http://example.com/item");
 	item->set_author("Newsboat Testsuite");
-	item->set_description("");
+	item->set_description("", "");
 	item->set_pubDate(time(nullptr)); // current time
 	item->set_unread(true);
 	feed->add_item(item);
@@ -355,13 +355,13 @@ TEST_CASE("fetch_descriptions fills out feed item's descriptions", "[Cache]")
 	rsscache.externalize_rssfeed(feed, false);
 
 	for (auto& item : feed->items()) {
-		item->set_description("your test failed!");
+		item->set_description("your test failed!", "text/plain");
 	}
 
 	REQUIRE_NOTHROW(rsscache.fetch_descriptions(feed.get()));
 
 	for (auto& item : feed->items()) {
-		REQUIRE(item->description() != "your test failed!");
+		REQUIRE(item->description().text != "your test failed!");
 	}
 }
 
@@ -676,7 +676,8 @@ TEST_CASE(
 			REQUIRE((*fst_it)->title() == (*snd_it)->title());
 			REQUIRE((*fst_it)->link() == (*snd_it)->link());
 			REQUIRE((*fst_it)->author() == (*snd_it)->author());
-			REQUIRE((*fst_it)->description() == (*snd_it)->description());
+			REQUIRE((*fst_it)->description().text == (*snd_it)->description().text);
+			REQUIRE((*fst_it)->description().mime == (*snd_it)->description().mime);
 			REQUIRE((*fst_it)->size() == (*snd_it)->size());
 			REQUIRE((*fst_it)->length() == (*snd_it)->length());
 			REQUIRE((*fst_it)->pubDate() == (*snd_it)->pubDate());
@@ -851,7 +852,7 @@ TEST_CASE(
 	feed->load();
 	REQUIRE_FALSE(feed->items()[0]->unread());
 	feed->items()[0]->set_unread_nowrite(true);
-	feed->items()[0]->set_description("changed!");
+	feed->items()[0]->set_description("changed!", "text/plain");
 
 	SECTION("reset_unread = false; item remains read") {
 		rsscache->externalize_rssfeed(feed, false);

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -48,7 +48,7 @@ TEST_CASE("OP_OPEN displays article using an external pager",
 	item->set_link(test_url);
 	item->set_title(test_title);
 	item->set_author(test_author);
-	item->set_description(test_description);
+	item->set_description(test_description, "text/plain");
 	item->set_pubDate(test_pubDate);
 	item->set_unread(true);
 	feed->add_item(item);
@@ -406,7 +406,7 @@ TEST_CASE("OP_SHOWURLS shows the article's properties", "[ItemListFormAction]")
 	item->set_link(test_url);
 	item->set_title(test_title);
 	item->set_author(test_author);
-	item->set_description(test_description);
+	item->set_description(test_description, "text/plain");
 	item->set_pubDate(test_pubDate);
 	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
 
@@ -611,7 +611,7 @@ TEST_CASE("OP_SAVE writes an article's attributes to the specified file",
 	item->set_title(test_title);
 	item->set_author(test_author);
 	item->set_pubDate(test_pubDate);
-	item->set_description(test_description);
+	item->set_description(test_description, "text/plain");
 
 	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
 
@@ -801,7 +801,7 @@ TEST_CASE("OP_PIPE_TO pipes an article's content to an external command",
 	item->set_title(test_title);
 	item->set_author(test_author);
 	item->set_pubDate(test_pubDate);
-	item->set_description(test_description);
+	item->set_description(test_description, "text/plain");
 
 	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
 

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -72,7 +72,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 	std::tie(item, feed) = create_test_item(&rsscache);
 
 	SECTION("Item without an enclosure") {
-		item->set_description(ITEM_DESCRIPTON);
+		item->set_description(ITEM_DESCRIPTON, "text/html");
 
 		const auto result = item_renderer::to_plain_text(cfg, item);
 
@@ -90,7 +90,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 	}
 
 	SECTION("Item with an enclosure") {
-		item->set_description(ITEM_DESCRIPTON);
+		item->set_description(ITEM_DESCRIPTON, "text/html");
 		item->set_enclosure_url(ITEM_ENCLOSURE_URL);
 
 		const auto result = item_renderer::to_plain_text(cfg, item);
@@ -110,7 +110,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 	}
 
 	SECTION("Item with an enclosure that has a MIME type") {
-		item->set_description(ITEM_DESCRIPTON);
+		item->set_description(ITEM_DESCRIPTON, "text/html");
 		item->set_enclosure_url(ITEM_ENCLOSURE_URL);
 		item->set_enclosure_type(ITEM_ENCLOSURE_TYPE);
 
@@ -134,7 +134,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 	SECTION("Item with some links in the description") {
 		item->set_description(
 			ITEM_DESCRIPTON +
-			"<p>See also <a href='https://example.com'>this site</a>.</p>");
+			"<p>See also <a href='https://example.com'>this site</a>.</p>", "text/html");
 
 		const auto result = item_renderer::to_plain_text(cfg, item);
 
@@ -176,7 +176,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 		"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
 		"Pellentesque nisl massa, luctus ut ligula vitae, suscipit tempus "
 		"velit. Vivamus sodales, quam in convallis posuere, libero nisi "
-		"ultricies orci, nec lobortis.");
+		"ultricies orci, nec lobortis.", "text/html");
 
 	const auto header = std::string() +
 		"Feed: " + FEED_TITLE + '\n' +
@@ -253,7 +253,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 		item->set_description(
 			"&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;&lt;" // 10 characters
 			"&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;" // 10 characters
-			"Lorem ipsum dolor sit amet");
+			"Lorem ipsum dolor sit amet", "text/html");
 
 		const auto result = item_renderer::to_plain_text(cfg, item);
 
@@ -282,7 +282,7 @@ TEST_CASE("to_plain_text() does not escape '<' and '>' in header and body",
 	feed->set_title("<" + FEED_TITLE + ">");
 	item->set_title("<" + ITEM_TITLE + ">");
 	item->set_author("<" + ITEM_AUTHOR + ">");
-	item->set_description("&lt;test&gt;");
+	item->set_description("&lt;test&gt;", "text/html");
 
 	const auto expected = std::string() +
 		"Feed: <" + FEED_TITLE + ">\n" +
@@ -379,7 +379,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 	}
 
 	SECTION("Item without an enclosure") {
-		item->set_description(ITEM_DESCRIPTON);
+		item->set_description(ITEM_DESCRIPTON, "text/html");
 
 		const auto result = item_renderer::to_plain_text(cfg, item);
 
@@ -432,7 +432,7 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 		const auto description = std::string() +
 			"<p>Hello, world! Check out "
 			"<a href='https://example.com'>our site</a>.</p>";
-		item->set_description(description);
+		item->set_description(description, "text/html");
 
 		SECTION("internal renderer") {
 			cfg.set_configvalue("html-renderer", "internal");
@@ -481,7 +481,7 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 		const auto description = std::string() +
 			"<p>Hello, world!</p>\n\n"
 			"<p>Check out <a href='https://example.com'>our site</a>.</p>";
-		item->set_description(description);
+		item->set_description(description, "text/html");
 
 		SECTION("internal renderer") {
 			cfg.set_configvalue("html-renderer", "internal");
@@ -616,7 +616,7 @@ TEST_CASE("Functions used for rendering articles escape '<' into `<>` for use wi
 	feed->set_title("<" + FEED_TITLE + ">");
 	item->set_title("<" + ITEM_TITLE + ">");
 	item->set_author("<" + ITEM_AUTHOR + ">");
-	item->set_description("<html>&lt;test&gt;</html>");
+	item->set_description("<html>&lt;test&gt;</html>", "text/html");
 
 	SECTION("to_stfl_list()") {
 		const auto expected = std::string() +

--- a/test/rssitem.cpp
+++ b/test/rssitem.cpp
@@ -115,7 +115,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 		const auto attr = "content";
 
 		const auto description = "First line.\nSecond one.\nAnd finally the third";
-		item.set_description(description);
+		item.set_description(description, "text/plain");
 
 		REQUIRE(item.attribute_value(attr) == description);
 
@@ -137,7 +137,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 
 			const auto description = "こんにちは"; // "good afternoon"
 
-			item.set_description(description);
+			item.set_description(description, "text/plain");
 
 			REQUIRE_FALSE(item.attribute_value(attr) == description);
 		}

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -235,27 +235,27 @@ TEST_CASE("Extracts data from media:... tags in atom feed", "[rsspp::Parser]")
 	REQUIRE(f.items.size() == 5u);
 	REQUIRE(f.items[0].title == "using regular content");
 	REQUIRE(f.items[0].description == "regular html content");
-	REQUIRE(f.items[0].description_type == "html");
+	REQUIRE(f.items[0].description_mime_type == "text/html");
 
 	REQUIRE(f.items[1].title == "using media:description");
 	REQUIRE(f.items[1].description == "media plaintext content");
-	REQUIRE(f.items[1].description_type == "text");
+	REQUIRE(f.items[1].description_mime_type == "text/plain");
 
 	REQUIRE(f.items[2].title == "using multiple media tags");
 	REQUIRE(f.items[2].description == "media html content");
-	REQUIRE(f.items[2].description_type == "html");
+	REQUIRE(f.items[2].description_mime_type == "text/html");
 	REQUIRE(f.items[2].link == "http://example.com/player.html");
 
 	REQUIRE(f.items[3].title ==
 		"using multiple media tags nested in group/content");
 	REQUIRE(f.items[3].description == "nested media html content");
-	REQUIRE(f.items[3].description_type == "html");
+	REQUIRE(f.items[3].description_mime_type == "text/html");
 	REQUIRE(f.items[3].link == "http://example.com/player.html");
 
 	SECTION("media:{title,description,player} does not overwrite regular title, description, and link if they exist") {
 		REQUIRE(f.items[4].title == "regular title");
 		REQUIRE(f.items[4].description == "regular content");
-		REQUIRE(f.items[4].description_type == "html");
+		REQUIRE(f.items[4].description_mime_type == "text/html");
 		REQUIRE(f.items[4].link == "http://example.com/regular-link");
 	}
 }
@@ -276,12 +276,12 @@ TEST_CASE("Extracts data from media:... tags in  RSS 2.0 feeds",
 
 	REQUIRE(f.items[0].title == "using multiple media tags");
 	REQUIRE(f.items[0].description == "media html content");
-	REQUIRE(f.items[0].description_type == "html");
+	REQUIRE(f.items[0].description_mime_type == "text/html");
 	REQUIRE(f.items[0].link == "http://example.com/player.html");
 
 	REQUIRE(f.items[1].title ==
 		"using multiple media tags nested in group/content");
 	REQUIRE(f.items[1].description == "nested media html content");
-	REQUIRE(f.items[1].description_type == "html");
+	REQUIRE(f.items[1].description_mime_type == "text/html");
 	REQUIRE(f.items[1].link == "http://example.com/player.html");
 }


### PR DESCRIPTION
This can be used as part of a solution for:
- https://github.com/newsboat/newsboat/issues/468
- https://github.com/newsboat/newsboat/issues/1010
- https://github.com/newsboat/newsboat/issues/1022
- https://github.com/newsboat/newsboat/issues/1176 (maybe related)

Fixing the above issues might require per-feed `text-width` configuration.