### PR TITLE
Use flushinp() instead of ignoring input events one-by-one

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -57,7 +57,7 @@ public:
 		return keys;
 	}
 	void set_tags(const std::vector<std::string>& t);
-	void drop_queued_input(Stfl::Form& form);
+	void drop_queued_input();
 	void pop_current_formaction();
 	void remove_formaction(unsigned int pos);
 	void set_current_formaction(unsigned int pos);
@@ -73,7 +73,7 @@ public:
 	void push_itemview(std::shared_ptr<RssFeed> f,
 		const std::string& guid,
 		const std::string& searchphrase = "");
-	std::shared_ptr<FormAction> push_empty_formaction();
+	void push_empty_formaction();
 	void push_help();
 	void push_urlview(const std::vector<LinkPair>& links,
 		std::shared_ptr<RssFeed>& feed);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -795,10 +795,10 @@ void Controller::edit_urls_file()
 			editor,
 			utils::replace_all(configpaths.url_file(), "\"", "\\\""));
 
-	auto form_action = v->push_empty_formaction();
+	v->push_empty_formaction();
 	Stfl::reset();
 	utils::run_interactively(cmdline, "Controller::edit_urls_file");
-	v->drop_queued_input(form_action->get_form());
+	v->drop_queued_input();
 
 	v->pop_current_formaction();
 

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -568,10 +568,10 @@ std::string FormAction::bookmark(const std::string& url,
 		LOG(Level::DEBUG, "FormAction::bookmark: cmd = %s", cmdline);
 
 		if (is_interactive) {
-			auto form_action = v->push_empty_formaction();
+			v->push_empty_formaction();
 			Stfl::reset();
 			utils::run_interactively(cmdline, "FormAction::bookmark");
-			v->drop_queued_input(form_action->get_form());
+			v->drop_queued_input();
 			v->pop_current_formaction();
 			return "";
 		} else {

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -804,7 +804,7 @@ void ItemListFormAction::finished_qna(Operation op)
 			std::ostringstream ostr;
 			v->get_ctrl()->write_item(
 				visible_items[itempos].first, ostr);
-			auto form_action = v->push_empty_formaction();
+			v->push_empty_formaction();
 			Stfl::reset();
 			FILE* f = popen(cmd.c_str(), "w");
 			if (f) {
@@ -812,7 +812,7 @@ void ItemListFormAction::finished_qna(Operation op)
 				fwrite(data.c_str(), data.length(), 1, f);
 				pclose(f);
 			}
-			v->drop_queued_input(form_action->get_form());
+			v->drop_queued_input();
 			v->pop_current_formaction();
 		}
 	}

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -572,7 +572,7 @@ void ItemViewFormAction::finished_qna(Operation op)
 		std::string cmd = qna_responses[0];
 		std::ostringstream ostr;
 		v->get_ctrl()->write_item(feed->get_item_by_guid(guid), ostr);
-		auto form_action = v->push_empty_formaction();
+		v->push_empty_formaction();
 		Stfl::reset();
 		FILE* f = popen(cmd.c_str(), "w");
 		if (f) {
@@ -580,7 +580,7 @@ void ItemViewFormAction::finished_qna(Operation op)
 			fwrite(data.c_str(), data.length(), 1, f);
 			pclose(f);
 		}
-		v->drop_queued_input(form_action->get_form());
+		v->drop_queued_input();
 		v->pop_current_formaction();
 	}
 	break;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -303,13 +303,9 @@ std::string View::get_filename_suggestion(const std::string& s)
 	return retval;
 }
 
-void View::drop_queued_input(Stfl::Form& form)
+void View::drop_queued_input()
 {
-	// Ignore queued input
-	auto event = form.run(1);
-	while (event != nullptr && strcmp(event, "TIMEOUT") != 0) {
-		event = form.run(1);
-	}
+	flushinp();
 }
 
 void View::open_in_pager(const std::string& filename)
@@ -332,10 +328,10 @@ void View::open_in_pager(const std::string& filename)
 		cmdline.append(" ");
 		cmdline.append(filename);
 	}
-	auto form_action = push_empty_formaction();
+	push_empty_formaction();
 	Stfl::reset();
 	utils::run_interactively(cmdline, "View::open_in_pager");
-	drop_queued_input(form_action->get_form());
+	drop_queued_input();
 	pop_current_formaction();
 }
 
@@ -355,10 +351,10 @@ nonstd::optional<std::uint8_t> View::open_in_browser(const std::string& url)
 		cmdline.append(" " + escaped_url);
 	}
 
-	auto form_action = push_empty_formaction();
+	push_empty_formaction();
 	Stfl::reset();
 	const auto ret = utils::run_interactively(cmdline, "View::open_in_browser");
-	drop_queued_input(form_action->get_form());
+	drop_queued_input();
 
 	pop_current_formaction();
 
@@ -524,7 +520,7 @@ void View::view_dialogs()
 	}
 }
 
-std::shared_ptr<FormAction> View::push_empty_formaction()
+void View::push_empty_formaction()
 {
 	auto fa = get_current_formaction();
 
@@ -534,8 +530,6 @@ std::shared_ptr<FormAction> View::push_empty_formaction()
 	empty_view->init();
 	formaction_stack.push_back(empty_view);
 	current_formaction = formaction_stack_size() - 1;
-
-	return empty_view;
 }
 
 void View::push_help()
@@ -620,7 +614,7 @@ char View::confirm(const std::string& prompt, const std::string& charset)
 
 	std::shared_ptr<FormAction> f = get_current_formaction();
 	// Push empty formaction so our "msg" is not overwritten
-	auto form_action = push_empty_formaction();
+	push_empty_formaction();
 	f->get_form().set("msg", prompt);
 
 	char result = 0;


### PR DESCRIPTION
A small improvement on top of https://github.com/newsboat/newsboat/pull/1259.

This reduces screen-flickering (caused by drawing the `EmptyFormAction`) and might be a bit faster (single curses call without waiting for 1 ms timeout).