### PR TITLE
RegexManager: Dump both "highlight" and "highlight-article" rules

### DIFF
--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -39,6 +39,12 @@ void RegexManager::handle_action(const std::string& action,
 		throw ConfigHandlerException(
 			ActionHandlerStatus::INVALID_COMMAND);
 	}
+	std::string line = action;
+	for (const auto& param : params) {
+		line.append(" ");
+		line.append(utils::quote(param));
+	}
+	cheat_store_for_dump_config.push_back(line);
 }
 
 int RegexManager::article_matches(Matchable* item)
@@ -277,12 +283,6 @@ void RegexManager::handle_highlight_action(const std::vector<std::string>&
 			location.second.push_back({sharedRegex, colorstr});
 		}
 	}
-	std::string line = "highlight";
-	for (const auto& param : params) {
-		line.append(" ");
-		line.append(utils::quote(param));
-	}
-	cheat_store_for_dump_config.push_back(line);
 }
 
 void RegexManager::handle_highlight_article_action(const

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -226,8 +226,8 @@ TEST_CASE("quote_and_highlight wraps highlighted text in numbered tags",
 	}
 }
 
-TEST_CASE("RegexManager::dump_config turns each `highlight` rule into a string, "
-	"and appends them onto a vector",
+TEST_CASE("RegexManager::dump_config turns each `highlight` and "
+	"`highlight-article` rule into a string, and appends them onto a vector",
 	"[RegexManager]")
 {
 	RegexManager rxman;
@@ -251,8 +251,9 @@ TEST_CASE("RegexManager::dump_config turns each `highlight` rule into a string, 
 			"highlight-article",
 		{"title==\"\"", "green", "black"});
 		REQUIRE_NOTHROW(rxman.dump_config(result));
-		REQUIRE(result.size() == 1);
+		REQUIRE(result.size() == 2);
 		REQUIRE(result[0] == R"#(highlight "all" "keywords" "red" "blue")#");
+		REQUIRE(result[1] == R"#(highlight-article "title==\"\"" "green" "black")#");
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/635.