### PR TITLE
Only create lock-file after applying `cache-file` option

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -134,7 +134,7 @@ private:
 	RegexManager rxman;
 	RemoteApi* api;
 
-	std::unique_ptr<FsLock> fslock;
+	FsLock fslock;
 
 	ConfigPaths& configpaths;
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -148,19 +148,6 @@ int Controller::run(const CliArgsParser& args)
 					PROGRAM_NAME,
 					utils::program_version())
 				<< std::endl;
-
-		fslock = std::unique_ptr<FsLock>(new FsLock());
-		pid_t pid;
-		if (!fslock->try_lock(configpaths.lock_file(), pid)) {
-			if (!args.cmds_to_execute().has_value()) {
-				std::cout << strprintf::fmt(
-						_("Error: an instance of %s is already running (PID: %u)"),
-						PROGRAM_NAME,
-						pid)
-					<< std::endl;
-			}
-			return EXIT_FAILURE;
-		}
 	}
 
 	if (!args.silent()) {
@@ -207,17 +194,18 @@ int Controller::run(const CliArgsParser& args)
 	std::string cachefilepath = cfg.get_configvalue("cache-file");
 	if (cachefilepath.length() > 0 && !args.cache_file().has_value()) {
 		configpaths.set_cache_file(cachefilepath);
-		fslock = std::unique_ptr<FsLock>(new FsLock());
-		pid_t pid;
-		if (!fslock->try_lock(configpaths.lock_file(), pid)) {
-			std::cout << strprintf::fmt(
-					_("Error: an instance of %s is "
-						"already running (PID: %u)"),
-					PROGRAM_NAME,
-					pid)
-				<< std::endl;
-			return EXIT_FAILURE;
-		}
+	}
+
+	fslock = std::unique_ptr<FsLock>(new FsLock());
+	pid_t pid;
+	if (!fslock->try_lock(configpaths.lock_file(), pid)) {
+		std::cout << strprintf::fmt(
+				_("Error: an instance of %s is "
+					"already running (PID: %u)"),
+				PROGRAM_NAME,
+				pid)
+			<< std::endl;
+		return EXIT_FAILURE;
 	}
 
 	if (!args.silent()) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -196,9 +196,8 @@ int Controller::run(const CliArgsParser& args)
 		configpaths.set_cache_file(cachefilepath);
 	}
 
-	fslock = std::unique_ptr<FsLock>(new FsLock());
 	pid_t pid;
-	if (!fslock->try_lock(configpaths.lock_file(), pid)) {
+	if (!fslock.try_lock(configpaths.lock_file(), pid)) {
 		std::cout << strprintf::fmt(
 				_("Error: an instance of %s is "
 					"already running (PID: %u)"),


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1318.