### PR TITLE
Document locations of lock files

### DIFF
--- a/doc/chapter-files.asciidoc
+++ b/doc/chapter-files.asciidoc
@@ -7,12 +7,12 @@ which splits the files between the following locations:
 - _$XDG_CONFIG_HOME/newsboat/_
 - _$XDG_DATA_HOME/newsboat/_
 
-If `XDG_CONFIG_HOME` environment variable is not set, Newsboat behaves as if it
-was set to _~/.config_. Similarly, `XDG_DATA_HOME` defaults to
+If the `XDG_CONFIG_HOME` environment variable is not set, Newsboat behaves as
+if it was set to _~/.config_. Similarly, `XDG_DATA_HOME` defaults to
 _~/.local/share_.
 
-If the config directory exists, Newsboat will use XDG directories, otherwise it
-will default to _~/.newsboat_.
+If the XDG config directory exists, Newsboat will use XDG directories, creating
+the data directory if necessary. Otherwise, it will default to _~/.newsboat_.
 
 If you're currently using _~/.newsboat/_ but wish to migrate to XDG
 directories, you should move the files as follows:

--- a/doc/chapter-files.asciidoc
+++ b/doc/chapter-files.asciidoc
@@ -23,3 +23,25 @@ _config_, _urls_::
 _cache.db_, _history.search_, _history.cmdline_, _queue_::
         to _$XDG_DATA_HOME/newsboat/_
 
+Newsboat and Podboat also create "lock files". These prevent you from starting
+two instances of the same program, and thus from corrupting your data. Newsboat
+and Podboat remove these files when you quit the program, so there is no need
+to copy them anywhere — just be aware of them in case you write scripts that
+work with _cache.db_ or _queue_. By default, lock files are located as follows:
+
+|===
+||dotdir|XDG
+
+|Newsboat
+|_~/.newsboat/cache.db.lock_
+|_$XDG_DATA_HOME/newsboat/cache.db.lock_
+
+|Podboat
+|_~/.newsboat/pb-lock.pid_
+|_$XDG_DATA_HOME/newsboat/.lock_
+|===
+
+Newsboat places the lock file next to the cache file, so if you specify
+<<cache-file,cache-file>> setting or pass `--cache-file` command-line argument,
+the path to the lock file will change too. Podboat, on the other hand, always
+places its lock file as shown above.

--- a/doc/chapter-files.asciidoc
+++ b/doc/chapter-files.asciidoc
@@ -7,8 +7,8 @@ which splits the files between the following locations:
 - _~/.local/share/newsboat/_
 - _~/.config/newsboat/_
 
-If these directories exist, Newsboat will use them, otherwise it will default
-to _~/.newsboat_.
+If the config directory exists, Newsboat will use XDG directories, otherwise it
+will default to _~/.newsboat_.
 
 If you're currently using _~/.newsboat/_ but wish to migrate to XDG
 directories, you should move the files as follows:

--- a/doc/chapter-files.asciidoc
+++ b/doc/chapter-files.asciidoc
@@ -1,5 +1,5 @@
 By default, Newsboat stores all the files in a traditional Unix fashion, i.e.
-in the "dotdir" located at _~/.newsboat_. However, it also supports a modern
+in a "dotdir" located at _~/.newsboat_. However, it also supports a modern
 way,
 https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html[XDG Base Directory Specification],
 which splits the files between the following locations:
@@ -9,7 +9,7 @@ which splits the files between the following locations:
 
 If these directories exist or the environment variables `$XDG_CONFIG_HOME` and
 `$XDG_DATA_HOME` are set, Newsboat will use these directories, otherwise it
-will default to _~/.newsboat_ as its configuration directory.
+will default to _~/.newsboat_.
 
 If you're currently using _~/.newsboat/_ but wish to migrate to XDG
 directories, you should move the files as follows:

--- a/doc/chapter-files.asciidoc
+++ b/doc/chapter-files.asciidoc
@@ -7,9 +7,8 @@ which splits the files between the following locations:
 - _~/.local/share/newsboat/_
 - _~/.config/newsboat/_
 
