### PR TITLE
Migrate FsLock rust binding to cxx crate

### DIFF
--- a/include/fslock.h
+++ b/include/fslock.h
@@ -1,30 +1,22 @@
 #ifndef NEWSBOAT_FSLOCK_H_
 #define NEWSBOAT_FSLOCK_H_
 
+#include "fslock.rs.h"
+
 #include <string>
 #include <sys/types.h>
-
-extern "C" {
-
-	void* rs_fslock_new();
-
-	void rs_fslock_free(void* ptr);
-
-	bool rs_fslock_try_lock(void* ptr, const char* new_lock_filepath, pid_t* pid);
-
-} // extern "C"
 
 namespace newsboat {
 
 class FsLock {
 public:
 	FsLock();
-	~FsLock();
+	~FsLock() = default;
 
 	bool try_lock(const std::string& lock_file, pid_t& pid);
 
 private:
-	void* rs_fslock = nullptr;
+	rust::Box<fslock::bridged::FsLock> rs_object;
 };
 
 } // namespace newsboat

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -13,7 +13,8 @@ newsboat.o: newsboat.cpp include/cache.h include/configcontainer.h \
  include/strprintf.h config.h include/configpaths.h \
  include/cliargsparser.h include/controller.h include/cache.h \
  include/colormanager.h include/stflpp.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
+ include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h include/reloader.h include/remoteapi.h \
@@ -29,7 +30,8 @@ newsboat.o: newsboat.cpp include/cache.h include/configcontainer.h \
 podboat.o: podboat.cpp config.h include/exception.h \
  include/pbcontroller.h include/colormanager.h include/configparser.h \
  include/configactionhandler.h include/stflpp.h include/configcontainer.h \
- include/download.h include/fslock.h include/keymap.h \
+ include/download.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/keymap.h \
  include/queueloader.h include/pbview.h include/listwidget.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h include/textviewwidget.h \
@@ -83,7 +85,8 @@ src/cache.o: src/cache.cpp include/cache.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h config.h \
  include/configcontainer.h include/controller.h include/cache.h \
  include/colormanager.h include/stflpp.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
+ include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
  include/queuemanager.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h include/reloader.h \
@@ -106,18 +109,19 @@ src/colormanager.o: src/colormanager.cpp include/colormanager.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
  include/view.h include/colormanager.h include/controller.h \
  include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h \
- include/filebrowserformaction.h include/helpformaction.h \
- include/textviewwidget.h include/itemlistformaction.h \
- include/itemviewformaction.h include/logger.h include/strprintf.h \
- include/matcherexception.h include/pbview.h include/selectformaction.h \
- include/strprintf.h include/urlviewformaction.h include/utils.h \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h include/filebrowserformaction.h \
+ include/helpformaction.h include/textviewwidget.h \
+ include/itemlistformaction.h include/itemviewformaction.h \
+ include/logger.h include/strprintf.h include/matcherexception.h \
+ include/pbview.h include/selectformaction.h include/strprintf.h \
+ include/urlviewformaction.h include/utils.h include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/configactionhandler.o: src/configactionhandler.cpp \
  include/configactionhandler.h include/utils.h 3rd-party/optional.hpp \
  include/configcontainer.h include/configparser.h \
