### PR TITLE
Add "hints" field to avoid crash when swapping title with hints

### DIFF
--- a/stfl/empty.stfl
+++ b/stfl/empty.stfl
@@ -3,6 +3,9 @@ vbox
     text[head]:"empty formaction"
     .expand:h
     .display[showtitle]:1
+  vbox[hints]
+    .expand:0
+    .display[showhint]:1
   hbox[lastline]
     .expand:0
     label[msglabel]


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1399.

I want to check a bit more thoroughly if we have any similar interactions with STFL which could be broken.
I plan to do that later today.

- [x] Check for similar issues with STFL interaction