### PR TITLE
Add descriptive names for special values passed to stfl_run()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ for this release also includes:
 
 ### Deprecated
 ### Removed
+
+- `dumpform` command-line command which was only intended for debugging
+    Newsboat's UI code
+
 ### Fixed
 ### Security
 

--- a/doc/cmdline-commands.dsv
+++ b/doc/cmdline-commands.dsv
@@ -6,6 +6,5 @@ tag||<tagname>||Only display feeds with the tag <tagname>.||tag news
 goto||<case-insensitive substring>||Search for a feed whose name contains the case-insensitive substring.||goto foo
 source||<filename> [...]||Load the specified configuration files. This allows it to load alternative configuration files or reload already loaded configuration files on-the-fly from the filesystem.||source ~/.newsboat/colors
 dumpconfig||<filename>||Save current internal state of configuration to file, so that it can be instantly reused as configuration file.||dumpconfig ~/.newsboat/config.saved
-dumpform||||Dump current dialog to text file. This is meant for debugging purposes only.||dumpform
 exec||<operation>||Run a keybind operation in the current context.||exec open-all-unread-in-browser-and-mark-read
 number||||Jump to the entry with the index <number> (usually seen at the left side of the list). This currently works for the feed list, article list, tag selection and filter selection forms.||30

--- a/doc/hackers-guide.asciidoc
+++ b/doc/hackers-guide.asciidoc
@@ -182,11 +182,6 @@ test" to build the tests, the result is a binary called "test" within the test
 subdirectory. Run it and see whether everything still works as expected. Run
 "make clean-test" to clean up after the tests.
 
-=== Dump an STFL form
-
-You can dump the currently shown STFL form with the "dumpform" command on the
-internal commandline. This can help debugging of rendering issues.
-
 == Keys
 
 === Unused keys

--- a/include/colormanager.h
+++ b/include/colormanager.h
@@ -1,11 +1,11 @@
 #ifndef NEWSBOAT_COLORMANAGER_H_
 #define NEWSBOAT_COLORMANAGER_H_
 
+#include <functional>
 #include <map>
 #include <vector>
 
 #include "configactionhandler.h"
