### PR TITLE
Modify option set for single conflict case while saving feeds

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1553,8 +1553,7 @@ void ItemListFormAction::handle_op_saveall()
 				} else {
 					c = v->confirm(strprintf::fmt(
 								_("Overwrite `%s' in `%s'? "
-									"There are no more conflicts like this "
-									"(y:Yes a:Yes to all n:No q:No to all)"),
+									"(y:Yes n:No)"),
 								filename, directory),
 							input_options);
 				}


### PR DESCRIPTION
Pull request which aims to fix https://github.com/newsboat/newsboat/issues/657

Remove `yes to all` and `no to all` option when only one single file is found as candidate for conflict while saving feeds.

Although, the new conflict prompt still allows usage of `a` and `q` option, it will not create any undesired side effects. Therefore, I did not handle key press event in both branches and thereby keep the implementation simple.

Thanks @Minoru for providing a detailed instruction about how to reproduce this issue.
