### PR TITLE
Bump Rust to 1.50.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -140,13 +140,13 @@ macos_task:
     before_cache_script: *before_cache_script
 
     matrix:
-        - name: macOS Big Sur, Clang, Rust 1.49.0
+        - name: macOS Big Sur, Clang, Rust 1.50.0
           osx_instance:
               image: big-sur-base
           env:
               CC: clang
               CXX: clang++
-              RUST: 1.49.0
+              RUST: 1.50.0
         # This job tests our minimum supported Rust version, so only bump on
         # Newsboat release day
         - name: macOS Catalina, GCC, Rust 1.46.0
@@ -212,98 +212,98 @@ linux_task:
                 cxx: clang++-11
           env: *extra_warnings_and_checks_env
 
-        - name: Rust 1.49.0, GCC 5 (Ubuntu 18.04)
+        - name: Rust 1.50.0, GCC 5 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-5
                 cc: gcc-5
                 cxx: g++-5
-        - name: Rust 1.49.0, GCC 6 (Ubuntu 18.04)
+        - name: Rust 1.50.0, GCC 6 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-6
                 cc: gcc-6
                 cxx: g++-6
-        - name: Rust 1.49.0, GCC 7 (Ubuntu 18.04)
+        - name: Rust 1.50.0, GCC 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-7
                 cc: gcc-7
                 cxx: g++-7
-        - name: Rust 1.49.0, GCC 8 (Ubuntu 18.04)
+        - name: Rust 1.50.0, GCC 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-8
                 cc: gcc-8
                 cxx: g++-8
-        - name: Rust 1.49.0, GCC 9 (Ubuntu 20.04)
+        - name: Rust 1.50.0, GCC 9 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-9
                 cc: gcc-9
                 cxx: g++-9
-        - name: Rust 1.49.0, GCC 10 (Ubuntu 20.04)
+        - name: Rust 1.50.0, GCC 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: g++-10
                 cc: gcc-10
                 cxx: g++-10
-        - name: Rust 1.49.0, Clang 4.0 (Ubuntu 18.04)
+        - name: Rust 1.50.0, Clang 4.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-4.0
                 cc: clang-4.0
                 cxx: clang++-4.0
-        - name: Rust 1.49.0, Clang 5.0 (Ubuntu 18.04)
+        - name: Rust 1.50.0, Clang 5.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-5.0
                 cc: clang-5.0
                 cxx: clang++-5.0
-        - name: Rust 1.49.0, Clang 6.0 (Ubuntu 18.04)
+        - name: Rust 1.50.0, Clang 6.0 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-6.0
                 cc: clang-6.0
                 cxx: clang++-6.0
-        - name: Rust 1.49.0, Clang 7 (Ubuntu 18.04)
+        - name: Rust 1.50.0, Clang 7 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-7
                 cc: clang-7
                 cxx: clang++-7
-        - name: Rust 1.49.0, Clang 8 (Ubuntu 18.04)
+        - name: Rust 1.50.0, Clang 8 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-8
                 cc: clang-8
                 cxx: clang++-8
-        - name: Rust 1.49.0, Clang 9 (Ubuntu 18.04)
+        - name: Rust 1.50.0, Clang 9 (Ubuntu 18.04)
           container:
             dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-9
                 cc: clang-9
                 cxx: clang++-9
-        - name: Rust 1.49.0, Clang 10 (Ubuntu 20.04)
+        - name: Rust 1.50.0, Clang 10 (Ubuntu 20.04)
           container:
             dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
             docker_arguments:
                 cxx_package: clang-10
                 cc: clang-10
                 cxx: clang++-10
-        - name: Rust 1.49.0, Clang 11 (Ubuntu 20.10)
+        - name: Rust 1.50.0, Clang 11 (Ubuntu 20.10)
           container:
             dockerfile: docker/ubuntu_20.10-build-tools.dockerfile
             docker_arguments:

--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.49.0 by default.
+# and Rust 1.50.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-8
-# - rust_version -- Rust version to install. Default: 1.49.0
+# - rust_version -- Rust version to install. Default: 1.50.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-8
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.49.0
+ARG rust_version=1.50.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -82,7 +82,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain 1.49.0 \
+        --default-toolchain 1.50.0 \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 9 and Rust 1.49.0 by default.
+# compilers. Contains GCC 9 and Rust 1.50.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.49.0
+# - rust_version -- Rust version to install. Default: 1.50.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.49.0
+ARG rust_version=1.50.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_20.10-build-tools.dockerfile
+++ b/docker/ubuntu_20.10-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 10 and Rust 1.49.0 by default.
+# compilers. Contains GCC 10 and Rust 1.50.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-10
-# - rust_version -- Rust version to install. Default: 1.49.0
+# - rust_version -- Rust version to install. Default: 1.50.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-10
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.49.0
+ARG rust_version=1.50.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use libnewsboat::configpaths::ConfigPaths;
 use rand::random;
 use section_testing::{enable_sections, section};

