### PR TITLE
Replaced gcov with LLVM coverage tool

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Calculate test coverage
         # Note that we override the path to gcov tool.
-        run: GCOV=$(pwd)/gcov grcov . --binary-path ./target/debug/deps/ --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
+        run: GCOV=$(pwd)/gcov grcov . --binary-path ./test/test --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
 
       - name: Submit coverage to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -13,13 +13,10 @@ jobs:
       CC: clang-12
       CXX: clang++-12
       # Enable test coverage.
-      PROFILE: 1
-      # These flags are necessary for grcov to correctly calculate coverage.
-      CARGO_INCREMENTAL: 0
+      CXXFLAGS: '-fprofile-instr-generate -fcoverage-mapping'
       # We add `-A warnings` because we aren't interested in warnings from Rust
       # Nightly -- GitHub turns them into annotations, which is annoying.
-      RUSTFLAGS: '-A warnings -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
-      RUSTDOCFLAGS: '-Cpanic=abort'
+      RUSTFLAGS: '-A warnings -Zinstrument-coverage'
       # Some of our tests use ncurses, which require a terminal of some sort.
       # We pretend ours is a simple one.
       TERM: 'dumb'
@@ -45,10 +42,12 @@ jobs:
           echo 'ru_RU.CP1251 CP1251' | sudo tee --append /etc/locale.gen
           sudo locale-gen
 
-      - name: Install Rust
-        uses: ATiltedTree/setup-rust@v1
+      - name: Toolchain setup
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: nightly
+          toolchain: nightly
+          override: true
+          components: llvm-tools-preview
 
       - uses: actions/checkout@v2
 
@@ -78,7 +77,7 @@ jobs:
 
       - name: Calculate test coverage
         # Note that we override the path to gcov tool.
-        run: GCOV=$(pwd)/gcov grcov . --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
+        run: GCOV=$(pwd)/gcov grcov . --binary-path ./target/debug/deps/ --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
 
       - name: Submit coverage to Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -17,6 +17,7 @@ jobs:
       # We add `-A warnings` because we aren't interested in warnings from Rust
       # Nightly -- GitHub turns them into annotations, which is annoying.
       RUSTFLAGS: '-A warnings -Zinstrument-coverage'
+      LLVM_PROFILE_FILE: '%p-%m.profraw'
       # Some of our tests use ncurses, which require a terminal of some sort.
       # We pretend ours is a simple one.
       TERM: 'dumb'

--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Calculate test coverage
         # Note that we override the path to gcov tool.
-        run: GCOV=$(pwd)/gcov grcov . --binary-path ./test/test --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
+        run: GCOV=$(pwd)/gcov grcov . --binary-path ./test/test --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
 
       - name: Submit coverage to Coveralls
         uses: coverallsapp/github-action@master

--- a/rust/libnewsboat/tests/chdir_helpers/mod.rs
+++ b/rust/libnewsboat/tests/chdir_helpers/mod.rs
@@ -1,0 +1,24 @@
+use libnewsboat::utils;
+use std::env;
+use std::path::Path;
+use std::path::PathBuf;
+
+pub struct Chdir {
+    old_path: PathBuf,
+}
+
+impl Chdir {
+    pub fn new(path: &Path) -> Chdir {
+        let c = Chdir {
+            old_path: utils::getcwd().unwrap(),
+        };
+        assert!(env::set_current_dir(path).is_ok());
+        c
+    }
+}
+
+impl Drop for Chdir {
+    fn drop(&mut self) {
+        env::set_current_dir(Path::new(&self.old_path));
+    }
+}

--- a/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
+++ b/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
@@ -2,14 +2,14 @@ use libnewsboat::utils;
 use std::env;
 use tempfile::TempDir;
 
+mod chdir_helpers;
+
 #[test]
 fn t_getcwd_returns_an_error_if_current_directory_doesnt_exist() {
-    {
-        let tmp = TempDir::new().unwrap();
-        let chdir_result = env::set_current_dir(&tmp.path());
-        assert!(chdir_result.is_ok());
-    }
+    let tmp = TempDir::new().unwrap();
+    let _chdir = chdir_helpers::Chdir::new(&tmp.path());
 
+    drop(tmp);
     // `tmp` went out of scope and removed the directory, but we're still in it
 
     assert!(utils::getcwd().is_err());

--- a/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
+++ b/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
@@ -2,14 +2,16 @@ use libnewsboat::utils;
 use std::env;
 use tempfile::TempDir;
 
+mod chdir_helpers;
+
 #[test]
 fn t_getcwd_value_depends_on_current_directory() {
     let initial_dir = utils::getcwd().unwrap();
 
     let tmp = TempDir::new().unwrap();
     assert_ne!(&initial_dir, tmp.path());
-    let chdir_result = env::set_current_dir(&tmp.path());
-    assert!(chdir_result.is_ok());
+
+    let _chdir = chdir_helpers::Chdir::new(&tmp.path());
 
     let new_dir = utils::getcwd().unwrap();
 


### PR DESCRIPTION
LLVM code coverage instrumentation provides Source-based coverage. Source-based coverage provides more accurate coverage data (as it [operates on AST and preprocessor information directly](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html)) at the expense of slower execution.

There is likely more work to be done before this is ready to be merged. I wanted to submit this to show my progress.