### PR TITLE
Reduce (future) code duplication for code related to using open_in_browser()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ CXX_FOR_BUILD?=$(CXX)
 # compiler and linker flags
 DEFINES=-DLOCALEDIR='"$(localedir)"'
 
-WARNFLAGS=-Werror -Wall -Wextra -Wunreachable-code
+WARNFLAGS=-Werror -Wall -Wextra -Wunreachable-code -Wno-unknown-warning-option -Wno-unknown-pragmas
 INCLUDES=-Iinclude -Istfl -Ifilter -I. -Irss -I$(relative_cargo_target_dir)/cxxbridge/libnewsboat-ffi/src/
 BARE_CXXFLAGS=-std=c++11 -O2 -ggdb $(INCLUDES)
 LDFLAGS+=-L.

--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -60,6 +60,8 @@ private:
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
 
+	bool open_feed_in_browser(const std::shared_ptr<RssFeed>& feed) const;
+
 	void goto_feed(const std::string& str);
 
 	void save_filterpos();

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -83,6 +83,9 @@ private:
 	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
+
+	bool open_item_in_browser(const std::shared_ptr<RssItem>& item) const;
+
 	void set_head(const std::string& s,
 		unsigned int unread,
 		unsigned int total,

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -58,6 +58,9 @@ private:
 	bool process_operation(Operation op,
 		bool automatic = false,
 		std::vector<std::string>* args = nullptr) override;
+
+	bool open_link_in_browser(const std::string& link) const;
+
 	void update_head(const std::shared_ptr<RssItem>& item);
 	void set_head(const std::string& s,
 		const std::string& feedtitle,

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -237,8 +237,11 @@ REDO:
 					v->show_error(_("Failed to spawn browser"));
 					return false;
 				} else if (*exit_code != 0) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"),
 							*exit_code));
+#pragma GCC diagnostic pop
 					return false;
 				}
 			}
@@ -263,7 +266,10 @@ REDO:
 					v->show_error(_("Failed to spawn browser"));
 					return false;
 				} else if (*exit_code != 0) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
+#pragma GCC diagnostic pop
 					return false;
 				}
 

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -212,47 +212,10 @@ REDO:
 	break;
 	case OP_OPENINBROWSER:
 		if (visible_feeds.size() > 0 && feedpos.length() > 0) {
-			std::shared_ptr<RssFeed> feed =
-				v->get_ctrl()->get_feedcontainer()->get_feed(pos);
+			std::shared_ptr<RssFeed> feed = v->get_ctrl()->get_feedcontainer()->get_feed(
+					pos);
 			if (feed) {
-				if (!feed->is_query_feed()) {
-					LOG(Level::INFO,
-						"FeedListFormAction: opening "
-						"feed "
-						"at position `%s': %s",
-						feedpos,
-						feed->link());
-
-					std::string url;
-					if (!feed->link().empty()) {
-						url = feed->link();
-					} else if (!feed->rssurl().empty()) {
-						url = feed->rssurl();
-					} else {
-						// rssurl can't be empty, so if we got to this branch,
-						// something is clearly wrong with Newsboat internals.
-						// That's why we write a message to the log, and not
-						// just display it to the user.
-						LOG(Level::INFO,
-							"FeedListFormAction: cannot open feed in browser "
-							"because both `link' and `rssurl' fields are "
-							"empty");
-					}
-
-					if (!url.empty()) {
-						const std::string feedurl = feed->rssurl();
-						const auto exit_code = v->open_in_browser(url, feedurl);
-						if (!exit_code.has_value()) {
-							v->show_error(_("Failed to spawn browser"));
-							return false;
-						} else if (*exit_code != 0) {
-							v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
-							return false;
-						}
-					}
-				} else {
-					v->show_error(_("Cannot open query feeds in the browser!"));
-				}
+				return open_feed_in_browser(feed);
 			}
 		} else {
 			v->show_error(_("No feed selected!"));
@@ -554,6 +517,48 @@ REDO:
 		}
 	}
 	return true;
