### PR TITLE
And a subsection re snap

### DIFF
--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -104,8 +104,8 @@ important bit.
 +
     browser "~/bin/newsboat-browser.sh"
 
-=== A note regarding `snap` installations
+== Regarding Newsboat snap installations
 
-The Newsboat `snap` will issue similar error messages, because it is being prevented from accessing resources outside its `strict` confinement. Add the following to your Newsboat's config so that it can open your default browser:
-+
+The Newsboat snap will also issue error messages related to browser error codes, because it is being prevented from accessing resources outside its strict confinement. Add the following to your Newsboat's config so that it can open your default browser:
+
     browser "xdg-open %u"

--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -26,7 +26,7 @@ query feeds].
 
 == After I open a link in the browser, Newsboat stays unresponsive until the browser is closed
 
-Newsboat has to behave like that in order to accomodate users of text-based
+Newsboat has to behave like that in order to accommodate users of text-based
 browsers like lynx and w3m. It has to relinquish the terminal and stay out of
 the way, otherwise people won't be able to see their browsers.
 
@@ -103,3 +103,9 @@ important bit.
 3. Add the following to your Newsboat's config:
 +
     browser "~/bin/newsboat-browser.sh"
+
+=== A note regarding `snap` installations
+
+The Newsboat `snap` will issue similar error messages, because it is being prevented from accessing resources outside its `strict` confinement. Add the following to your Newsboat's config so that it can open your default browser:
++
+    browser "xdg-open %u"

--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -106,6 +106,9 @@ important bit.
 
 == Regarding Newsboat snap installations
 
-The Newsboat snap will also issue error messages related to browser error codes, because it is being prevented from accessing resources outside its strict confinement. Add the following to your Newsboat's config so that it can open your default browser:
+The Newsboat snap will also issue error messages related to browser error codes,
+because it is being prevented from accessing resources outside its strict
+confinement. Add the following to your Newsboat's config so that it can open
+your default browser:
 
     browser "xdg-open %u"


### PR DESCRIPTION
As per an IRC discussion, just highlighting that, regardless of the Newsboat version (to date), references to `/usr/bin` will throw error code 127 as command not found, and references to `/home` will throw 126 as permission denied. But `xdg-open` is respected, and so offers an option for invoking the default browser without making further configuration changes.

Oh, and I fixed a typo.