### PR TITLE
Nudge users towards enabling `cleanup-on-quit` or running `newsboat --cleanup`

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -51,7 +51,7 @@ public:
 		const std::string& feedurl);
 	void update_rssitem_unread_and_enqueued(RssItem* item,
 		const std::string& feedurl);
-	int cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
+	std::uint64_t cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
 		bool always_clean = false);
 	void do_vacuum();
 	std::vector<std::shared_ptr<RssItem>> search_for_items(

--- a/include/cache.h
+++ b/include/cache.h
@@ -51,7 +51,7 @@ public:
 		const std::string& feedurl);
 	void update_rssitem_unread_and_enqueued(RssItem* item,
 		const std::string& feedurl);
-	void cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
+	int cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
 		bool always_clean = false);
 	void do_vacuum();
 	std::vector<std::shared_ptr<RssItem>> search_for_items(

--- a/include/cache.h
+++ b/include/cache.h
@@ -51,6 +51,8 @@ public:
 		const std::string& feedurl);
 	void update_rssitem_unread_and_enqueued(RssItem* item,
 		const std::string& feedurl);
+	/// if requested, removes unreachable data stored in cache.
+	/// returns a count of unreachable feeds and items.
 	std::uint64_t cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
 		bool always_clean = false);
 	void do_vacuum();

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -747,8 +747,6 @@ void Cache::do_vacuum()
 	run_sql("VACUUM;");
 }
 
-/// if requested, removes unreachable data stored in cache.
-/// returns a count of unreachable feeds and items.
 std::uint64_t Cache::cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
 	bool always_clean)
 {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -747,9 +747,20 @@ void Cache::do_vacuum()
 	run_sql("VACUUM;");
 }
 
-void Cache::cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
+int Cache::cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
 	bool always_clean)
 {
+	int unreachable = 0;
+	std::string list = "(";
+
+	for (const auto& feed : feeds) {
+		std::string name =
+			prepare_query("'%q'", feed->rssurl());
+		list.append(name);
+		list.append(", ");
+	}
+	list.append("'')");
+
 	// we don't use the std::lock_guard<> here... see comments below
 	mtx.lock();
 
@@ -767,15 +778,6 @@ void Cache::cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
 	 */
 	if (always_clean || cfg->get_configvalue_as_bool("cleanup-on-quit")) {
 		LOG(Level::DEBUG, "Cache::cleanup_cache: cleaning up cache...");
-		std::string list = "(";
-
-		for (const auto& feed : feeds) {
-			std::string name =
-				prepare_query("'%q'", feed->rssurl());
-			list.append(name);
-			list.append(", ");
-		}
-		list.append("'')");
 
 		std::string cleanup_rss_feeds_statement(
 			"DELETE FROM rss_feed WHERE rssurl NOT IN ");
@@ -803,7 +805,24 @@ void Cache::cleanup_cache(std::vector<std::shared_ptr<RssFeed>> feeds,
 	} else {
 		LOG(Level::DEBUG,
 			"Cache::cleanup_cache: NOT cleaning up cache...");
+
+		std::string query = (
+				"SELECT count(rss) "
+				"FROM ("
+				"SELECT feedurl AS rss FROM rss_item "
+				"UNION ALL "
+				"SELECT rssurl FROM rss_feed"
+				") "
+				"WHERE rss NOT IN "
+			);
+		query.append(list);
+		query.push_back(';');
+
+		CbHandler count_cbh;
+		run_sql(query, count_callback, &count_cbh);
+		unreachable = count_cbh.count();
 	}
+	return unreachable;
 }
 
 void Cache::update_rssitem_unlocked(std::shared_ptr<RssItem> item,

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -532,10 +532,11 @@ int Controller::run(const CliArgsParser& args)
 		std::cout.flush();
 	}
 	try {
-		int amt = rsscache->cleanup_cache(feedcontainer.get_all_feeds());
+		const std::uint64_t amt = rsscache->cleanup_cache(
+				feedcontainer.get_all_feeds());
 		if (!args.silent()) {
 			std::cout << _("done.") << std::endl;
-			if (amt > 0) {
+			if (amt > 0u) {
 				std::cout << _("Unreachable feeds found, consider setting "
 						"`cleanup-on-quit yes` or run `newsboat --cleanup`")
 					<< std::endl;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -532,9 +532,14 @@ int Controller::run(const CliArgsParser& args)
 		std::cout.flush();
 	}
 	try {
-		rsscache->cleanup_cache(feedcontainer.get_all_feeds());
+		int amt = rsscache->cleanup_cache(feedcontainer.get_all_feeds());
 		if (!args.silent()) {
 			std::cout << _("done.") << std::endl;
+			if (amt > 0) {
+				std::cout << _("Unreachable feeds found, consider setting "
+						"`cleanup-on-quit yes` or run `newsboat --cleanup`")
+					<< std::endl;
+			}
 		}
 	} catch (const DbException& e) {
 		LOG(Level::USERERROR, "Cleaning up cache failed: %s", e.what());


### PR DESCRIPTION
Feeds/items become unreachable when the user decides to delete a feed. 
This PR adds logic to remind them that they can decide to remove them with either:

* running `newsboat --cleanup` or 
* setting `cleanup-on-quit yes` in their config file

Suggested by #1184