### PR TITLE
Ask gettext to return UTF-8

### DIFF
--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -220,8 +220,11 @@ int main(int argc, char* argv[])
 	setlocale(LC_CTYPE, "");
 	setlocale(LC_MESSAGES, "");
 
-	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
+	bindtextdomain(PACKAGE, LOCALEDIR);
+	// Internally, Newsboat stores all strings in UTF-8, so we require gettext
+	// to return messages in that encoding.
+	bind_textdomain_codeset(PACKAGE, "UTF-8");
 
 	rsspp::Parser::global_init();
 

--- a/podboat.cpp
+++ b/podboat.cpp
@@ -22,8 +22,11 @@ int main(int argc, char* argv[])
 	setlocale(LC_CTYPE, "");
 	setlocale(LC_MESSAGES, "");
 
-	bindtextdomain(PACKAGE, LOCALEDIR);
 	textdomain(PACKAGE);
+	bindtextdomain(PACKAGE, LOCALEDIR);
+	// Internally, Newsboat stores all strings in UTF-8, so we require gettext
+	// to return messages in that encoding.
+	bind_textdomain_codeset(PACKAGE, "UTF-8");
 
 	PbController c;
 


### PR DESCRIPTION
By default, gettext converts messages to current locale charset. This doesn't sit well with Newsboat's default of UTF-8 for all internal strings. I don't remember any bugs that got tracked down to this, but it's better to fix it anyway.

I'm surprised this didn't manifest in bugs yet, so I'm going to dogfood on this for a week and see if I spot any problems. **If your locale is not en_US.UTF-8, please build this branch and see if anything breaks!**