### PR TITLE
Add utils::locale_to_utf8()

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -37,6 +37,15 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install --assume-yes --no-install-suggests clang-11 libsqlite3-dev libcurl4-openssl-dev libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev
 
+      - name: Generate locales
+        run: |
+          sudo apt-get install --assume-yes locales
+          echo 'en_US.UTF-8 UTF-8' | sudo tee --append /etc/locale.gen
+          echo 'ru_RU.KOI8-R KOI8-R' | sudo tee --append /etc/locale.gen
+          echo 'nl_NL.ISO-8859-1 ISO-8859-1' | sudo tee --append /etc/locale.gen
+          echo 'ru_RU.CP1251 CP1251' | sudo tee --append /etc/locale.gen
+          sudo locale-gen
+
       - name: Install Rust
         uses: ATiltedTree/setup-rust@v1
         with:

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -81,6 +81,9 @@ RUN addgroup --gid 1000 builder \
 
 RUN apt-get install locales \
     && echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
+    && echo 'ru_RU.KOI8-R KOI8-R' >> /etc/locale.gen \
+    && echo 'nl_NL.ISO-8859-1 ISO-8859-1' >> /etc/locale.gen \
+    && echo 'ru_RU.CP1251 CP1251' >> /etc/locale.gen \
     && locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -68,6 +68,9 @@ RUN addgroup --gid 1000 builder \
 RUN apt-get update \
     && apt-get install locales \
     && echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
+    && echo 'ru_RU.KOI8-R KOI8-R' >> /etc/locale.gen \
+    && echo 'nl_NL.ISO-8859-1 ISO-8859-1' >> /etc/locale.gen \
+    && echo 'ru_RU.CP1251 CP1251' >> /etc/locale.gen \
     && locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -81,6 +81,9 @@ RUN addgroup --gid 1000 builder \
 
 RUN apt-get install locales \
     && echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
+    && echo 'ru_RU.KOI8-R KOI8-R' >> /etc/locale.gen \
+    && echo 'nl_NL.ISO-8859-1 ISO-8859-1' >> /etc/locale.gen \
+    && echo 'ru_RU.CP1251 CP1251' >> /etc/locale.gen \
     && locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/docker/ubuntu_20.10-build-tools.dockerfile
+++ b/docker/ubuntu_20.10-build-tools.dockerfile
@@ -81,6 +81,9 @@ RUN addgroup --gid 1000 builder \
 
 RUN apt-get install locales \
     && echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
+    && echo 'ru_RU.KOI8-R KOI8-R' >> /etc/locale.gen \
+    && echo 'nl_NL.ISO-8859-1 ISO-8859-1' >> /etc/locale.gen \
+    && echo 'ru_RU.CP1251 CP1251' >> /etc/locale.gen \
     && locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/include/utils.h
