### PR TITLE
Address some of CppCheck's suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ doc/podboat-cmds-linked.asciidoc
 /target/
 **/*.rs.bk
 .vscode
+/cppcheck.log

--- a/Makefile
+++ b/Makefile
@@ -283,9 +283,11 @@ fmt:
 
 cppcheck:
 	cppcheck -j$(CPPCHECK_JOBS) --force --enable=all --suppress=unusedFunction \
+		--config-exclude=3rd-party --config-exclude=$(relative_cargo_target_dir) --config-exclude=/usr/include \
+		--suppress=*:3rd-party/* --suppress=*:$(relative_cargo_target_dir)/* --suppress=*:/usr/include/* \
 		-DDEBUG=1 \
 		$(INCLUDES) $(DEFINES) \
-		include filter newsboat.cpp podboat.cpp rss src stfl test \
+		include newsboat.cpp podboat.cpp rss src stfl test \
 		2>cppcheck.log
 	@echo "Done! See cppcheck.log for details."
 

--- a/include/regexowner.h
+++ b/include/regexowner.h
@@ -12,7 +12,7 @@ namespace newsboat {
 
 class Regex {
 private:
-	Regex(const regex_t& r);
+	explicit Regex(const regex_t& r);
 
 public:
 	~Regex();

--- a/include/scopemeasure.h
+++ b/include/scopemeasure.h
@@ -9,7 +9,7 @@ namespace newsboat {
 
 class ScopeMeasure {
 public:
-	ScopeMeasure(const std::string& func);
+	explicit ScopeMeasure(const std::string& func);
 	~ScopeMeasure() = default;
 	void stopover(const std::string& son = "");
 

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -78,8 +78,8 @@ rss/rssparser.o: rss/rssparser.cpp rss/rssparser.h rss/exception.h \
  include/configactionhandler.h include/logger.h config.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 rss/rssparserfactory.o: rss/rssparserfactory.cpp rss/rssparserfactory.h \
- rss/rssparser.h rss/atomparser.h config.h rss/exception.h rss/feed.h \
- rss/item.h rss/rss09xparser.h rss/rss10parser.h rss/rss20parser.h
+ rss/feed.h rss/item.h rss/rssparser.h rss/atomparser.h config.h \
+ rss/exception.h rss/rss09xparser.h rss/rss10parser.h rss/rss20parser.h
 rss/xmlutilities.o: rss/xmlutilities.cpp rss/xmlutilities.h
 src/cache.o: src/cache.cpp include/cache.h include/configcontainer.h \
  include/configactionhandler.h config.h include/configcontainer.h \

--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -370,7 +370,7 @@ Feed Parser::parse_xmlnode(xmlNode* node)
 			}
 
 			std::shared_ptr<RssParser> parser =
-				RssParserFactory::get_object(f, doc);
+				RssParserFactory::get_object(f.rss_version, doc);
 
 			try {
 				parser->parse_feed(f, node);

--- a/rss/rssparserfactory.cpp
+++ b/rss/rssparserfactory.cpp
@@ -3,17 +3,17 @@
 #include "atomparser.h"
 #include "config.h"
 #include "exception.h"
-#include "feed.h"
 #include "rss09xparser.h"
 #include "rss10parser.h"
 #include "rss20parser.h"
 
 namespace rsspp {
 
-std::shared_ptr<RssParser> RssParserFactory::get_object(Feed& f,
+std::shared_ptr<RssParser> RssParserFactory::get_object(
+	Feed::Version rss_version,
 	xmlDocPtr doc)
 {
-	switch (f.rss_version) {
+	switch (rss_version) {
 	case Feed::RSS_0_91:
 	case Feed::RSS_0_92:
 	case Feed::RSS_0_94:

--- a/rss/rssparserfactory.h
+++ b/rss/rssparserfactory.h
@@ -4,14 +4,14 @@
 #include <memory>
 #include <libxml/tree.h>
 
+#include "feed.h"
 #include "rssparser.h"
 
 namespace rsspp {
 
-class Feed;
-
 struct RssParserFactory {
-	static std::shared_ptr<RssParser> get_object(Feed& f, xmlDocPtr doc);
+	static std::shared_ptr<RssParser> get_object(Feed::Version rss_version,
+		xmlDocPtr doc);
 };
 
 } // namespace rsspp

--- a/test/data/test-urls.txt
+++ b/test/data/test-urls.txt
@@ -1,5 +1,5 @@
-http://test1.url.cc/feed.xml tag1 tag2
+http://test1.url.cc/feed.xml ~title tag1 tag2
 http://anotherfeed.com/
 # a comment
-http://onemorefeed.at/feed/	tag1	tag3
+http://onemorefeed.at/feed/	tag1	"~another title" tag3
 # comment

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -38,12 +38,17 @@ TEST_CASE("URL reader extracts feeds' tags", "[FileUrlReader]")
 	FileUrlReader u("data/test-urls.txt");
 	u.reload();
 
-	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml").size() == 2);
-	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml")[0] == "tag1");
-	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml")[1] == "tag2");
+	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml").size() == 3);
+	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml")[0] == "~title");
+	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml")[1] == "tag1");
+	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml")[2] == "tag2");
 
 	REQUIRE(u.get_tags("http://anotherfeed.com/").size() == 0);
-	REQUIRE(u.get_tags("http://onemorefeed.at/feed/").size() == 2);
+
+	REQUIRE(u.get_tags("http://onemorefeed.at/feed/").size() == 3);
+	REQUIRE(u.get_tags("http://onemorefeed.at/feed/")[0] == "tag1");
+	REQUIRE(u.get_tags("http://onemorefeed.at/feed/")[1] == "~another title");
+	REQUIRE(u.get_tags("http://onemorefeed.at/feed/")[2] == "tag3");
 }
 
 TEST_CASE("URL reader keeps track of unique tags", "[FileUrlReader]")
@@ -186,4 +191,18 @@ TEST_CASE("URL reader returns error message if file contains invalid UTF-8 codep
 	auto error_message = u.reload();
 	REQUIRE(error_message.has_value());
 	REQUIRE(error_message.value().size() > 0);
+}
+
+TEST_CASE("FileUrlReader::get_alltags() returns all unique tags across all feeds, "
+	"excluding the title tags",
+	"[FileUrlReader]")
+{
+	FileUrlReader u("data/test-urls.txt");
+	u.reload();
+
+	const auto tags = u.get_alltags();
+	REQUIRE(tags.size() == 3);
+	REQUIRE(tags[0] == "tag1");
+	REQUIRE(tags[1] == "tag2");
+	REQUIRE(tags[2] == "tag3");
 }

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -96,9 +96,9 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 	using Tag = std::string;
 	using Tags = std::vector<Tag>;
 	const std::map<URL, Tags> testUrls {
-		{"http://test1.url.cc/feed.xml", {"tag1", "tag2"}},
+		{"http://test1.url.cc/feed.xml", {"~title", "tag1", "tag2"}},
 		{"http://anotherfeed.com/", {}},
-		{"http://onemorefeed.at/feed/", {"tag1", "tag3"}}
+		{"http://onemorefeed.at/feed/", {"tag1", "~another title", "tag3"}}
 	};
 
 	FileUrlReader urlcfg(urlsFile.get_path());
@@ -228,9 +228,9 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 	using Tag = std::string;
 	using Tags = std::vector<Tag>;
 	const std::map<URL, Tags> testUrls {
-		{"http://test1.url.cc/feed.xml", {"tag1", "tag2"}},
+		{"http://test1.url.cc/feed.xml", {"~title", "tag1", "tag2"}},
 		{"http://anotherfeed.com/", {}},
-		{"http://onemorefeed.at/feed/", {"tag1", "tag3"}}
+		{"http://onemorefeed.at/feed/", {"tag1", "~another title", "tag3"}}
 	};
 
 	FileUrlReader urlcfg(urlsFile.get_path());

--- a/test/test-helpers/maintempdir.cpp
+++ b/test/test-helpers/maintempdir.cpp
@@ -8,9 +8,8 @@
 
 TestHelpers::MainTempDir::tempfileexception::tempfileexception(
 	const std::string& error)
+	: msg("tempfileexception: " + error)
 {
-	msg = "tempfileexception: ";
-	msg += error;
 };
 
 const char* TestHelpers::MainTempDir::tempfileexception::what() const throw()

--- a/test/test-helpers/maintempdir.h
+++ b/test/test-helpers/maintempdir.h
@@ -17,7 +17,7 @@ public:
 		virtual const char* what() const throw();
 
 	private:
-		std::string msg;
+		const std::string msg;
 	};
 
 	MainTempDir();


### PR DESCRIPTION
It's been on my personal to-do list for a while to run CppCheck on Newsboat and see what it finds. Newsbeuter already had a Make target for that, so I updated it a bit and got a pretty short report with nothing really interesting in it. Most of the report is CppCheck being unable to parse our tests, plus a few suggestions that I don't want to apply.

It'd probably be better to add CppCheck to CI, but that would require: 1) adding suppression comments for things that I don't want to fix; 2) grepping out parse errors so they don't fail the build. Frankly, I'm too lazy for that at the moment, so I just added a monthly task for myself to re-run CppCheck manually and see what pops up. If it keeps turning up somewhat useful things, I'll probably get motivated enough to add it to CI :)

Reviews are welcome! It's holiday season, so I won't hurry this PR and will merge it in a week instead of the usual three days.