-#include "stflpp.h"
 
 namespace podboat {
 class PbView;
@@ -31,7 +31,8 @@ public:
 	void handle_action(const std::string& action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;
-	void apply_colors(Stfl::Form& form) const;
+	void apply_colors(std::function<void(const std::string&, const std::string&)>
+		stfl_value_setter) const;
 	std::map<std::string, TextStyle> get_styles() const
 	{
 		return element_styles;

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -40,6 +40,8 @@ public:
 
 	virtual std::string get_value(const std::string& value);
 
+	void draw_form();
+
 	virtual void handle_cmdline(const std::string& cmd);
 
 	bool process_op(Operation op,

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -38,7 +38,7 @@ public:
 
 	virtual std::string id() const = 0;
 
-	virtual std::string get_value(const std::string& value);
+	std::string get_value(const std::string& name);
 
 	void draw_form();
 	std::string draw_form_wait_for_event(unsigned int timeout);

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -28,7 +28,6 @@ public:
 	virtual ~FormAction();
 	virtual void prepare() = 0;
 	virtual void init() = 0;
-	Stfl::Form& get_form();
 	virtual void set_redraw(bool b)
 	{
 		do_redraw = b;

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -41,6 +41,7 @@ public:
 	virtual std::string get_value(const std::string& value);
 
 	void draw_form();
+	void recalculate_widget_dimensions();
 
 	virtual void handle_cmdline(const std::string& cmd);
 
@@ -51,8 +52,6 @@ public:
 	virtual void finished_qna(Operation op);
 
 	void start_cmdline(std::string default_value = "");
-
-	virtual void recalculate_form();
 
 	std::string get_qna_response(unsigned int i)
 	{

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -41,6 +41,7 @@ public:
 	virtual std::string get_value(const std::string& value);
 
 	void draw_form();
+	std::string draw_form_wait_for_event(unsigned int timeout);
 	void recalculate_widget_dimensions();
 
 	virtual void handle_cmdline(const std::string& cmd);

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -39,6 +39,7 @@ public:
 	virtual std::string id() const = 0;
 
 	std::string get_value(const std::string& name);
+	void set_value(const std::string& name, const std::string& value);
 
 	void draw_form();
 	std::string draw_form_wait_for_event(unsigned int timeout);

--- a/include/view.h
+++ b/include/view.h
@@ -137,8 +137,6 @@ public:
 	void inside_qna(bool f);
 	void inside_cmdline(bool f);
 
-	void dump_current_form();
-
 	static void ctrl_c_action(int sig);
 
 protected:

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -13,31 +13,32 @@ newsboat.o: newsboat.cpp include/cache.h include/configcontainer.h \
  3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
  config.h include/configpaths.h include/cliargsparser.h \
  include/controller.h include/cache.h include/colormanager.h \
- include/stflpp.h include/configparser.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/regexmanager.h include/matcher.h filter/FilterParser.h \
- include/regexowner.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dbexception.h include/exception.h include/matcherexception.h \
- rss/parser.h include/remoteapi.h rss/feed.h rss/item.h include/utils.h \
- 3rd-party/expected.hpp target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/view.h include/controller.h include/dirbrowserformaction.h \
- include/listformatter.h include/listwidget.h include/formaction.h \
- include/history.h include/keymap.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h xlicense.h
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/dbexception.h include/exception.h \
+ include/matcherexception.h rss/parser.h include/remoteapi.h rss/feed.h \
+ rss/item.h include/utils.h 3rd-party/expected.hpp \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
+ include/controller.h include/dirbrowserformaction.h \
+ include/listformatter.h include/listwidget.h include/stflpp.h \
+ include/formaction.h include/history.h include/keymap.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h xlicense.h
 podboat.o: podboat.cpp config.h include/exception.h \
  include/pbcontroller.h include/colormanager.h \
- include/configactionhandler.h include/stflpp.h include/configcontainer.h \
+ include/configactionhandler.h include/configcontainer.h \
  include/download.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/keymap.h \
  include/queueloader.h include/pbview.h include/listwidget.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/textviewwidget.h \
- include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/logger.h config.h include/strprintf.h \
+ filter/FilterParser.h include/regexowner.h include/stflpp.h \
+ include/textviewwidget.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 rss/atomparser.o: rss/atomparser.cpp rss/atomparser.h rss/rssparser.h \
  config.h rss/exception.h rss/feed.h rss/item.h rss/medianamespace.h \
@@ -84,17 +85,17 @@ rss/xmlutilities.o: rss/xmlutilities.cpp rss/xmlutilities.h
 src/cache.o: src/cache.cpp include/cache.h include/configcontainer.h \
  include/configactionhandler.h config.h include/configcontainer.h \
  include/controller.h include/cache.h include/colormanager.h \
- include/stflpp.h include/configparser.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/dbexception.h include/logger.h \
- include/strprintf.h include/matcherexception.h include/rssfeed.h \
- include/utils.h 3rd-party/expected.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ 3rd-party/optional.hpp include/queuemanager.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/dbexception.h \
+ include/logger.h include/strprintf.h include/matcherexception.h \
+ include/rssfeed.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/utils.h
 src/cliargsparser.o: src/cliargsparser.cpp include/cliargsparser.h \
@@ -102,10 +103,10 @@ src/cliargsparser.o: src/cliargsparser.cpp include/cliargsparser.h \
  3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
  include/globals.h include/ruststring.h include/strprintf.h
 src/colormanager.o: src/colormanager.cpp include/colormanager.h \
- include/configactionhandler.h include/stflpp.h config.h \
- include/confighandlerexception.h include/feedlistformaction.h \
- 3rd-party/optional.hpp include/configcontainer.h include/history.h \
- include/listformaction.h include/formaction.h include/keymap.h \
+ include/configactionhandler.h config.h include/confighandlerexception.h \
+ include/feedlistformaction.h 3rd-party/optional.hpp \
+ include/configcontainer.h include/history.h include/listformaction.h \
+ include/formaction.h include/keymap.h include/stflpp.h \
  include/listwidget.h include/listformatter.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
  include/view.h include/colormanager.h include/controller.h \
@@ -154,8 +155,8 @@ src/configpaths.o: src/configpaths.cpp include/configpaths.h \
  include/globals.h include/ruststring.h include/strprintf.h
 src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/configcontainer.h include/configactionhandler.h \
- include/colormanager.h include/stflpp.h include/configparser.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ include/colormanager.h include/configparser.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
  include/queuemanager.h include/regexmanager.h include/matcher.h \
@@ -183,9 +184,9 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/strprintf.h include/ttrssapi.h include/ttrssurlreader.h \
  include/utils.h include/view.h include/controller.h \
  include/dirbrowserformaction.h include/listformatter.h \
- include/listwidget.h include/formaction.h include/history.h \
- include/keymap.h include/feedlistformaction.h include/listformaction.h \
- include/view.h include/filebrowserformaction.h
+ include/listwidget.h include/stflpp.h include/formaction.h \
+ include/history.h include/keymap.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h
 src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/dialogsformaction.h include/formaction.h include/history.h \
  include/keymap.h include/configactionhandler.h include/stflpp.h \
@@ -225,7 +226,7 @@ src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  include/htmlrenderer.h include/textformatter.h
 src/download.o: src/download.cpp include/download.h config.h \
  include/pbcontroller.h include/colormanager.h \
- include/configactionhandler.h include/stflpp.h include/configcontainer.h \
+ include/configactionhandler.h include/configcontainer.h \
  include/download.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/keymap.h \
  include/queueloader.h
@@ -537,7 +538,7 @@ src/opmlurlreader.o: src/opmlurlreader.cpp include/opmlurlreader.h \
  3rd-party/expected.hpp include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
- include/colormanager.h include/configactionhandler.h include/stflpp.h \
+ include/colormanager.h include/configactionhandler.h \
  include/configcontainer.h include/download.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/keymap.h \
  include/queueloader.h config.h include/configcontainer.h \
@@ -545,14 +546,15 @@ src/pbcontroller.o: src/pbcontroller.cpp include/pbcontroller.h \
  include/logger.h include/strprintf.h include/matcherexception.h \
  include/nullconfigactionhandler.h include/pbview.h include/listwidget.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/textviewwidget.h \
- include/poddlthread.h include/queueloader.h include/strprintf.h \
- include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ filter/FilterParser.h include/regexowner.h include/stflpp.h \
+ include/textviewwidget.h include/poddlthread.h include/queueloader.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
- include/configactionhandler.h include/stflpp.h include/keymap.h \
- include/listwidget.h include/listformatter.h include/regexmanager.h \
- include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/configactionhandler.h include/keymap.h include/listwidget.h \
+ include/listformatter.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/stflpp.h \
  include/textviewwidget.h config.h include/configcontainer.h \
  stfl/dllist.h include/download.h include/fmtstrformatter.h stfl/help.h \
  include/listformatter.h include/logger.h include/strprintf.h \
@@ -593,15 +595,14 @@ src/regexowner.o: src/regexowner.cpp include/regexowner.h
 src/reloader.o: src/reloader.cpp include/reloader.h \
  include/configcontainer.h include/configactionhandler.h \
  include/controller.h include/cache.h include/colormanager.h \
- include/stflpp.h include/configparser.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/curlhandle.h include/dbexception.h \
- include/downloadthread.h include/fmtstrformatter.h \
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ 3rd-party/optional.hpp include/queuemanager.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/curlhandle.h \
+ include/dbexception.h include/downloadthread.h include/fmtstrformatter.h \
  include/reloadrangethread.h include/reloadthread.h include/controller.h \
  rss/exception.h include/rssfeed.h include/utils.h 3rd-party/expected.hpp \
  include/logger.h config.h include/strprintf.h \
@@ -609,24 +610,24 @@ src/reloader.o: src/reloader.cpp include/reloader.h \
  rss/feed.h rss/item.h include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h include/utils.h \
  include/view.h include/dirbrowserformaction.h include/listformatter.h \
- include/listwidget.h include/formaction.h include/history.h \
- include/keymap.h include/feedlistformaction.h include/listformaction.h \
- include/view.h include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h
+ include/listwidget.h include/stflpp.h include/formaction.h \
+ include/history.h include/keymap.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h
 src/reloadrangethread.o: src/reloadrangethread.cpp \
  include/reloadrangethread.h include/reloader.h include/configcontainer.h \
  include/configactionhandler.h
 src/reloadthread.o: src/reloadthread.cpp include/reloadthread.h \
  include/configcontainer.h include/configactionhandler.h \
  include/controller.h include/cache.h include/colormanager.h \
- include/stflpp.h include/configparser.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h 3rd-party/optional.hpp \
- include/queuemanager.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/reloader.h \
- include/remoteapi.h include/rssignores.h include/rssitem.h \
- include/matchable.h include/logger.h config.h include/strprintf.h
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ 3rd-party/optional.hpp include/queuemanager.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/logger.h config.h \
+ include/strprintf.h
 src/remoteapi.o: src/remoteapi.cpp include/remoteapi.h \
  include/configcontainer.h include/configactionhandler.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h config.h \
@@ -764,7 +765,7 @@ src/utils.o: src/utils.cpp include/utils.h 3rd-party/expected.hpp \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
  include/logger.h include/ruststring.h include/strprintf.h
 src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
- include/colormanager.h include/configactionhandler.h include/stflpp.h \
+ include/colormanager.h include/configactionhandler.h \
  include/configcontainer.h include/controller.h include/cache.h \
  include/configparser.h include/feedcontainer.h include/filtercontainer.h \
  include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
@@ -773,16 +774,16 @@ src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
  filter/FilterParser.h include/regexowner.h include/reloader.h \
  include/remoteapi.h include/rssignores.h include/rssitem.h \
  include/matchable.h include/dirbrowserformaction.h \
- include/listformatter.h include/listwidget.h include/formaction.h \
- include/history.h include/keymap.h include/feedlistformaction.h \
- include/listformaction.h include/view.h include/filebrowserformaction.h \
- include/htmlrenderer.h include/textformatter.h config.h \
- include/dbexception.h stfl/dialogs.h include/dialogsformaction.h \
- include/emptyformaction.h stfl/empty.h include/exception.h \
- stfl/feedlist.h stfl/filebrowser.h include/fmtstrformatter.h \
- include/formaction.h stfl/help.h include/helpformaction.h \
- include/textviewwidget.h include/htmlrenderer.h stfl/itemlist.h \
- include/itemlistformaction.h stfl/itemview.h \
+ include/listformatter.h include/listwidget.h include/stflpp.h \
+ include/formaction.h include/history.h include/keymap.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h config.h include/dbexception.h stfl/dialogs.h \
+ include/dialogsformaction.h include/emptyformaction.h stfl/empty.h \
+ include/exception.h stfl/feedlist.h stfl/filebrowser.h \
+ include/fmtstrformatter.h include/formaction.h stfl/help.h \
+ include/helpformaction.h include/textviewwidget.h include/htmlrenderer.h \
+ stfl/itemlist.h include/itemlistformaction.h stfl/itemview.h \
  include/itemviewformaction.h include/keymap.h include/logger.h \
  include/strprintf.h include/matcherexception.h include/regexmanager.h \
  include/reloadthread.h include/rssfeed.h include/utils.h \
@@ -807,7 +808,7 @@ test/cliargsparser.o: test/cliargsparser.cpp 3rd-party/catch.hpp \
  test/test-helpers/stringmaker/optional.h test/test-helpers/tempdir.h \
  test/test-helpers/maintempdir.h
 test/colormanager.o: test/colormanager.cpp include/colormanager.h \
- include/configactionhandler.h include/stflpp.h 3rd-party/catch.hpp \
+ include/configactionhandler.h 3rd-party/catch.hpp \
  include/confighandlerexception.h include/configparser.h
 test/configcontainer.o: test/configcontainer.cpp \
  include/configcontainer.h include/configactionhandler.h \

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -104,7 +104,9 @@ void ColorManager::dump_config(std::vector<std::string>& config_output) const
 	}
 }
 
-void ColorManager::apply_colors(Stfl::Form& form) const
+void ColorManager::apply_colors(
+	std::function<void(const std::string&, const std::string&)> stfl_value_setter)
+const
 {
 	for (const auto& element_style : element_styles) {
 		const std::string& element = element_style.first;
@@ -134,7 +136,7 @@ void ColorManager::apply_colors(Stfl::Form& form) const
 			element,
 			colorattr);
 
-		form.set(element, colorattr);
+		stfl_value_setter(element, colorattr);
 
 		if (element == "article") {
 			std::string bold = colorattr;
@@ -149,8 +151,8 @@ void ColorManager::apply_colors(Stfl::Form& form) const
 			ul.append("attr=underline");
 			// STFL will just ignore those in forms which don't have the
 			// `color_bold` and `color_underline` variables.
-			form.set("color_bold", bold);
-			form.set("color_underline", ul);
+			stfl_value_setter("color_bold", bold);
+			stfl_value_setter("color_underline", ul);
 		}
 	}
 }

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -27,7 +27,7 @@ void DialogsFormAction::init()
 {
 	set_keymap_hints();
 
-	f.run(-3); // compute all widget dimensions
+	recalculate_widget_dimensions();
 }
 
 void DialogsFormAction::prepare()

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -69,7 +69,7 @@ void DialogsFormAction::update_heading()
 	FmtStrFormatter fmt;
 	fmt.register_fmt('N', PROGRAM_NAME);
 	fmt.register_fmt('V', utils::program_version());
-	f.set("head", fmt.do_format(title_format, width));
+	set_value("head", fmt.do_format(title_format, width));
 }
 
 KeyMapHintEntry* DialogsFormAction::get_keymap_hint()

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -110,7 +110,7 @@ bool DirBrowserFormAction::process_operation(Operation op,
 							base + 1,
 							std::string::npos);
 					}
-					f.set("filenametext", fn);
+					set_value("filenametext", fn);
 					do_redraw = true;
 				}
 				break;