+++ b/include/utils.h
@@ -55,6 +55,9 @@ std::string convert_text(const std::string& text,
 /// Converts input string from UTF-8 to the locale's encoding (as detected by
 /// nl_langinfo(CODESET)).
 std::string utf8_to_locale(const std::string& text);
+/// Converts input string from the locale's encoding (as detected by
+/// nl_langinfo(CODESET)) to UTF-8.
+std::string locale_to_utf8(const std::string& text);
 
 std::string get_command_output(const std::string& cmd);
 std::string http_method_str(const HTTPMethod method);

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -982,8 +982,7 @@ void FeedListFormAction::op_start_search()
 		searchhistory.add_line(searchphrase);
 		std::vector<std::shared_ptr<RssItem>> items;
 		try {
-			std::string utf8searchphrase = utils::convert_text(
-					searchphrase, "utf-8", nl_langinfo(CODESET));
+			const auto utf8searchphrase = utils::locale_to_utf8(searchphrase);
 			items = v->get_ctrl()->search_for_items(
 					utf8searchphrase, nullptr);
 		} catch (const DbException& e) {

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -882,8 +882,7 @@ void ItemListFormAction::qna_start_search()
 	searchhistory.add_line(searchphrase);
 	std::vector<std::shared_ptr<RssItem>> items;
 	try {
-		std::string utf8searchphrase = utils::convert_text(
-				searchphrase, "utf-8", nl_langinfo(CODESET));
+		const auto utf8searchphrase = utils::locale_to_utf8(searchphrase);
 		items = v->get_ctrl()->search_for_items(
 				utf8searchphrase, feed);
 	} catch (const DbException& e) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -320,8 +320,21 @@ std::string utils::convert_text(const std::string& text,
 		return text;
 	}
 
-	iconv_t cd = ::iconv_open(
-			translit(tocode, fromcode).c_str(), fromcode.c_str());
+	const auto tocode_translit = translit(tocode, fromcode);
+
+	// Illegal and incomplete multi-byte sequences will be replaced by this
+	// placeholder. By default, we use an ASCII value for "question mark".
+	std::string question_mark("\x3f");
+	// This `if` prevens the function to recurse indefinitely.
+	if (text != question_mark && fromcode != "ASCII") {
+		question_mark = utils::convert_text("\x3f", tocode_translit, "ASCII");
+	}
+	// If we can't even convert a question mark, let's just give up.
+	if (question_mark.empty()) {
+		return result;
+	}
+
+	iconv_t cd = ::iconv_open(tocode_translit.c_str(), fromcode.c_str());
 
 	if (cd == reinterpret_cast<iconv_t>(-1)) {
 		return result;
@@ -366,7 +379,7 @@ std::string utils::convert_text(const std::string& text,
 			case EILSEQ:
 			case EINVAL:
 				result.append(old_outbufp, outbufp - old_outbufp);
-				result.append("?");
+				result.append(question_mark);
 				inbufp += 1;
 				inbytesleft -= 1;
 				break;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -405,6 +405,15 @@ std::string utils::utf8_to_locale(const std::string& text)
 	return utils::convert_text(text, nl_langinfo(CODESET), "utf-8");
 }
 
+std::string utils::locale_to_utf8(const std::string& text)
+{
+	if (text.empty()) {
+		return {};
+	}
+
+	return utils::convert_text(text, "utf-8", nl_langinfo(CODESET));
+}
+
 std::string utils::get_command_output(const std::string& cmd)
 {
 	return std::string(utils::bridged::get_command_output(cmd));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -360,16 +360,14 @@ std::string utils::convert_text(const std::string& text,
 					old_outbufp, outbufp - old_outbufp);
 				outbufp = outbuf;
 				outbytesleft = sizeof(outbuf);
-				inbufp += strlen(inbufp) - inbytesleft;
-				inbytesleft = strlen(inbufp);
 				break;
 			case EILSEQ:
 			case EINVAL:
 				result.append(
 					old_outbufp, outbufp - old_outbufp);
 				result.append("?");
-				inbufp += strlen(inbufp) - inbytesleft + 1;
-				inbytesleft = strlen(inbufp);
+				inbufp += 1;
+				inbytesleft -= 1;
 				break;
 			default:
 				break;

--- a/test/test-helpers/envvar.h
+++ b/test/test-helpers/envvar.h
@@ -37,7 +37,7 @@ public:
 	/// a temporary or a string literal anyway. Just do it, and use set() and
 	/// unset() methods, instead of keeping a local variable with a name in it
 	/// and calling setenv(3) and unsetenv(3).
-	EnvVar(std::string name_);
+	explicit EnvVar(std::string name_);
 
 	~EnvVar();
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1802,9 +1802,7 @@ TEST_CASE("convert_text() replaces incomplete multi-byte sequences with a questi
 	SECTION("From UTF-8 to UTF-16LE") {
 		// "oops" in Russian, but the last byte is missing
 		const std::string input("\xd0\xbe\xd0");
-		// FIXME: the question mark is encoded by a single byte here, which is
-		// wrong; it should be \x3f\x00 instead.
-		const std::string expected("\x3e\x04\x3f");
+		const std::string expected("\x3e\x04\x3f\x00", 4);
 		REQUIRE(utils::convert_text(input, "UTF-16LE", "UTF-8") == expected);
 	}
 
@@ -1833,7 +1831,7 @@ TEST_CASE("convert_text() replaces invalid multi-byte sequences with "
 		// "日本", "Japan", but the third byte of the first character (0xa5) is
 		// missing, making the whole first character an illegal sequence.
 		const std::string input("\xe6\x97\xe6\x9c\xac");
-		const std::string expected("??\x2c\x67");
+		const std::string expected("\x3f\x00\x3f\x00\x2c\x67", 6);
 		REQUIRE(utils::convert_text(input, "UTF-16LE", "UTF-8") == expected);
 	}
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1784,7 +1784,7 @@ TEST_CASE("convert_text() returns input string if `fromcode` and `tocode` are th
 TEST_CASE("convert_text() returns empty string if conversion is impossible",
 	"[utils]")
 {
-	// "Hello", in Russian, encoded in UTF-8.
+	// "Привет", "Hello", in Russian, encoded in UTF-8.
 	const std::string input("\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82");
 
 	SECTION("Can't convert from non-existent encoding") {
@@ -1800,7 +1800,7 @@ TEST_CASE("convert_text() replaces incomplete multi-byte sequences with a questi
 	"[utils]")
 {
 	SECTION("From UTF-8 to UTF-16LE") {
-		// "oops" in Russian, but the last byte is missing
+		// "ой", "oops" in Russian, but the last byte is missing
 		const std::string input("\xd0\xbe\xd0");
 		const std::string expected("\x3e\x04\x3f\x00", 4);
 		REQUIRE(utils::convert_text(input, "UTF-16LE", "UTF-8") == expected);
@@ -1815,7 +1815,7 @@ TEST_CASE("convert_text() replaces incomplete multi-byte sequences with a questi
 		}
 
 		SECTION("Input doesn't contain zero bytes") {
-			// "hey" in Russian, but the last byte is missing
+			// "эй", "hey" in Russian, but the last byte is missing
 			const std::string input("\x4d\x04\x39", 3);
 			const std::string expected("\xd1\x8d?");
 			REQUIRE(utils::convert_text(input, "UTF-8", "UTF-16LE") == expected);
@@ -1850,7 +1850,7 @@ TEST_CASE("convert_text() replaces invalid multi-byte sequences with "
 TEST_CASE("convert_text() converts text between encodings", "[utils]")
 {
 	SECTION("From UTF-8 to UTF-16LE") {
-		// "Testing" in Russian.
+		// "Тестирую", "Testing" in Russian.
 		const std::string input("\xd0\xa2\xd0\xb5\xd1\x81\xd1\x82\xd0\xb8\xd1"
 			"\x80\xd1\x83\xd1\x8e");
 		const std::string expected("\x22\x04\x35\x04\x41\x04\x42\x04"
@@ -1859,7 +1859,7 @@ TEST_CASE("convert_text() converts text between encodings", "[utils]")
 	}
 
 	SECTION("From UTF-8 to KOI8-R") {
-		// "Check" in Russian.
+		// "Проверка", "Check" in Russian.
 		const std::string input("\xd0\x9f\xd1\x80\xd0\xbe\xd0\xb2\xd0\xb5\xd1"
 			"\x80\xd0\xba\xd0\xb0");
 		const std::string expected("\xf0\xd2\xcf\xd7\xc5\xd2\xcb\xc1");
@@ -1867,7 +1867,8 @@ TEST_CASE("convert_text() converts text between encodings", "[utils]")
 	}
 
 	SECTION("From UTF-8 to ISO-8859-1 (transliterating if need be)") {
-		// Mix of Cyrillic (unsupported by ISO-8859-1) and ISO-8859-1 characters.
+		// "вау °±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃ": a mix of Cyrillic (unsupported by
+		// ISO-8859-1) and ISO-8859-1 characters.
 		const std::string input("\xd0\xb2\xd0\xb0\xd1\x83\x20\xc2\xb0\xc2\xb1"
 			"\xc2\xb2\xc2\xb3\xc2\xb4\xc2\xb5\xc2\xb6\xc2\xb7\xc2\xb8\xc2\xb9"
 			"\xc2\xba\xc2\xbb\xc2\xbc\xc2\xbd\xc2\xbe\xc2\xbf\xc3\x80\xc3\x81"
@@ -1881,7 +1882,7 @@ TEST_CASE("convert_text() converts text between encodings", "[utils]")
 	}
 
 	SECTION("From UTF-16LE to UTF-8") {
-		// "Success" in Russian.
+		// "Успех", "Success" in Russian.
 		const std::string input("\xff\xfe\x23\x04\x41\x04\x3f\x04\x35\x04\x45\x04");
 		const std::string expected("\xef\xbb\xbf\xd0\xa3\xd1\x81\xd0\xbf\xd0\xb5"
 			"\xd1\x85");
@@ -1889,7 +1890,7 @@ TEST_CASE("convert_text() converts text between encodings", "[utils]")
 	}
 
 	SECTION("From KOI8-R to UTF-8") {
-		// "History" in Russian.
+		// "История", "History" in Russian.
 		const std::string input("\xe9\xd3\xd4\xcf\xd2\xc9\xd1");
 		const std::string expected("\xd0\x98\xd1\x81\xd1\x82\xd0\xbe\xd1\x80"
 			"\xd0\xb8\xd1\x8f");
@@ -1897,7 +1898,7 @@ TEST_CASE("convert_text() converts text between encodings", "[utils]")
 	}
 
 	SECTION("From ISO-8859-1 to UTF-8") {
-		// Some umlauts and Latin letters.
+		// "ÄÅÆÇÈÉÊËÌÍÎÏ": some umlauts and Latin letters.
 		const std::string input("\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf");
 		const std::string expected("\xc3\x84\xc3\x85\xc3\x86\xc3\x87\xc3\x88\xc3"
 			"\x89\xc3\x8a\xc3\x8b\xc3\x8c\xc3\x8d\xc3\x8e\xc3\x8f");
@@ -1934,7 +1935,7 @@ TEST_CASE("utf8_to_locale() converts text from UTF-8 to the encoding specified "
 
 		REQUIRE(utils::utf8_to_locale("") == "");
 
-		// "Just testing this" in Russian.
+		// "Просто проверяю", "Just testing" in Russian.
 		const std::string text("\xd0\x9f\xd1\x80\xd0\xbe\xd1\x81\xd1\x82\xd0"
 			"\xbe\x20\xd0\xbf\xd1\x80\xd0\xbe\xd0\xb2\xd0\xb5\xd1\x80\xd1\x8f\xd1\x8e");
 		REQUIRE(utils::utf8_to_locale(text) == text);
@@ -1947,7 +1948,7 @@ TEST_CASE("utf8_to_locale() converts text from UTF-8 to the encoding specified "
 
 		REQUIRE(utils::utf8_to_locale("") == "");
 
-		// "another test" in Russian.
+		// "ещё один тест", "another test" in Russian.
 		const std::string input("\xd0\xb5\xd1\x89\xd1\x91\x20\xd0\xbe\xd0\xb4"
 			"\xd0\xb8\xd0\xbd\x20\xd1\x82\xd0\xb5\xd1\x81\xd1\x82");
 		const std::string expected("\xc5\xdd\xa3\x20\xcf\xc4\xc9\xce\x20\xd4"
@@ -1962,7 +1963,7 @@ TEST_CASE("utf8_to_locale() converts text from UTF-8 to the encoding specified "
 
 		REQUIRE(utils::utf8_to_locale("") == "");
 
-		// "Greetings!" in Russian.
+		// "Приветствую!", "Greetings!" in Russian.
 		const std::string input("\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1"
 			"\x82\xd1\x81\xd1\x82\xd0\xb2\xd1\x83\xd1\x8e\x21");
 		const std::string expected("\xcf\xf0\xe8\xe2\xe5\xf2\xf1\xf2\xe2\xf3"
@@ -2003,7 +2004,7 @@ TEST_CASE("utf8_to_locale() transliterates characters unsupported by the locale'
 			return;
 		}
 
-		// "Song" in Ukrainian.
+		// "Пісня", "Song" in Ukrainian.
 		const std::string input("\xd0\x9f\xd1\x96\xd1\x81\xd0\xbd\xd1\x8f");
 
 		const auto result = utils::utf8_to_locale(input);
@@ -2016,7 +2017,7 @@ TEST_CASE("utf8_to_locale() transliterates characters unsupported by the locale'
 			return;
 		}
 
-		// "Japan" in Japanese
+		// "日本", "Japan" in Japanese
 		const std::string input("\xe6\x97\xa5\xe6\x9c\xac");
 
 		const auto result = utils::utf8_to_locale(input);
@@ -2054,7 +2055,7 @@ TEST_CASE("locale_to_utf8() converts text from the encoding specified by locale 
 
 		REQUIRE(utils::locale_to_utf8("") == "");
 
-		// "I like Newsboat" in Russian.
+		// "Newsboat мне нравится", "I like Newsboat" in Russian.
 		const std::string text("\x4e\x65\x77\x73\x62\x6f\x61\x74\x20\xd0\xbc"
 			"\xd0\xbd\xd0\xb5\x20\xd0\xbd\xd1\x80\xd0\xb0\xd0\xb2\xd0\xb8"
 			"\xd1\x82\xd1\x81\xd1\x8f");
@@ -2068,7 +2069,7 @@ TEST_CASE("locale_to_utf8() converts text from the encoding specified by locale 
 
 		REQUIRE(utils::locale_to_utf8("") == "");
 
-		// "excellent check" in Russian.
+		// "великолепная проверка", "excellent check" in Russian.
 		const std::string input("\xd7\xc5\xcc\xc9\xcb\xcf\xcc\xc5\xd0\xce\xc1"
 			"\xd1\x20\xd0\xd2\xcf\xd7\xc5\xd2\xcb\xc1");
 		const std::string expected("\xd0\xb2\xd0\xb5\xd0\xbb\xd0\xb8\xd0\xba\xd0"
@@ -2084,7 +2085,7 @@ TEST_CASE("locale_to_utf8() converts text from the encoding specified by locale 
 
 		REQUIRE(utils::locale_to_utf8("") == "");
 
-		// "All tests green!" in Russian.
+		// "Все тесты зелёные!", "All tests green!" in Russian.
 		const std::string input("\xc2\xf1\xe5\x20\xf2\xe5\xf1\xf2\xfb\x20\xe7"
 			"\xe5\xeb\xb8\xed\xfb\xe5\x21");
 		const std::string expected("\xd0\x92\xd1\x81\xd0\xb5\x20\xd1\x82\xd0\xb5"

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1809,16 +1809,19 @@ TEST_CASE("convert_text() replaces incomplete multi-byte sequences with a questi
 	}
 
 	SECTION("From UTF-16LE to UTF-8") {
-		// FIXME: when I tried to use ASCII for input, I got the wrong result
-		// because in UTF-16, ASCII characters are represented by adding a zero
-		// byte at the end. This throws off `strlen()` calls inside
-		// `convert_text()`. I should replace those calls with
-		// `std::string::length()` or something.
+		SECTION("Input contains zero bytes") {
+			// "hi", but the last byte is missing
+			const std::string input("\x68\x00\x69", 3);
+			const std::string expected("h?");
+			REQUIRE(utils::convert_text(input, "UTF-8", "UTF-16LE") == expected);
+		}
 
-		// "hey" in Russian, but the last byte is missing
-		const std::string input("\x4d\x04\x39", 3);
-		const std::string expected("\xd1\x8d?");
-		REQUIRE(utils::convert_text(input, "UTF-8", "UTF-16LE") == expected);
+		SECTION("Input doesn't contain zero bytes") {
+			// "hey" in Russian, but the last byte is missing
+			const std::string input("\x4d\x04\x39", 3);
+			const std::string expected("\xd1\x8d?");
+			REQUIRE(utils::convert_text(input, "UTF-8", "UTF-16LE") == expected);
+		}
 	}
 }
 


### PR DESCRIPTION
This is a little detour from #1344, but kind of productive as well. Added some tests, plus a little helper function to save on typing in a few places.

Reviews are welcome! If no issues are raised, I'll merge in three days.