### PR TITLE
Code coverage: Ignore generated code

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Calculate test coverage
         # Note that we override the path to gcov tool.
-        run: GCOV=$(pwd)/gcov grcov . --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
+        run: GCOV=$(pwd)/gcov grcov . --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
 
       - name: Submit coverage to Coveralls
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
Specifically, this ignores code genereated by cxxbridge in `target/cxxbridge/libnewsboat-ffi/src`:
![image](https://user-images.githubusercontent.com/4629607/103078304-d93bfa00-45d1-11eb-9695-0dbddcb7a7a3.png)
![image](https://user-images.githubusercontent.com/4629607/103078329-e953d980-45d1-11eb-9d35-345fe6884fc4.png)
