### PR TITLE
Bump section_testing to 0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,9 +726,9 @@ checksum = "7e114536316b51a5aa7a0e59fc49661fd263c5507dd08bd28de052e57626ce69"
 
 [[package]]
 name = "section_testing"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece4d7d98fdab75ddff5c4fad54a4c7ad0222a13c8a3c6859f1037a1d9e53f28"
+checksum = "5fd2493b68af689f4863060b240cbdffb350cee9ed69e2c50f8d71a62ca2aea1"
 
 [[package]]
 name = "static_assertions"

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -61,4 +61,4 @@ default-features = false
 tempfile = "3"
 # 0.9.6 fixes build failures on Nightly >=2020-04-08: https://github.com/newsboat/newsboat/issues/870
 proptest = ">=0.9.6"
-section_testing = "0.0.4"
+section_testing = "0.0.5"

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_false_if_xdg_config_dir_exists_but_data_dir_doesnt_and_couldnt_be_created.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
+++ b/rust/libnewsboat/tests/configpaths_create_dirs_returns_true_if_both_config_and_data_dirs_exist_now.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use libnewsboat::configpaths::ConfigPaths;
 use rand::random;
 use section_testing::{enable_sections, section};

--- a/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
+++ b/rust/libnewsboat/tests/configpaths_returns_paths_to_newsboat_xdg_dirs_if_they_exist_and_dotdir_doesnt.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use libnewsboat::configpaths::ConfigPaths;
 use section_testing::{enable_sections, section};
 use std::{env, fs, path};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_config_paths_were_specified_via_cli.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use libnewsboat::{cliargsparser::CliArgsParser, configpaths::ConfigPaths};
 use section_testing::{enable_sections, section};
 use std::env;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_config_dir_already_exists.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_empty_newsboat_xdg_data_dir_already_exists.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_config_dir_couldnt_be_created.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_newsboat_xdg_data_dir_couldnt_be_created.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use section_testing::{enable_sections, section};
 use std::{env, fs};
 use tempfile::TempDir;

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_does_not_migrate_if_urls_file_already_exists.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use libnewsboat::configpaths::ConfigPaths;
 use section_testing::{enable_sections, section};
 use std::{env, fs, path};

--- a/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
+++ b/rust/libnewsboat/tests/configpaths_try_migrate_from_newsbeuter_migrates_default_newsbeuter_xdg_dirs_to_default_newsboat_xdg_dirs.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use libnewsboat::configpaths::ConfigPaths;
 use section_testing::{enable_sections, section};
 use std::{env, fs, path};

--- a/rust/libnewsboat/tests/locale_to_utf8_converts_text_from_the_locale_encoding_to_utf8.rs
+++ b/rust/libnewsboat/tests/locale_to_utf8_converts_text_from_the_locale_encoding_to_utf8.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use section_testing::{enable_sections, section};
 
 use libnewsboat::utils::locale_to_utf8;

--- a/rust/libnewsboat/tests/utf8_to_locale_converts_text_from_utf8_to_the_locale_encoding.rs
+++ b/rust/libnewsboat/tests/utf8_to_locale_converts_text_from_utf8_to_the_locale_encoding.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use section_testing::{enable_sections, section};
 
 use libnewsboat::utils::utf8_to_locale;

--- a/rust/libnewsboat/tests/utf8_to_locale_transliterates_characters_unsupported_by_the_locale_encoding.rs
+++ b/rust/libnewsboat/tests/utf8_to_locale_transliterates_characters_unsupported_by_the_locale_encoding.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, non_fmt_panic)] // See https://github.com/newsboat/newsboat/issues/1480.
-
 use section_testing::{enable_sections, section};
 
 use libnewsboat::utils::utf8_to_locale;


### PR DESCRIPTION
This also reverts commit 3a816b208f2340232b40e7eef86d26b6b3affd74, which suppressed the warnings which section_testing 0.0.4 produced. section_testing 0.0.5 fixed the warnings, so suppression is no longer necessary.

Fixes #1480.

Nothing controversial here, so I'll merge once CI is green.