-If these directories exist or the environment variables `$XDG_CONFIG_HOME` and
-`$XDG_DATA_HOME` are set, Newsboat will use these directories, otherwise it
-will default to _~/.newsboat_.
+If these directories exist, Newsboat will use them, otherwise it will default
+to _~/.newsboat_.
 
 If you're currently using _~/.newsboat/_ but wish to migrate to XDG
 directories, you should move the files as follows:

--- a/doc/chapter-files.asciidoc
+++ b/doc/chapter-files.asciidoc
@@ -4,8 +4,12 @@ way,
 https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html[XDG Base Directory Specification],
 which splits the files between the following locations:
 
-- _~/.local/share/newsboat/_
-- _~/.config/newsboat/_
+- _$XDG_CONFIG_HOME/newsboat/_
+- _$XDG_DATA_HOME/newsboat/_
+
+If `XDG_CONFIG_HOME` environment variable is not set, Newsboat behaves as if it
+was set to _~/.config_. Similarly, `XDG_DATA_HOME` defaults to
+_~/.local/share_.
 
 If the config directory exists, Newsboat will use XDG directories, otherwise it
 will default to _~/.newsboat_.
@@ -14,8 +18,8 @@ If you're currently using _~/.newsboat/_ but wish to migrate to XDG
 directories, you should move the files as follows:
 
 _config_, _urls_::
-        to _$HOME/.config/newsboat/_
+        to _$XDG_CONFIG_HOME/newsboat/_
 
 _cache.db_, _history.search_, _history.cmdline_, _queue_::
-        to _$HOME/.local/share/newsboat/_
+        to _$XDG_DATA_HOME/newsboat/_
 