@@ -149,21 +153,21 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/colormanager.h include/stflpp.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- 3rd-party/optional.hpp include/queuemanager.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/cliargsparser.h \
- include/logger.h config.h include/strprintf.h include/colormanager.h \
- include/configcontainer.h include/configexception.h \
- include/configparser.h include/configpaths.h include/cliargsparser.h \
- include/dbexception.h include/downloadthread.h include/exception.h \
- include/feedhqapi.h include/feedhqurlreader.h include/fileurlreader.h \
- include/globals.h include/inoreaderapi.h include/inoreaderurlreader.h \
- include/itemrenderer.h include/htmlrenderer.h include/textformatter.h \
- include/logger.h include/minifluxapi.h 3rd-party/json.hpp rss/feed.h \
- rss/item.h include/utils.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/cliargsparser.h include/logger.h config.h \
+ include/strprintf.h include/colormanager.h include/configcontainer.h \
+ include/configexception.h include/configparser.h include/configpaths.h \
+ include/cliargsparser.h include/dbexception.h include/downloadthread.h \
+ include/exception.h include/feedhqapi.h include/feedhqurlreader.h \
+ include/fileurlreader.h include/globals.h include/inoreaderapi.h \
+ include/inoreaderurlreader.h include/itemrenderer.h \
+ include/htmlrenderer.h include/textformatter.h include/logger.h \
+ include/minifluxapi.h 3rd-party/json.hpp rss/feed.h rss/item.h \
+ include/utils.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  include/minifluxurlreader.h include/newsblurapi.h \
  include/newsblururlreader.h include/ocnewsapi.h \
  include/ocnewsurlreader.h include/oldreaderapi.h \
@@ -188,13 +192,13 @@ src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  include/view.h include/colormanager.h include/controller.h \
  include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/dirbrowserformaction.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h \
@@ -206,17 +210,18 @@ src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  include/view.h include/colormanager.h include/controller.h \
  include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
  include/pbcontroller.h include/colormanager.h include/configparser.h \
  include/configactionhandler.h include/stflpp.h include/configcontainer.h \
- include/download.h include/fslock.h include/keymap.h \
+ include/download.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/keymap.h \
  include/queueloader.h
 src/downloadthread.o: src/downloadthread.cpp include/downloadthread.h \
  include/reloader.h include/configcontainer.h include/configparser.h \
@@ -254,13 +259,14 @@ src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
  include/view.h include/colormanager.h include/controller.h \
  include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h include/opml.h include/fileurlreader.h \
- include/urlreader.h include/queuemanager.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h config.h \
- include/dbexception.h include/feedcontainer.h include/fmtstrformatter.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h config.h include/dbexception.h \
+ include/feedcontainer.h include/fmtstrformatter.h \
  include/listformatter.h include/logger.h include/strprintf.h \
  include/reloader.h include/rssfeed.h include/utils.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
@@ -278,12 +284,13 @@ src/filebrowserformaction.o: src/filebrowserformaction.cpp \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/fileurlreader.o: src/fileurlreader.cpp include/fileurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/utils.h \
  include/configcontainer.h include/configparser.h \
@@ -306,17 +313,18 @@ src/formaction.o: src/formaction.cpp include/formaction.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/dirbrowserformaction.h \
- include/listformatter.h include/listwidget.h include/formaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
-src/fslock.o: src/fslock.cpp include/fslock.h include/logger.h config.h \
- include/strprintf.h
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/listformatter.h \
+ include/listwidget.h include/formaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
+src/fslock.o: src/fslock.cpp include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/logger.h \
+ config.h include/strprintf.h
 src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
  include/formaction.h include/history.h include/keymap.h \
  include/configparser.h include/configactionhandler.h include/stflpp.h \
@@ -328,13 +336,14 @@ src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/listformatter.h \
- include/listwidget.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+ include/listformatter.h include/listwidget.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/history.o: src/history.cpp include/history.h include/ruststring.h
 src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
  include/textformatter.h include/regexmanager.h include/configparser.h \
@@ -364,7 +373,8 @@ src/itemlistformaction.o: src/itemlistformaction.cpp \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
  include/view.h include/colormanager.h include/configcontainer.h \
  include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
+ include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
  include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
@@ -396,13 +406,13 @@ src/itemviewformaction.o: src/itemviewformaction.cpp \
  include/listformatter.h include/view.h include/colormanager.h \
  include/configcontainer.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/feedlistformaction.h \
