### PR TITLE
Re-introduce toggle (!) and reset(&) options for `set` in macros

### DIFF
--- a/include/formaction.h
+++ b/include/formaction.h
@@ -45,6 +45,7 @@ public:
 	void recalculate_widget_dimensions();
 
 	virtual void handle_cmdline(const std::string& cmd);
+	bool handle_single_argument_set(std::string argument);
 
 	bool process_op(Operation op,
 		bool automatic = false,

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -284,10 +284,7 @@ void FormAction::handle_cmdline(const std::string& cmdline)
 		std::string cmd = tokens[0];
 		tokens.erase(tokens.begin());
 		if (cmd == "set") {
-			if (tokens.empty()) {
-				v->get_statusline().show_error(
-					_("usage: set <variable>[=<value>]"));
-			} else if (tokens.size() == 1) {
+			if (tokens.size() == 1) {
 				const std::string var = tokens[0];
 				if (handle_single_argument_set(var)) {
 					return;

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -134,11 +134,26 @@ bool FormAction::process_op(Operation op,
 				const std::string key = args->at(0);
 				const std::string value = args->at(1);
 				cfg->set_configvalue(key, value);
+				set_redraw(true);
 				return true;
-			} else {
-				v->get_statusline().show_error(_("usage: set <config-option> <value>"));
-				return false;
 			}
+			if (args && args->size() == 1) {
+				std::string key = args->at(0);
+				if (key.size() >= 1 && key.back() == '!') {
+					key.pop_back();
+					cfg->toggle(key);
+					set_redraw(true);
+					return true;
+				}
+				if (key.size() >= 1 && key.back() == '&') {
+					key.pop_back();
+					cfg->reset_to_default(key);
+					set_redraw(true);
+					return true;
+				}
+			}
+			v->get_statusline().show_error(_("usage: set <config-option> <value>"));
+			return false;
 		} else {
 			LOG(Level::WARN,
 				"FormAction::process_op: got OP_INT_SET, but "


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1491.

Tested with config:
```
macro m set mark-as-read-on-hover!

macro a set feedlist-title-format "changed title"
macro b set feedlist-title-format&
```