### PR TITLE
Do not trigger -Wmaybe-uninitialized on GCC 9 with -O2 (and check this in CI)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -166,7 +166,6 @@ formatting_task:
 linux_task:
     env:
         RUSTFLAGS: '-D warnings'
-        PROFILE: 1
 
     matrix:
         # These two jobs test our minimum supported Rust version, so only bump on
@@ -197,7 +196,6 @@ linux_task:
                 cxx: g++-10
           env: &extra_warnings_and_checks_env
             CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
-            PROFILE: 0
         - name: Clang 11, more warnings and checks (Ubuntu 20.10)
           container:
             dockerfile: docker/ubuntu_20.10-build-tools.dockerfile

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ CXX_FOR_BUILD?=$(CXX)
 # compiler and linker flags
 DEFINES=-DLOCALEDIR='"$(localedir)"'
 
-WARNFLAGS=-Werror -Wall -Wextra -Wunreachable-code -Wno-unknown-warning-option -Wno-unknown-pragmas
+WARNFLAGS=-Werror -Wall -Wextra -Wunreachable-code
 INCLUDES=-Iinclude -Istfl -Ifilter -I. -Irss -I$(relative_cargo_target_dir)/cxxbridge/libnewsboat-ffi/src/
 BARE_CXXFLAGS=-std=c++11 -O2 -ggdb $(INCLUDES)
 LDFLAGS+=-L.

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -229,16 +229,17 @@ REDO:
 					"items in feed at position `%s'",
 					feedpos.c_str());
 
-				const auto exit_code = open_unread_items_in_browser(feed, false);
+				// We can't just `const auto exit_code = ...` here because this
+				// triggers -Wmaybe-initialized in GCC 9 with -O2.
+				nonstd::optional<std::uint8_t> exit_code;
+				exit_code = open_unread_items_in_browser(feed, false);
+
 				if (!exit_code.has_value()) {
 					v->show_error(_("Failed to spawn browser"));
 					return false;
 				} else if (*exit_code != 0) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"),
 							*exit_code));
-#pragma GCC diagnostic pop
 					return false;
 				}
 			}
@@ -258,15 +259,16 @@ REDO:
 					"marking read",
 					feedpos.c_str());
 
-				const auto exit_code = open_unread_items_in_browser(feed, true);
+				// We can't just `const auto exit_code = ...` here because this
+				// triggers -Wmaybe-initialized in GCC 9 with -O2.
+				nonstd::optional<std::uint8_t> exit_code;
+				exit_code = open_unread_items_in_browser(feed, true);
+
 				if (!exit_code.has_value()) {
 					v->show_error(_("Failed to spawn browser"));
 					return false;
 				} else if (*exit_code != 0) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 					v->show_error(strprintf::fmt(_("Browser returned error code %i"), *exit_code));
-#pragma GCC diagnostic pop
 					return false;
 				}
 

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -167,7 +167,12 @@ bool ItemListFormAction::process_operation(Operation op,
 				"ItemListFormAction: opening all unread items "
 				"in "
 				"browser");
-			const auto exit_code = open_unread_items_in_browser(feed, false);
+
+			// We can't just `const auto exit_code = ...` here because this
+			// triggers -Wmaybe-initialized in GCC 9 with -O2.
+			nonstd::optional<std::uint8_t> exit_code;
+			exit_code = open_unread_items_in_browser(feed, true);
+
 			if (!exit_code.has_value()) {
 				v->show_error(_("Failed to spawn browser"));
 				return false;
@@ -184,7 +189,12 @@ bool ItemListFormAction::process_operation(Operation op,
 				"ItemListFormAction: opening all unread items "
 				"in "
 				"browser and marking read");
-			const auto exit_code = open_unread_items_in_browser(feed, true);
+
+			// We can't just `const auto exit_code = ...` here because this
+			// triggers -Wmaybe-initialized in GCC 9 with -O2.
+			nonstd::optional<std::uint8_t> exit_code;
+			exit_code = open_unread_items_in_browser(feed, true);
+
 			if (!exit_code.has_value()) {
 				v->show_error(_("Failed to spawn browser"));
 				return false;


### PR DESCRIPTION
This is the PR I promised in https://github.com/newsboat/newsboat/issues/1351#issuecomment-753624763. Please read the commit messages here to get the whole story.

I plan to ship this with 2.22.1, so I'll merge tomorrow. Reviews are welcome though!