### PR TITLE
Itemlist: reset `do_redraw` after acting on it

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1006,6 +1006,7 @@ void ItemListFormAction::prepare()
 	if (do_redraw || old_width != width) {
 		invalidate_list();
 		old_width = width;
+		do_redraw = false;
 	}
 
 	if (invalidation_mode == InvalidationMode::NONE) {


### PR DESCRIPTION
Without this change, the list is redrawn on each iteration, which is
expensive because redrawing involves invalidation and thus re-formatting
all the items in the list.

Fixes #1372.