- include/filebrowserformaction.h include/itemrenderer.h \
- include/htmlrenderer.h include/logger.h include/strprintf.h \
- include/rssfeed.h include/utils.h include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+ include/feedlistformaction.h include/filebrowserformaction.h \
+ include/itemrenderer.h include/htmlrenderer.h include/logger.h \
+ include/strprintf.h include/rssfeed.h include/utils.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/textformatter.h include/utils.h \
@@ -423,12 +433,12 @@ src/listformaction.o: src/listformaction.cpp include/listformaction.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/listformatter.o: src/listformatter.cpp include/listformatter.h \
  include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
@@ -519,7 +529,8 @@ src/opmlurlreader.o: src/opmlurlreader.cpp include/opmlurlreader.h \
 src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
  include/colormanager.h include/configparser.h \
  include/configactionhandler.h include/stflpp.h include/configcontainer.h \
- include/download.h include/fslock.h include/keymap.h \
+ include/download.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/keymap.h \
  include/queueloader.h config.h include/configcontainer.h \
  include/configexception.h include/globals.h include/logger.h \
  include/strprintf.h include/matcherexception.h \
@@ -538,8 +549,9 @@ src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
  include/fmtstrformatter.h stfl/help.h include/listformatter.h \
  include/logger.h include/strprintf.h include/pbcontroller.h \
  include/configcontainer.h include/download.h include/fslock.h \
- include/queueloader.h include/poddlthread.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/queueloader.h \
+ include/poddlthread.h include/strprintf.h include/utils.h \
+ 3rd-party/optional.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
  include/configcontainer.h include/configparser.h \
@@ -575,7 +587,8 @@ src/reloader.o: src/reloader.cpp include/reloader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/controller.h include/cache.h \
  include/colormanager.h include/stflpp.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
+ include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
  include/queuemanager.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h include/reloader.h \
@@ -600,7 +613,8 @@ src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/controller.h include/cache.h \
  include/colormanager.h include/stflpp.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
+ include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
  include/queuemanager.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h include/reloader.h \
@@ -669,7 +683,8 @@ src/selectformaction.o: src/selectformaction.cpp \
  include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/fslock.h include/opml.h \
+ include/feedcontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
  include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
@@ -728,7 +743,8 @@ src/urlviewformaction.o: src/urlviewformaction.cpp \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/strprintf.h \
  include/utils.h include/view.h include/colormanager.h \
  include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
+ include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
  include/dirbrowserformaction.h include/feedlistformaction.h \
@@ -745,7 +761,8 @@ src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
  include/colormanager.h include/configparser.h \
  include/configactionhandler.h include/stflpp.h include/configcontainer.h \
  include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
+ include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h include/reloader.h include/remoteapi.h \
@@ -821,7 +838,8 @@ test/filterparser.o: test/filterparser.cpp filter/FilterParser.h \
  3rd-party/catch.hpp
 test/fmtstrformatter.o: test/fmtstrformatter.cpp \
  include/fmtstrformatter.h 3rd-party/catch.hpp
-test/fslock.o: test/fslock.cpp include/fslock.h 3rd-party/catch.hpp \
+test/fslock.o: test/fslock.cpp include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h 3rd-party/catch.hpp \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
  test/test-helpers/tempfile.h
 test/history.o: test/history.cpp include/history.h 3rd-party/catch.hpp \
@@ -841,7 +859,8 @@ test/itemlistformaction.o: test/itemlistformaction.cpp \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
  include/view.h include/colormanager.h include/configcontainer.h \
  include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h include/opml.h \
+ include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
  include/rssitem.h include/matchable.h include/dirbrowserformaction.h \

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -6,6 +6,7 @@ fn add_cxxbridge(module: &str) {
 }
 
 fn main() {
-    add_cxxbridge("utils");
+    add_cxxbridge("fslock");
     add_cxxbridge("scopemeasure");
+    add_cxxbridge("utils");
 }

--- a/rust/libnewsboat-ffi/src/fslock.rs
+++ b/rust/libnewsboat-ffi/src/fslock.rs
@@ -1,15 +1,24 @@
 use libnewsboat::fslock::FsLock;
 
