### PR TITLE
Bugfix/issue 1292

### DIFF
--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -29,12 +29,6 @@ public:
 	void prepare() override;
 	void init() override;
 
-	void set_redraw(bool b) override
-	{
-		FormAction::set_redraw(b);
-		invalidate_everything();
-	}
-
 	void set_feed(std::shared_ptr<RssFeed> fd);
 
 	std::string id() const override
@@ -74,6 +68,10 @@ public:
 	}
 
 	void recalculate_form() override;
+	void set_should_update_list()
+	{
+		should_update_list = true;
+	}
 
 private:
 	void register_format_styles();
@@ -145,6 +143,7 @@ private:
 	RegexManager& rxman;
 
 	unsigned int old_width;
+	bool should_update_list;
 	int old_itempos;
 	nonstd::optional<ArticleSortStrategy> old_sort_strategy;
 

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -67,10 +67,11 @@ public:
 		search_phrase = s;
 	}
 
-	void set_should_update_list()
+	void invalidate_list()
 	{
-		should_update_list = true;
+		invalidation_mode = InvalidationMode::COMPLETE;
 	}
+
 	void restore_selected_position();
 
 private:
@@ -102,11 +103,6 @@ private:
 	std::string gen_flags(std::shared_ptr<RssItem> item);
 
 	void prepare_set_filterpos();
-
-	void invalidate_everything()
-	{
-		invalidation_mode = InvalidationMode::COMPLETE;
-	}
 
 	void invalidate(const unsigned int invalidated_pos)
 	{
@@ -143,7 +139,6 @@ private:
 	RegexManager& rxman;
 
 	unsigned int old_width;
-	bool should_update_list;
 	int old_itempos;
 	nonstd::optional<ArticleSortStrategy> old_sort_strategy;
 

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -67,11 +67,11 @@ public:
 		search_phrase = s;
 	}
 
-	void recalculate_form() override;
 	void set_should_update_list()
 	{
 		should_update_list = true;
 	}
+	void restore_selected_position();
 
 private:
 	void register_format_styles();

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -341,19 +341,20 @@ src/itemviewformaction.o: src/itemviewformaction.cpp \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h include/textviewwidget.h config.h \
  include/confighandlerexception.h include/dbexception.h \
- include/fmtstrformatter.h include/itemrenderer.h include/htmlrenderer.h \
- include/logger.h include/strprintf.h include/rssfeed.h \
- include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
- include/utils.h include/configcontainer.h include/logger.h \
+ include/fmtstrformatter.h include/itemlistformaction.h \
+ 3rd-party/optional.hpp include/listformaction.h include/listwidget.h \
+ include/listformatter.h include/view.h include/colormanager.h \
+ include/configcontainer.h include/controller.h include/cache.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/filebrowserformaction.h include/itemrenderer.h \
+ include/htmlrenderer.h include/logger.h include/strprintf.h \
+ include/rssfeed.h include/utils.h include/logger.h \
  include/scopemeasure.h include/strprintf.h include/textformatter.h \
- include/utils.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/dirbrowserformaction.h include/listformatter.h \
- include/listwidget.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h
+ include/utils.h include/view.h
 src/keymap.o: src/keymap.cpp include/keymap.h include/configparser.h \
  include/configactionhandler.h config.h include/confighandlerexception.h \
  include/logger.h include/strprintf.h include/strprintf.h include/utils.h \

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1336,22 +1336,21 @@ int ItemListFormAction::get_pos(unsigned int realidx)
 	return -1;
 }
 