--- a/doc/chapter-firststeps.asciidoc
+++ b/doc/chapter-firststeps.asciidoc
@@ -26,7 +26,7 @@ usage: ./newsboat [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x <command> .
 
 This means that Newsboat can't start without any configured feeds. To add
 feeds to Newsboat, you can either add URLs to the configuration file
-_$HOME/.newsboat/urls_ or you can import an OPML file by running `newsboat -i
+_~/.newsboat/urls_ or you can import an OPML file by running `newsboat -i
 blogroll.opml`. To manually add URLs, open the file with your favorite text
 editor and add the URLs, one per line:
 
@@ -39,7 +39,7 @@ provide the username/password in the following way:
 	https://username:password@hostname.domain.tld/feed.rss
 
 In order to protect username and password, make sure that
-_$HOME/.newsboat/urls_ is only readable by you and, optionally, your group:
+_~/.newsboat/urls_ is only readable by you and, optionally, your group:
 
     $ chmod u=rw,g=r,o= ~/.newsboat/urls
 

--- a/doc/manpage-newsboat.asciidoc
+++ b/doc/manpage-newsboat.asciidoc
@@ -17,7 +17,7 @@ newsboat - an RSS/Atom feed reader for text terminals
 _Newsboat_ is an RSS/Atom feed reader for text terminals. RSS and Atom are a
 number of widely-used XML formats to transmit, publish and syndicate articles, 
 for example news or blog articles.  Newsboat is designed to be used on text 
-terminals on Unix or Unix-like systems such as GNU/Linux, BSD or Mac OS X.
+terminals on Unix or Unix-like systems such as GNU/Linux, BSD or macOS.
 
 
 == OPTIONS

--- a/doc/manpage-newsboat.asciidoc
+++ b/doc/manpage-newsboat.asciidoc
@@ -142,9 +142,9 @@ _<number>_::
 include::chapter-files.asciidoc[]
 
 dotfiles::
-        _$HOME/.newsboat/config_
+        _~/.newsboat/config_
 +
-_$HOME/.newsboat/urls_
+_~/.newsboat/urls_
 
 XDG::
         _$XDG_CONFIG_HOME/newsboat/config_

--- a/doc/manpage-newsboat.asciidoc
+++ b/doc/manpage-newsboat.asciidoc
@@ -151,7 +151,7 @@ XDG::
 +
 _$XDG_CONFIG_HOME/newsboat/urls_
 +
-Note: if `XDG_CONFIG_HOME` environment variable is not set, Newsboat behaves as if it was set to _~/.config_.
+Note: if the `XDG_CONFIG_HOME` environment variable is not set, Newsboat behaves as if it was set to _~/.config_.
 
 
 == ENVIRONMENT

--- a/doc/manpage-newsboat.asciidoc
+++ b/doc/manpage-newsboat.asciidoc
@@ -147,9 +147,11 @@ dotfiles::
 _$HOME/.newsboat/urls_
 
 XDG::
-        _$HOME/.config/newsboat/config_
+        _$XDG_CONFIG_HOME/newsboat/config_
 +
-_$HOME/.config/newsboat/urls_
+_$XDG_CONFIG_HOME/newsboat/urls_
++
+Note: if `XDG_CONFIG_HOME` environment variable is not set, Newsboat behaves as if it was set to _~/.config_.
 
 
 == ENVIRONMENT

--- a/doc/manpage-podboat.asciidoc
+++ b/doc/manpage-podboat.asciidoc
@@ -67,9 +67,13 @@ dotfiles::
 _$HOME/.newsboat/queue_
 
 XDG::
-        _$HOME/.config/newsboat/config_
+        _$XDG_CONFIG_HOME/newsboat/config_
 +
-_$HOME/.local/share/newsboat/queue_
+_$XDG_DATA_HOME/newsboat/queue_
++
+Note: if `XDG_CONFIG_HOME` environment variable is not set, Newsboat behaves as
+if it was set to _~/.config_. Similarly, `XDG_DATA_HOME` defaults to
+    _~/.local/share_.
 
 
 == ENVIRONMENT

--- a/doc/manpage-podboat.asciidoc
+++ b/doc/manpage-podboat.asciidoc
@@ -62,9 +62,9 @@ include::podboat-cfgcmds.asciidoc[]
 include::chapter-files.asciidoc[]
 
 dotfiles::
-        _$HOME/.newsboat/config_
+        _~/.newsboat/config_
 +
-_$HOME/.newsboat/queue_
+_~/.newsboat/queue_
 
 XDG::
         _$XDG_CONFIG_HOME/newsboat/config_

--- a/doc/manpage-podboat.asciidoc
+++ b/doc/manpage-podboat.asciidoc
@@ -71,9 +71,9 @@ XDG::
 +
 _$XDG_DATA_HOME/newsboat/queue_
 +
-Note: if `XDG_CONFIG_HOME` environment variable is not set, Newsboat behaves as
+Note: if the `XDG_CONFIG_HOME` environment variable is not set, Podboat behaves as
 if it was set to _~/.config_. Similarly, `XDG_DATA_HOME` defaults to
-    _~/.local/share_.
+_~/.local/share_.
 
 
 == ENVIRONMENT

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -636,7 +636,7 @@ TEST_CASE("run_command() doesn't wait for the command to finish",
 	REQUIRE(runtime.count() < 60000);
 }
 
-TEST_CASE("resolve_tilde() replaces ~ with the path to the $HOME directory",
+TEST_CASE("resolve_tilde() replaces ~ with the path to the home directory",
 	"[utils]")
 {
 	TestHelpers::EnvVar envVar("HOME");


### PR DESCRIPTION
The main idea behind this PR came from https://github.com/newsboat/newsboat/pull/1382#discussion_r548750032, because I was surprised that Podboat calls its locks differently depending on which file layout it uses — dotdir or XDG. The rest of changes here are just me trying to make the doc a little bit better while I'm at it.

Reviews are very much welcome, and since it's documentation and it's the New Year soon, I think I'll wait a bit longer before merging — let's say a week. As usual, I'm explicitly asking for a review from @der-lyse, who usually reviews the docs.