+}
+
+bool FeedListFormAction::open_feed_in_browser(const std::shared_ptr<RssFeed>&
+	feed) const
+{
+	if (!feed->is_query_feed()) {
+		LOG(Level::INFO,
+			"FeedListFormAction: opening feed %s",
+			feed->link());
+
+		std::string url;
+		if (!feed->link().empty()) {
+			url = feed->link();
+		} else if (!feed->rssurl().empty()) {
+			url = feed->rssurl();
+		} else {
+			// rssurl can't be empty, so if we got to this branch,
+			// something is clearly wrong with Newsboat internals.
+			// That's why we write a message to the log, and not
+			// just display it to the user.
+			LOG(Level::INFO,
+				"FeedListFormAction: cannot open feed in browser "
+				"because both `link' and `rssurl' fields are "
+				"empty");
+		}
+
+		if (!url.empty()) {
+			const std::string feedurl = feed->rssurl();
+			const auto exit_code = v->open_in_browser(url, feedurl);
+			if (!exit_code.has_value()) {
+				v->show_error(_("Failed to spawn browser"));
+				return false;
+			} else if (*exit_code != 0) {
+				v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
+				return false;
+			}
+		}
+		return true;
+	} else {
+		v->show_error(_("Cannot open query feeds in the browser!"));
+		return false;
+	}
 }
 
 void FeedListFormAction::update_visible_feeds(

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -236,9 +236,9 @@ REDO:
 				if (!exit_code.has_value()) {
 					v->show_error(_("Failed to spawn browser"));
 					return false;
-				} else if (exit_code.value() != 0) {
+				} else if (*exit_code != 0) {
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"),
-							exit_code.value()));
+							*exit_code));
 					return false;
 				}
 			}

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -159,6 +159,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			if (!open_item_in_browser(item)) {
 				break;
 			}
