### PR TITLE
Nextcloud: Mark multiple items read in single request

### DIFF
--- a/include/ocnewsapi.h
+++ b/include/ocnewsapi.h
@@ -17,6 +17,7 @@ public:
 	std::vector<TaggedFeedUrl> get_subscribed_urls() override;
 	bool mark_all_read(const std::string& feedurl) override;
 	bool mark_article_read(const std::string& guid, bool read) override;
+	bool mark_articles_read(const std::vector<std::string>& guids) override;
 	bool update_article_flags(const std::string& oldflags,
 		const std::string& newflags,
 		const std::string& guid) override;

--- a/include/remoteapi.h
+++ b/include/remoteapi.h
@@ -29,6 +29,7 @@ public:
 	virtual void add_custom_headers(curl_slist** custom_headers) = 0;
 	virtual bool mark_all_read(const std::string& feedurl) = 0;
 	virtual bool mark_article_read(const std::string& guid, bool read) = 0;
+	virtual bool mark_articles_read(const std::vector<std::string>& guids);
 	virtual bool update_article_flags(const std::string& oldflags,
 		const std::string& newflags,
 		const std::string& guid) = 0;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -611,11 +611,13 @@ void Controller::mark_all_read(unsigned int pos)
 
 	if (feed->is_query_feed()) {
 		if (api) {
+			std::vector<std::string> item_guids;
 			for (const auto& item : feed->items()) {
 				if (item->unread()) {
-					api->mark_article_read(item->guid(), true);
+					item_guids.push_back(item->guid());
 				}
 			}
+			api->mark_articles_read(item_guids);
 		}
 		rsscache->mark_all_read(feed);
 	} else {

--- a/src/remoteapi.cpp
+++ b/src/remoteapi.cpp
@@ -9,6 +9,17 @@
 
 namespace newsboat {
 
+bool RemoteApi::mark_articles_read(const std::vector<std::string>& guids)
+{
+	bool success = true;
+	for (const auto& guid : guids) {
+		if (!this->mark_article_read(guid, true)) {
+			success = false;
+		}
+	}
+	return success;
+}
+
 const std::string RemoteApi::read_password(const std::string& file)
 {
 	glob_t exp;


### PR DESCRIPTION
Supersedes https://github.com/newsboat/newsboat/pull/1283, using @Minoru's idea https://github.com/newsboat/newsboat/pull/1283#issuecomment-726965670:
> I also wonder if it would make more sense to add mark_all_read() to RemoteAPI. We can provide a default implementation that calls mark_read() in a loop, and OcNewsApi can provide an optimized implementation. This neatly avoids the problem with shared state.