@@ -120,7 +120,7 @@ bool DirBrowserFormAction::process_operation(Operation op,
 						fn.push_back(NEWSBEUTER_PATH_SEP);
 					}
 					fn.append(filename);
-					f.set("filenametext", fn);
+					set_value("filenametext", fn);
 					f.set_focus("filename");
 				}
 				break;
@@ -165,7 +165,7 @@ bool DirBrowserFormAction::process_operation(Operation op,
 		if (f.get_focus() == "files") {
 			files_list.move_to_first();
 		} else {
-			f.set("filenametext_pos", "0");
+			set_value("filenametext_pos", "0");
 		}
 		break;
 	case OP_SK_END:
@@ -173,7 +173,7 @@ bool DirBrowserFormAction::process_operation(Operation op,
 			files_list.move_to_last();
 		} else {
 			const std::size_t text_length = f.get("filenametext").length();
-			f.set("filenametext_pos", std::to_string(text_length));
+			set_value("filenametext_pos", std::to_string(text_length));
 		}
 		break;
 	case OP_SK_PGUP:
@@ -190,14 +190,14 @@ bool DirBrowserFormAction::process_operation(Operation op,
 		LOG(Level::DEBUG, "view::dirbrowser: quitting");
 		curs_set(0);
 		v->pop_current_formaction();
-		f.set("filenametext", "");
+		set_value("filenametext", "");
 		break;
 	case OP_HARDQUIT:
 		LOG(Level::DEBUG, "view::dirbrowser: hard quitting");
 		while (v->formaction_stack_size() > 0) {
 			v->pop_current_formaction();
 		}
-		f.set("filenametext", "");
+		set_value("filenametext", "");
 		break;
 	default:
 		break;
@@ -217,7 +217,7 @@ void DirBrowserFormAction::update_title(const std::string& working_directory)
 	const std::string title = fmt.do_format(
 			cfg->get_configvalue("dirbrowser-title-format"), width);
 
-	f.set("head", title);
+	set_value("head", title);
 }
 
 std::vector<std::string> get_sorted_dirlist()
@@ -293,7 +293,7 @@ void DirBrowserFormAction::init()
 {
 	set_keymap_hints();
 
-	f.set("fileprompt", _("Directory: "));
+	set_value("fileprompt", _("Directory: "));
 
 	if (dir == "") {
 		std::string save_path = cfg->get_configvalue("save-path");
@@ -308,11 +308,11 @@ void DirBrowserFormAction::init()
 	int status = ::chdir(dir.c_str());
 	LOG(Level::DEBUG, "view::dirbrowser: chdir(%s) = %i", dir, status);
 
-	f.set("filenametext", dir);
+	set_value("filenametext", dir);
 
 	// Set position to 0 and back to ensure that the text is visible
 	draw_form();
-	f.set("filenametext_pos", std::to_string(dir.length()));
+	set_value("filenametext_pos", std::to_string(dir.length()));
 }
 
 KeyMapHintEntry* DirBrowserFormAction::get_keymap_hint()

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -311,7 +311,7 @@ void DirBrowserFormAction::init()
 	f.set("filenametext", dir);
 
 	// Set position to 0 and back to ensure that the text is visible
-	f.run(-1);
+	draw_form();
 	f.set("filenametext_pos", std::to_string(dir.length()));
 }
 

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -47,7 +47,7 @@ void FeedListFormAction::init()
 {
 	set_keymap_hints();
 
-	f.run(-3); // compute all widget dimensions
+	recalculate_widget_dimensions();
 
 	if (v->get_ctrl()->get_refresh_on_start()) {
 		v->get_ctrl()->get_reloader()->start_reload_all_thread();

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -941,7 +941,7 @@ void FeedListFormAction::update_form_title(unsigned int width)
 	fmt.register_fmt('t', std::to_string(visible_feeds.size()));
 	fmt.register_fmt('F', apply_filter ? matcher.get_expression() : "");
 
-	f.set("head", fmt.do_format(title_format, width));
+	set_value("head", fmt.do_format(title_format, width));
 }
 
 unsigned int FeedListFormAction::count_unread_feeds()

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -303,7 +303,7 @@ void FileBrowserFormAction::init()
 	f.set("filenametext", default_filename);
 
 	// Set position to 0 and back to ensure that the text is visible
-	f.run(-1);
+	draw_form();
 	f.set("filenametext_pos", std::to_string(default_filename.length()));
 }
 

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -89,7 +89,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 							base + 1,
 							std::string::npos);
 					}
