### PR TITLE
Bump lexical-core to 0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,13 +294,13 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexical-core"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
+checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
 ]


### PR DESCRIPTION
This fixes the compile error that made 0.7.4 fail to build with recent Nightly compilers (in turn failing our PRs #1459 and #1461). The change in Nightly was reverted, giving lexical-core time to get fixed (https://github.com/Alexhuszagh/rust-lexical/issues/55). Now that that's done, we can expect the change to be re-introduced into Nightly, and so we have to update to lexical-core 0.7.5 lest our build breaks again.

This PR is just mundane maintenance, so I'll merge it once the CI is green. Feel free to leave a comment anyway if you have something to say ;)