### PR TITLE
Do not crash on invalid UTF-8 configs

### DIFF
--- a/include/colormanager.h
+++ b/include/colormanager.h
@@ -4,7 +4,7 @@
 #include <map>
 #include <vector>
 
-#include "configparser.h"
+#include "configactionhandler.h"
 #include "stflpp.h"
 
 namespace podboat {
@@ -14,6 +14,8 @@ class PbView;
 class View;
 
 namespace newsboat {
+
+class ConfigParser;
 
 struct TextStyle {
 	std::string fg_color;

--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -6,11 +6,12 @@
 #include <string>
 #include <vector>
 
-#include "configparser.h"
+#include "configactionhandler.h"
 
 namespace newsboat {
 
 class ConfigData;
+class ConfigParser;
 
 enum class FeedSortMethod {
 	NONE,

--- a/include/confighandlerexception.h
+++ b/include/confighandlerexception.h
@@ -4,9 +4,9 @@
 #include <stdexcept>
 #include <string>
 
-#include "configparser.h"
-
 namespace newsboat {
+
+enum class ActionHandlerStatus;
 
 class ConfigHandlerException : public std::exception {
 public:

--- a/include/configparser.h
+++ b/include/configparser.h
@@ -28,7 +28,17 @@ public:
 	{
 		/* nothing because ConfigParser itself only handles include */
 	}
+
+	/// Processes configuration commands from a file at \a filename.
+	///
+	/// Returns:
+	/// - `false` if the file couldn't be opened;
+	/// - `true` if the whole file was processed completely.
+	///
+	/// If the file contains any errors, throws `ConfigException` with
+	/// a message explaining the problem.
 	bool parse_file(const std::string& filename);
+
 	void parse_line(const std::string& line, const std::string& location);
 	static std::string evaluate_backticks(std::string token);
 

--- a/include/controller.h
+++ b/include/controller.h
@@ -6,6 +6,7 @@
 #include "cache.h"
 #include "colormanager.h"
 #include "configcontainer.h"
+#include "configparser.h"
 #include "feedcontainer.h"
 #include "filtercontainer.h"
 #include "fslock.h"

--- a/include/filtercontainer.h
+++ b/include/filtercontainer.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_FILTERCONTAINER_H_
 #define NEWSBOAT_FILTERCONTAINER_H_
 
-#include "configparser.h"
+#include "configactionhandler.h"
 
 namespace newsboat {
 

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include "configparser.h"
+#include "configactionhandler.h"
 
 // in configuration: bind-key <key> <operation>
 

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -1,15 +1,16 @@
 #ifndef NEWSBOAT_REGEXMANAGER_H_
 #define NEWSBOAT_REGEXMANAGER_H_
 
+#include <map>
 #include <memory>
-#include <regex>
 #include <regex.h>
+#include <regex>
 #include <string>
 #include <sys/types.h>
 #include <utility>
 #include <vector>
 
-#include "configparser.h"
+#include "configactionhandler.h"
 #include "matcher.h"
 #include "regexowner.h"
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -161,8 +161,12 @@ struct ReadTextFileError {
 	ReadTextFileErrorKind kind;
 	std::string message;
 };
-nonstd::expected<std::vector<std::string>, ReadTextFileError> read_text_file(
-	const std::string& filename);
+// We define an alias for this to work around a bug in AStyle: the poor
+// formatter can't decide how to split the function declaration into multiple
+// lines, and re-formats it differently on each invocation.
+using ReadTextFileResult =
+	nonstd::expected<std::vector<std::string>, ReadTextFileError>;
+ReadTextFileResult read_text_file(const std::string& filename);
 
 int strnaturalcmp(const std::string& a, const std::string& b);
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -153,7 +153,15 @@ nonstd::optional<std::uint8_t> run_interactively(const std::string& command,
 
 std::string getcwd();
 
-nonstd::expected<std::vector<std::string>, std::string> read_text_file(
+enum class ReadTextFileErrorKind {
+	CantOpen,
+	LineError
+};
+struct ReadTextFileError {
+	ReadTextFileErrorKind kind;
+	std::string message;
+};
+nonstd::expected<std::vector<std::string>, ReadTextFileError> read_text_file(
 	const std::string& filename);
 
 int strnaturalcmp(const std::string& a, const std::string& b);

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -1,18 +1,18 @@
 filter/FilterParser.o: filter/FilterParser.cpp filter/FilterParser.h \
  include/logger.h config.h include/strprintf.h filter/Parser.h \
  filter/Scanner.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 filter/Parser.o: filter/Parser.cpp filter/Parser.h filter/FilterParser.h \
  filter/Scanner.h
 filter/Scanner.o: filter/Scanner.cpp filter/Scanner.h
 newsboat.o: newsboat.cpp include/cache.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
- include/strprintf.h config.h include/configpaths.h \
- include/cliargsparser.h include/controller.h include/cache.h \
- include/colormanager.h include/stflpp.h include/feedcontainer.h \
+ include/configactionhandler.h include/cliargsparser.h \
+ 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
+ config.h include/configpaths.h include/cliargsparser.h \
+ include/controller.h include/cache.h include/colormanager.h \
+ include/stflpp.h include/configparser.h include/feedcontainer.h \
  include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
@@ -28,7 +28,7 @@ newsboat.o: newsboat.cpp include/cache.h include/configcontainer.h \
  include/listformaction.h include/view.h include/filebrowserformaction.h \
  include/htmlrenderer.h include/textformatter.h xlicense.h
 podboat.o: podboat.cpp config.h include/exception.h \
- include/pbcontroller.h include/colormanager.h include/configparser.h \
+ include/pbcontroller.h include/colormanager.h \
  include/configactionhandler.h include/stflpp.h include/configcontainer.h \
  include/download.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/keymap.h \
@@ -41,42 +41,39 @@ podboat.o: podboat.cpp config.h include/exception.h \
 rss/atomparser.o: rss/atomparser.cpp rss/atomparser.h rss/rssparser.h \
  config.h rss/exception.h rss/feed.h rss/item.h rss/medianamespace.h \
  rss/rsspp_uris.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h rss/xmlutilities.h
 rss/exception.o: rss/exception.cpp rss/exception.h
 rss/medianamespace.o: rss/medianamespace.cpp rss/medianamespace.h \
  rss/item.h include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- rss/xmlutilities.h
+ include/configcontainer.h include/configactionhandler.h include/logger.h \
+ config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h rss/xmlutilities.h
 rss/parser.o: rss/parser.cpp rss/parser.h include/remoteapi.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h rss/feed.h rss/item.h config.h \
- rss/exception.h include/logger.h include/strprintf.h rss/rssparser.h \
- rss/rssparserfactory.h rss/rsspp_uris.h include/strprintf.h \
- include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h rss/feed.h \
+ rss/item.h config.h rss/exception.h include/logger.h include/strprintf.h \
+ rss/rssparser.h rss/rssparserfactory.h rss/rsspp_uris.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 rss/rss09xparser.o: rss/rss09xparser.cpp rss/rss09xparser.h \
  rss/rssparser.h config.h rss/exception.h rss/feed.h rss/item.h \
  rss/medianamespace.h rss/rsspp_uris.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- rss/xmlutilities.h
+ include/configactionhandler.h include/logger.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h rss/xmlutilities.h
 rss/rss10parser.o: rss/rss10parser.cpp rss/rss10parser.h rss/rssparser.h \
  config.h rss/exception.h rss/feed.h rss/item.h rss/rsspp_uris.h \
  rss/xmlutilities.h
 rss/rss20parser.o: rss/rss20parser.cpp rss/rss20parser.h \
  rss/rss09xparser.h rss/rssparser.h config.h rss/exception.h rss/feed.h \
  rss/item.h include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h include/logger.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 rss/rssparser.o: rss/rssparser.cpp rss/rssparser.h rss/exception.h \
  rss/xmlutilities.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 rss/rssparserfactory.o: rss/rssparserfactory.cpp rss/rssparserfactory.h \
@@ -84,9 +81,9 @@ rss/rssparserfactory.o: rss/rssparserfactory.cpp rss/rssparserfactory.h \
  rss/item.h rss/rss09xparser.h rss/rss10parser.h rss/rss20parser.h
 rss/xmlutilities.o: rss/xmlutilities.cpp rss/xmlutilities.h
 src/cache.o: src/cache.cpp include/cache.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h config.h \
- include/configcontainer.h include/controller.h include/cache.h \
- include/colormanager.h include/stflpp.h include/feedcontainer.h \
+ include/configactionhandler.h config.h include/configcontainer.h \
+ include/controller.h include/cache.h include/colormanager.h \
+ include/stflpp.h include/configparser.h include/feedcontainer.h \
  include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
@@ -103,35 +100,36 @@ src/cliargsparser.o: src/cliargsparser.cpp include/cliargsparser.h \
  3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
  include/globals.h include/ruststring.h include/strprintf.h
 src/colormanager.o: src/colormanager.cpp include/colormanager.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- config.h include/confighandlerexception.h include/feedlistformaction.h \
+ include/configactionhandler.h include/stflpp.h config.h \
+ include/confighandlerexception.h include/feedlistformaction.h \
  3rd-party/optional.hpp include/configcontainer.h include/history.h \
  include/listformaction.h include/formaction.h include/keymap.h \
  include/listwidget.h include/listformatter.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
  include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/feedlistformaction.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h include/filebrowserformaction.h \
- include/helpformaction.h include/textviewwidget.h \
- include/itemlistformaction.h include/itemviewformaction.h \
- include/logger.h include/strprintf.h include/matcherexception.h \
- include/pbview.h include/selectformaction.h include/strprintf.h \
- include/urlviewformaction.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/cache.h include/configparser.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+ include/feedlistformaction.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h \
+ include/filebrowserformaction.h include/helpformaction.h \
+ include/textviewwidget.h include/itemlistformaction.h \
+ include/itemviewformaction.h include/logger.h include/strprintf.h \
+ include/matcherexception.h include/pbview.h include/selectformaction.h \
+ include/strprintf.h include/urlviewformaction.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/configactionhandler.o: src/configactionhandler.cpp \
  include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/configcontainer.o: src/configcontainer.cpp include/configcontainer.h \
- include/configparser.h include/configactionhandler.h config.h \
- include/configparser.h include/configdata.h 3rd-party/expected.hpp \
+ include/configactionhandler.h config.h include/configparser.h \
+ include/configdata.h 3rd-party/expected.hpp \
  include/confighandlerexception.h include/logger.h include/strprintf.h \
  include/strprintf.h include/utils.h 3rd-party/optional.hpp \
  include/configcontainer.h include/logger.h \
@@ -139,22 +137,21 @@ src/configcontainer.o: src/configcontainer.cpp include/configcontainer.h \
 src/configdata.o: src/configdata.cpp include/configdata.h \
  3rd-party/expected.hpp config.h include/strprintf.h
 src/confighandlerexception.o: src/confighandlerexception.cpp \
- include/confighandlerexception.h include/configparser.h \
- include/configactionhandler.h config.h
+ include/confighandlerexception.h config.h include/configparser.h \
+ include/configactionhandler.h
 src/configparser.o: src/configparser.cpp include/configparser.h \
  include/configactionhandler.h config.h include/configexception.h \
- include/confighandlerexception.h include/configparser.h include/logger.h \
- include/strprintf.h include/strprintf.h include/tagsouppullparser.h \
- include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/confighandlerexception.h include/logger.h include/strprintf.h \
+ include/strprintf.h include/tagsouppullparser.h include/utils.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/configpaths.o: src/configpaths.cpp include/configpaths.h \
  include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
  include/strprintf.h include/globals.h include/ruststring.h \
  include/strprintf.h
 src/controller.o: src/controller.cpp include/controller.h include/cache.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/colormanager.h include/stflpp.h \
+ include/configcontainer.h include/configactionhandler.h \
+ include/colormanager.h include/stflpp.h include/configparser.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
@@ -163,14 +160,13 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/remoteapi.h include/rssignores.h include/rssitem.h \
  include/matchable.h include/cliargsparser.h include/logger.h config.h \
  include/strprintf.h include/colormanager.h include/configcontainer.h \
- include/configexception.h include/configparser.h include/configpaths.h \
- include/cliargsparser.h include/dbexception.h include/downloadthread.h \
- include/exception.h include/feedhqapi.h include/feedhqurlreader.h \
- include/fileurlreader.h include/globals.h include/inoreaderapi.h \
- include/inoreaderurlreader.h include/itemrenderer.h \
- include/htmlrenderer.h include/textformatter.h include/logger.h \
- include/minifluxapi.h 3rd-party/json.hpp rss/feed.h rss/item.h \
- include/utils.h 3rd-party/expected.hpp \
+ include/configexception.h include/configpaths.h include/cliargsparser.h \
+ include/dbexception.h include/downloadthread.h include/exception.h \
+ include/feedhqapi.h include/feedhqurlreader.h include/fileurlreader.h \
+ include/globals.h include/inoreaderapi.h include/inoreaderurlreader.h \
+ include/itemrenderer.h include/htmlrenderer.h include/textformatter.h \
+ include/logger.h include/minifluxapi.h 3rd-party/json.hpp rss/feed.h \
+ rss/item.h include/utils.h 3rd-party/expected.hpp \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  include/minifluxurlreader.h include/newsblurapi.h \
  include/newsblururlreader.h include/ocnewsapi.h \
@@ -187,85 +183,82 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/view.h include/filebrowserformaction.h
 src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/dialogsformaction.h include/formaction.h include/history.h \
- include/keymap.h include/configparser.h include/configactionhandler.h \
- include/stflpp.h include/listwidget.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h config.h include/fmtstrformatter.h \
- include/listformatter.h include/strprintf.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h include/strprintf.h \
+ include/keymap.h include/configactionhandler.h include/stflpp.h \
+ include/listwidget.h include/listformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h config.h \
+ include/fmtstrformatter.h include/listformatter.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/dirbrowserformaction.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/listwidget.h \
- include/stflpp.h include/formaction.h include/history.h include/keymap.h \
- config.h include/fmtstrformatter.h include/logger.h include/strprintf.h \
+ include/configactionhandler.h include/listformatter.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/listwidget.h include/stflpp.h \
+ include/formaction.h include/history.h include/keymap.h config.h \
+ include/fmtstrformatter.h include/logger.h include/strprintf.h \
  include/strprintf.h include/utils.h 3rd-party/expected.hpp \
  3rd-party/optional.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
- include/pbcontroller.h include/colormanager.h include/configparser.h \
+ include/pbcontroller.h include/colormanager.h \
  include/configactionhandler.h include/stflpp.h include/configcontainer.h \
  include/download.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/keymap.h \
  include/queueloader.h
 src/downloadthread.o: src/downloadthread.cpp include/downloadthread.h \
- include/reloader.h include/configcontainer.h include/configparser.h \
+ include/reloader.h include/configcontainer.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h
 src/emptyformaction.o: src/emptyformaction.cpp include/emptyformaction.h \
  include/formaction.h include/history.h include/keymap.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h
+ include/configactionhandler.h include/stflpp.h
 src/exception.o: src/exception.cpp include/exception.h config.h
 src/feedcontainer.o: src/feedcontainer.cpp include/feedcontainer.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/utils.h
+ include/configcontainer.h include/configactionhandler.h \
+ include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
+ include/rssitem.h include/matcher.h filter/FilterParser.h \
+ include/utils.h 3rd-party/expected.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/utils.h
 src/feedhqapi.o: src/feedhqapi.cpp include/feedhqapi.h include/cache.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/remoteapi.h config.h \
- include/strprintf.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/logger.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h \
+ include/remoteapi.h config.h include/strprintf.h include/utils.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/feedhqurlreader.o: src/feedhqurlreader.cpp include/feedhqurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/fileurlreader.h include/logger.h config.h include/strprintf.h \
- include/remoteapi.h include/configcontainer.h include/utils.h \
- 3rd-party/expected.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configactionhandler.h include/fileurlreader.h include/logger.h \
+ config.h include/strprintf.h include/remoteapi.h \
+ include/configcontainer.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/feedlistformaction.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/history.h include/listformaction.h \
- include/formaction.h include/keymap.h include/stflpp.h \
- include/listwidget.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
+ include/configcontainer.h include/configactionhandler.h \
+ include/history.h include/listformaction.h include/formaction.h \
+ include/keymap.h include/stflpp.h include/listwidget.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
  include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
  include/opml.h include/fileurlreader.h include/urlreader.h \
  include/queuemanager.h include/reloader.h include/remoteapi.h \
@@ -282,45 +275,45 @@ src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/strprintf.h include/utils.h include/view.h
 src/filebrowserformaction.o: src/filebrowserformaction.cpp \
  include/filebrowserformaction.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/listwidget.h \
- include/stflpp.h include/formaction.h include/history.h include/keymap.h \
- config.h include/fmtstrformatter.h include/listformatter.h \
- include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
+ include/configactionhandler.h include/listformatter.h \
+ include/regexmanager.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/listwidget.h include/stflpp.h \
+ include/formaction.h include/history.h include/keymap.h config.h \
+ include/fmtstrformatter.h include/listformatter.h include/logger.h \
+ include/strprintf.h include/strprintf.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/fileurlreader.o: src/fileurlreader.cpp include/fileurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/utils.h \
- 3rd-party/expected.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/expected.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/filtercontainer.o: src/filtercontainer.cpp include/filtercontainer.h \
- include/configparser.h include/configactionhandler.h config.h \
- include/confighandlerexception.h include/matcher.h filter/FilterParser.h \
+ include/configactionhandler.h config.h include/confighandlerexception.h \
+ include/configparser.h include/matcher.h filter/FilterParser.h \
  include/strprintf.h include/utils.h 3rd-party/expected.hpp \
  3rd-party/optional.hpp include/configcontainer.h include/logger.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/fmtstrformatter.o: src/fmtstrformatter.cpp include/fmtstrformatter.h \
  include/logger.h config.h include/strprintf.h include/ruststring.h
 src/formaction.o: src/formaction.cpp include/formaction.h \
- include/history.h include/keymap.h include/configparser.h \
- include/configactionhandler.h include/stflpp.h config.h \
- include/configexception.h include/logger.h include/strprintf.h \
- include/matcherexception.h include/strprintf.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
+ include/history.h include/keymap.h include/configactionhandler.h \
+ include/stflpp.h config.h include/configexception.h include/logger.h \
+ include/strprintf.h include/matcherexception.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
  include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
  include/opml.h include/fileurlreader.h include/urlreader.h \
  include/queuemanager.h include/regexmanager.h include/matcher.h \
@@ -336,15 +329,15 @@ src/fslock.o: src/fslock.cpp include/fslock.h \
  config.h include/strprintf.h
 src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
  include/formaction.h include/history.h include/keymap.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- include/textviewwidget.h config.h include/fmtstrformatter.h \
- include/keymap.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/strprintf.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/feedcontainer.h include/filtercontainer.h \
+ include/configactionhandler.h include/stflpp.h include/textviewwidget.h \
+ config.h include/fmtstrformatter.h include/keymap.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
  include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
  include/opml.h include/fileurlreader.h include/urlreader.h \
  include/queuemanager.h include/reloader.h include/remoteapi.h \
@@ -355,33 +348,33 @@ src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
  include/htmlrenderer.h include/textformatter.h
 src/history.o: src/history.cpp include/history.h include/ruststring.h
 src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
- include/textformatter.h include/regexmanager.h include/configparser.h \
+ include/textformatter.h include/regexmanager.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h config.h include/logger.h include/strprintf.h \
  include/strprintf.h include/tagsouppullparser.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
  include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/inoreaderapi.o: src/inoreaderapi.cpp include/inoreaderapi.h \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/remoteapi.h include/urlreader.h \
- 3rd-party/optional.hpp config.h include/strprintf.h include/utils.h \
- 3rd-party/expected.hpp include/logger.h include/strprintf.h \
+ include/cache.h include/configcontainer.h include/configactionhandler.h \
+ include/remoteapi.h include/urlreader.h 3rd-party/optional.hpp config.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/inoreaderurlreader.o: src/inoreaderurlreader.cpp \
  include/inoreaderurlreader.h include/urlreader.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/fileurlreader.h include/logger.h \
- config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h \
+ include/fileurlreader.h include/logger.h config.h include/strprintf.h \
+ include/remoteapi.h include/configcontainer.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/itemlistformaction.o: src/itemlistformaction.cpp \
  include/itemlistformaction.h 3rd-party/optional.hpp include/history.h \
  include/listformaction.h include/formaction.h include/keymap.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- include/listwidget.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/view.h include/colormanager.h include/configcontainer.h \
- include/controller.h include/cache.h include/feedcontainer.h \
+ include/configactionhandler.h include/stflpp.h include/listwidget.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/view.h \
+ include/colormanager.h include/configcontainer.h include/controller.h \
+ include/cache.h include/configparser.h include/feedcontainer.h \
  include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
@@ -398,24 +391,23 @@ src/itemlistformaction.o: src/itemlistformaction.cpp \
  include/strprintf.h include/utils.h include/view.h
 src/itemrenderer.o: src/itemrenderer.cpp include/itemrenderer.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
- include/configparser.h include/configactionhandler.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/configcontainer.h \
- include/htmlrenderer.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/utils.h \
- 3rd-party/expected.hpp include/configcontainer.h include/logger.h \
- config.h include/strprintf.h \
+ include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h include/configcontainer.h include/htmlrenderer.h \
+ include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
+ include/rssitem.h include/utils.h 3rd-party/expected.hpp \
+ include/configcontainer.h include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/textformatter.h
 src/itemviewformaction.o: src/itemviewformaction.cpp \
  include/itemviewformaction.h include/formaction.h include/history.h \
- include/keymap.h include/configparser.h include/configactionhandler.h \
- include/stflpp.h include/htmlrenderer.h include/textformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/textviewwidget.h config.h \
- include/confighandlerexception.h include/dbexception.h \
- include/fmtstrformatter.h include/itemlistformaction.h \
- 3rd-party/optional.hpp include/listformaction.h include/listwidget.h \
- include/listformatter.h include/view.h include/colormanager.h \
- include/configcontainer.h include/controller.h include/cache.h \
+ include/keymap.h include/configactionhandler.h include/stflpp.h \
+ include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/textviewwidget.h config.h include/confighandlerexception.h \
+ include/dbexception.h include/fmtstrformatter.h \
+ include/itemlistformaction.h 3rd-party/optional.hpp \
+ include/listformaction.h include/listwidget.h include/listformatter.h \
+ include/view.h include/colormanager.h include/configcontainer.h \
+ include/controller.h include/cache.h include/configparser.h \
  include/feedcontainer.h include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
@@ -429,38 +421,40 @@ src/itemviewformaction.o: src/itemviewformaction.cpp \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/textformatter.h include/utils.h \
  include/view.h
-src/keymap.o: src/keymap.cpp include/keymap.h include/configparser.h \
+src/keymap.o: src/keymap.cpp include/keymap.h \
  include/configactionhandler.h config.h include/confighandlerexception.h \
- include/logger.h include/strprintf.h include/strprintf.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/configparser.h include/logger.h include/strprintf.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/keymap.rs.h
 src/listformaction.o: src/listformaction.cpp include/listformaction.h \
  3rd-party/optional.hpp include/formaction.h include/history.h \
- include/keymap.h include/configparser.h include/configactionhandler.h \
- include/stflpp.h include/listwidget.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/rssfeed.h include/matchable.h \
- include/rssitem.h include/utils.h 3rd-party/expected.hpp \
- include/configcontainer.h include/logger.h config.h include/strprintf.h \
+ include/keymap.h include/configactionhandler.h include/stflpp.h \
+ include/listwidget.h include/listformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/rssfeed.h include/matchable.h include/rssitem.h include/utils.h \
+ 3rd-party/expected.hpp include/configcontainer.h include/logger.h \
+ config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/dirbrowserformaction.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/dirbrowserformaction.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h
 src/listformatter.o: src/listformatter.cpp include/listformatter.h \
- include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/stflpp.h include/strprintf.h \
- include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h config.h include/strprintf.h \
+ include/regexmanager.h include/configactionhandler.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/stflpp.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/listwidget.o: src/listwidget.cpp include/listwidget.h \
- include/listformatter.h include/regexmanager.h include/configparser.h \
+ include/listformatter.h include/regexmanager.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h include/stflpp.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
@@ -472,7 +466,7 @@ src/matcher.o: src/matcher.cpp include/matcher.h filter/FilterParser.h \
  include/logger.h config.h include/strprintf.h include/matchable.h \
  3rd-party/optional.hpp include/matcherexception.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h include/utils.h \
- 3rd-party/expected.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/expected.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/matcherexception.o: src/matcherexception.cpp \
@@ -480,19 +474,18 @@ src/matcherexception.o: src/matcherexception.cpp \
  include/strprintf.h
 src/minifluxapi.o: src/minifluxapi.cpp include/minifluxapi.h \
  3rd-party/json.hpp include/remoteapi.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h rss/feed.h \
- rss/item.h include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/logger.h \
- include/remoteapi.h include/strprintf.h include/utils.h
+ include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/logger.h include/remoteapi.h include/strprintf.h include/utils.h
 src/minifluxurlreader.o: src/minifluxurlreader.cpp \
  include/minifluxurlreader.h include/urlreader.h 3rd-party/optional.hpp \
  include/fileurlreader.h include/logger.h config.h include/strprintf.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
+ include/remoteapi.h include/configcontainer.h \
  include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
  include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/newsblurapi.o: src/newsblurapi.cpp include/newsblurapi.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
+ include/remoteapi.h include/configcontainer.h \
  include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
@@ -501,54 +494,50 @@ src/newsblururlreader.o: src/newsblururlreader.cpp \
  include/newsblururlreader.h rss/feed.h rss/item.h include/urlreader.h \
  3rd-party/optional.hpp include/fileurlreader.h include/logger.h config.h \
  include/strprintf.h include/remoteapi.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/utils.h \
- 3rd-party/expected.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ocnewsapi.o: src/ocnewsapi.cpp include/ocnewsapi.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
+ include/remoteapi.h include/configcontainer.h \
  include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ocnewsurlreader.o: src/ocnewsurlreader.cpp include/ocnewsurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/fileurlreader.h \
  include/logger.h config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
-src/oldreaderapi.o: src/oldreaderapi.cpp include/oldreaderapi.h \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/remoteapi.h config.h \
- include/strprintf.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/logger.h include/strprintf.h \
+ include/configcontainer.h include/configactionhandler.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+src/oldreaderapi.o: src/oldreaderapi.cpp include/oldreaderapi.h \
+ include/cache.h include/configcontainer.h include/configactionhandler.h \
+ include/remoteapi.h config.h include/strprintf.h include/utils.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/oldreaderurlreader.o: src/oldreaderurlreader.cpp \
  include/oldreaderurlreader.h include/urlreader.h 3rd-party/optional.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/fileurlreader.h include/logger.h \
- config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h \
+ include/fileurlreader.h include/logger.h config.h include/strprintf.h \
+ include/remoteapi.h include/configcontainer.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/opml.o: src/opml.cpp include/opml.h include/feedcontainer.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/fileurlreader.h \
- include/urlreader.h 3rd-party/optional.hpp include/rssfeed.h \
- include/matchable.h include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h config.h include/strprintf.h \
+ include/configcontainer.h include/configactionhandler.h \
+ include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
+ include/rssfeed.h include/matchable.h include/rssitem.h \
+ include/matcher.h filter/FilterParser.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/opmlurlreader.o: src/opmlurlreader.cpp include/opmlurlreader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/urlreader.h 3rd-party/optional.hpp \
- include/utils.h 3rd-party/expected.hpp include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h \
+ include/urlreader.h 3rd-party/optional.hpp include/utils.h \
+ 3rd-party/expected.hpp include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
- include/colormanager.h include/configparser.h \
- include/configactionhandler.h include/stflpp.h include/configcontainer.h \
- include/download.h include/fslock.h \
+ include/colormanager.h include/configactionhandler.h include/stflpp.h \
+ include/configcontainer.h include/download.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/keymap.h \
  include/queueloader.h config.h include/configcontainer.h \
- include/configexception.h include/globals.h include/logger.h \
- include/strprintf.h include/matcherexception.h \
+ include/configexception.h include/configparser.h include/globals.h \
+ include/logger.h include/strprintf.h include/matcherexception.h \
  include/nullconfigactionhandler.h include/pbview.h include/listwidget.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h include/textviewwidget.h \
@@ -556,29 +545,26 @@ src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
  include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
  include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- include/keymap.h include/listwidget.h include/listformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/textviewwidget.h config.h \
- include/configcontainer.h stfl/dllist.h include/download.h \
- include/fmtstrformatter.h stfl/help.h include/listformatter.h \
- include/logger.h include/strprintf.h include/pbcontroller.h \
- include/configcontainer.h include/download.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/queueloader.h \
- include/poddlthread.h include/strprintf.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configactionhandler.h include/stflpp.h include/keymap.h \
+ include/listwidget.h include/listformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/textviewwidget.h config.h include/configcontainer.h \
+ stfl/dllist.h include/download.h include/fmtstrformatter.h stfl/help.h \
+ include/listformatter.h include/logger.h include/strprintf.h \
+ include/pbcontroller.h include/configcontainer.h include/download.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/queueloader.h include/poddlthread.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/download.h config.h \
- include/logger.h include/strprintf.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h \
+ include/download.h config.h include/logger.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/queueloader.o: src/queueloader.cpp include/queueloader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/download.h config.h \
- include/configcontainer.h include/logger.h include/strprintf.h \
- include/stflpp.h include/strprintf.h include/utils.h \
+ include/configcontainer.h include/configactionhandler.h \
+ include/download.h config.h include/configcontainer.h include/logger.h \
+ include/strprintf.h include/stflpp.h include/strprintf.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/queuemanager.o: src/queuemanager.cpp include/queuemanager.h \
@@ -586,22 +572,22 @@ src/queuemanager.o: src/queuemanager.cpp include/queuemanager.h \
  include/logger.h config.h include/strprintf.h include/fmtstrformatter.h \
  include/rssfeed.h include/matchable.h include/rssitem.h \
  include/matcher.h filter/FilterParser.h include/utils.h \
- 3rd-party/expected.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/expected.hpp include/configcontainer.h \
  include/configactionhandler.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/stflpp.h \
  include/utils.h
 src/regexmanager.o: src/regexmanager.cpp include/regexmanager.h \
- include/configparser.h include/configactionhandler.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h config.h \
- include/confighandlerexception.h include/logger.h include/strprintf.h \
+ include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h config.h include/confighandlerexception.h \
+ include/configparser.h include/logger.h include/strprintf.h \
  include/strprintf.h include/utils.h 3rd-party/expected.hpp \
  3rd-party/optional.hpp include/configcontainer.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/regexowner.o: src/regexowner.cpp include/regexowner.h
 src/reloader.o: src/reloader.cpp include/reloader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/controller.h include/cache.h \
- include/colormanager.h include/stflpp.h include/feedcontainer.h \
+ include/configcontainer.h include/configactionhandler.h \
+ include/controller.h include/cache.h include/colormanager.h \
+ include/stflpp.h include/configparser.h include/feedcontainer.h \
  include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
@@ -623,11 +609,11 @@ src/reloader.o: src/reloader.cpp include/reloader.h \
  include/textformatter.h
 src/reloadrangethread.o: src/reloadrangethread.cpp \
  include/reloadrangethread.h include/reloader.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h
+ include/configactionhandler.h
 src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/controller.h include/cache.h \
- include/colormanager.h include/stflpp.h include/feedcontainer.h \
+ include/configcontainer.h include/configactionhandler.h \
+ include/controller.h include/cache.h include/colormanager.h \
+ include/stflpp.h include/configparser.h include/feedcontainer.h \
  include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
@@ -636,44 +622,43 @@ src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
  include/remoteapi.h include/rssignores.h include/rssitem.h \
  include/matchable.h include/logger.h config.h include/strprintf.h
 src/remoteapi.o: src/remoteapi.cpp include/remoteapi.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h include/utils.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/rssfeed.o: src/rssfeed.cpp include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
  filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/cache.h include/configcontainer.h \
- include/confighandlerexception.h include/dbexception.h \
- include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
- include/regexowner.h include/logger.h include/scopemeasure.h \
+ include/configcontainer.h include/configactionhandler.h include/logger.h \
+ config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/cache.h \
+ include/configcontainer.h include/confighandlerexception.h \
+ include/dbexception.h include/htmlrenderer.h include/textformatter.h \
+ include/regexmanager.h include/regexowner.h include/logger.h \
+ include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/tagsouppullparser.h include/utils.h
 src/rssignores.o: src/rssignores.cpp include/rssignores.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
- include/cache.h include/configcontainer.h include/configparser.h \
- config.h include/configcontainer.h include/confighandlerexception.h \
- include/dbexception.h include/htmlrenderer.h include/textformatter.h \
- include/regexmanager.h include/regexowner.h include/logger.h \
- include/strprintf.h include/rssfeed.h include/utils.h \
+ include/cache.h include/configcontainer.h config.h \
+ include/configcontainer.h include/confighandlerexception.h \
+ include/configparser.h include/dbexception.h include/htmlrenderer.h \
+ include/textformatter.h include/regexmanager.h include/regexowner.h \
+ include/logger.h include/strprintf.h include/rssfeed.h include/utils.h \
  3rd-party/expected.hpp include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/strprintf.h \
  include/tagsouppullparser.h include/utils.h
 src/rssitem.o: src/rssitem.cpp include/rssitem.h include/matchable.h \
  3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/dbexception.h include/rssfeed.h \
- include/rssitem.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
+ include/cache.h include/configcontainer.h include/configactionhandler.h \
+ include/dbexception.h include/rssfeed.h include/rssitem.h \
+ include/utils.h 3rd-party/expected.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/utils.h
 src/rssparser.o: src/rssparser.cpp include/rssparser.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
+ include/remoteapi.h include/configcontainer.h \
  include/configactionhandler.h rss/feed.h rss/item.h include/cache.h \
  config.h include/configcontainer.h include/curlhandle.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
@@ -691,16 +676,16 @@ src/scopemeasure.o: src/scopemeasure.cpp include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h
 src/selectformaction.o: src/selectformaction.cpp \
  include/selectformaction.h include/filtercontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/formaction.h include/history.h include/keymap.h include/stflpp.h \
- include/listwidget.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h config.h \
+ include/configactionhandler.h include/formaction.h include/history.h \
+ include/keymap.h include/stflpp.h include/listwidget.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h config.h \
  include/fmtstrformatter.h include/listformatter.h include/strprintf.h \
  include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
  include/configcontainer.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
- include/feedcontainer.h include/fslock.h \
+ include/configparser.h include/feedcontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
@@ -711,64 +696,62 @@ src/selectformaction.o: src/selectformaction.cpp \
 src/stflpp.o: src/stflpp.cpp include/stflpp.h include/exception.h \
  include/logger.h config.h include/strprintf.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
- include/configparser.h include/configactionhandler.h include/logger.h \
+ include/configactionhandler.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/strprintf.o: src/strprintf.cpp include/strprintf.h
 src/tagsouppullparser.o: src/tagsouppullparser.cpp \
  include/tagsouppullparser.h config.h include/logger.h \
  include/strprintf.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/xmlexception.h
 src/textformatter.o: src/textformatter.cpp include/textformatter.h \
- include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/htmlrenderer.h include/textformatter.h \
- include/stflpp.h include/strprintf.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
- include/logger.h config.h include/strprintf.h \
+ include/regexmanager.h include/configactionhandler.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/htmlrenderer.h \
+ include/textformatter.h include/stflpp.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/configcontainer.h include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/textviewwidget.o: src/textviewwidget.cpp include/textviewwidget.h \
  include/stflpp.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ttrssapi.o: src/ttrssapi.cpp include/ttrssapi.h 3rd-party/json.hpp \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/remoteapi.h include/logger.h \
- config.h include/strprintf.h include/remoteapi.h rss/feed.h rss/item.h \
- include/strprintf.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/cache.h include/configcontainer.h include/configactionhandler.h \
+ include/remoteapi.h include/logger.h config.h include/strprintf.h \
+ include/remoteapi.h rss/feed.h rss/item.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ttrssurlreader.o: src/ttrssurlreader.cpp include/ttrssurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/fileurlreader.h \
  include/logger.h config.h include/strprintf.h include/remoteapi.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/urlreader.o: src/urlreader.cpp include/urlreader.h \
  3rd-party/optional.hpp
 src/urlviewformaction.o: src/urlviewformaction.cpp \
  include/urlviewformaction.h include/formaction.h include/history.h \
- include/keymap.h include/configparser.h include/configactionhandler.h \
- include/stflpp.h include/htmlrenderer.h include/textformatter.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/listwidget.h include/listformatter.h \
- config.h include/fmtstrformatter.h include/listformatter.h \
- include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
- include/rssitem.h include/utils.h 3rd-party/expected.hpp \
- include/configcontainer.h include/logger.h include/strprintf.h \
+ include/keymap.h include/configactionhandler.h include/stflpp.h \
+ include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/listwidget.h include/listformatter.h config.h \
+ include/fmtstrformatter.h include/listformatter.h include/rssfeed.h \
+ include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
+ include/utils.h 3rd-party/expected.hpp include/configcontainer.h \
+ include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/strprintf.h \
  include/utils.h include/view.h include/colormanager.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h \
+ include/controller.h include/cache.h include/configparser.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
  include/dirbrowserformaction.h include/feedlistformaction.h \
  include/listformaction.h include/view.h include/filebrowserformaction.h
 src/utils.o: src/utils.cpp include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
@@ -776,25 +759,25 @@ src/utils.o: src/utils.cpp include/utils.h 3rd-party/expected.hpp \
  include/logger.h include/ruststring.h include/strprintf.h \
  include/rs_utils.h
 src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
- include/colormanager.h include/configparser.h \
- include/configactionhandler.h include/stflpp.h include/configcontainer.h \
- include/controller.h include/cache.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/listformatter.h \
- include/listwidget.h include/formaction.h include/history.h \
- include/keymap.h include/feedlistformaction.h include/listformaction.h \
- include/view.h include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h config.h include/dbexception.h stfl/dialogs.h \
- include/dialogsformaction.h include/emptyformaction.h stfl/empty.h \
- include/exception.h stfl/feedlist.h stfl/filebrowser.h \
- include/fmtstrformatter.h include/formaction.h stfl/help.h \
- include/helpformaction.h include/textviewwidget.h include/htmlrenderer.h \
- stfl/itemlist.h include/itemlistformaction.h stfl/itemview.h \
+ include/colormanager.h include/configactionhandler.h include/stflpp.h \
+ include/configcontainer.h include/controller.h include/cache.h \
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/dirbrowserformaction.h \
+ include/listformatter.h include/listwidget.h include/formaction.h \
+ include/history.h include/keymap.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h config.h \
+ include/dbexception.h stfl/dialogs.h include/dialogsformaction.h \
+ include/emptyformaction.h stfl/empty.h include/exception.h \
+ stfl/feedlist.h stfl/filebrowser.h include/fmtstrformatter.h \
+ include/formaction.h stfl/help.h include/helpformaction.h \
+ include/textviewwidget.h include/htmlrenderer.h stfl/itemlist.h \
+ include/itemlistformaction.h stfl/itemview.h \
  include/itemviewformaction.h include/keymap.h include/logger.h \
  include/strprintf.h include/matcherexception.h include/regexmanager.h \
  include/reloadthread.h include/rssfeed.h include/utils.h \
@@ -803,7 +786,7 @@ src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
  include/selectformaction.h stfl/selecttag.h include/strprintf.h \
  stfl/urlview.h include/urlviewformaction.h include/utils.h
 test/cache.o: test/cache.cpp include/cache.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h 3rd-party/catch.hpp \
+ include/configactionhandler.h 3rd-party/catch.hpp \
  include/configcontainer.h include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
  filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
@@ -817,18 +800,17 @@ test/cliargsparser.o: test/cliargsparser.cpp 3rd-party/catch.hpp \
  test/test-helpers/stringmaker/optional.h test/test-helpers/tempdir.h \
  test/test-helpers/maintempdir.h
 test/colormanager.o: test/colormanager.cpp include/colormanager.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- 3rd-party/catch.hpp include/confighandlerexception.h
+ include/configactionhandler.h include/stflpp.h 3rd-party/catch.hpp \
+ include/confighandlerexception.h include/configparser.h
 test/configcontainer.o: test/configcontainer.cpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h 3rd-party/catch.hpp include/configdata.h \
- 3rd-party/expected.hpp include/confighandlerexception.h \
- include/configparser.h include/keymap.h
+ include/configcontainer.h include/configactionhandler.h \
+ 3rd-party/catch.hpp include/configdata.h 3rd-party/expected.hpp \
+ include/confighandlerexception.h include/configparser.h include/keymap.h
 test/configdata.o: test/configdata.cpp 3rd-party/catch.hpp \
  include/configdata.h 3rd-party/expected.hpp
 test/configparser.o: test/configparser.cpp include/configparser.h \
  include/configactionhandler.h 3rd-party/catch.hpp include/keymap.h \
- include/configparser.h test/test-helpers/envvar.h 3rd-party/optional.hpp \
+ test/test-helpers/envvar.h 3rd-party/optional.hpp \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/configpaths.o: test/configpaths.cpp include/configpaths.h \
  include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
@@ -836,25 +818,23 @@ test/configpaths.o: test/configpaths.cpp include/configpaths.h \
  test/test-helpers/envvar.h test/test-helpers/opts.h \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
  include/utils.h 3rd-party/expected.hpp include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
+ include/configactionhandler.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 test/download.o: test/download.cpp include/download.h 3rd-party/catch.hpp
 test/feedcontainer.o: test/feedcontainer.cpp 3rd-party/catch.hpp \
- include/cache.h include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/configcontainer.h \
- include/feedcontainer.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h config.h include/strprintf.h \
+ include/cache.h include/configcontainer.h include/configactionhandler.h \
+ include/configcontainer.h include/feedcontainer.h include/rssfeed.h \
+ include/matchable.h 3rd-party/optional.hpp include/rssitem.h \
+ include/matcher.h filter/FilterParser.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 test/fileurlreader.o: test/fileurlreader.cpp include/fileurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp 3rd-party/catch.hpp \
  test/test-helpers/chmod.h test/test-helpers/misc.h \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/filtercontainer.o: test/filtercontainer.cpp \
- include/filtercontainer.h include/configparser.h \
- include/configactionhandler.h 3rd-party/catch.hpp \
- include/confighandlerexception.h
+ include/filtercontainer.h include/configactionhandler.h \
+ 3rd-party/catch.hpp include/confighandlerexception.h
 test/filterparser.o: test/filterparser.cpp filter/FilterParser.h \
  3rd-party/catch.hpp
 test/fmtstrformatter.o: test/fmtstrformatter.cpp \
@@ -866,7 +846,7 @@ test/fslock.o: test/fslock.cpp include/fslock.h \
 test/history.o: test/history.cpp include/history.h 3rd-party/catch.hpp \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h
 test/htmlrenderer.o: test/htmlrenderer.cpp include/htmlrenderer.h \
- include/textformatter.h include/regexmanager.h include/configparser.h \
+ include/textformatter.h include/regexmanager.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h 3rd-party/catch.hpp include/strprintf.h \
  include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
@@ -875,11 +855,11 @@ test/htmlrenderer.o: test/htmlrenderer.cpp include/htmlrenderer.h \
 test/itemlistformaction.o: test/itemlistformaction.cpp \
  include/itemlistformaction.h 3rd-party/optional.hpp include/history.h \
  include/listformaction.h include/formaction.h include/keymap.h \
- include/configparser.h include/configactionhandler.h include/stflpp.h \
- include/listwidget.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/view.h include/colormanager.h include/configcontainer.h \
- include/controller.h include/cache.h include/feedcontainer.h \
+ include/configactionhandler.h include/stflpp.h include/listwidget.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/view.h \
+ include/colormanager.h include/configcontainer.h include/controller.h \
+ include/cache.h include/configparser.h include/feedcontainer.h \
  include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
@@ -896,83 +876,80 @@ test/itemlistformaction.o: test/itemlistformaction.cpp \
  test/test-helpers/maintempdir.h
 test/itemrenderer.o: test/itemrenderer.cpp include/itemrenderer.h \
  include/htmlrenderer.h include/textformatter.h include/regexmanager.h \
- include/configparser.h include/configactionhandler.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h 3rd-party/catch.hpp \
- include/cache.h include/configcontainer.h include/configcontainer.h \
+ include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h 3rd-party/catch.hpp include/cache.h \
+ include/configcontainer.h include/configcontainer.h \
  include/regexmanager.h include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/utils.h \
  3rd-party/expected.hpp include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  test/test-helpers/envvar.h
-test/keymap.o: test/keymap.cpp include/keymap.h include/configparser.h \
+test/keymap.o: test/keymap.cpp include/keymap.h \
  include/configactionhandler.h 3rd-party/catch.hpp \
  include/confighandlerexception.h
 test/listformatter.o: test/listformatter.cpp include/listformatter.h \
- include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h 3rd-party/catch.hpp
+ include/regexmanager.h include/configactionhandler.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h 3rd-party/catch.hpp
 test/matcher.o: test/matcher.cpp include/matcher.h filter/FilterParser.h \
  3rd-party/catch.hpp include/matchable.h 3rd-party/optional.hpp \
  include/matcherexception.h test/test-helpers/stringmaker/optional.h
 test/matcherexception.o: test/matcherexception.cpp \
  include/matcherexception.h 3rd-party/catch.hpp
 test/opml.o: test/opml.cpp include/opml.h include/feedcontainer.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/fileurlreader.h \
- include/urlreader.h 3rd-party/optional.hpp 3rd-party/catch.hpp \
- include/cache.h include/fileurlreader.h include/rssfeed.h \
- include/matchable.h include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h config.h include/strprintf.h \
+ include/configcontainer.h include/configactionhandler.h \
+ include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
+ 3rd-party/catch.hpp include/cache.h include/fileurlreader.h \
+ include/rssfeed.h include/matchable.h include/rssitem.h \
+ include/matcher.h filter/FilterParser.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h test/test-helpers/misc.h \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/opmlurlreader.o: test/opmlurlreader.cpp include/opmlurlreader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/urlreader.h 3rd-party/optional.hpp \
- 3rd-party/catch.hpp test/test-helpers/misc.h \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h \
- include/utils.h 3rd-party/expected.hpp include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/configcontainer.h include/configactionhandler.h \
+ include/urlreader.h 3rd-party/optional.hpp 3rd-party/catch.hpp \
+ test/test-helpers/misc.h test/test-helpers/tempfile.h \
+ test/test-helpers/maintempdir.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 test/queueloader.o: test/queueloader.cpp include/queueloader.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/download.h 3rd-party/catch.hpp \
- include/configcontainer.h include/download.h \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+ include/configcontainer.h include/configactionhandler.h \
+ include/download.h 3rd-party/catch.hpp include/configcontainer.h \
+ include/download.h test/test-helpers/tempfile.h \
+ test/test-helpers/maintempdir.h
 test/regexmanager.o: test/regexmanager.cpp include/regexmanager.h \
- include/configparser.h include/configactionhandler.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h 3rd-party/catch.hpp \
+ include/configactionhandler.h include/matcher.h filter/FilterParser.h \
+ include/regexowner.h 3rd-party/catch.hpp \
  include/confighandlerexception.h include/matchable.h \
  3rd-party/optional.hpp
 test/regexowner.o: test/regexowner.cpp include/regexowner.h \
  3rd-party/catch.hpp
 test/remoteapi.o: test/remoteapi.cpp include/remoteapi.h \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h 3rd-party/catch.hpp
+ include/configcontainer.h include/configactionhandler.h \
+ 3rd-party/catch.hpp include/configparser.h
 test/rssfeed.o: test/rssfeed.cpp include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/matcher.h \
  filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
- include/configcontainer.h include/configparser.h \
- include/configactionhandler.h include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- 3rd-party/catch.hpp include/cache.h include/configcontainer.h \
- include/rssparser.h include/remoteapi.h rss/feed.h rss/item.h \
- test/test-helpers/envvar.h test/test-helpers/stringmaker/optional.h
+ include/configcontainer.h include/configactionhandler.h include/logger.h \
+ config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h 3rd-party/catch.hpp \
+ include/cache.h include/configcontainer.h include/rssparser.h \
+ include/remoteapi.h rss/feed.h rss/item.h test/test-helpers/envvar.h \
+ test/test-helpers/stringmaker/optional.h
 test/rssignores.o: test/rssignores.cpp include/rssignores.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
  include/rssitem.h include/matchable.h 3rd-party/optional.hpp \
  3rd-party/catch.hpp include/cache.h include/configcontainer.h \
- include/configparser.h include/confighandlerexception.h \
- include/rssitem.h
+ include/confighandlerexception.h include/rssitem.h
 test/rssitem.o: test/rssitem.cpp include/rssitem.h include/matchable.h \
  3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
  3rd-party/catch.hpp include/cache.h include/configcontainer.h \
- include/configparser.h include/configactionhandler.h \
- include/configcontainer.h include/rssfeed.h include/rssitem.h \
- include/utils.h 3rd-party/expected.hpp include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/configactionhandler.h include/configcontainer.h \
+ include/rssfeed.h include/rssitem.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  test/test-helpers/envvar.h test/test-helpers/stringmaker/optional.h
 test/rsspp_parser.o: test/rsspp_parser.cpp rss/parser.h \
- include/remoteapi.h include/configcontainer.h include/configparser.h \
+ include/remoteapi.h include/configcontainer.h \
  include/configactionhandler.h rss/feed.h rss/item.h 3rd-party/catch.hpp \
  rss/exception.h test/test-helpers/exceptionwithmsg.h
 test/rsspp_rssparser.o: test/rsspp_rssparser.cpp rss/rssparser.h \
@@ -992,7 +969,7 @@ test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
  include/strprintf.h
 test/test-helpers/chdir.o: test/test-helpers/chdir.cpp \
  test/test-helpers/chdir.h include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 test/test-helpers/chmod.o: test/test-helpers/chmod.cpp \
@@ -1013,11 +990,10 @@ test/test-helpers/tempdir.o: test/test-helpers/tempdir.cpp \
 test/test-helpers/tempfile.o: test/test-helpers/tempfile.cpp \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
 test/textformatter.o: test/textformatter.cpp include/textformatter.h \
- include/regexmanager.h include/configparser.h \
- include/configactionhandler.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h 3rd-party/catch.hpp
+ include/regexmanager.h include/configactionhandler.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h 3rd-party/catch.hpp
 test/utils.o: test/utils.cpp include/utils.h 3rd-party/expected.hpp \
- 3rd-party/optional.hpp include/configcontainer.h include/configparser.h \
+ 3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  3rd-party/catch.hpp include/htmlrenderer.h include/textformatter.h \

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -809,9 +809,10 @@ test/configcontainer.o: test/configcontainer.cpp \
 test/configdata.o: test/configdata.cpp 3rd-party/catch.hpp \
  include/configdata.h 3rd-party/expected.hpp
 test/configparser.o: test/configparser.cpp include/configparser.h \
- include/configactionhandler.h 3rd-party/catch.hpp include/keymap.h \
- test/test-helpers/envvar.h 3rd-party/optional.hpp \
- test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+ include/configactionhandler.h 3rd-party/catch.hpp \
+ include/configexception.h include/keymap.h test/test-helpers/envvar.h \
+ 3rd-party/optional.hpp test/test-helpers/tempfile.h \
+ test/test-helpers/maintempdir.h
 test/configpaths.o: test/configpaths.cpp include/configpaths.h \
  include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
  include/strprintf.h 3rd-party/catch.hpp test/test-helpers/chmod.h \

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -25,7 +25,8 @@ mod bridged {
         fn read_text_file(
             filename: String,
             contents: &mut Vec<String>,
-            error_message: &mut String,
+            error_line_number: &mut u64,
+            error_reason: &mut String,
         ) -> bool;
     }
 
@@ -42,7 +43,8 @@ mod bridged {
 pub fn read_text_file(
     filename: String,
     contents: &mut Vec<String>,
-    error_message: &mut String,
+    error_line_number: &mut u64,
+    error_reason: &mut String,
 ) -> bool {
     use std::path::Path;
 
@@ -52,7 +54,21 @@ pub fn read_text_file(
             true
         }
         Err(e) => {
-            *error_message = e;
+            use utils::ReadTextFileError::*;
+            match e {
+                CantOpen { reason } => {
+                    *error_line_number = 0;
+                    *error_reason = reason.to_string();
+                }
+
+                LineError {
+                    line_number,
+                    reason,
+                } => {
+                    *error_line_number = line_number as u64;
+                    *error_reason = reason.to_string();
+                }
+            }
             false
         }
     }

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -38,8 +38,7 @@ void ColorManager::handle_action(const std::string& action,
 		action);
 	if (action == "color") {
 		if (params.size() < 3) {
-			throw ConfigHandlerException(
-				ActionHandlerStatus::TOO_FEW_PARAMS);
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 		}
 
 		/*
@@ -50,19 +49,22 @@ void ColorManager::handle_action(const std::string& action,
 		std::string fgcolor = params[1];
 		std::string bgcolor = params[2];
 
-		if (!utils::is_valid_color(fgcolor))
+		if (!utils::is_valid_color(fgcolor)) {
 			throw ConfigHandlerException(strprintf::fmt(
 					_("`%s' is not a valid color"), fgcolor));
-		if (!utils::is_valid_color(bgcolor))
+		}
+		if (!utils::is_valid_color(bgcolor)) {
 			throw ConfigHandlerException(strprintf::fmt(
 					_("`%s' is not a valid color"), bgcolor));
+		}
 
 		std::vector<std::string> attribs;
 		for (unsigned int i = 3; i < params.size(); ++i) {
-			if (!utils::is_valid_attribute(params[i]))
+			if (!utils::is_valid_attribute(params[i])) {
 				throw ConfigHandlerException(strprintf::fmt(
 						_("`%s' is not a valid attribute"),
 						params[i]));
+			}
 			attribs.push_back(params[i]);
 		}
 
@@ -74,14 +76,15 @@ void ColorManager::handle_action(const std::string& action,
 			element == "background" || element == "article" ||
 			element == "end-of-text-marker") {
 			element_styles[element] = {fgcolor, bgcolor, attribs};
-		} else
+		} else {
 			throw ConfigHandlerException(strprintf::fmt(
 					_("`%s' is not a valid configuration element"),
 					element));
+		}
 
-	} else
-		throw ConfigHandlerException(
-			ActionHandlerStatus::INVALID_COMMAND);
+	} else {
+		throw ConfigHandlerException(ActionHandlerStatus::INVALID_COMMAND);
+	}
 }
 
 void ColorManager::dump_config(std::vector<std::string>& config_output) const

--- a/src/confighandlerexception.cpp
+++ b/src/confighandlerexception.cpp
@@ -1,6 +1,7 @@
 #include "confighandlerexception.h"
 
 #include "config.h"
+#include "configparser.h"
 
 namespace newsboat {
 

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -33,18 +33,17 @@ void ConfigParser::handle_action(const std::string& action,
 	 */
 	if (action == "include") {
 		if (params.size() < 1) {
-			throw ConfigHandlerException(
-				ActionHandlerStatus::TOO_FEW_PARAMS);
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 		}
 
-		std::string tilde_expanded = utils::resolve_tilde(params[0]);
-		std::string current_fpath = included_files.back();
-		if (!this->parse_file(utils::resolve_relative(current_fpath, tilde_expanded)))
-			throw ConfigHandlerException(
-				ActionHandlerStatus::FILENOTFOUND);
-	} else
-		throw ConfigHandlerException(
-			ActionHandlerStatus::INVALID_COMMAND);
+		const std::string tilde_expanded = utils::resolve_tilde(params[0]);
+		const std::string current_fpath = included_files.back();
+		if (!this->parse_file(utils::resolve_relative(current_fpath, tilde_expanded))) {
+			throw ConfigHandlerException(ActionHandlerStatus::FILENOTFOUND);
+		}
+	} else {
+		throw ConfigHandlerException(ActionHandlerStatus::INVALID_COMMAND);
+	}
 }
 
 bool ConfigParser::parse_file(const std::string& tmp_filename)
@@ -111,7 +110,7 @@ void ConfigParser::parse_line(const std::string& line,
 	auto evaluated = evaluate_backticks(std::move(stripped));
 	const auto token = utils::extract_token_quoted(evaluated);
 	if (token.has_value()) {
-		std::string cmd = token.value();
+		const std::string cmd = token.value();
 		const std::string params = evaluated;
 
 		if (action_handlers.count(cmd) < 1) {
@@ -170,7 +169,7 @@ std::string ConfigParser::evaluate_backticks(std::string token)
 		find_non_escaped_backtick(token, pos1 + 1);
 
 	while (pos1 != std::string::npos && pos2 != std::string::npos) {
-		std::string cmd = token.substr(pos1 + 1, pos2 - pos1 - 1);
+		const std::string cmd = token.substr(pos1 + 1, pos2 - pos1 - 1);
 		token.erase(pos1, pos2 - pos1 + 1);
 		std::string result = utils::get_command_output(cmd);
 		utils::trim_end(result);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -29,7 +29,6 @@
 #include "config.h"
 #include "configcontainer.h"
 #include "configexception.h"
-#include "configparser.h"
 #include "configpaths.h"
 #include "dbexception.h"
 #include "downloadthread.h"

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -27,7 +27,7 @@ nonstd::optional<std::string> FileUrlReader::reload()
 	if (!result) {
 		return strprintf::fmt(_("Error: Failed to read URLs from file \"%s\" (%s)"),
 				filename,
-				result.error());
+				result.error().message);
 	}
 	std::vector<std::string> lines = result.value();
 

--- a/src/filtercontainer.cpp
+++ b/src/filtercontainer.cpp
@@ -2,6 +2,7 @@
 
 #include "config.h"
 #include "confighandlerexception.h"
+#include "configparser.h"
 #include "matcher.h"
 #include "strprintf.h"
 #include "utils.h"
@@ -21,8 +22,7 @@ void FilterContainer::handle_action(const std::string& action,
 	 */
 	if (action == "define-filter") {
 		if (params.size() < 2) {
-			throw ConfigHandlerException(
-				ActionHandlerStatus::TOO_FEW_PARAMS);
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 		}
 
 		FilterNameExprPair filter;
@@ -39,8 +39,7 @@ void FilterContainer::handle_action(const std::string& action,
 
 		filters.emplace_back(std::move(filter));
 	} else {
-		throw ConfigHandlerException(
-			ActionHandlerStatus::INVALID_COMMAND);
+		throw ConfigHandlerException(ActionHandlerStatus::INVALID_COMMAND);
 	}
 }
 

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -691,16 +691,17 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 	LOG(Level::DEBUG, "KeyMap::handle_action(%s, ...) called", action);
 	if (action == "bind-key") {
 		const auto tokens = utils::tokenize_quoted(params);
-		if (tokens.size() < 2)
-			throw ConfigHandlerException(
-				ActionHandlerStatus::TOO_FEW_PARAMS);
+		if (tokens.size() < 2) {
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
 		std::string context = "all";
 		if (tokens.size() >= 3) {
 			context = tokens[2];
 		}
-		if (!is_valid_context(context))
+		if (!is_valid_context(context)) {
 			throw ConfigHandlerException(strprintf::fmt(
 					_("`%s' is not a valid context"), context));
+		}
 		const Operation op = get_opcode(tokens[1]);
 		if (op == OP_NIL) {
 			throw ConfigHandlerException(

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -8,6 +8,7 @@
 
 #include "config.h"
 #include "confighandlerexception.h"
+#include "configparser.h"
 #include "logger.h"
 #include "strprintf.h"
 #include "utils.h"

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -17,6 +17,7 @@
 #include "config.h"
 #include "configcontainer.h"
 #include "configexception.h"
+#include "configparser.h"
 #include "globals.h"
 #include "logger.h"
 #include "matcherexception.h"

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -200,8 +200,7 @@ void RegexManager::handle_highlight_action(const std::vector<std::string>&
 	params)
 {
 	if (params.size() < 3) {
-		throw ConfigHandlerException(
-			ActionHandlerStatus::TOO_FEW_PARAMS);
+		throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 	}
 
 	std::string location = params[0];
@@ -290,8 +289,7 @@ void RegexManager::handle_highlight_article_action(const
 	std::vector<std::string>& params)
 {
 	if (params.size() < 3) {
-		throw ConfigHandlerException(
-			ActionHandlerStatus::TOO_FEW_PARAMS);
+		throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 	}
 
 	std::string expr = params[0];

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -6,6 +6,7 @@
 
 #include "config.h"
 #include "confighandlerexception.h"
+#include "configparser.h"
 #include "logger.h"
 #include "strprintf.h"
 #include "utils.h"

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -16,6 +16,7 @@
 #include "config.h"
 #include "configcontainer.h"
 #include "confighandlerexception.h"
+#include "configparser.h"
 #include "dbexception.h"
 #include "htmlrenderer.h"
 #include "logger.h"

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -61,8 +61,7 @@ void RssIgnores::handle_action(const std::string& action,
 			resetflag.push_back(param);
 		}
 	} else {
-		throw ConfigHandlerException(
-			ActionHandlerStatus::INVALID_COMMAND);
+		throw ConfigHandlerException(ActionHandlerStatus::INVALID_COMMAND);
 	}
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -924,9 +924,7 @@ std::string utils::getcwd()
 	return RustString(rs_getcwd());
 }
 
-nonstd::expected<std::vector<std::string>, utils::ReadTextFileError>
-utils::read_text_file(
-	const std::string& filename)
+utils::ReadTextFileResult utils::read_text_file( const std::string& filename)
 {
 	rust::Vec<rust::String> c;
 	std::uint64_t error_line_number{};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -924,12 +924,15 @@ std::string utils::getcwd()
 	return RustString(rs_getcwd());
 }
 
-nonstd::expected<std::vector<std::string>, std::string> utils::read_text_file(
+nonstd::expected<std::vector<std::string>, utils::ReadTextFileError>
+utils::read_text_file(
 	const std::string& filename)
 {
 	rust::Vec<rust::String> c;
-	rust::String e;
-	bool result = bridged::read_text_file(filename, c, e);
+	std::uint64_t error_line_number{};
+	rust::String error_reason;
+	const bool result = bridged::read_text_file(filename, c, error_line_number,
+			error_reason);
 
 	if (result) {
 		std::vector<std::string> contents;
@@ -938,7 +941,19 @@ nonstd::expected<std::vector<std::string>, std::string> utils::read_text_file(
 		}
 		return contents;
 	} else {
-		return nonstd::make_unexpected(std::string(e));
+		ReadTextFileError error;
+
+		if (error_line_number == 0) {
+			error.kind = ReadTextFileErrorKind::CantOpen;
+			error.message = strprintf::fmt(_("Failed to open file (%s)"),
+					std::string(error_reason));
+		} else {
+			error.kind = ReadTextFileErrorKind::LineError;
+			error.message = strprintf::fmt(_("Failed to read line %u (%s)"),
+					error_line_number, std::string(error_reason));
+		}
+
+		return nonstd::make_unexpected(error);
 	}
 }
 

--- a/test/colormanager.cpp
+++ b/test/colormanager.cpp
@@ -5,7 +5,9 @@
 #include <vector>
 
 #include "3rd-party/catch.hpp"
+
 #include "confighandlerexception.h"
+#include "configparser.h"
 
 using namespace newsboat;
 

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -256,6 +256,10 @@ TEST_CASE("`include` directive includes other config files", "[ConfigParser]")
 		REQUIRE_THROWS_AS(cfgparser.parse_file("data/config-missing-include"),
 			ConfigException);
 	}
+	SECTION("Errors on invalid UTF-8 in file") {
+		REQUIRE_THROWS_AS(cfgparser.parse_file("data/config-invalid-utf-8"),
+			ConfigException);
+	}
 	SECTION("Terminates on recursive include") {
 		REQUIRE_THROWS_AS(cfgparser.parse_file("data/config-recursive-include"),
 			ConfigException);

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -5,6 +5,8 @@
 #include <vector>
 
 #include "3rd-party/catch.hpp"
+
+#include "configexception.h"
 #include "keymap.h"
 #include "test-helpers/envvar.h"
 #include "test-helpers/tempfile.h"
@@ -28,7 +30,7 @@ public:
 
 } // Anonymous namespace
 
-TEST_CASE("parse_line() Handles both lines with and without quoting",
+TEST_CASE("parse_line() handles both lines with and without quoting",
 	"[ConfigParser]")
 {
 	ConfigParser cfgParser;
@@ -39,8 +41,9 @@ TEST_CASE("parse_line() Handles both lines with and without quoting",
 	const std::string location = "dummy-location";
 
 	SECTION("unknown command results in exception") {
-		REQUIRE_THROWS(cfgParser.parse_line("foo", location));
-		REQUIRE_THROWS(cfgParser.parse_line("foo arg1 arg2", location));
+		REQUIRE_THROWS_AS(cfgParser.parse_line("foo", location), ConfigException);
+		REQUIRE_THROWS_AS(cfgParser.parse_line("foo arg1 arg2", location),
+			ConfigException);
 	}
 
 	SECTION("different combinations of (un)quoted commands/arguments have the same result") {
@@ -245,15 +248,17 @@ TEST_CASE("\"unbind-key -a\" removes all key bindings", "[ConfigParser]")
 	}
 }
 
-TEST_CASE("include directive includes other config files", "[ConfigParser]")
+TEST_CASE("`include` directive includes other config files", "[ConfigParser]")
 {
 	// TODO: error messages should be more descriptive than "file couldn't be opened"
 	ConfigParser cfgparser;
-	SECTION("Errors on not found file") {
-		REQUIRE_THROWS(cfgparser.parse_file("data/config-missing-include"));
+	SECTION("Errors if file is not found") {
+		REQUIRE_THROWS_AS(cfgparser.parse_file("data/config-missing-include"),
+			ConfigException);
 	}
 	SECTION("Terminates on recursive include") {
-		REQUIRE_THROWS(cfgparser.parse_file("data/config-recursive-include"));
+		REQUIRE_THROWS_AS(cfgparser.parse_file("data/config-recursive-include"),
+			ConfigException);
 	}
 	SECTION("Successfully includes existing file") {
 		REQUIRE_NOTHROW(cfgparser.parse_file("data/config-absolute-include"));

--- a/test/data/config-invalid-utf-8
+++ b/test/data/config-invalid-utf-8
@@ -1,0 +1,1 @@
+set browser firefoxÿ

--- a/test/remoteapi.cpp
+++ b/test/remoteapi.cpp
@@ -4,6 +4,8 @@
 
 #include "3rd-party/catch.hpp"
 
+#include "configparser.h"
+
 using namespace newsboat;
 
 /*

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1298,7 +1298,7 @@ TEST_CASE("read_text_file() returns file contents line by line", "[utils]")
 
 		const auto result = utils::read_text_file(tempfile.get_path());
 		REQUIRE_FALSE(result);
-		REQUIRE(result.error().size() > 0);
+		REQUIRE(result.error().message.size() > 0);
 	}
 }
 


### PR DESCRIPTION
This employs the new `read_text_file()` function to fix the same bug as #844, but for configs. I had to rework the bridge for `read_text_file()` so I could distinguish between "failed to open" and "failed to read" errors on the C++ side — `ConfigParser` returns `false` on the former but throws `ConfigException` on the latter. A lot of churn, but conceptually a pretty simple fix.

On an input from #723, this now errors appropriately:

```
$ newsboat
Starting newsboat r2.21-304-g2698-dirty...
Loading configuration...Failed to read line 1 (stream did not contain valid UTF-8)
```

The error message could be better, e.g. it could show the path to the file. However, this would require adding a new string to the POT file, which we already shipped off to translators (in #1339). I don't think it's important enough.

I should look really look at all our other files too, but this PR is big enough already. I'll file an issue about that, and try to do this before the 2.22 release.

I'd like people to test this before 2.22 release, which is only two weeks away, so I'm requesting a review from @dennisschagt and will merge once it's done. (But reviews from others are welcome too!)