-					f.set("filenametext", fn);
+					set_value("filenametext", fn);
 					do_redraw = true;
 				}
 				break;
@@ -99,7 +99,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 						fn.push_back(NEWSBEUTER_PATH_SEP);
 					}
 					fn.append(filename);
-					f.set("filenametext", fn);
+					set_value("filenametext", fn);
 					f.set_focus("filename");
 				}
 				break;
@@ -166,7 +166,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 		if (f.get_focus() == "files") {
 			files_list.move_to_first();
 		} else {
-			f.set("filenametext_pos", "0");
+			set_value("filenametext_pos", "0");
 		}
 		break;
 	case OP_SK_END:
@@ -174,7 +174,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 			files_list.move_to_last();
 		} else {
 			const std::size_t text_length = f.get("filenametext").length();
-			f.set("filenametext_pos", std::to_string(text_length));
+			set_value("filenametext_pos", std::to_string(text_length));
 		}
 		break;
 	case OP_SK_PGUP:
@@ -191,14 +191,14 @@ bool FileBrowserFormAction::process_operation(Operation op,
 		LOG(Level::DEBUG, "view::filebrowser: quitting");
 		curs_set(0);
 		v->pop_current_formaction();
-		f.set("filenametext", "");
+		set_value("filenametext", "");
 		break;
 	case OP_HARDQUIT:
 		LOG(Level::DEBUG, "view::filebrowser: hard quitting");
 		while (v->formaction_stack_size() > 0) {
 			v->pop_current_formaction();
 		}
-		f.set("filenametext", "");
+		set_value("filenametext", "");
 		break;
 	default:
 		break;
@@ -218,7 +218,7 @@ void FileBrowserFormAction::update_title(const std::string& working_directory)
 	const std::string title = fmt.do_format(
 			cfg->get_configvalue("filebrowser-title-format"), width);
 
-	f.set("head", title);
+	set_value("head", title);
 }
 
 std::vector<std::string> get_sorted_filelist()