--- a/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
+++ b/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use libnewsboat::configpaths::ConfigPaths;
 use section_testing::{enable_sections, section};
 use std::{env, fs, path};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use libnewsboat::{cliargsparser::CliArgsParser, configpaths::ConfigPaths};
 use section_testing::{enable_sections, section};
 use std::env;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use libnewsboat::configpaths::ConfigPaths;
 use section_testing::{enable_sections, section};
 use std::{env, fs, path};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use libnewsboat::configpaths::ConfigPaths;
 use section_testing::{enable_sections, section};
 use std::{env, fs, path};

--- a/rust/libnewsboat/tests/locale_to_utf8_converts_text_from_the_locale_encoding_to_utf8.rs
+++ b/rust/libnewsboat/tests/locale_to_utf8_converts_text_from_the_locale_encoding_to_utf8.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use section_testing::{enable_sections, section};
 
 use libnewsboat::utils::locale_to_utf8;

--- a/rust/libnewsboat/tests/utf8_to_locale_converts_text_from_utf8_to_the_locale_encoding.rs
+++ b/rust/libnewsboat/tests/utf8_to_locale_converts_text_from_utf8_to_the_locale_encoding.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use section_testing::{enable_sections, section};
 
 use libnewsboat::utils::utf8_to_locale;

--- a/rust/libnewsboat/tests/utf8_to_locale_transliterates_characters_unsupported_by_the_locale_encoding.rs
+++ b/rust/libnewsboat/tests/utf8_to_locale_transliterates_characters_unsupported_by_the_locale_encoding.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
+
 use section_testing::{enable_sections, section};
 
 use libnewsboat::utils::utf8_to_locale;

--- a/rust/strprintf/src/lib.rs
+++ b/rust/strprintf/src/lib.rs
@@ -84,7 +84,7 @@ where
     CString::new(format).ok().and_then(|local_format_cstring| {
         // Returns None if a holder couldn't be obtained - e.g. the value is a String that
         // contains a null byte
-        arg.to_c_repr_holder().and_then(|arg_c_repr_holder| {
+        arg.into_c_repr_holder().and_then(|arg_c_repr_holder| {
             match fmt_arg_with_buffer_size(&local_format_cstring, &arg_c_repr_holder, 1024) {
                 Ok(formatted) => Some(formatted),
                 Err(buf_size) => {

--- a/rust/strprintf/src/traits.rs
+++ b/rust/strprintf/src/traits.rs
@@ -40,33 +40,33 @@ pub trait Printfable {
     ///
     /// This can fail for some types, e.g. `String` might fail to convert to `CString` if it
     /// contains null bytes.
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder>;
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder>;
 }
 
 impl Printfable for i32 {
     type Holder = i32;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         Some(self)
     }
 }
 
 impl Printfable for u32 {
     type Holder = u32;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         Some(self)
     }
 }
 
 impl Printfable for i64 {
     type Holder = i64;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         Some(self)
     }
 }
 
 impl Printfable for u64 {
     type Holder = u64;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         Some(self)
     }
 }
@@ -74,42 +74,42 @@ impl Printfable for u64 {
 /// `f32` can't be passed to variadic functions like `snprintf`, so it's converted into `f64`
 impl Printfable for f32 {
     type Holder = f64;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         Some(self as f64)
     }
 }
 
 impl Printfable for f64 {
     type Holder = f64;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         Some(self)
     }
 }
 
 impl<'a> Printfable for &'a str {
     type Holder = CString;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         CString::new(self).ok()
     }
 }
 
 impl<'a> Printfable for &'a String {
     type Holder = CString;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         CString::new(self.as_str()).ok()
     }
 }
 
 impl Printfable for String {
     type Holder = CString;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         CString::new(self).ok()
     }
 }
 
 impl<T> Printfable for *const T {
     type Holder = *const libc::c_void;
-    fn to_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
+    fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         Some(self as *const libc::c_void)
     }
 }
@@ -151,7 +151,7 @@ impl CReprHolder for u64 {
 }
 
 // No need to implement CReprHolder for f32, as this trait is only invoked on results of
-// `Printfable::to_c_repr_holder`, and that converts f32 to f64
+// `Printfable::into_c_repr_holder`, and that converts f32 to f64
 
 impl CReprHolder for f64 {
     type Output = f64;


### PR DESCRIPTION
section_testing crate that we use in some integration tests now trigger `non_fmt_panic` warning. I submitted [a pull request](https://github.com/evanw/section_testing/pull/1) that would fix it, and will hold this PR until that's merged (or until I run out of patience and just suppress the warning).