### PR TITLE
Render <div>s onto a new line

### DIFF
--- a/include/htmlrenderer.h
+++ b/include/htmlrenderer.h
@@ -30,6 +30,7 @@ enum class HtmlTag {
 	H5,
 	H6,
 	P,
+	DIV,
 	OL,
 	UL,
 	LI,

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -29,6 +29,7 @@ HtmlRenderer::HtmlRenderer(bool raw)
 	tags["blockquote"] = HtmlTag::BLOCKQUOTE;
 	tags["aside"] = HtmlTag::BLOCKQUOTE;
 	tags["p"] = HtmlTag::P;
+	tags["div"] = HtmlTag::DIV;
 	tags["h1"] = HtmlTag::H1;
 	tags["h2"] = HtmlTag::H2;
 	tags["h3"] = HtmlTag::H3;
@@ -320,7 +321,8 @@ void HtmlRenderer::render(std::istream& input,
 			case HtmlTag::H4:
 			case HtmlTag::H5:
 			case HtmlTag::H6:
-			case HtmlTag::P: {
+			case HtmlTag::P:
+			case HtmlTag::DIV: {
 				add_nonempty_line(curline, tables, lines);
 				if (lines.size() > 0) {
 					std::string::size_type last_line_len =
@@ -718,6 +720,7 @@ void HtmlRenderer::render(std::istream& input,
 			case HtmlTag::H5:
 			case HtmlTag::H6:
 			case HtmlTag::P:
+			case HtmlTag::DIV:
 				add_nonempty_line(curline, tables, lines);
 				prepare_new_line(curline,
 					tables.size() ? 0 : indent_level);

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -1483,3 +1483,35 @@ TEST_CASE("Skips contents of <script> tags", "[HtmlRenderer]")
 	REQUIRE(lines.size() == 0);
 	REQUIRE(links.size() == 0);
 }
+
+TEST_CASE("<div> is always rendered on a new line", "[HtmlRenderer]")
+{
+	HtmlRenderer rnd;
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	const std::string
+	input("<div>oh</div>"
+		"<div>hello there,</div>"
+		"<p>world</p>"
+		"<div>!</div>"
+		"<div>"
+		"    <div>"
+		"        <p>hehe</p>"
+		"    </div>"
+		"</div>");
+
+	rnd.render(input, lines, links, "");
+
+	REQUIRE(lines.size() == 9);
+	REQUIRE(lines[0] == p(LineType::wrappable, "oh"));
+	REQUIRE(lines[1] == p(LineType::wrappable, ""));
+	REQUIRE(lines[2] == p(LineType::wrappable, "hello there,"));
+	REQUIRE(lines[3] == p(LineType::wrappable, ""));
+	REQUIRE(lines[4] == p(LineType::wrappable, "world"));
+	REQUIRE(lines[5] == p(LineType::wrappable, ""));
+	REQUIRE(lines[6] == p(LineType::wrappable, "!"));
+	REQUIRE(lines[7] == p(LineType::wrappable, ""));
+	REQUIRE(lines[8] == p(LineType::wrappable, "hehe"));
+	REQUIRE(links.size() == 0);
+}


### PR DESCRIPTION
\<div> is a "block element", meaning it should be rendered on a new line. We treat is the same as \<p>.

Fixes #1405.

@tsipinakis, please test this, and review the code if you have a moment to spare :)