### PR TITLE
Add `read_text_file()` function which detects and rejects invalid unicode characters

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -152,6 +152,9 @@ nonstd::optional<std::uint8_t> run_interactively(const std::string& command,
 
 std::string getcwd();
 
+bool read_text_file(const std::string& filename,
+	std::vector<std::string>& contents, std::string& error_message);
+
 int strnaturalcmp(const std::string& a, const std::string& b);
 
 void remove_soft_hyphens(std::string& text);

--- a/include/utils.h
+++ b/include/utils.h
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "3rd-party/expected.hpp"
 #include "3rd-party/optional.hpp"
 
 #include "configcontainer.h"
@@ -152,8 +153,8 @@ nonstd::optional<std::uint8_t> run_interactively(const std::string& command,
 
 std::string getcwd();
 
-bool read_text_file(const std::string& filename,
-	std::vector<std::string>& contents, std::string& error_message);
+nonstd::expected<std::vector<std::string>, std::string> read_text_file(
+	const std::string& filename);
 
 int strnaturalcmp(const std::string& a, const std::string& b);
 

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -1,7 +1,7 @@
 filter/FilterParser.o: filter/FilterParser.cpp filter/FilterParser.h \
  include/logger.h config.h include/strprintf.h filter/Parser.h \
- filter/Scanner.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
+ filter/Scanner.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 filter/Parser.o: filter/Parser.cpp filter/Parser.h filter/FilterParser.h \
@@ -21,8 +21,8 @@ newsboat.o: newsboat.cpp include/cache.h include/configcontainer.h \
  include/rssignores.h include/rssitem.h include/matchable.h \
  include/dbexception.h include/exception.h include/matcherexception.h \
  rss/parser.h include/remoteapi.h rss/feed.h rss/item.h include/utils.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
- include/controller.h include/dirbrowserformaction.h \
+ 3rd-party/expected.hpp target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/view.h include/controller.h include/dirbrowserformaction.h \
  include/listformatter.h include/listwidget.h include/formaction.h \
  include/history.h include/keymap.h include/feedlistformaction.h \
  include/listformaction.h include/view.h include/filebrowserformaction.h \
@@ -35,17 +35,18 @@ podboat.o: podboat.cpp config.h include/exception.h \
  include/queueloader.h include/pbview.h include/listwidget.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h include/textviewwidget.h \
- include/utils.h 3rd-party/optional.hpp include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 rss/atomparser.o: rss/atomparser.cpp rss/atomparser.h rss/rssparser.h \
  config.h rss/exception.h rss/feed.h rss/item.h rss/medianamespace.h \
- rss/rsspp_uris.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
+ rss/rsspp_uris.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h rss/xmlutilities.h
 rss/exception.o: rss/exception.cpp rss/exception.h
 rss/medianamespace.o: rss/medianamespace.cpp rss/medianamespace.h \
- rss/item.h include/utils.h 3rd-party/optional.hpp \
+ rss/item.h include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
@@ -55,26 +56,27 @@ rss/parser.o: rss/parser.cpp rss/parser.h include/remoteapi.h \
  include/configactionhandler.h rss/feed.h rss/item.h config.h \
  rss/exception.h include/logger.h include/strprintf.h rss/rssparser.h \
  rss/rssparserfactory.h rss/rsspp_uris.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 rss/rss09xparser.o: rss/rss09xparser.cpp rss/rss09xparser.h \
  rss/rssparser.h config.h rss/exception.h rss/feed.h rss/item.h \
  rss/medianamespace.h rss/rsspp_uris.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h rss/xmlutilities.h
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h include/logger.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ rss/xmlutilities.h
 rss/rss10parser.o: rss/rss10parser.cpp rss/rss10parser.h rss/rssparser.h \
  config.h rss/exception.h rss/feed.h rss/item.h rss/rsspp_uris.h \
  rss/xmlutilities.h
 rss/rss20parser.o: rss/rss20parser.cpp rss/rss20parser.h \
  rss/rss09xparser.h rss/rssparser.h config.h rss/exception.h rss/feed.h \
- rss/item.h include/utils.h 3rd-party/optional.hpp \
+ rss/item.h include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 rss/rssparser.o: rss/rssparser.cpp rss/rssparser.h rss/exception.h \
- rss/xmlutilities.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
+ rss/xmlutilities.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 rss/rssparserfactory.o: rss/rssparserfactory.cpp rss/rssparserfactory.h \
@@ -93,7 +95,7 @@ src/cache.o: src/cache.cpp include/cache.h include/configcontainer.h \
  include/remoteapi.h include/rssignores.h include/rssitem.h \
  include/matchable.h include/dbexception.h include/logger.h \
  include/strprintf.h include/matcherexception.h include/rssfeed.h \
- include/utils.h include/logger.h \
+ include/utils.h 3rd-party/expected.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/utils.h
@@ -120,11 +122,11 @@ src/colormanager.o: src/colormanager.cpp include/colormanager.h \
  include/itemlistformaction.h include/itemviewformaction.h \
  include/logger.h include/strprintf.h include/matcherexception.h \
  include/pbview.h include/selectformaction.h include/strprintf.h \
- include/urlviewformaction.h include/utils.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/urlviewformaction.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/configactionhandler.o: src/configactionhandler.cpp \
- include/configactionhandler.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/configcontainer.o: src/configcontainer.cpp include/configcontainer.h \
@@ -143,8 +145,9 @@ src/configparser.o: src/configparser.cpp include/configparser.h \
  include/configactionhandler.h config.h include/configexception.h \
  include/confighandlerexception.h include/configparser.h include/logger.h \
  include/strprintf.h include/strprintf.h include/tagsouppullparser.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/configpaths.o: src/configpaths.cpp include/configpaths.h \
  include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
  include/strprintf.h include/globals.h include/ruststring.h \
@@ -167,7 +170,8 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/inoreaderurlreader.h include/itemrenderer.h \
  include/htmlrenderer.h include/textformatter.h include/logger.h \
  include/minifluxapi.h 3rd-party/json.hpp rss/feed.h rss/item.h \
- include/utils.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/utils.h 3rd-party/expected.hpp \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  include/minifluxurlreader.h include/newsblurapi.h \
  include/newsblururlreader.h include/ocnewsapi.h \
  include/ocnewsurlreader.h include/oldreaderapi.h \
@@ -188,17 +192,18 @@ src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h config.h include/fmtstrformatter.h \
  include/listformatter.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/dirbrowserformaction.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h \
@@ -206,17 +211,18 @@ src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  filter/FilterParser.h include/regexowner.h include/listwidget.h \
  include/stflpp.h include/formaction.h include/history.h include/keymap.h \
  config.h include/fmtstrformatter.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
  include/pbcontroller.h include/colormanager.h include/configparser.h \
  include/configactionhandler.h include/stflpp.h include/configcontainer.h \
@@ -235,21 +241,22 @@ src/feedcontainer.o: src/feedcontainer.cpp include/feedcontainer.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/utils.h
+ filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/utils.h
 src/feedhqapi.o: src/feedhqapi.cpp include/feedhqapi.h include/cache.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/remoteapi.h config.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h include/strprintf.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/feedhqurlreader.o: src/feedhqurlreader.cpp include/feedhqurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/configcontainer.h \
  include/configparser.h include/configactionhandler.h \
  include/fileurlreader.h include/logger.h config.h include/strprintf.h \
  include/remoteapi.h include/configcontainer.h include/utils.h \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ 3rd-party/expected.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/feedlistformaction.h 3rd-party/optional.hpp \
  include/configcontainer.h include/configparser.h \
@@ -268,7 +275,8 @@ src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/textformatter.h config.h include/dbexception.h \
  include/feedcontainer.h include/fmtstrformatter.h \
  include/listformatter.h include/logger.h include/strprintf.h \
- include/reloader.h include/rssfeed.h include/utils.h include/logger.h \
+ include/reloader.h include/rssfeed.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/utils.h include/view.h
@@ -280,7 +288,7 @@ src/filebrowserformaction.o: src/filebrowserformaction.cpp \
  include/stflpp.h include/formaction.h include/history.h include/keymap.h \
  config.h include/fmtstrformatter.h include/listformatter.h \
  include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
@@ -293,15 +301,15 @@ src/filebrowserformaction.o: src/filebrowserformaction.cpp \
  include/textformatter.h
 src/fileurlreader.o: src/fileurlreader.cpp include/fileurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/utils.h \
- include/configcontainer.h include/configparser.h \
+ 3rd-party/expected.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/filtercontainer.o: src/filtercontainer.cpp include/filtercontainer.h \
  include/configparser.h include/configactionhandler.h config.h \
  include/confighandlerexception.h include/matcher.h filter/FilterParser.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/fmtstrformatter.o: src/fmtstrformatter.cpp include/fmtstrformatter.h \
  include/logger.h config.h include/strprintf.h include/ruststring.h
 src/formaction.o: src/formaction.cpp include/formaction.h \
@@ -309,19 +317,20 @@ src/formaction.o: src/formaction.cpp include/formaction.h \
  include/configactionhandler.h include/stflpp.h config.h \
  include/configexception.h include/logger.h include/strprintf.h \
  include/matcherexception.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/listformatter.h \
- include/listwidget.h include/formaction.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/view.h include/colormanager.h include/controller.h \
+ include/cache.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/dirbrowserformaction.h \
+ include/listformatter.h include/listwidget.h include/formaction.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/fslock.o: src/fslock.cpp include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/logger.h \
  config.h include/strprintf.h
@@ -331,40 +340,40 @@ src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
  include/textviewwidget.h config.h include/fmtstrformatter.h \
  include/keymap.h include/listformatter.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
- include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
- include/listformatter.h include/listwidget.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/view.h include/colormanager.h include/controller.h \
+ include/cache.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/listformatter.h \
+ include/listwidget.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/history.o: src/history.cpp include/history.h include/ruststring.h
 src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
  include/textformatter.h include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h config.h include/logger.h include/strprintf.h \
  include/strprintf.h include/tagsouppullparser.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/inoreaderapi.o: src/inoreaderapi.cpp include/inoreaderapi.h \
  include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/remoteapi.h include/urlreader.h \
  3rd-party/optional.hpp config.h include/strprintf.h include/utils.h \
- include/logger.h include/strprintf.h \
+ 3rd-party/expected.hpp include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/inoreaderurlreader.o: src/inoreaderurlreader.cpp \
  include/inoreaderurlreader.h include/urlreader.h 3rd-party/optional.hpp \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/fileurlreader.h include/logger.h \
  config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/itemlistformaction.o: src/itemlistformaction.cpp \
  include/itemlistformaction.h 3rd-party/optional.hpp include/history.h \
  include/listformaction.h include/formaction.h include/keymap.h \
@@ -382,8 +391,9 @@ src/itemlistformaction.o: src/itemlistformaction.cpp \
  include/htmlrenderer.h include/textformatter.h config.h \
  include/controller.h include/dbexception.h include/fmtstrformatter.h \
  include/logger.h include/strprintf.h include/matcherexception.h \
- include/rssfeed.h include/utils.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
+ include/rssfeed.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/utils.h include/view.h
 src/itemrenderer.o: src/itemrenderer.cpp include/itemrenderer.h \
@@ -392,7 +402,8 @@ src/itemrenderer.o: src/itemrenderer.cpp include/itemrenderer.h \
  filter/FilterParser.h include/regexowner.h include/configcontainer.h \
  include/htmlrenderer.h include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/utils.h \
- include/configcontainer.h include/logger.h config.h include/strprintf.h \
+ 3rd-party/expected.hpp include/configcontainer.h include/logger.h \
+ config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/textformatter.h
 src/itemviewformaction.o: src/itemviewformaction.cpp \
  include/itemviewformaction.h include/formaction.h include/history.h \
@@ -412,7 +423,8 @@ src/itemviewformaction.o: src/itemviewformaction.cpp \
  include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
  include/feedlistformaction.h include/filebrowserformaction.h \
  include/itemrenderer.h include/htmlrenderer.h include/logger.h \
- include/strprintf.h include/rssfeed.h include/utils.h include/logger.h \
+ include/strprintf.h include/rssfeed.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/textformatter.h include/utils.h \
@@ -420,8 +432,8 @@ src/itemviewformaction.o: src/itemviewformaction.cpp \
 src/keymap.o: src/keymap.cpp include/keymap.h include/configparser.h \
  include/configactionhandler.h config.h include/confighandlerexception.h \
  include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/keymap.rs.h
 src/listformaction.o: src/listformaction.cpp include/listformaction.h \
  3rd-party/optional.hpp include/formaction.h include/history.h \
@@ -429,8 +441,8 @@ src/listformaction.o: src/listformaction.cpp include/listformaction.h \
  include/stflpp.h include/listwidget.h include/listformatter.h \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h include/rssfeed.h include/matchable.h \
- include/rssitem.h include/utils.h include/configcontainer.h \
- include/logger.h config.h include/strprintf.h \
+ include/rssitem.h include/utils.h 3rd-party/expected.hpp \
+ include/configcontainer.h include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
@@ -444,15 +456,15 @@ src/listformatter.o: src/listformatter.cpp include/listformatter.h \
  include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h include/stflpp.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h config.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/listwidget.o: src/listwidget.cpp include/listwidget.h \
  include/listformatter.h include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h include/stflpp.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- config.h include/strprintf.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/logger.o: src/logger.cpp include/logger.h config.h \
  include/strprintf.h
@@ -460,7 +472,7 @@ src/matcher.o: src/matcher.cpp include/matcher.h filter/FilterParser.h \
  include/logger.h config.h include/strprintf.h include/matchable.h \
  3rd-party/optional.hpp include/matcherexception.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h include/utils.h \
- include/configcontainer.h include/configparser.h \
+ 3rd-party/expected.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/matcherexception.o: src/matcherexception.cpp \
@@ -469,64 +481,66 @@ src/matcherexception.o: src/matcherexception.cpp \
 src/minifluxapi.o: src/minifluxapi.cpp include/minifluxapi.h \
  3rd-party/json.hpp include/remoteapi.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h rss/feed.h \
- rss/item.h include/utils.h 3rd-party/optional.hpp include/logger.h \
- config.h include/strprintf.h \
+ rss/item.h include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/logger.h \
  include/remoteapi.h include/strprintf.h include/utils.h
 src/minifluxurlreader.o: src/minifluxurlreader.cpp \
  include/minifluxurlreader.h include/urlreader.h 3rd-party/optional.hpp \
  include/fileurlreader.h include/logger.h config.h include/strprintf.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/newsblurapi.o: src/newsblurapi.cpp include/newsblurapi.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/remoteapi.h \
- include/strprintf.h include/utils.h
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/remoteapi.h include/strprintf.h include/utils.h
 src/newsblururlreader.o: src/newsblururlreader.cpp \
  include/newsblururlreader.h rss/feed.h rss/item.h include/urlreader.h \
  3rd-party/optional.hpp include/fileurlreader.h include/logger.h config.h \
  include/strprintf.h include/remoteapi.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h include/utils.h \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ 3rd-party/expected.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ocnewsapi.o: src/ocnewsapi.cpp include/ocnewsapi.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ocnewsurlreader.o: src/ocnewsurlreader.cpp include/ocnewsurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/fileurlreader.h \
  include/logger.h config.h include/strprintf.h include/remoteapi.h \
  include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/oldreaderapi.o: src/oldreaderapi.cpp include/oldreaderapi.h \
  include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/remoteapi.h config.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h include/strprintf.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/oldreaderurlreader.o: src/oldreaderurlreader.cpp \
  include/oldreaderurlreader.h include/urlreader.h 3rd-party/optional.hpp \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/fileurlreader.h include/logger.h \
  config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/opml.o: src/opml.cpp include/opml.h include/feedcontainer.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/fileurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/rssfeed.h \
  include/matchable.h include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/opmlurlreader.o: src/opmlurlreader.cpp include/opmlurlreader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/urlreader.h 3rd-party/optional.hpp \
- include/utils.h include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/utils.h 3rd-party/expected.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
  include/colormanager.h include/configparser.h \
  include/configactionhandler.h include/stflpp.h include/configcontainer.h \
@@ -539,8 +553,8 @@ src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h include/textviewwidget.h \
  include/poddlthread.h include/queueloader.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
  include/configparser.h include/configactionhandler.h include/stflpp.h \
  include/keymap.h include/listwidget.h include/listformatter.h \
@@ -552,27 +566,27 @@ src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
  include/configcontainer.h include/download.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/queueloader.h \
  include/poddlthread.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h config.h \
  include/logger.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/queueloader.o: src/queueloader.cpp include/queueloader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h config.h \
  include/configcontainer.h include/logger.h include/strprintf.h \
  include/stflpp.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/logger.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/queuemanager.o: src/queuemanager.cpp include/queuemanager.h \
  include/configpaths.h include/cliargsparser.h 3rd-party/optional.hpp \
  include/logger.h config.h include/strprintf.h include/fmtstrformatter.h \
  include/rssfeed.h include/matchable.h include/rssitem.h \
  include/matcher.h filter/FilterParser.h include/utils.h \
- include/configcontainer.h include/configparser.h \
+ 3rd-party/expected.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/stflpp.h \
  include/utils.h
@@ -580,8 +594,8 @@ src/regexmanager.o: src/regexmanager.cpp include/regexmanager.h \
  include/configparser.h include/configactionhandler.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h config.h \
  include/confighandlerexception.h include/logger.h include/strprintf.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/regexowner.o: src/regexowner.cpp include/regexowner.h
 src/reloader.o: src/reloader.cpp include/reloader.h \
@@ -597,8 +611,8 @@ src/reloader.o: src/reloader.cpp include/reloader.h \
  include/matchable.h include/curlhandle.h include/dbexception.h \
  include/downloadthread.h include/fmtstrformatter.h \
  include/reloadrangethread.h include/reloadthread.h include/controller.h \
- rss/exception.h include/rssfeed.h include/utils.h include/logger.h \
- config.h include/strprintf.h \
+ rss/exception.h include/rssfeed.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/rssparser.h \
  rss/feed.h rss/item.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h include/utils.h \
@@ -623,19 +637,19 @@ src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
  include/matchable.h include/logger.h config.h include/strprintf.h
 src/remoteapi.o: src/remoteapi.cpp include/remoteapi.h \
  include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h config.h include/strprintf.h \
+ include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/rssfeed.o: src/rssfeed.cpp include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/cache.h \
- include/configcontainer.h include/confighandlerexception.h \
- include/dbexception.h include/htmlrenderer.h include/textformatter.h \
- include/regexmanager.h include/regexowner.h include/logger.h \
- include/scopemeasure.h \
+ filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/cache.h include/configcontainer.h \
+ include/confighandlerexception.h include/dbexception.h \
+ include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
+ include/regexowner.h include/logger.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/tagsouppullparser.h include/utils.h
 src/rssignores.o: src/rssignores.cpp include/rssignores.h \
@@ -645,16 +659,17 @@ src/rssignores.o: src/rssignores.cpp include/rssignores.h \
  config.h include/configcontainer.h include/confighandlerexception.h \
  include/dbexception.h include/htmlrenderer.h include/textformatter.h \
  include/regexmanager.h include/regexowner.h include/logger.h \
- include/strprintf.h include/rssfeed.h include/utils.h include/logger.h \
+ include/strprintf.h include/rssfeed.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/strprintf.h \
  include/tagsouppullparser.h include/utils.h
 src/rssitem.o: src/rssitem.cpp include/rssitem.h include/matchable.h \
  3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
  include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/dbexception.h include/rssfeed.h \
- include/rssitem.h include/utils.h include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/scopemeasure.h \
+ include/rssitem.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/utils.h
 src/rssparser.o: src/rssparser.cpp include/rssparser.h \
@@ -664,12 +679,13 @@ src/rssparser.o: src/rssparser.cpp include/rssparser.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
  include/logger.h include/strprintf.h include/minifluxapi.h \
- 3rd-party/json.hpp include/utils.h 3rd-party/optional.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/newsblurapi.h include/ocnewsapi.h rss/exception.h rss/parser.h \
- include/remoteapi.h rss/feed.h rss/rssparser.h include/rssfeed.h \
- include/matchable.h include/rssitem.h include/rssignores.h \
- include/strprintf.h include/ttrssapi.h include/cache.h include/utils.h
+ 3rd-party/json.hpp include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/newsblurapi.h \
+ include/ocnewsapi.h rss/exception.h rss/parser.h include/remoteapi.h \
+ rss/feed.h rss/rssparser.h include/rssfeed.h include/matchable.h \
+ include/rssitem.h include/rssignores.h include/strprintf.h \
+ include/ttrssapi.h include/cache.h include/utils.h
 src/ruststring.o: src/ruststring.cpp include/ruststring.h
 src/scopemeasure.o: src/scopemeasure.cpp include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h
@@ -680,8 +696,8 @@ src/selectformaction.o: src/selectformaction.cpp \
  include/listwidget.h include/listformatter.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h config.h \
  include/fmtstrformatter.h include/listformatter.h include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/feedcontainer.h include/fslock.h \
@@ -694,14 +710,14 @@ src/selectformaction.o: src/selectformaction.cpp \
  include/textformatter.h
 src/stflpp.o: src/stflpp.cpp include/stflpp.h include/exception.h \
  include/logger.h config.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/strprintf.o: src/strprintf.cpp include/strprintf.h
 src/tagsouppullparser.o: src/tagsouppullparser.cpp \
  include/tagsouppullparser.h config.h include/logger.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/xmlexception.h
 src/textformatter.o: src/textformatter.cpp include/textformatter.h \
@@ -709,26 +725,27 @@ src/textformatter.o: src/textformatter.cpp include/textformatter.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h include/htmlrenderer.h include/textformatter.h \
  include/stflpp.h include/strprintf.h include/utils.h \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- config.h include/strprintf.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/textviewwidget.o: src/textviewwidget.cpp include/textviewwidget.h \
- include/stflpp.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
+ include/stflpp.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ttrssapi.o: src/ttrssapi.cpp include/ttrssapi.h 3rd-party/json.hpp \
  include/cache.h include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/remoteapi.h include/logger.h \
  config.h include/strprintf.h include/remoteapi.h rss/feed.h rss/item.h \
- include/strprintf.h include/utils.h 3rd-party/optional.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ttrssurlreader.o: src/ttrssurlreader.cpp include/ttrssurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/fileurlreader.h \
  include/logger.h config.h include/strprintf.h include/remoteapi.h \
  include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/urlreader.o: src/urlreader.cpp include/urlreader.h \
  3rd-party/optional.hpp
 src/urlviewformaction.o: src/urlviewformaction.cpp \
@@ -739,8 +756,8 @@ src/urlviewformaction.o: src/urlviewformaction.cpp \
  include/regexowner.h include/listwidget.h include/listformatter.h \
  config.h include/fmtstrformatter.h include/listformatter.h \
  include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
- include/rssitem.h include/utils.h include/configcontainer.h \
- include/logger.h include/strprintf.h \
+ include/rssitem.h include/utils.h 3rd-party/expected.hpp \
+ include/configcontainer.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/strprintf.h \
  include/utils.h include/view.h include/colormanager.h \
  include/controller.h include/cache.h include/feedcontainer.h \
@@ -750,8 +767,8 @@ src/urlviewformaction.o: src/urlviewformaction.cpp \
  include/reloader.h include/remoteapi.h include/rssignores.h \
  include/dirbrowserformaction.h include/feedlistformaction.h \
  include/listformaction.h include/view.h include/filebrowserformaction.h
-src/utils.o: src/utils.cpp include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
+src/utils.o: src/utils.cpp include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
@@ -781,17 +798,19 @@ src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
  include/itemviewformaction.h include/keymap.h include/logger.h \
  include/strprintf.h include/matcherexception.h include/regexmanager.h \
  include/reloadthread.h include/rssfeed.h include/utils.h \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ 3rd-party/expected.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  include/selectformaction.h stfl/selecttag.h include/strprintf.h \
  stfl/urlview.h include/urlviewformaction.h include/utils.h
 test/cache.o: test/cache.cpp include/cache.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h 3rd-party/catch.hpp \
  include/configcontainer.h include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/rssignores.h include/rssparser.h include/remoteapi.h rss/feed.h \
- rss/item.h test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+ filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/rssignores.h \
+ include/rssparser.h include/remoteapi.h rss/feed.h rss/item.h \
+ test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/cliargsparser.o: test/cliargsparser.cpp 3rd-party/catch.hpp \
  include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
  include/strprintf.h test/test-helpers/envvar.h test/test-helpers/opts.h \
@@ -816,8 +835,8 @@ test/configpaths.o: test/configpaths.cpp include/configpaths.h \
  include/strprintf.h 3rd-party/catch.hpp test/test-helpers/chmod.h \
  test/test-helpers/envvar.h test/test-helpers/opts.h \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
- include/utils.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h \
+ include/utils.h 3rd-party/expected.hpp include/configcontainer.h \
+ include/configparser.h include/configactionhandler.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 test/download.o: test/download.cpp include/download.h 3rd-party/catch.hpp
 test/feedcontainer.o: test/feedcontainer.cpp 3rd-party/catch.hpp \
@@ -825,8 +844,9 @@ test/feedcontainer.o: test/feedcontainer.cpp 3rd-party/catch.hpp \
  include/configactionhandler.h include/configcontainer.h \
  include/feedcontainer.h include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 test/fileurlreader.o: test/fileurlreader.cpp include/fileurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp 3rd-party/catch.hpp \
  test/test-helpers/chmod.h test/test-helpers/misc.h \
@@ -849,8 +869,8 @@ test/htmlrenderer.o: test/htmlrenderer.cpp include/htmlrenderer.h \
  include/textformatter.h include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h 3rd-party/catch.hpp include/strprintf.h \
- include/utils.h 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h config.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 test/itemlistformaction.o: test/itemlistformaction.cpp \
  include/itemlistformaction.h 3rd-party/optional.hpp include/history.h \
@@ -871,8 +891,9 @@ test/itemlistformaction.o: test/itemlistformaction.cpp \
  include/logger.h config.h include/strprintf.h \
  include/feedlistformaction.h stfl/itemlist.h include/keymap.h \
  include/regexmanager.h include/rssfeed.h include/utils.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h test/test-helpers/misc.h \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+ 3rd-party/expected.hpp target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ test/test-helpers/misc.h test/test-helpers/tempfile.h \
+ test/test-helpers/maintempdir.h
 test/itemrenderer.o: test/itemrenderer.cpp include/itemrenderer.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
  include/configparser.h include/configactionhandler.h include/matcher.h \
@@ -880,7 +901,7 @@ test/itemrenderer.o: test/itemrenderer.cpp include/itemrenderer.h \
  include/cache.h include/configcontainer.h include/configcontainer.h \
  include/regexmanager.h include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/utils.h \
- include/logger.h config.h include/strprintf.h \
+ 3rd-party/expected.hpp include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  test/test-helpers/envvar.h
 test/keymap.o: test/keymap.cpp include/keymap.h include/configparser.h \
@@ -901,17 +922,17 @@ test/opml.o: test/opml.cpp include/opml.h include/feedcontainer.h \
  include/urlreader.h 3rd-party/optional.hpp 3rd-party/catch.hpp \
  include/cache.h include/fileurlreader.h include/rssfeed.h \
  include/matchable.h include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- test/test-helpers/misc.h test/test-helpers/tempfile.h \
- test/test-helpers/maintempdir.h
+ filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h test/test-helpers/misc.h \
+ test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/opmlurlreader.o: test/opmlurlreader.cpp include/opmlurlreader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/urlreader.h 3rd-party/optional.hpp \
  3rd-party/catch.hpp test/test-helpers/misc.h \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h \
- include/utils.h include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/utils.h 3rd-party/expected.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 test/queueloader.o: test/queueloader.cpp include/queueloader.h \
  include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/download.h 3rd-party/catch.hpp \
@@ -929,13 +950,13 @@ test/remoteapi.o: test/remoteapi.cpp include/remoteapi.h \
  include/configactionhandler.h 3rd-party/catch.hpp
 test/rssfeed.o: test/rssfeed.cpp include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h 3rd-party/catch.hpp \
- include/cache.h include/configcontainer.h include/rssparser.h \
- include/remoteapi.h rss/feed.h rss/item.h test/test-helpers/envvar.h \
- test/test-helpers/stringmaker/optional.h
+ filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
+ include/configcontainer.h include/configparser.h \
+ include/configactionhandler.h include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ 3rd-party/catch.hpp include/cache.h include/configcontainer.h \
+ include/rssparser.h include/remoteapi.h rss/feed.h rss/item.h \
+ test/test-helpers/envvar.h test/test-helpers/stringmaker/optional.h
 test/rssignores.o: test/rssignores.cpp include/rssignores.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
@@ -947,8 +968,8 @@ test/rssitem.o: test/rssitem.cpp include/rssitem.h include/matchable.h \
  3rd-party/catch.hpp include/cache.h include/configcontainer.h \
  include/configparser.h include/configactionhandler.h \
  include/configcontainer.h include/rssfeed.h include/rssitem.h \
- include/utils.h include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/utils.h 3rd-party/expected.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  test/test-helpers/envvar.h test/test-helpers/stringmaker/optional.h
 test/rsspp_parser.o: test/rsspp_parser.cpp rss/parser.h \
  include/remoteapi.h include/configcontainer.h include/configparser.h \
@@ -970,8 +991,8 @@ test/tagsouppullparser.o: test/tagsouppullparser.cpp \
 test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
  include/strprintf.h
 test/test-helpers/chdir.o: test/test-helpers/chdir.cpp \
- test/test-helpers/chdir.h include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
+ test/test-helpers/chdir.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 test/test-helpers/chmod.o: test/test-helpers/chmod.cpp \
@@ -995,8 +1016,8 @@ test/textformatter.o: test/textformatter.cpp include/textformatter.h \
  include/regexmanager.h include/configparser.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h 3rd-party/catch.hpp
-test/utils.o: test/utils.cpp include/utils.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
+test/utils.o: test/utils.cpp include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  3rd-party/catch.hpp include/htmlrenderer.h include/textformatter.h \

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -52,7 +52,7 @@ pub fn read_text_file(
             true
         }
         Err(e) => {
-            *error_message = e.to_string();
+            *error_message = e;
             false
         }
     }

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -21,6 +21,40 @@ mod ffi {
 mod bridged {
     extern "Rust" {
         fn to_u(input: String, default_value: u32) -> u32;
+
+        fn read_text_file(
+            filename: String,
+            contents: &mut Vec<String>,
+            error_message: &mut String,
+        ) -> bool;
+    }
+
+    extern "C++" {
+        // cxx uses `std::out_of_range`, but doesn't include the header that defines that
+        // exception. So we do it for them.
+        include!("stdexcept");
+        // Also inject a header that defines ptrdiff_t. Note this is *not* a C++ header, because
+        // cxx uses a non-C++ name of the type.
+        include!("stddef.h");
+    }
+}
+
+pub fn read_text_file(
+    filename: String,
+    contents: &mut Vec<String>,
+    error_message: &mut String,
+) -> bool {
+    use std::path::Path;
+
+    match utils::read_text_file(Path::new(&filename)) {
+        Ok(c) => {
+            *contents = c;
+            true
+        }
+        Err(e) => {
+            *error_message = e.to_string();
+            false
+        }
     }
 }
 

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -688,6 +688,15 @@ pub fn getcwd() -> Result<PathBuf, io::Error> {
     env::current_dir()
 }
 
+/// Get the lines of text contained in a file.
+pub fn read_text_file(filename: &Path) -> Result<Vec<String>, std::io::Error> {
+    use std::fs::File;
+    use std::io::BufRead;
+    let file = File::open(filename)?;
+    let buffered = io::BufReader::new(file);
+    buffered.lines().collect::<Result<Vec<_>, _>>()
+}
+
 pub fn strnaturalcmp(a: &str, b: &str) -> std::cmp::Ordering {
     natord::compare(a, b)
 }
@@ -1400,6 +1409,36 @@ mod tests {
         // rerun on existing directories
         let result = mkdir_parents(&path, mode);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn t_read_text_file_valid_unicode() {
+        use std::fs;
+        use tempfile::NamedTempFile;
+
+        let text_file_location = NamedTempFile::new().unwrap();
+        let data = "lorem ipsum\ntest1\ntest2";
+        fs::write(text_file_location.path(), data).expect("unable to write test data to file");
+
+        let lines = read_text_file(text_file_location.path()).unwrap();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], "lorem ipsum");
+        assert_eq!(lines[1], "test1");
+        assert_eq!(lines[2], "test2");
+    }
+
+    #[test]
+    fn t_read_text_file_invalid_unicode() {
+        use std::fs;
+        use tempfile::NamedTempFile;
+
+        let text_file_location = NamedTempFile::new().unwrap();
+        let data: Vec<u8> = vec![
+            0x74, 0x65, 0x73, 0x74, 0x31, 0x0a, 0x74, 0xff, 0x73, 0x74, 0x32, 0x0a,
+        ];
+        fs::write(text_file_location.path(), data).expect("unable to write test data to file");
+
+        assert!(read_text_file(text_file_location.path()).is_err());
     }
 
     #[test]

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -337,7 +337,8 @@ int Controller::run(const CliArgsParser& args)
 	}
 	const auto error_message = urlcfg->reload();
 	if (error_message.has_value()) {
-		std::cout << error_message.value() << std::endl;
+		std::cout << error_message.value() << std::endl << std::endl;
+		return EXIT_FAILURE;
 	} else if (!args.do_export() && !args.silent()) {
 		std::cout << _("done.") << std::endl;
 	}

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -23,16 +23,15 @@ nonstd::optional<std::string> FileUrlReader::reload()
 	tags.clear();
 	alltags.clear();
 