+use std::path::Path;
+
 #[cxx::bridge(namespace = "newsboat::fslock::bridged")]
 mod bridged {
     extern "Rust" {
         type FsLock;
 
         fn create() -> Box<FsLock>;
-        fn try_lock_ffi(&mut self, new_lock_path: &str, pid: &mut i64) -> bool;
+        fn try_lock(fslock: &mut FsLock, new_lock_path: &str, pid: &mut i64) -> bool;
     }
 }
 
 fn create() -> Box<FsLock> {
     Box::new(FsLock::default())
+}
+
+fn try_lock(fslock: &mut FsLock, new_lock_path: &str, pid: &mut i64) -> bool {
+    let p: &mut libc::pid_t = &mut 0;
+    let result = fslock.try_lock(Path::new(new_lock_path), p);
+    *pid = i64::from(*p);
+    result
 }

--- a/rust/libnewsboat-ffi/src/fslock.rs
+++ b/rust/libnewsboat-ffi/src/fslock.rs
@@ -1,39 +1,15 @@
-use crate::abort_on_panic;
 use libnewsboat::fslock::FsLock;
-use std::ffi::CStr;
 
-#[no_mangle]
-pub extern "C" fn rs_fslock_new() -> *mut FsLock {
-    Box::into_raw(Box::new(FsLock::default()))
+#[cxx::bridge(namespace = "newsboat::fslock::bridged")]
+mod bridged {
+    extern "Rust" {
+        type FsLock;
+
+        fn create() -> Box<FsLock>;
+        fn try_lock_ffi(&mut self, new_lock_path: &str, pid: &mut i64) -> bool;
+    }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_fslock_free(ptr: *mut FsLock) {
-    abort_on_panic(|| {
-        if ptr.is_null() {
-            return;
-        }
-        Box::from_raw(ptr);
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_fslock_try_lock(
-    ptr: *mut FsLock,
-    new_lock_filepath: *const libc::c_char,
-    pid: *mut libc::pid_t,
-) -> bool {
-    abort_on_panic(|| {
-        let fslock = {
-            assert!(!ptr.is_null());
-            &mut *ptr
-        };
-        let new_lock_filepath = {
-            assert!(!new_lock_filepath.is_null());
-            CStr::from_ptr(new_lock_filepath)
-        };
-        let pid = { &mut *pid };
-        let new_lock_filepath = new_lock_filepath.to_string_lossy().into_owned();
-        fslock.try_lock(new_lock_filepath.as_ref(), pid)
-    })
+fn create() -> Box<FsLock> {
+    Box::new(FsLock::default())
 }

--- a/rust/libnewsboat/src/fslock.rs
+++ b/rust/libnewsboat/src/fslock.rs
@@ -97,11 +97,4 @@ impl FsLock {
             false
         }
     }
-
-    pub fn try_lock_ffi(&mut self, new_lock_path: &str, pid: &mut i64) -> bool {
-        let p: &mut libc::pid_t = &mut 0;
-        let result = self.try_lock(Path::new(new_lock_path), p);
-        *pid = i64::from(*p);
-        result
-    }
 }

--- a/rust/libnewsboat/src/fslock.rs
+++ b/rust/libnewsboat/src/fslock.rs
@@ -97,4 +97,11 @@ impl FsLock {
             false
         }
     }
+
+    pub fn try_lock_ffi(&mut self, new_lock_path: &str, pid: &mut i64) -> bool {
+        let p: &mut libc::pid_t = &mut 0;
+        let result = self.try_lock(Path::new(new_lock_path), p);
+        *pid = i64::from(*p);
+        result
+    }
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cerrno>
+#include <cstdint>
 #include <cstdlib>
 #include <ctime>
 #include <curl/curl.h>
@@ -153,10 +154,12 @@ int Controller::run(const CliArgsParser& args)
 		pid_t pid;
 		if (!fslock->try_lock(configpaths.lock_file(), pid)) {
 			if (!args.cmds_to_execute().has_value()) {
+				// pid_t size could vary so cast to known integer format to get correct print format
+				std::int64_t p = pid;
 				std::cout << strprintf::fmt(
-						_("Error: an instance of %s is already running (PID: %u)"),
+						_("Error: an instance of %s is already running (PID: %" PRId64 ")"),
 						PROGRAM_NAME,
-						pid)
+						p)
 					<< std::endl;
 			}
 			return EXIT_FAILURE;
@@ -210,11 +213,13 @@ int Controller::run(const CliArgsParser& args)
 		fslock = std::unique_ptr<FsLock>(new FsLock());
 		pid_t pid;
 		if (!fslock->try_lock(configpaths.lock_file(), pid)) {
+			// pid_t size could vary so cast to known integer format to get correct print format
+			std::int64_t p = pid;
 			std::cout << strprintf::fmt(
 					_("Error: an instance of %s is "
-						"already running (PID: %u)"),
+						"already running (PID: %" PRId64 ")"),
 					PROGRAM_NAME,
-					pid)
+					p)
 				<< std::endl;
 			return EXIT_FAILURE;
 		}

--- a/src/fslock.cpp
+++ b/src/fslock.cpp
@@ -18,7 +18,8 @@ FsLock::FsLock()
 bool FsLock::try_lock(const std::string& new_lock_filepath, pid_t& pid)
 {
 	std::int64_t p;
-	const bool result =  rs_object->try_lock_ffi(new_lock_filepath, p);
+	const bool result = newsboat::fslock::bridged::try_lock(*rs_object,
+			new_lock_filepath, p);
 
 	// We use `libc::pid_t` on the rust side so we can guarantee this will fit
 	pid = static_cast<std::int64_t>(p);

--- a/src/fslock.cpp
+++ b/src/fslock.cpp
@@ -11,18 +11,18 @@
 namespace newsboat {
 
 FsLock::FsLock()
+	: rs_object(fslock::bridged::create())
 {
-	rs_fslock = rs_fslock_new();
-}
-
-FsLock::~FsLock()
-{
-	rs_fslock_free(rs_fslock);
 }
 
 bool FsLock::try_lock(const std::string& new_lock_filepath, pid_t& pid)
 {
-	return rs_fslock_try_lock(rs_fslock, new_lock_filepath.c_str(), &pid);
+	std::int64_t p;
+	const bool result =  rs_object->try_lock_ffi(new_lock_filepath, p);
+
+	// We use `libc::pid_t` on the rust side so we can guarantee this will fit
+	pid = static_cast<std::int64_t>(p);
+	return result;
 }
 
 } // namespace newsboat

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -1,5 +1,7 @@
 #include "pbcontroller.h"
 
+#include <cinttypes>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -249,11 +251,13 @@ void PbController::initialize(int argc, char* argv[])
 	fslock = std::unique_ptr<FsLock>(new FsLock());
 	pid_t pid;
 	if (!fslock->try_lock(lock_file, pid)) {
+		// pid_t size could vary so cast to known integer format to get correct print format
+		std::int64_t p = pid;
 		std::cout << strprintf::fmt(
 				_("Error: an instance of %s is already "
-					"running (PID: %u)"),
+					"running (PID: %" PRId64 ")"),
 				"podboat",
-				pid)
+				p)
 			<< std::endl;
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
I wanted to get some experience with the cxx crate.

I expect the `pid_t` to `std::int64_t` conversion to be fine:
> From https://man7.org/linux/man-pages/man3/pid_t.3.html:
> pid_t: … According to POSIX, it shall be a signed integer type, and the implementation shall support one or more programming environments where the width of pid_t is no greater than the width of the type long.

This PR depends on https://github.com/newsboat/newsboat/pull/1304.
I will rebase onto master when that PR is merged (and change the target branch).