### PR TITLE
Fixed Italian translation feed list title format.

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -242,7 +242,7 @@ msgid ""
 "%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `"
 "%F'&?%?T? - tag `%T'&?"
 msgstr ""
-"%N %V - %?F?Feeds&I tuoi feed (%u non letti, %t totali)%?F? corrispondenti al filtro `"
+"%N %V - %?F?Feed&I tuoi feed? (%u non letti, %t totali)%?F? corrispondenti al filtro `"
 "%F'&?%?T? - tag `%T'&?"
 
 #: src/configcontainer.cpp:287


### PR DESCRIPTION
- The feed list title format wasn't showing properly with Italian localization.
In 8880ba431012964d62c8d798191995e53a58a99f I introduced a bug in the format string used by the title removing a "?" from a conditional expression used to change the string when a filter is used.
I've fixed it by adding it in again and it's showing the correct format with tags, filter as well as the normal view.
- I also removed an `s` from the English plural not needed in Italian for that sentence.

I didn't notice this problem until recently using newsboat in an Arch based PC with a newer version than the 2.18 or something like that, in the Ubuntu repositories used by my main machine.

I've tested this building the last git version to verify it works properly.

I'll take a look at the other strings with parameters and create another pull request if something else looks weird.