### PR TITLE
Simplify formatting in HelpFormAction

### DIFF
--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -142,67 +142,36 @@ void HelpFormAction::prepare()
 			listfmt.add_line("");
 			listfmt.add_line(_("Generic bindings:"));
 			listfmt.add_line("");
-		}
 
-		for (unsigned int i = 1; i < 3; i++) {
 			for (const auto& desc : descs) {
-				bool hide_description = false;
-				switch (i) {
-				case 1:
-					hide_description = !(desc.flags & KM_SYSKEYS);
-					break;
-				case 2:
-					hide_description = (desc.key.length() > 0 ||
-							desc.flags & KM_SYSKEYS);
-					break;
-				default:
-					hide_description = true;
-					break;
-				}
-				if (hide_description) {
+				if (!(desc.flags & KM_SYSKEYS)) {
 					continue;
 				}
 				if (should_be_visible(desc)) {
-					std::string line;
-					switch (i) {
-					case 1:
-						line = strprintf::fmt(
-								"%-15s %-23s %s",
-								desc.key,
-								desc.cmd,
-								desc.desc);
-						break;
-					case 2:
-						line = strprintf::fmt(
-								"%-39s %s",
-								desc.cmd,
-								desc.desc);
-						break;
-					}
-					LOG(Level::DEBUG,
-						"HelpFormAction::prepare: "
-						"step 1 "
-						"- line = %s",
-						line);
+					auto line = strprintf::fmt("%-15s %-23s %s", desc.key, desc.cmd, desc.desc);
 					line = utils::quote_for_stfl(line);
-					LOG(Level::DEBUG,
-						"HelpFormAction::prepare: "
-						"step 2 "
-						"- line = %s",
-						line);
 					line = apply_highlights(line);
 					listfmt.add_line(line);
 				}
 			}
-			switch (i) {
-			case 1:
-				if (unbound_count > 0) {
-					listfmt.add_line("");
-					listfmt.add_line(
-						_("Unbound functions:"));
-					listfmt.add_line("");
+		}
+
+		if (unbound_count > 0) {
+			listfmt.add_line("");
+			listfmt.add_line(
+				_("Unbound functions:"));
+			listfmt.add_line("");
+
+			for (const auto& desc : descs) {
+				if (desc.key.length() > 0 || desc.flags & KM_SYSKEYS) {
+					continue;
 				}
-				break;
+				if (should_be_visible(desc)) {
+					std::string line = strprintf::fmt("%-39s %s", desc.cmd, desc.desc);
+					line = utils::quote_for_stfl(line);
+					line = apply_highlights(line);
+					listfmt.add_line(line);
+				}
 			}
 		}
 

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -107,10 +107,10 @@ void HelpFormAction::prepare()
 
 		for (unsigned int i = 0; i < 3; i++) {
 			for (const auto& desc : descs) {
-				bool condition;
+				bool hide_description = false;
 				switch (i) {
 				case 0:
-					condition = (desc.key.length() == 0 ||
+					hide_description = (desc.key.length() == 0 ||
 							desc.flags & KM_SYSKEYS);
 					if (desc.key.length() == 0) {
 						unbound_count++;
@@ -120,17 +120,17 @@ void HelpFormAction::prepare()
 					}
 					break;
 				case 1:
-					condition = !(desc.flags & KM_SYSKEYS);
+					hide_description = !(desc.flags & KM_SYSKEYS);
 					break;
 				case 2:
-					condition = (desc.key.length() > 0 ||
+					hide_description = (desc.key.length() > 0 ||
 							desc.flags & KM_SYSKEYS);
 					break;
 				default:
-					condition = true;
+					hide_description = true;
 					break;
 				}
-				if (condition) {
+				if (hide_description) {
 					continue;
 				}
 				if (!apply_search ||

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -130,8 +130,7 @@ void HelpFormAction::prepare()
 					condition = true;
 					break;
 				}
-				if (context.length() > 0 &&
-					(desc.ctx != context || condition)) {
+				if (condition) {
 					continue;
 				}
 				if (!apply_search ||

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -126,14 +126,28 @@ void HelpFormAction::prepare()
 			return line;
 		};
 
-		for (unsigned int i = 0; i < 3; i++) {
+		for (const auto& desc : descs) {
+			if (desc.key.length() == 0 || desc.flags & KM_SYSKEYS) {
+				continue;
+			}
+			if (should_be_visible(desc)) {
+				auto line = strprintf::fmt("%-15s %-23s %s", desc.key, desc.cmd, desc.desc);
+				line = utils::quote_for_stfl(line);
+				line = apply_highlights(line);
+				listfmt.add_line(line);
+			}
+		}
+
+		if (syskey_count > 0) {
+			listfmt.add_line("");
+			listfmt.add_line(_("Generic bindings:"));
+			listfmt.add_line("");
+		}
+
+		for (unsigned int i = 1; i < 3; i++) {
 			for (const auto& desc : descs) {
 				bool hide_description = false;
 				switch (i) {
-				case 0:
-					hide_description = (desc.key.length() == 0 ||
-							desc.flags & KM_SYSKEYS);
-					break;
 				case 1:
 					hide_description = !(desc.flags & KM_SYSKEYS);
 					break;
@@ -151,7 +165,6 @@ void HelpFormAction::prepare()
 				if (should_be_visible(desc)) {
 					std::string line;
 					switch (i) {
-					case 0:
 					case 1:
 						line = strprintf::fmt(
 								"%-15s %-23s %s",
@@ -182,14 +195,6 @@ void HelpFormAction::prepare()
 				}
 			}
 			switch (i) {
-			case 0:
-				if (syskey_count > 0) {
-					listfmt.add_line("");
-					listfmt.add_line(
-						_("Generic bindings:"));
-					listfmt.add_line("");
-				}
-				break;
 			case 1:
 				if (unbound_count > 0) {
 					listfmt.add_line("");

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -1,5 +1,6 @@
 #include "helpformaction.h"
 
+#include <algorithm>
 #include <cstring>
 #include <sstream>
 
@@ -102,8 +103,14 @@ void HelpFormAction::prepare()
 		set_value("highlight", make_colorstring(colors));
 		ListFormatter listfmt;
 
-		unsigned int unbound_count = 0;
-		unsigned int syskey_count = 0;
+		const unsigned int unbound_count = std::count_if(descs.begin(),
+		descs.end(), [](const KeyMapDesc& desc) {
+			return desc.key.length() == 0;
+		});
+		const unsigned int syskey_count = std::count_if(descs.begin(),
+		descs.end(), [](const KeyMapDesc& desc) {
+			return desc.flags & KM_SYSKEYS;
+		});
 
 		for (unsigned int i = 0; i < 3; i++) {
 			for (const auto& desc : descs) {
@@ -112,12 +119,6 @@ void HelpFormAction::prepare()
 				case 0:
 					hide_description = (desc.key.length() == 0 ||
 							desc.flags & KM_SYSKEYS);
-					if (desc.key.length() == 0) {
-						unbound_count++;
-					}
-					if (desc.flags & KM_SYSKEYS) {
-						syskey_count++;
-					}
 					break;
 				case 1:
 					hide_description = !(desc.flags & KM_SYSKEYS);

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -112,6 +112,20 @@ void HelpFormAction::prepare()
 			return desc.flags & KM_SYSKEYS;
 		});
 
+		const auto should_be_visible = [&](const KeyMapDesc& desc) {
+			return !apply_search
+				|| strcasestr(desc.key.c_str(), searchphrase.c_str()) != nullptr
+				|| strcasestr(desc.cmd.c_str(), searchphrase.c_str()) != nullptr
+				|| strcasestr(desc.desc.c_str(), searchphrase.c_str()) != nullptr;
+		};
+
+		const auto apply_highlights = [&](const std::string& line) {
+			if (apply_search && searchphrase.length() > 0) {
+				return utils::replace_all(line, searchphrase, highlighted_searchphrase);
+			}
+			return line;
+		};
+
 		for (unsigned int i = 0; i < 3; i++) {
 			for (const auto& desc : descs) {
 				bool hide_description = false;
@@ -134,16 +148,7 @@ void HelpFormAction::prepare()
 				if (hide_description) {
 					continue;
 				}
-				if (!apply_search ||
-					strcasestr(desc.key.c_str(),
-						searchphrase.c_str()) !=
-					nullptr ||
-					strcasestr(desc.cmd.c_str(),
-						searchphrase.c_str()) !=
-					nullptr ||
-					strcasestr(desc.desc.c_str(),
-						searchphrase.c_str()) !=
-					nullptr) {
+				if (should_be_visible(desc)) {
 					std::string line;
 					switch (i) {
 					case 0:
@@ -172,17 +177,7 @@ void HelpFormAction::prepare()
 						"step 2 "
 						"- line = %s",
 						line);
-					if (apply_search &&
-						searchphrase.length() > 0) {
-						line = utils::replace_all(line,
-								searchphrase,
-								highlighted_searchphrase);
-						LOG(Level::DEBUG,
-							"HelpFormAction::"
-							"prepare: "
-							"step 3 - line = %s",
-							line);
-					}
+					line = apply_highlights(line);
 					listfmt.add_line(line);
 				}
 			}


### PR DESCRIPTION
The main improvement is the unrolling of a complex loop.
I believe this makes it easier to understand the function.

The changes have been split into several commits.
If useful, I'm completely fine with squashing those commits together.