### PR TITLE
CI: decrease the number of macOS jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -90,9 +90,6 @@ freebsd_task:
     before_cache_script: *before_cache_script
 
 macos_task:
-    osx_instance:
-        image: big-sur-base
-
     cargo_cache: *cargo_cache
 
     after_cache_script: *after_cache_script
@@ -132,26 +129,18 @@ macos_task:
     before_cache_script: *before_cache_script
 
     matrix:
-        - name: macOS Catalina, Clang, Rust 1.48.0
-          env:
-              CC: clang
-              CXX: clang++
-              RUST: 1.48.0
-          osx_instance:
-              image: catalina-base
         - name: macOS Big Sur, Clang, Rust 1.48.0
+          osx_instance:
+              image: big-sur-base
           env:
               CC: clang
               CXX: clang++
-              RUST: 1.48.0
-        - name: macOS Big Sur, GCC, Rust 1.48.0
-          env:
-              CC: gcc
-              CXX: g++
               RUST: 1.48.0
         # This job tests our minimum supported Rust version, so only bump on
         # Newsboat release day
         - name: macOS Big Sur, GCC, Rust 1.46.0
+          osx_instance:
+              image: catalina-base
           env:
               CC: gcc
               CXX: g++


### PR DESCRIPTION
macOS builders are a scarce resource and low parallelism (only one job
at a time). This commit combines four jobs into two, which should
hopefully make our CI a little bit faster. We *could* miss some problems
this way, but I don't think the risk is very high because:

1. I haven't seen macOS build failures in a while;
2. we have an extensive build matrix for Linux, which checks plenty of
   compiler combinations. The purpose of macOS CI jobs is, then, to
   ensure that Newsboat builds there at all — compiler-specific bugs
   will be caught by Linux anyway.

This is just maintenance, so I think I'll merge this on a short timeline — tomorrow. Reviews are still welcome though if you feel like it ;)