### PR TITLE
Move i18nspector job from Travis to Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -400,3 +400,18 @@ asciidoctor_warnings_task:
         ASCIIDOCTOR_OPTS: '--failure-level WARN'
 
     script: make doc
+
+i18nspector_task:
+    name: .po files
+
+    container:
+      cpu: 1
+      memory: 512MB
+      dockerfile: docker/i18nspector.dockerfile
+
+    # `tee` displays the output of `i18nspector`, but also store it in the file
+    # for later analysis. `egrep` returns exit code 0 if it finds something,
+    # and 1 otherwise. We need the opposite, so we negate the exit code using
+    # an exclamation mark. This fails the build if the log contains errors or
+    # warnings.
+    script: make run-i18nspector | tee i18nspector.log && ! egrep --silent "^(E|W):" i18nspector.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ matrix:
       env:
         - COMPILER=clang++-11
         - PROFILE=1
-        - REPORT_COVERAGE=yes
       before_install:
         - cargo install grcov
 
@@ -46,13 +45,6 @@ matrix:
         - export CARGO_INCREMENTAL=0
         - export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
         - export RUSTDOCFLAGS="-Cpanic=abort"
-    - name: "i18nspector"
-      addons:
-        apt:
-          packages:
-            - i18nspector
-      env:
-        - CHECKS=i18nspector
 
 install:
   - export CXX=$COMPILER
@@ -64,10 +56,9 @@ script:
   # stuff. To maximize the benefits, we ask Make to process as many rules as
   # possible before failing. This enables developers to fix more errors before
   # re-submitting the code to CI, which should increase throughput.
-  - if [ -z "$CHECKS" ]; then   make -j2 --keep-going all test   ; fi
-  - if [ -z "$CHECKS" ]; then   make ci-check   ; fi
-  - if [ "$CHECKS" = "i18nspector" ]; then   make run-i18nspector | tee i18nspector.log && if `egrep '^(E|W):' i18nspector.log >/dev/null 2>&1` ; then false else true; fi   ; fi
+  - make -j2 --keep-going all test
+  - make ci-check
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR}
-  - if [ -n "${REPORT_COVERAGE}" ]; then   ./submit-to-coveralls.sh   ; fi
+  - ./submit-to-coveralls.sh

--- a/docker/i18nspector.dockerfile
+++ b/docker/i18nspector.dockerfile
@@ -1,0 +1,30 @@
+# This image contains i18nspector, a tool we use to check our
+# internationalization files (*.po).
+#
+# Build:
+#
+#   docker build \
+#       --tag=newsboat-i18nspector \
+#       --file=docker/i18nspector.dockerfile \
+#       docker
+#
+# Run on your local files:
+#
+#   docker run \
+#       --rm \
+#       --mount type=bind,source=$(pwd),target=/workdir \
+#       newsboat-i18nspector \
+#       make run-i18nspector
+#
+# On continuous integration, we fail a build if i18nspector prints out any
+# errors or warnings (lines that start with "E:" and "W:").
+
+FROM ubuntu:20.10
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+    && apt-get upgrade --assume-yes \
+    && apt-get install --assume-yes --no-install-recommends i18nspector make
+
+WORKDIR /workdir


### PR DESCRIPTION
This brings us one step closer to ditching Travis entirely. Cirrus CI, with its built-in handling of Dockerfiles, is just perfect.

I'm already working on moving the Coveralls job as well, so I'll merge this PR after just one day. Reviews and comments are still welcome though!