### PR TITLE
Do not misreport successful OPML import as failure

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -684,9 +684,12 @@ int Controller::import_opml(const std::string& opmlFile,
 		return EXIT_FAILURE;
 	}
 
-	if (!opml::import(opmlFile, urlReader)) {
+	const auto import_error = opml::import(opmlFile, urlReader);
+	if (import_error.has_value()) {
 		std::cout << strprintf::fmt(
-				_("An error occurred while parsing %s."), opmlFile)
+				_("An error occurred while parsing %s: %s"),
+				opmlFile,
+				import_error.value())
 			<< std::endl;
 		return EXIT_FAILURE;
 	} else {


### PR DESCRIPTION
The return type of `opml::import()` changed from `bool` (indicating success) to `nonstd::optional` (indicating an error) in 036c637f72ec873fc4a7986138684d9ccd4de12b, but an `if` that acted on the return wasn't updated, causing the program to show error on success and report success on error.

Reported on IRC by dngray.

Reviews are welcome! Will merge in three days.