-void ItemListFormAction::recalculate_form()
+void ItemListFormAction::restore_selected_position()
 {
-	FormAction::recalculate_form();
-	invalidate_everything();
-
+	// If the old position was set and it is less than the current itempos, use
+	// it for the feed's itempos.
+	// This corrects a problem which occurs when you open an article, move to
+	// the next article (one or more times), and then exit to the itemlist. If
+	// `"show-read-articles" == false`, the itempos would be "wrong" without
+	// this fix.
 	const unsigned int itempos = list.get_position();
-
-	// If the old position was set and it is less than the itempos, use it
-	// for the feed's itempos Correct the problem when you open itemview and
-	// jump to next then exit to itemlist and the itempos is wrong This only
-	// applies when "show-read-articles" is set to false
 	if ((old_itempos != -1) && itempos > (unsigned int)old_itempos &&
 		!cfg->get_configvalue_as_bool("show-read-articles")) {
 		list.set_position(old_itempos);
 		old_itempos = -1; // Reset
 	}
+
 }
 
 void ItemListFormAction::save_article(const std::string& filename,

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -36,6 +36,7 @@ ItemListFormAction::ItemListFormAction(View* vv,
 	, filterpos(0)
 	, rxman(r)
 	, old_width(0)
+	, should_update_list(true)
 	, old_itempos(-1)
 	, invalidation_mode(InvalidationMode::NONE)
 	, listfmt(&rxman, "articlelist")
@@ -977,6 +978,11 @@ void ItemListFormAction::prepare()
 {
 	std::lock_guard<std::mutex> mtx(redraw_mtx);
 
+	if (should_update_list) {
+		invalidate_everything();
+		should_update_list = false;
+	}
+
 	const auto sort_strategy = cfg->get_article_sort_strategy();
 	if (!old_sort_strategy || sort_strategy != *old_sort_strategy) {
 		feed->sort(sort_strategy);
@@ -1007,7 +1013,7 @@ void ItemListFormAction::prepare()
 
 	const unsigned int width = list.get_width();
 
-	if (old_width != width) {
+	if (do_redraw || old_width != width) {
 		invalidate_everything();
 		old_width = width;
 	}

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -476,6 +476,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 			(get_parent_formaction());
 		if (parent_itemlist != nullptr) {
 			parent_itemlist->set_should_update_list();
+			parent_itemlist->restore_selected_position();
 		}
 	}
 

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -8,6 +8,7 @@
 #include "confighandlerexception.h"
 #include "dbexception.h"
 #include "fmtstrformatter.h"
+#include "itemlistformaction.h"
 #include "itemrenderer.h"
 #include "htmlrenderer.h"
 #include "logger.h"
@@ -470,6 +471,12 @@ bool ItemViewFormAction::process_operation(Operation op,
 		}
 	} else if (quit) {
 		v->pop_current_formaction();
+
+		auto parent_itemlist = std::dynamic_pointer_cast<ItemListFormAction>
+			(get_parent_formaction());
+		if (parent_itemlist != nullptr) {
+			parent_itemlist->set_should_update_list();
+		}
 	}
 
 	update_percent();

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -475,7 +475,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 		auto parent_itemlist = std::dynamic_pointer_cast<ItemListFormAction>
 			(get_parent_formaction());
 		if (parent_itemlist != nullptr) {
-			parent_itemlist->set_should_update_list();
+			parent_itemlist->invalidate_list();
 			parent_itemlist->restore_selected_position();
 		}
 	}

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -668,6 +668,7 @@ void View::notify_itemlist_change(std::shared_ptr<RssFeed> feed)
 					f->rssurl() == feed->rssurl()) {
 					itemlist->set_feed(feed);
 					itemlist->set_redraw(true);
+					itemlist->set_should_update_list();
 				}
 			}
 		}

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -668,7 +668,7 @@ void View::notify_itemlist_change(std::shared_ptr<RssFeed> feed)
 					f->rssurl() == feed->rssurl()) {
 					itemlist->set_feed(feed);
 					itemlist->set_redraw(true);
-					itemlist->set_should_update_list();
+					itemlist->invalidate_list();
 				}
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1292.

It looks like the ItemList is the only FormAction with issues related to `do_redraw`.
I did create some commits to make the different redraw reasons more obvious in other FormActions as well: https://github.com/newsboat/newsboat/compare/master...dennisschagt:feature/split-redraw-update-reasons
If you want I can submit a PR for those (or include those commits in this PR).

I created a test to verify the interaction with `open-in-browser`: https://github.com/newsboat/newsboat/compare/master...dennisschagt:test/issue-1292.
It has some issues so I didn't include it in this PR.
The main issue is that multiple `Stfl::reset()` calls are needed because otherwise Catch error output is not visible.