### PR TITLE
Provide a reason when lock-file can't be opened or locked

### DIFF
--- a/include/fslock.h
+++ b/include/fslock.h
@@ -13,7 +13,8 @@ public:
 	FsLock();
 	~FsLock() = default;
 
-	bool try_lock(const std::string& lock_file, pid_t& pid);
+	bool try_lock(const std::string& lock_file, pid_t& pid,
+		std::string& error_message);
 
 private:
 	rust::Box<fslock::bridged::FsLock> rs_object;

--- a/rust/libnewsboat-ffi/src/fslock.rs
+++ b/rust/libnewsboat-ffi/src/fslock.rs
@@ -8,7 +8,12 @@ mod bridged {
         type FsLock;
 
         fn create() -> Box<FsLock>;
-        fn try_lock(fslock: &mut FsLock, new_lock_path: &str, pid: &mut i64) -> bool;
+        fn try_lock(
+            fslock: &mut FsLock,
+            new_lock_path: &str,
+            pid: &mut i64,
+            error_message: &mut String,
+        ) -> bool;
     }
 }
 
@@ -16,9 +21,18 @@ fn create() -> Box<FsLock> {
     Box::new(FsLock::default())
 }
 
-fn try_lock(fslock: &mut FsLock, new_lock_path: &str, pid: &mut i64) -> bool {
+fn try_lock(
+    fslock: &mut FsLock,
+    new_lock_path: &str,
+    pid: &mut i64,
+    error_message: &mut String,
+) -> bool {
     let p: &mut libc::pid_t = &mut 0;
     let result = fslock.try_lock(Path::new(new_lock_path), p);
     *pid = i64::from(*p);
-    result
+    match result {
+        Ok(_) => return true,
+        Err(message) => *error_message = message,
+    }
+    false
 }

--- a/rust/libnewsboat/src/bin/lock-process.rs
+++ b/rust/libnewsboat/src/bin/lock-process.rs
@@ -5,7 +5,7 @@ fn main() {
     let lock_location = std::env::args().nth(1).unwrap();
 
     let mut lock = FsLock::default();
-    assert!(lock.try_lock(lock_location.as_ref(), &mut 0));
+    assert!(lock.try_lock(lock_location.as_ref(), &mut 0).is_ok());
 
     // signal that we already lock file
     println!();

--- a/rust/libnewsboat/src/fslock.rs
+++ b/rust/libnewsboat/src/fslock.rs
@@ -30,9 +30,9 @@ impl Drop for FsLock {
 }
 
 impl FsLock {
-    pub fn try_lock(&mut self, new_lock_path: &Path, pid: &mut libc::pid_t) -> bool {
+    pub fn try_lock(&mut self, new_lock_path: &Path, pid: &mut libc::pid_t) -> Result<(), String> {
         if self.lock_file.is_some() && self.lock_path == new_lock_path {
-            return true;
+            return Ok(());
         }
 
         // pid == 0 indicates that something went majorly wrong during locking
@@ -49,7 +49,13 @@ impl FsLock {
         options.create(true).read(true).write(true).mode(0o600);
         let mut file = match options.open(&new_lock_path) {
             Ok(file) => file,
-            Err(_) => return false,
+            Err(reason) => {
+                return Err(format!(
+                    "Failed to open lock file: '{}' ({})",
+                    new_lock_path.display(),
+                    reason
+                ))
+            }
         };
 
         // then we lock it (returns immediately if locking is not possible)
@@ -60,23 +66,24 @@ impl FsLock {
                 new_lock_path.display()
             );
             let pid = process::id().to_string();
-            let success = file
+            if let Err(reason) = file
                 .set_len(0)
                 .and_then(|_| file.write_all(&pid.as_bytes()))
-                .is_ok();
-            log!(
-                Level::Debug,
-                "FsLock: PID written successfully: {}",
-                success as usize
-            );
-            if success {
-                if self.lock_file.take().is_some() {
-                    remove_lock(&self.lock_path);
-                }
-                self.lock_file = Some(file);
-                self.lock_path = new_lock_path.to_owned();
+            {
+                log!(Level::Debug, "FsLock: Failed to write PID");
+                return Err(format!(
+                    "Failed to write PID to lock file: '{}' ({})",
+                    new_lock_path.display(),
+                    reason
+                ));
             }
-            success
+            log!(Level::Debug, "FsLock: PID written successfully");
+            if self.lock_file.take().is_some() {
+                remove_lock(&self.lock_path);
+            }
+            self.lock_file = Some(file);
+            self.lock_path = new_lock_path.to_owned();
+            Ok(())
         } else {
             log!(
                 Level::Error,
@@ -94,7 +101,11 @@ impl FsLock {
                 "FsLock: locking failed, already locked by {}",
                 pid
             );
-            false
+            Err(format!(
+                "Failed to lock '{}', already locked by process with PID {}",
+                new_lock_path.display(),
+                pid
+            ))
         }
     }
 }

--- a/rust/libnewsboat/tests/fslock.rs
+++ b/rust/libnewsboat/tests/fslock.rs
@@ -25,7 +25,7 @@ fn t_returns_an_error_if_invalid_lock_location() {
     let mut lock = FsLock::default();
     let mut pid = -1;
 
-    assert!(!lock.try_lock(lock_location.as_ref(), &mut pid));
+    assert!(lock.try_lock(lock_location.as_ref(), &mut pid).is_err());
     assert_eq!(pid, 0);
 }
 
@@ -38,7 +38,7 @@ fn t_returns_an_error_lock_file_without_write_access() {
 
     let mut lock = FsLock::default();
     let mut pid = -1;
-    assert!(!lock.try_lock(lock_location.as_ref(), &mut pid));
+    assert!(lock.try_lock(lock_location.as_ref(), &mut pid).is_err());
     assert_eq!(pid, 0);
 }
 
@@ -70,7 +70,11 @@ fn t_fails_if_lock_was_already_created() {
     let stdout = child.stdout.as_mut().unwrap();
     stdout.read_exact(&mut [0]).unwrap();
 
-    assert!(!lock.try_lock(lock_location.as_ref(), &mut pid));
+    let result = lock.try_lock(lock_location.as_ref(), &mut pid);
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert!(!e.is_empty());
+    }
     assert_eq!(pid, cid, "pid should be process holding the lock");
 
     // notify child to exit and drop lock
@@ -84,17 +88,17 @@ fn t_succeeds_if_lock_file_location_is_valid_and_not_locked_by_different_process
     let mut lock = FsLock::default();
     let mut pid = 0;
 
-    assert!(lock.try_lock(lock_location.as_ref(), &mut pid));
+    assert!(lock.try_lock(lock_location.as_ref(), &mut pid).is_ok());
     assert!(lock_location.path().exists());
     assert!(
-        lock.try_lock(lock_location.as_ref(), &mut pid),
+        lock.try_lock(lock_location.as_ref(), &mut pid).is_ok(),
         "recall succeeds"
     );
 
     let new_lock_location = NamedTempFile::new().unwrap();
 
     assert!(lock_location.path().exists());
-    assert!(lock.try_lock(new_lock_location.as_ref(), &mut pid));
+    assert!(lock.try_lock(new_lock_location.as_ref(), &mut pid).is_ok());
     assert!(!lock_location.path().exists());
     assert!(new_lock_location.path().exists());
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -198,15 +198,20 @@ int Controller::run(const CliArgsParser& args)
 	}
 
 	pid_t pid;
-	if (!fslock.try_lock(configpaths.lock_file(), pid)) {
-		// pid_t size could vary so cast to known integer format to get correct print format
-		std::int64_t p = pid;
-		std::cout << strprintf::fmt(
-				_("Error: an instance of %s is "
-					"already running (PID: %" PRId64 ")"),
-				PROGRAM_NAME,
-				p)
-			<< std::endl;
+	std::string error;
+	if (!fslock.try_lock(configpaths.lock_file(), pid, error)) {
+		if (pid != 0) {
+			// pid_t size could vary so cast to known integer format to get correct print format
+			std::int64_t p = pid;
+			std::cout << strprintf::fmt(
+					_("Error: an instance of %s is "
+						"already running (PID: %" PRId64 ")"),
+					PROGRAM_NAME,
+					p)
+				<< std::endl;
+		} else {
+			std::cout << _("Error: ") << error << std::endl;
+		}
 		return EXIT_FAILURE;
 	}
 

--- a/src/fslock.cpp
+++ b/src/fslock.cpp
@@ -15,14 +15,18 @@ FsLock::FsLock()
 {
 }
 
-bool FsLock::try_lock(const std::string& new_lock_filepath, pid_t& pid)
+bool FsLock::try_lock(const std::string& new_lock_filepath, pid_t& pid,
+	std::string& error_message)
 {
 	std::int64_t p;
+	rust::String message;
 	const bool result = newsboat::fslock::bridged::try_lock(*rs_object,
-			new_lock_filepath, p);
+			new_lock_filepath, p, message);
 
 	// We use `libc::pid_t` on the rust side so we can guarantee this will fit
 	pid = static_cast<std::int64_t>(p);
+	error_message = std::string(message);
+
 	return result;
 }
 

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -250,15 +250,20 @@ void PbController::initialize(int argc, char* argv[])
 
 	fslock = std::unique_ptr<FsLock>(new FsLock());
 	pid_t pid;
-	if (!fslock->try_lock(lock_file, pid)) {
-		// pid_t size could vary so cast to known integer format to get correct print format
-		std::int64_t p = pid;
-		std::cout << strprintf::fmt(
-				_("Error: an instance of %s is already "
-					"running (PID: %" PRId64 ")"),
-				"podboat",
-				p)
-			<< std::endl;
+	std::string error_message;
+	if (!fslock->try_lock(lock_file, pid, error_message)) {
+		if (pid != 0) {
+			// pid_t size could vary so cast to known integer format to get correct print format
+			std::int64_t p = pid;
+			std::cout << strprintf::fmt(
+					_("Error: an instance of %s is already "
+						"running (PID: %" PRId64 ")"),
+					"podboat",
+					p)
+				<< std::endl;
+		} else {
+			std::cout << _("Error: ") << error_message << std::endl;
+		}
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/314.

Example output when the lock file is not writable:
![image](https://user-images.githubusercontent.com/4629607/101047065-d4ab9500-3581-11eb-96c6-4f3c469bd795.png)