+			invalidate(itempos);
 		} else {
 			v->show_error(_("No item selected!"));
 		}

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -135,7 +135,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		if (!visible_items.empty() && itempos < visible_items.size()) {
 			auto item = visible_items[itempos].first;
 			if (!open_item_in_browser(item)) {
-				break;
+				return false;
 			}
 			item->set_unread(false);
 			v->get_ctrl()->mark_article_read(item->guid(), true);
@@ -157,7 +157,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		if (!visible_items.empty() && itempos < visible_items.size()) {
 			auto item = visible_items[itempos].first;
 			if (!open_item_in_browser(item)) {
-				break;
+				return false;
 			}
 			invalidate(itempos);
 		} else {

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -132,59 +132,35 @@ bool ItemListFormAction::process_operation(Operation op,
 	break;
 	case OP_OPENBROWSER_AND_MARK: {
 		LOG(Level::INFO, "ItemListFormAction: opening item at pos `%u'", itempos);
-		if (!visible_items.empty()) {
-			if (itempos < visible_items.size()) {
-				const auto link = visible_items[itempos].first->link();
-				const auto feedurl = visible_items[itempos].first->feedurl();
-				const auto exit_code = v->open_in_browser(link, feedurl);
-				if (!exit_code.has_value()) {
-					v->show_error(_("Failed to spawn browser"));
-					break;
-				} else if (*exit_code != 0) {
-					v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
-					break;
-				}
-				visible_items[itempos].first->set_unread(false);
-				v->get_ctrl()->mark_article_read(
-					visible_items[itempos].first->guid(),
-					true);
-				if (!cfg->get_configvalue_as_bool(
-						"openbrowser-and-mark-jumps-to-"
-						"next-unread")) {
-					if (itempos <
-						visible_items.size() - 1) {
-						list.set_position(itempos + 1);
-					}
-				} else {
-					process_operation(OP_NEXTUNREAD);
-				}
-				invalidate(itempos);
+		if (!visible_items.empty() && itempos < visible_items.size()) {
+			auto item = visible_items[itempos].first;
+			if (!open_item_in_browser(item)) {
+				break;
 			}
+			item->set_unread(false);
+			v->get_ctrl()->mark_article_read(item->guid(), true);
+			if (cfg->get_configvalue_as_bool("openbrowser-and-mark-jumps-to-next-unread")) {
+				process_operation(OP_NEXTUNREAD);
+			} else {
+				if (itempos < visible_items.size() - 1) {
+					list.set_position(itempos + 1);
+				}
+			}
+			invalidate(itempos);
 		} else {
-			v->show_error(
-				_("No item selected!")); // should not happen
+			v->show_error(_("No item selected!"));
 		}
 	}
 	break;
 	case OP_OPENINBROWSER: {
 		LOG(Level::INFO, "ItemListFormAction: opening item at pos `%u'", itempos);
-		if (!visible_items.empty()) {
-			if (itempos < visible_items.size()) {
-				const auto link = visible_items[itempos].first->link();
-				const auto feedurl = visible_items[itempos].first->feedurl();
-				const auto exit_code = v->open_in_browser(link, feedurl);
-				if (!exit_code.has_value()) {
-					v->show_error(_("Failed to spawn browser"));
-					return false;
-				} else if (*exit_code != 0) {
-					v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
-					return false;
-				}
-				invalidate(itempos);
+		if (!visible_items.empty() && itempos < visible_items.size()) {
+			auto item = visible_items[itempos].first;
+			if (!open_item_in_browser(item)) {
+				break;
 			}
 		} else {
-			v->show_error(
-				_("No item selected!")); // should not happen
+			v->show_error(_("No item selected!"));
 		}
 	}
 	break;
@@ -775,6 +751,22 @@ bool ItemListFormAction::process_operation(Operation op,
 		}
 	} else if (quit) {
 		v->pop_current_formaction();
+	}
+	return true;
+}
+
+bool ItemListFormAction::open_item_in_browser(
+	const std::shared_ptr<RssItem>& item) const
+{
+	const auto link = item->link();
+	const auto feedurl = item->feedurl();
+	const auto exit_code = v->open_in_browser(link, feedurl);
+	if (!exit_code.has_value()) {
+		v->show_error(_("Failed to spawn browser"));
+		return false;
+	} else if (*exit_code != 0) {
+		v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
+		return false;
 	}
 	return true;
 }

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -245,17 +245,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 	case OP_OPENINBROWSER:
 	case OP_OPENBROWSER_AND_MARK: {
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: starting browser");
-		v->set_status(_("Starting browser..."));
-		const auto exit_code = v->open_in_browser(item->link(), item->feedurl());
-		if (!exit_code.has_value()) {
-			v->show_error(_("Failed to spawn browser"));
-			return false;
-		} else if (*exit_code != 0) {
-			v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
-			return false;
-		}
-
-		v->set_status("");
+		return open_link_in_browser(item->link());
 	}
 	break;
 	case OP_BOOKMARK:
@@ -431,18 +421,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 			op,
 			idx);
 		if (idx < links.size()) {
-			v->set_status(_("Starting browser..."));
-
-			const auto exit_code = v->open_in_browser(links[idx].first, item->feedurl());
-			if (!exit_code.has_value()) {
-				v->show_error(_("Failed to spawn browser"));
-				return false;
-			} else if (*exit_code != 0) {
-				v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
-				return false;
-			}
-
-			v->set_status("");
+			return open_link_in_browser(links[idx].first);
 		}
 	}
 	break;
@@ -481,6 +460,20 @@ bool ItemViewFormAction::process_operation(Operation op,
 
 	update_percent();
 
+	return true;
+}
+
+bool ItemViewFormAction::open_link_in_browser(const std::string& link) const
+{
+	const std::string feedurl = item->feedurl();
+	const auto exit_code = v->open_in_browser(link, feedurl);
+	if (!exit_code.has_value()) {
+		v->show_error(_("Failed to spawn browser"));
+		return false;
+	} else if (*exit_code != 0) {
+		v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
+		return false;
+	}
 	return true;
 }
 
@@ -588,9 +581,7 @@ void ItemViewFormAction::finished_qna(Operation op)
 		unsigned int idx = 0;
 		sscanf(qna_responses[0].c_str(), "%u", &idx);
 		if (idx && idx - 1 < links.size()) {
-			v->set_status(_("Starting browser..."));
-			v->open_in_browser(links[idx - 1].first, item->feedurl());
-			v->set_status("");
+			open_link_in_browser(links[idx - 1].first);
 		}
 	}
 	break;


### PR DESCRIPTION
https://github.com/newsboat/newsboat/pull/1335#issuecomment-739505009 suggests adding a new operation (`open-in-background-browser`) which will probably require code similar to the `OP_OPENINBROWSER` operation.
In this PR, I try to extract that (soon-to-be) duplicate code into separate functions.