### PR TITLE
FeedList: Remove faulty position validation

### DIFF
--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -527,7 +527,7 @@ REDO:
 bool FeedListFormAction::open_position_in_browser(unsigned int pos,
 	bool interactive) const
 {
-	if (visible_feeds.empty() || pos >= visible_feeds.size()) {
+	if (visible_feeds.empty()) {
 		v->show_error(_("No feed selected!"));
 		return false;
 	}


### PR DESCRIPTION
`pos` stores a position into the full list of feeds while `visible_feeds` only contains feeds which are not filtered out.

The check is not necessary as the result of the following `FeedContainer::get_feed()` is checked anyway (it returns nullptr if the index is out of bounds).

Git bisect points to https://github.com/newsboat/newsboat/commit/7f6ce535a715779e5ff937e6ff56bda4c7831c18 as the commit which introduced this small regression.