### PR TITLE
Fix regression introduced by 54617872ff36d7420505e

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -171,7 +171,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			// We can't just `const auto exit_code = ...` here because this
 			// triggers -Wmaybe-initialized in GCC 9 with -O2.
 			nonstd::optional<std::uint8_t> exit_code;
-			exit_code = open_unread_items_in_browser(feed, true);
+			exit_code = open_unread_items_in_browser(feed, false);
 
 			if (!exit_code.has_value()) {
 				v->show_error(_("Failed to spawn browser"));


### PR DESCRIPTION
A copy-and-paste error in 54617872ff36d7420505e4c82cc08a14ed16f6c3
changed "false" to "true", and so `open-all-unread-in-browser` started
behaving the same as `open-all-unread-in-browser-and-mark-read`.

This is dead-simple fix, so I'll merge it tomorrow when the CI jobs are done.