-	std::fstream f;
-	f.open(filename, std::fstream::in);
-	if (!f.is_open()) {
-		const auto error_message = strerror(errno);
-		return strprintf::fmt(_("Error: Failed to open file \"%s\" (%s)"),
+	std::vector<std::string> lines;
+	std::string error_message;
+	if (!utils::read_text_file(filename, lines, error_message)) {
+		return strprintf::fmt(_("Error: Failed to read urls from file \"%s\" (%s)"),
 				filename,
 				error_message);
 	}
 
-	for (std::string line; std::getline(f, line); /* nothing */) {
+	for (const std::string& line : lines) {
 		// skip empty lines and comments
 		if (line.empty() || line[0] == '#') {
 			continue;

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -26,7 +26,7 @@ nonstd::optional<std::string> FileUrlReader::reload()
 	std::vector<std::string> lines;
 	std::string error_message;
 	if (!utils::read_text_file(filename, lines, error_message)) {
-		return strprintf::fmt(_("Error: Failed to read urls from file \"%s\" (%s)"),
+		return strprintf::fmt(_("Error: Failed to read URLs from file \"%s\" (%s)"),
 				filename,
 				error_message);
 	}

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -23,13 +23,13 @@ nonstd::optional<std::string> FileUrlReader::reload()
 	tags.clear();
 	alltags.clear();
 
-	std::vector<std::string> lines;
-	std::string error_message;
-	if (!utils::read_text_file(filename, lines, error_message)) {
+	auto result = utils::read_text_file(filename);
+	if (!result) {
 		return strprintf::fmt(_("Error: Failed to read URLs from file \"%s\" (%s)"),
 				filename,
-				error_message);
+				result.error());
 	}
+	std::vector<std::string> lines = result.value();
 
 	for (const std::string& line : lines) {
 		// skip empty lines and comments

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -924,6 +924,20 @@ std::string utils::getcwd()
 	return RustString(rs_getcwd());
 }
 
+bool utils::read_text_file(const std::string& filename,
+	std::vector<std::string>& contents, std::string& error_message)
+{
+	rust::Vec<rust::String> c;
+	rust::String e;
+	bool result = bridged::read_text_file(filename, c, e);
+	contents.clear();
+	for (const auto& line : c) {
+		contents.push_back(std::string(line));
+	}
+	error_message = std::string(e);
+	return result;
+}
+
 int utils::strnaturalcmp(const std::string& a, const std::string& b)
 {
 	return rs_strnaturalcmp(a.c_str(), b.c_str());

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -924,18 +924,22 @@ std::string utils::getcwd()
 	return RustString(rs_getcwd());
 }
 
-bool utils::read_text_file(const std::string& filename,
-	std::vector<std::string>& contents, std::string& error_message)
+nonstd::expected<std::vector<std::string>, std::string> utils::read_text_file(
+	const std::string& filename)
 {
 	rust::Vec<rust::String> c;
 	rust::String e;
 	bool result = bridged::read_text_file(filename, c, e);
-	contents.clear();
-	for (const auto& line : c) {
-		contents.push_back(std::string(line));
+
+	if (result) {
+		std::vector<std::string> contents;
+		for (const auto& line : c) {
+			contents.push_back(std::string(line));
+		}
+		return contents;
+	} else {
+		return nonstd::make_unexpected(std::string(e));
 	}
-	error_message = std::string(e);
-	return result;
 }
 
 int utils::strnaturalcmp(const std::string& a, const std::string& b)

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -170,3 +170,20 @@ TEST_CASE("URL reader returns error message if file cannot be opened",
 		}
 	}
 }
+
+TEST_CASE("URL reader returns error message if file contains invalid unicode character",
+	"[FileUrlReader]")
+{
+	TestHelpers::TempFile urlsFile;
+
+	{
+		std::ofstream f(urlsFile.get_path());
+		f << "http://exmample.com/atom.xml" << std::endl;
+		f << "http://invalid.com/\xff.xml" << std::endl;
+	}
+
+	FileUrlReader u(urlsFile.get_path());
+	auto error_message = u.reload();
+	REQUIRE(error_message.has_value());
+	REQUIRE(error_message.value().size() > 0);
+}

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1278,10 +1278,10 @@ TEST_CASE("read_text_file() returns file contents line by line", "[utils]")
 			std::ofstream f(tempfile.get_path());
 			f << "lorem ipsum\ntest1\ntest2";
 		}
-		std::vector<std::string> content;
-		std::string error_message;
 
-		REQUIRE(utils::read_text_file(tempfile.get_path(), content, error_message));
+		const auto result = utils::read_text_file(tempfile.get_path());
+		REQUIRE(result);
+		const auto content = result.value();
 		REQUIRE(content.size() == 3);
 		REQUIRE(content[0] == "lorem ipsum");
 		REQUIRE(content[1] == "test1");
@@ -1296,10 +1296,9 @@ TEST_CASE("read_text_file() returns file contents line by line", "[utils]")
 		std::vector<std::string> content;
 		std::string error_message;
 
-		REQUIRE_FALSE(utils::read_text_file(tempfile.get_path(), content,
-				error_message));
-		REQUIRE(content.size() == 0);
-		REQUIRE(error_message.size() > 0);
+		const auto result = utils::read_text_file(tempfile.get_path());
+		REQUIRE_FALSE(result);
+		REQUIRE(result.error().size() > 0);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/844.

Current output when urls file contains an invalid unicode character:
![image](https://user-images.githubusercontent.com/4629607/101089582-a5af1680-35b5-11eb-88c7-8a65f7df6103.png)

I think it would be helpful to include the line number of the first line containing an invalid unicode character.