### PR TITLE
Make sure we can't accidentally overwrite a feed's rssurl

### DIFF
--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -126,11 +126,6 @@ public:
 
 	void update_items(std::vector<std::shared_ptr<RssFeed>> feeds);
 
-	void set_query(const std::string& s)
-	{
-		query = s;
-	}
-
 	bool is_query_feed() const
 	{
 		return rssurl_.substr(0, 6) == "query:";

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -101,8 +101,7 @@ public:
 	std::shared_ptr<RssItem> get_item_by_guid_unlocked(
 		const std::string& guid);
 
-	/// \brief User-specified feed URL. Can't be empty, otherwise we wouldn't
-	/// be able to fetch the feed.
+	/// \brief User-specified feed URL.
 	const std::string& rssurl() const
 	{
 		return rssurl_;

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -19,7 +19,7 @@ class Cache;
 
 class RssFeed : public Matchable {
 public:
-	explicit RssFeed(Cache* c);
+	explicit RssFeed(Cache* c, const std::string& rssurl);
 	RssFeed();
 	~RssFeed() override;
 	std::string title_raw() const
@@ -108,7 +108,6 @@ public:
 	{
 		return rssurl_;
 	}
-	void set_rssurl(const std::string& u);
 
 	unsigned int unread_item_count() const;
 	unsigned int total_item_count() const
@@ -201,7 +200,7 @@ private:
 	std::string description_;
 	std::string link_;
 	time_t pubDate_;
-	std::string rssurl_;
+	const std::string rssurl_;
 	std::vector<std::shared_ptr<RssItem>> items_;
 	std::unordered_map<std::string, std::shared_ptr<RssItem>>
 		items_guid_map;

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -20,7 +20,6 @@ class Cache;
 class RssFeed : public Matchable {
 public:
 	explicit RssFeed(Cache* c, const std::string& rssurl);
-	RssFeed();
 	~RssFeed() override;
 	std::string title_raw() const
 	{

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -565,8 +565,7 @@ std::shared_ptr<RssFeed> Cache::internalize_rssfeed(std::string rssurl,
 {
 	ScopeMeasure m1("Cache::internalize_rssfeed");
 
-	std::shared_ptr<RssFeed> feed(new RssFeed(this));
-	feed->set_rssurl(rssurl);
+	std::shared_ptr<RssFeed> feed(new RssFeed(this, rssurl));
 
 	if (utils::is_query_url(rssurl)) {
 		return feed;

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -992,7 +992,7 @@ void FeedListFormAction::op_start_search()
 			return;
 		}
 		if (!items.empty()) {
-			std::shared_ptr<RssFeed> search_dummy_feed(new RssFeed(cache));
+			std::shared_ptr<RssFeed> search_dummy_feed(new RssFeed(cache, ""));
 			search_dummy_feed->set_search_feed(true);
 			search_dummy_feed->add_items(items);
 			v->push_searchresult(search_dummy_feed, searchphrase);

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -889,7 +889,7 @@ void ItemListFormAction::qna_start_search()
 		return;
 	}
 
-	std::shared_ptr<RssFeed> search_dummy_feed(new RssFeed(rsscache));
+	std::shared_ptr<RssFeed> search_dummy_feed(new RssFeed(rsscache, ""));
 	search_dummy_feed->set_search_feed(true);
 	search_dummy_feed->add_items(items);
 

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -235,7 +235,7 @@ void RssFeed::set_rssurl(const std::string& u)
 			query);
 
 		set_title(tokens[1]);
-		set_query(query);
+		this->query = query;
 	}
 }
 

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -55,8 +55,7 @@ std::shared_ptr<RssFeed> RssParser::parse()
 		return nullptr;
 	}
 
-	std::shared_ptr<RssFeed> feed(new RssFeed(ch));
-	feed->set_rssurl(my_uri);
+	std::shared_ptr<RssFeed> feed(new RssFeed(ch, my_uri));
 
 	/*
 	 * After parsing is done, we fill our feed object with title,

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -130,7 +130,7 @@ TEST_CASE("mark_all_read marks all items in the feed read", "[Cache]")
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 
-	test_feed = std::make_shared<RssFeed>(&rsscache);
+	test_feed = std::make_shared<RssFeed>(&rsscache, "");
 	test_feed->set_title("Test feed");
 	auto test_feed_url = "http://example.com/atom.xml";
 	test_feed->set_link(test_feed_url);
@@ -913,8 +913,8 @@ TEST_CASE(
 	ConfigContainer cfg;
 	std::unique_ptr<Cache> rsscache(new Cache(dbfile.get_path(), &cfg));
 
-	auto feed = std::make_shared<RssFeed>(rsscache.get());
-	feed->set_rssurl("query:All unread:unread = \"yes\"");
+	auto feed = std::make_shared<RssFeed>(rsscache.get(),
+			"query:All unread:unread = \"yes\"");
 
 	REQUIRE_NOTHROW(rsscache->externalize_rssfeed(feed, false));
 

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -914,7 +914,6 @@ TEST_CASE(
 	std::unique_ptr<Cache> rsscache(new Cache(dbfile.get_path(), &cfg));
 
 	auto feed = std::make_shared<RssFeed>(rsscache.get());
-	feed->set_query("unread = \"yes\"");
 	feed->set_rssurl("query:All unread:unread = \"yes\"");
 
 	REQUIRE_NOTHROW(rsscache->externalize_rssfeed(feed, false));

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -42,7 +42,7 @@ TEST_CASE("OP_OPEN displays article using an external pager",
 	Cache rsscache(":memory:", &cfg);
 	cfg.set_configvalue("pager", "cat %f > " + pagerfile.get_path());
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	item->set_link(test_url);
@@ -79,7 +79,7 @@ TEST_CASE("OP_PURGE_DELETED purges previously deleted items",
 	Cache rsscache(":memory:", &cfg);
 	FilterContainer filters;
 	RegexManager rxman;
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	feed->add_item(item);
 
@@ -120,7 +120,7 @@ TEST_CASE(
 	FilterContainer filters;
 	RegexManager rxman;
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	item->set_link(test_url);
 	item->set_unread(true);
@@ -157,7 +157,7 @@ TEST_CASE(
 	FilterContainer filters;
 	RegexManager rxman;
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	item->set_link(test_url);
 	item->set_unread(true);
@@ -190,7 +190,7 @@ TEST_CASE("OP_OPENINBROWSER passes the url to the browser",
 	FilterContainer filters;
 	RegexManager rxman;
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	item->set_link(test_url);
 	feed->add_item(item);
@@ -224,7 +224,7 @@ TEST_CASE("OP_OPENINBROWSER_NONINTERACTIVE passes the url to the browser",
 	FilterContainer filters;
 	RegexManager rxman;
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	item->set_link(test_url);
 	feed->add_item(item);
@@ -260,7 +260,7 @@ TEST_CASE("OP_OPENALLUNREADINBROWSER passes the url list to the browser",
 	FilterContainer filters;
 	RegexManager rxman;
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 
 	for (int i = 0; i < itemCount; i++) {
 		std::shared_ptr<RssItem> item =
@@ -344,7 +344,7 @@ TEST_CASE(
 	FilterContainer filters;
 	RegexManager rxman;
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 
 	for (unsigned int i = 0; i < itemCount; i++) {
 		std::shared_ptr<RssItem> item =
@@ -434,7 +434,7 @@ TEST_CASE("OP_SHOWURLS shows the article's properties", "[ItemListFormAction]")
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 
 	item->set_link(test_url);
@@ -494,7 +494,7 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	feed->set_title(feed_title);
 
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
@@ -536,7 +536,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 
 	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
@@ -638,7 +638,7 @@ TEST_CASE("OP_SAVE writes an article's attributes to the specified file",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	item->set_link(test_url);
@@ -676,7 +676,7 @@ TEST_CASE("OP_HELP command is processed", "[ItemListFormAction]")
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 
 	feed->add_item(item);
@@ -702,7 +702,7 @@ TEST_CASE("OP_HARDQUIT command is processed", "[ItemListFormAction]")
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 
 	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
@@ -736,7 +736,7 @@ TEST_CASE("Navigate back and forth using OP_NEXT and OP_PREV",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	item->set_title(first_article_title);
@@ -778,7 +778,7 @@ TEST_CASE("OP_TOGGLESHOWREAD switches the value of show-read-articles",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	feed->add_item(item);
@@ -828,7 +828,7 @@ TEST_CASE("OP_PIPE_TO pipes an article's content to an external command",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 	item->set_link(test_url);
@@ -873,7 +873,7 @@ TEST_CASE("OP_OPENINBROWSER does not result in itemlist invalidation",
 	std::shared_ptr<RssItem> item3 = std::make_shared<RssItem>(&rsscache);
 	item3->set_link("https://example.com/3");
 
-	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache);
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	feed->add_item(item1);
 	feed->add_item(item2);
 	feed->add_item(item3);

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -13,7 +13,7 @@ using namespace newsboat;
 static const auto FEED_TITLE = std::string("Funniest jokes ever");
 std::shared_ptr<RssFeed> create_test_feed(Cache* c)
 {
-	auto feed = std::make_shared<RssFeed>(c);
+	auto feed = std::make_shared<RssFeed>(c, "");
 
 	feed->set_title(FEED_TITLE);
 
@@ -584,15 +584,15 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed URL "
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 
-	std::shared_ptr<RssItem> item;
-	std::shared_ptr<RssFeed> feed;
-	std::tie(item, feed) = create_test_item(&rsscache);
-
 	const auto feedurl = std::string("https://example.com/~joe/entries.rss");
+
+	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, feedurl);
+	auto item = std::make_shared<RssItem>(&rsscache);
+	item->set_feedptr(feed);
+
 
 	feed->set_title("");
 	feed->set_link("");
-	feed->set_rssurl(feedurl);
 
 	const auto result = item_renderer::get_feedtitle(item);
 	REQUIRE(result == feedurl);

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -56,16 +56,14 @@ TEST_CASE("opml::generate creates an XML document with feed URLs in OPML format"
 		FeedContainer feeds;
 
 		std::shared_ptr<RssFeed> feed =
-			std::make_shared<RssFeed>(&rsscache);
+			std::make_shared<RssFeed>(&rsscache, "https://example.com/feed1.xml");
 		feed->set_title("Feed 1");
 		feed->set_link("https://example.com/feed1/");
-		feed->set_rssurl("https://example.com/feed1.xml");
 		feeds.add_feed(std::move(feed));
 
-		feed = std::make_shared<RssFeed>(&rsscache);
+		feed = std::make_shared<RssFeed>(&rsscache, "https://example.com/feed2.xml");
 		feed->set_title("Feed 2");
 		feed->set_link("https://example.com/feed2/");
-		feed->set_rssurl("https://example.com/feed2.xml");
 		feeds.add_feed(std::move(feed));
 
 		const std::string expectedOpmlText(

--- a/test/rssitem.cpp
+++ b/test/rssitem.cpp
@@ -254,7 +254,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 	}
 
 	SECTION("unknown attributes are forwarded to parent feed") {
-		auto feed = std::make_shared<RssFeed>(&rsscache);
+		auto feed = std::make_shared<RssFeed>(&rsscache, "");
 		auto item = std::make_shared<RssItem>(&rsscache);
 		feed->add_item(item);
 


### PR DESCRIPTION
Previously, a feed's rssurl could get overwritten accidentally, leading to https://github.com/newsboat/newsboat/issues/685.
This PR makes sure we can no longer overwrite a feed's rssurl (by marking it const).