@@ -285,7 +285,7 @@ void FileBrowserFormAction::init()
 {
 	set_keymap_hints();
 
-	f.set("fileprompt", _("File: "));
+	set_value("fileprompt", _("File: "));
 
 	if (dir == "") {
 		std::string save_path = cfg->get_configvalue("save-path");
@@ -300,11 +300,11 @@ void FileBrowserFormAction::init()
 	int status = ::chdir(dir.c_str());
 	LOG(Level::DEBUG, "view::filebrowser: chdir(%s) = %i", dir, status);
 
-	f.set("filenametext", default_filename);
+	set_value("filenametext", default_filename);
 
 	// Set position to 0 and back to ensure that the text is visible
 	draw_form();
-	f.set("filenametext_pos", std::to_string(default_filename.length()));
+	set_value("filenametext_pos", std::to_string(default_filename.length()));
 }
 
 KeyMapHintEntry* FileBrowserFormAction::get_keymap_hint()

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -56,11 +56,6 @@ void FormAction::set_keymap_hints()
 
 FormAction::~FormAction() {}
 
-Stfl::Form& FormAction::get_form()
-{
-	return f;
-}
-
 std::string FormAction::prepare_keymap_hint(KeyMapHintEntry* hints)
 {
 	/*

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -85,9 +85,9 @@ std::string FormAction::prepare_keymap_hint(KeyMapHintEntry* hints)
 	return keymap_hint;
 }
 
-std::string FormAction::get_value(const std::string& value)
+std::string FormAction::get_value(const std::string& name)
 {
-	return f.get(value);
+	return f.get(name);
 }
 
 void FormAction::draw_form()
@@ -174,7 +174,7 @@ bool FormAction::process_op(Operation op,
 		 * An answer has been entered, we save the value, and ask the
 		 * next question.
 		 */
-		qna_responses.push_back(f.get("qna_value"));
+		qna_responses.push_back(get_value("qna_value"));
 		start_next_question();
 		break;
 	case OP_VIEWDIALOGS:

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -55,11 +55,6 @@ void FormAction::set_keymap_hints()
 	f.set("help", prepare_keymap_hint(this->get_keymap_hint()));
 }
 
-void FormAction::recalculate_form()
-{
-	f.run(-3);
-}
-
 FormAction::~FormAction() {}
 
 Stfl::Form& FormAction::get_form()
@@ -99,6 +94,12 @@ void FormAction::draw_form()
 {
 	f.run(-1);
 }
+
+void FormAction::recalculate_widget_dimensions()
+{
+	f.run(-3);
+}
+
 
 void FormAction::start_cmdline(std::string default_value)
 {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -27,10 +27,10 @@ FormAction::FormAction(View* vv, std::string formstr, ConfigContainer* cfg)
 {
 	if (v) {
 		if (cfg->get_configvalue_as_bool("show-keymap-hint") == false) {
-			f.set("showhint", "0");
+			set_value("showhint", "0");
 		}
 		if (cfg->get_configvalue_as_bool("show-title-bar") == false) {
-			f.set("showtitle", "0");
+			set_value("showtitle", "0");
 		}
 		if (cfg->get_configvalue_as_bool("swap-title-and-hints") ==
 			true) {
@@ -52,7 +52,7 @@ FormAction::FormAction(View* vv, std::string formstr, ConfigContainer* cfg)
 
 void FormAction::set_keymap_hints()
 {
-	f.set("help", prepare_keymap_hint(this->get_keymap_hint()));
+	set_value("help", prepare_keymap_hint(this->get_keymap_hint()));
 }
 
 FormAction::~FormAction() {}
@@ -90,6 +90,11 @@ std::string FormAction::get_value(const std::string& name)
 	return f.get(name);
 }
 
+void FormAction::set_value(const std::string& name, const std::string& value)
+{
+	f.set(name, value);
+}
+
 void FormAction::draw_form()
 {
 	f.run(-1);
@@ -108,7 +113,6 @@ void FormAction::recalculate_widget_dimensions()
 {
 	f.run(-3);
 }
-
 
 void FormAction::start_cmdline(std::string default_value)
 {
@@ -158,15 +162,15 @@ bool FormAction::process_op(Operation op,
 	case OP_INT_QNA_NEXTHIST:
 		if (qna_history) {
 			std::string entry = qna_history->next_line();
-			f.set("qna_value", entry);
-			f.set("qna_value_pos", std::to_string(entry.length()));
+			set_value("qna_value", entry);
+			set_value("qna_value_pos", std::to_string(entry.length()));
 		}
 		break;
 	case OP_INT_QNA_PREVHIST:
 		if (qna_history) {
 			std::string entry = qna_history->previous_line();
-			f.set("qna_value", entry);
-			f.set("qna_value_pos", std::to_string(entry.length()));
+			set_value("qna_value", entry);
+			set_value("qna_value_pos", std::to_string(entry.length()));
 		}
 		break;
 	case OP_INT_END_QUESTION:
@@ -527,7 +531,7 @@ void FormAction::start_next_question()
 
 		// Set position to 0 and back to ensure that the text is visible
 		draw_form();
-		f.set("qna_value_pos",
+		set_value("qna_value_pos",
 			std::to_string(qna_prompts[0].second.length()));
 
 		qna_prompts.erase(qna_prompts.begin());

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -95,6 +95,11 @@ std::string FormAction::get_value(const std::string& value)
 	return f.get(value);
 }
 
+void FormAction::draw_form()
+{
+	f.run(-1);
+}
+
 void FormAction::start_cmdline(std::string default_value)
 {
 	std::vector<QnaPair> qna;
@@ -511,7 +516,7 @@ void FormAction::start_next_question()
 		f.set_focus("qnainput");
 
 		// Set position to 0 and back to ensure that the text is visible
-		f.run(-1);
+		draw_form();
 		f.set("qna_value_pos",
 			std::to_string(qna_prompts[0].second.length()));
 

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -46,7 +46,6 @@ FormAction::FormAction(View* vv, std::string formstr, ConfigContainer* cfg)
 	valid_cmds.push_back("quit");
 	valid_cmds.push_back("source");
 	valid_cmds.push_back("dumpconfig");
-	valid_cmds.push_back("dumpform");
 	valid_cmds.push_back("exec");
 }
 
@@ -348,8 +347,6 @@ void FormAction::handle_cmdline(const std::string& cmdline)
 						_("Saved configuration to %s"),
 						tokens[0]));
 			}
-		} else if (cmd == "dumpform") {
-			v->dump_current_form();
 		} else if (cmd == "exec") {
 			if (tokens.size() != 1) {
 				v->show_error(_("usage: exec <operation>"));

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -95,6 +95,15 @@ void FormAction::draw_form()
 	f.run(-1);
 }
 
+std::string FormAction::draw_form_wait_for_event(unsigned int timeout)
+{
+	const char* event = f.run(timeout);
+	if (event == nullptr) {
+		return "";
+	}
+	return std::string(event);
+}
+
 void FormAction::recalculate_widget_dimensions()
 {
 	f.run(-3);

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -90,9 +90,8 @@ void HelpFormAction::prepare()
 		FmtStrFormatter fmt;
 		fmt.register_fmt('N', PROGRAM_NAME);
 		fmt.register_fmt('V', utils::program_version());
-		f.set("head",
-			fmt.do_format(cfg->get_configvalue("help-title-format"),
-				width));
+		set_value("head",
+			fmt.do_format(cfg->get_configvalue("help-title-format"), width));
 
 		const auto descs = v->get_keymap()->get_keymap_descriptions(context);
 
@@ -100,7 +99,7 @@ void HelpFormAction::prepare()
 			strprintf::fmt("<hl>%s</>", searchphrase);
 		std::vector<std::string> colors = utils::tokenize(
 				cfg->get_configvalue("search-highlight-colors"), " ");
-		f.set("highlight", make_colorstring(colors));
+		set_value("highlight", make_colorstring(colors));
 		ListFormatter listfmt;
 
 		unsigned int unbound_count = 0;

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -83,7 +83,7 @@ bool HelpFormAction::process_operation(Operation op,
 void HelpFormAction::prepare()
 {
 	if (do_redraw) {
-		f.run(-3); // compute all widget dimensions
+		recalculate_widget_dimensions();
 
 		const unsigned int width = textview.get_width();
 

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1122,7 +1122,7 @@ void ItemListFormAction::init()
 {
 	recalculate_widget_dimensions();
 	list.set_position(0);
-	f.set("msg", "");
+	set_value("msg", "");
 	set_keymap_hints();
 	invalidate_list();
 	do_update_visible_items();
@@ -1174,7 +1174,7 @@ void ItemListFormAction::set_head(const std::string& s,
 				cfg->get_configvalue("searchresult-title-format"),
 				width);
 	}
-	f.set("head", title);
+	set_value("head", title);
 }
 
 bool ItemListFormAction::jump_to_previous_unread_item(bool start_with_last)

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1120,7 +1120,7 @@ void ItemListFormAction::goto_item(const std::string& title)
 
 void ItemListFormAction::init()
 {
-	f.run(-3); // FRUN - compute all widget dimensions
+	recalculate_widget_dimensions();
 	list.set_position(0);
 	f.set("msg", "");
 	set_keymap_hints();

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -93,7 +93,7 @@ void ItemViewFormAction::prepare()
 		{
 			ScopeMeasure("itemview::prepare: rendering");
 			// XXX HACK: render once so that we get a proper widget width
-			f.run(-3);
+			recalculate_widget_dimensions();
 		}
 
 		update_head(item);

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -45,15 +45,15 @@ ItemViewFormAction::~ItemViewFormAction() {}
 
 void ItemViewFormAction::init()
 {
-	f.set("msg", "");
+	set_value("msg", "");
 	do_redraw = true;
 	links.clear();
 	num_lines = 0;
 	if (!cfg->get_configvalue_as_bool("display-article-progress")) {
-		f.set("percentwidth", "0");
+		set_value("percentwidth", "0");
 	} else {
 		const size_t min_field_width = 6;
-		f.set("percentwidth",
+		set_value("percentwidth",
 			std::to_string(
 		std::max({
 			min_field_width,
@@ -141,7 +141,7 @@ void ItemViewFormAction::prepare()
 		}
 
 		textview.stfl_replace_lines(num_lines, formatted_text);
-		f.set("article_offset", "0");
+		set_value("article_offset", "0");
 
 		if (in_search) {
 			rxman.remove_last_regex("article");
@@ -521,7 +521,7 @@ void ItemViewFormAction::set_head(const std::string& s,
 
 	const unsigned int width = textview.get_width();
 
-	f.set("head",
+	set_value("head",
 		fmt.do_format(
 			cfg->get_configvalue("itemview-title-format"), width));
 }
@@ -634,11 +634,11 @@ void ItemViewFormAction::update_percent()
 			percent);
 
 		if (offset == 0 || percent == 0) {
-			f.set("percent", _("Top"));
+			set_value("percent", _("Top"));
 		} else if (offset == (num_lines - 1)) {
-			f.set("percent", _("Bottom"));
+			set_value("percent", _("Bottom"));
 		} else {
-			f.set("percent", strprintf::fmt("%3u %% ", percent));
+			set_value("percent", strprintf::fmt("%3u %% ", percent));
 		}
 	}
 }

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -285,8 +285,11 @@ void PbView::handle_resize()
 
 void PbView::apply_colors_to_all_forms()
 {
-	colorman.apply_colors(dllist_form);
-	colorman.apply_colors(help_form);
+	using namespace std::placeholders;
+	colorman.apply_colors(std::bind(&newsboat::Stfl::Form::set, &dllist_form, _1,
+			_2));
+	colorman.apply_colors(std::bind(&newsboat::Stfl::Form::set, &help_form, _1,
+			_2));
 }
 
 std::pair<double, std::string> PbView::get_speed_human_readable(double kbps)

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -243,7 +243,7 @@ void SelectFormAction::update_heading()
 	default:
 		assert(0); // should never happen
 	}
-	f.set("head", title);
+	set_value("head", title);
 }
 
 KeyMapHintEntry* SelectFormAction::get_keymap_hint()

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -190,7 +190,7 @@ void SelectFormAction::init()
 	quit = false;
 	value = "";
 
-	f.run(-3); // compute all widget dimensions
+	recalculate_widget_dimensions();
 
 	set_keymap_hints();
 }

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -151,7 +151,7 @@ void UrlViewFormAction::init()
 {
 	v->set_status("");
 
-	f.run(-3); // compute all widget dimensions
+	recalculate_widget_dimensions();
 
 	do_redraw = true;
 	quit = false;

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -166,7 +166,7 @@ void UrlViewFormAction::update_heading()
 	fmt.register_fmt('N', PROGRAM_NAME);
 	fmt.register_fmt('V', utils::program_version());
 
-	f.set("head",
+	set_value("head",
 		fmt.do_format(
 			cfg->get_configvalue("urlview-title-format"), width));
 }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -171,7 +171,7 @@ int View::run()
 		fa->prepare();
 
 		// we then receive the event and ignore timeouts.
-		const char* event_ptr = fa->get_form().run(60000);
+		const std::string event = fa->draw_form_wait_for_event(60000);
 
 		if (ctrl_c_hit) {
 			ctrl_c_hit = false;
@@ -186,13 +186,7 @@ int View::run()
 			}
 		}
 
-		if (!event_ptr) {
-			continue;
-		}
-
-		std::string event = event_ptr;
-
-		if (event == "TIMEOUT") {
+		if (event.empty() || event == "TIMEOUT") {
 			continue;
 		}
 
@@ -253,13 +247,13 @@ std::string View::run_modal(std::shared_ptr<FormAction> f,
 
 		fa->prepare();
 
-		const char* event = fa->get_form().run(1000);
+		const std::string event = fa->draw_form_wait_for_event(1000);
 		LOG(Level::DEBUG, "View::run: event = %s", event);
-		if (!event || strcmp(event, "TIMEOUT") == 0) {
+		if (event.empty() || event == "TIMEOUT") {
 			continue;
 		}
 
-		if (strcmp(event, "RESIZE") == 0) {
+		if (event == "RESIZE") {
 			handle_resize();
 			continue;
 		}
@@ -639,12 +633,12 @@ char View::confirm(const std::string& prompt, const std::string& charset)
 	char result = 0;
 
 	do {
-		const char* event = f->get_form().run(0);
+		const std::string event = f->draw_form_wait_for_event(0);
 		LOG(Level::DEBUG, "View::confirm: event = %s", event);
-		if (!event) {
+		if (event.empty()) {
 			continue;
 		}
-		if (strcmp(event, "ESC") == 0 || strcmp(event, "ENTER") == 0) {
+		if (event == "ESC" || event == "ENTER") {
 			result = 0;
 			LOG(Level::DEBUG,
 				"View::confirm: user pressed ESC or ENTER, we "

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -110,7 +110,7 @@ void View::set_status(const std::string& msg)
 	auto fa = get_current_formaction();
 	if (fa != nullptr
 		&& std::dynamic_pointer_cast<EmptyFormAction>(fa) == nullptr) {
-		fa->get_form().set("msg", msg);
+		fa->set_value("msg", msg);
 		fa->draw_form();
 	}
 }
@@ -628,7 +628,7 @@ char View::confirm(const std::string& prompt, const std::string& charset)
 	std::shared_ptr<FormAction> f = get_current_formaction();
 	// Push empty formaction so our "msg" is not overwritten
 	push_empty_formaction();
-	f->get_form().set("msg", prompt);
+	f->set_value("msg", prompt);
 
 	char result = 0;
 
@@ -652,7 +652,7 @@ char View::confirm(const std::string& prompt, const std::string& charset)
 			result);
 	} while (!result || strchr(charset.c_str(), result) == nullptr);
 
-	f->get_form().set("msg", "");
+	f->set_value("msg", "");
 	f->draw_form();
 
 	pop_current_formaction();
@@ -965,7 +965,7 @@ void View::pop_current_formaction()
 		std::shared_ptr<FormAction> f = get_current_formaction();
 		if (f) {
 			f->set_redraw(true);
-			f->get_form().set("msg", "");
+			f->set_value("msg", "");
 			f->recalculate_widget_dimensions();
 		}
 	}
@@ -1073,8 +1073,8 @@ void View::inside_cmdline(bool f)
 
 void View::clear_line(std::shared_ptr<FormAction> fa)
 {
-	fa->get_form().set("qna_value", "");
-	fa->get_form().set("qna_value_pos", "0");
+	fa->set_value("qna_value", "");
+	fa->set_value("qna_value_pos", "0");
 	LOG(Level::DEBUG, "View::clear_line: cleared line");
 }
 
@@ -1083,8 +1083,8 @@ void View::clear_eol(std::shared_ptr<FormAction> fa)
 	unsigned int pos = utils::to_u(fa->get_value("qna_value_pos"), 0);
 	std::string val = fa->get_value("qna_value");
 	val.erase(pos, val.length());
-	fa->get_form().set("qna_value", val);
-	fa->get_form().set("qna_value_pos", std::to_string(val.length()));
+	fa->set_value("qna_value", val);
+	fa->set_value("qna_value_pos", std::to_string(val.length()));
 	LOG(Level::DEBUG, "View::clear_eol: cleared to end of line");
 }
 
@@ -1117,8 +1117,8 @@ void View::delete_word(std::shared_ptr<FormAction> fa)
 	}
 	val.erase(firstpos, curpos - firstpos);
 	LOG(Level::DEBUG, "View::delete_word: after val = %s", val);
-	fa->get_form().set("qna_value", val);
-	fa->get_form().set("qna_value_pos", std::to_string(firstpos));
+	fa->set_value("qna_value", val);
+	fa->set_value("qna_value_pos", std::to_string(firstpos));
 }
 
 bool View::handle_qna_event(const std::string& event,
@@ -1186,9 +1186,8 @@ void View::handle_cmdline_completion(std::shared_ptr<FormAction> fa)
 		suggestion = suggestions[(tab_count - 1) % suggestions.size()];
 		break;
 	}
-	fa->get_form().set("qna_value", suggestion);
-	fa->get_form().set(
-		"qna_value_pos", std::to_string(suggestion.length()));
+	fa->set_value("qna_value", suggestion);
+	fa->set_value("qna_value_pos", std::to_string(suggestion.length()));
 	last_fragment = suggestion;
 }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -972,7 +972,7 @@ void View::pop_current_formaction()
 		if (f) {
 			f->set_redraw(true);
 			f->get_form().set("msg", "");
-			f->recalculate_form();
+			f->recalculate_widget_dimensions();
 		}
 	}
 }
@@ -1159,7 +1159,7 @@ void View::handle_resize()
 	for (const auto& form : formaction_stack) {
 		if (form != nullptr) {
 			// Recalculate width and height of stfl widgets
-			form->get_form().run(-3);
+			form->recalculate_widget_dimensions();
 			form->set_redraw(true);
 		}
 	}

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1080,8 +1080,8 @@ void View::clear_line(std::shared_ptr<FormAction> fa)
 
 void View::clear_eol(std::shared_ptr<FormAction> fa)
 {
-	unsigned int pos = utils::to_u(fa->get_form().get("qna_value_pos"), 0);
-	std::string val = fa->get_form().get("qna_value");
+	unsigned int pos = utils::to_u(fa->get_value("qna_value_pos"), 0);
+	std::string val = fa->get_value("qna_value");
 	val.erase(pos, val.length());
 	fa->get_form().set("qna_value", val);
 	fa->get_form().set("qna_value_pos", std::to_string(val.length()));
@@ -1097,8 +1097,8 @@ void View::cancel_input(std::shared_ptr<FormAction> fa)
 void View::delete_word(std::shared_ptr<FormAction> fa)
 {
 	std::string::size_type curpos =
-		utils::to_u(fa->get_form().get("qna_value_pos"), 0);
-	std::string val = fa->get_form().get("qna_value");
+		utils::to_u(fa->get_value("qna_value_pos"), 0);
+	std::string val = fa->get_value("qna_value");
 	std::string::size_type firstpos = curpos;
 	LOG(Level::DEBUG, "View::delete_word: before val = %s", val);
 	if (firstpos >= val.length() || ::isspace(val[firstpos])) {
@@ -1161,7 +1161,7 @@ void View::handle_resize()
 
 void View::handle_cmdline_completion(std::shared_ptr<FormAction> fa)
 {
-	std::string fragment = fa->get_form().get("qna_value");
+	std::string fragment = fa->get_value("qna_value");
 	if (fragment != last_fragment || fragment == "") {
 		last_fragment = fragment;
 		suggestions = fa->get_suggestions(fragment);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1013,7 +1013,11 @@ void View::apply_colors(std::shared_ptr<FormAction> fa)
 {
 	LOG(Level::DEBUG, "View::apply_colors: fa = %s", fa->id());
 
-	colorman.apply_colors(fa->get_form());
+	const auto stfl_value_setter = [&](const std::string& name,
+	const std::string& value) {
+		fa->set_value(name, value);
+	};
+	colorman.apply_colors(stfl_value_setter);
 }
 
 void View::feedlist_mark_pos_if_visible(unsigned int pos)

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -110,9 +110,8 @@ void View::set_status(const std::string& msg)
 	auto fa = get_current_formaction();
 	if (fa != nullptr
 		&& std::dynamic_pointer_cast<EmptyFormAction>(fa) == nullptr) {
-		Stfl::Form& form = fa->get_form();
-		form.set("msg", msg);
-		form.run(-1);
+		fa->get_form().set("msg", msg);
+		fa->draw_form();
 	}
 }
 
@@ -129,7 +128,7 @@ bool View::run_commands(const std::vector<MacroCmd>& commands)
 		}
 		std::shared_ptr<FormAction> fa = get_current_formaction();
 		fa->prepare();
-		fa->get_form().run(-1);
+		fa->draw_form();
 		if (!fa->process_op(command.op, true, &command.args)) {
 			// Operation failed, abort
 			return false;
@@ -660,7 +659,7 @@ char View::confirm(const std::string& prompt, const std::string& charset)
 	} while (!result || strchr(charset.c_str(), result) == nullptr);
 
 	f->get_form().set("msg", "");
-	f->get_form().run(-1);
+	f->draw_form();
 
 	pop_current_formaction();
 
@@ -934,7 +933,7 @@ void View::force_redraw()
 		&& std::dynamic_pointer_cast<EmptyFormAction>(fa) == nullptr) {
 		fa->set_redraw(true);
 		fa->prepare();
-		fa->get_form().run(-1);
+		fa->draw_form();
 	}
 }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1191,27 +1191,6 @@ void View::handle_cmdline_completion(std::shared_ptr<FormAction> fa)
 	last_fragment = suggestion;
 }
 
-void View::dump_current_form()
-{
-	std::string formtext =
-		formaction_stack[current_formaction]->get_form().dump(
-			"", "", 0);
-	time_t t = time(nullptr);
-	const auto fnbuf = utils::mt_strf_localtime(
-			"dumpform-%Y%m%d-%H%M%S.stfl",
-			t);
-	std::fstream f(fnbuf, std::ios_base::out);
-	if (!f.is_open()) {
-		show_error(strprintf::fmt("Error: couldn't open file %s: %s",
-				fnbuf,
-				strerror(errno)));
-		return;
-	}
-	f << formtext;
-	f.close();
-	set_status(strprintf::fmt("Dumped current form to file %s", fnbuf));
-}
-
 void View::ctrl_c_action(int /* sig */)
 {
 	LOG(Level::DEBUG, "caught SIGINT");


### PR DESCRIPTION
Relevant quotes from the [`stfl_run()` documentation](http://svn.clifford.at/stfl/trunk/README):
> Return the next event. If no more prior generated events are waiting display
> the form and process one input character. The event string can be an null
> value when something changed in the form (e.g. the user changed the focus of
> the current widget) but all inputs have been handled internally inside of STFL.

>The … parameter is a timeout in ms. When no key has been pressed until this
> timeout has been reached the function returns with a "TIMEOUT" event. Set this
> parameter to 0 to disable the timeout.
> 
> When the timeout parameter is set to -1 the form is displayed independent of
> the current status of the event queue and the function returns right after
> displaying the form without handling any input characters. In this mode always
> an null value is returned.
> 
> When the timeout parameter is set to -3, rendering (and setting the :x, :y, :w
> and :h pseudo-variables) is done but the screen is not updated and no events
> are fetched. This is useful for incrementing rendering processes where
> appropriate :x, :y, :w and/or :h values are needed for finishing the layout.