### PR TITLE
Use simple plaintext renderer if mime-type is "text/plain"

### DIFF
--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -19,6 +19,10 @@ namespace item_renderer {
 /// the title isn't available.
 std::string get_feedtitle(std::shared_ptr<RssItem> item);
 
+/// \brief Splits text into lines marked as wrappable
+void render_plaintext(const std::string& source,
+	std::vector<std::pair<LineType, std::string>>& lines);
+
 /// \brief Returns plain-text representation of the RssItem.
 ///
 /// Markup is mostly stripped. Links are numbered and tagged. The text is

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -1,5 +1,6 @@
 #include "itemrenderer.h"
 
+#include <set>
 #include <sstream>
 
 #include "configcontainer.h"
@@ -8,6 +9,17 @@
 #include "textformatter.h"
 
 namespace newsboat {
+
+bool should_render_as_html(const std::string mime_type)
+{
+	static const std::set<std::string> html_mime_types = {
+		"html",
+		"xhtml",
+		"text/html",
+		"application/xhtml+xml"
+	};
+	return (html_mime_types.count(mime_type) >= 1);
+}
 
 std::string item_renderer::get_feedtitle(std::shared_ptr<RssItem> item)
 {
@@ -158,10 +170,10 @@ std::string item_renderer::to_plain_text(
 	const auto base = get_item_base_link(item);
 	const auto body = utils::utf8_to_locale(item_description.text);
 
-	if (item_description.mime == "text/plain") {
-		render_plaintext(body, lines);
-	} else {
+	if (should_render_as_html(item_description.mime)) {
 		render_html(cfg, body, lines, links, base, true);
+	} else {
+		render_plaintext(body, lines);
 	}
 
 	TextFormatter txtfmt;
@@ -191,10 +203,10 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 	const std::string baseurl = get_item_base_link(item);
 	const auto body = utils::utf8_to_locale(item_description.text);
 
-	if (item_description.mime == "text/plain") {
-		render_plaintext(body, lines);
-	} else {
+	if (should_render_as_html(item_description.mime)) {
 		render_html(cfg, body, lines, links, baseurl, false);
+	} else {
+		render_plaintext(body, lines);
 	}
 
 	TextFormatter txtfmt;

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -146,10 +146,13 @@ void item_renderer::render_plaintext(
 	const std::string& source,
 	std::vector<std::pair<LineType, std::string>>& lines)
 {
+	std::string normalized = utils::replace_all(source, "\r\n", "\n");
+	normalized = utils::replace_all(normalized, "\r", "\n");
+
 	std::string::size_type pos = 0;
-	while (pos < source.size()) {
-		const auto end_of_line = source.find_first_of("\r\n", pos);
-		const std::string line = source.substr(pos, end_of_line - pos);
+	while (pos < normalized.size()) {
+		const auto end_of_line = normalized.find_first_of("\n", pos);
+		const std::string line = normalized.substr(pos, end_of_line - pos);
 		lines.push_back(std::make_pair(LineType::wrappable, line));
 		if (end_of_line == std::string::npos) {
 			break;

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -142,7 +142,7 @@ void render_html(
 	}
 }
 
-void render_plaintext(
+void item_renderer::render_plaintext(
 	const std::string& source,
 	std::vector<std::pair<LineType, std::string>>& lines)
 {

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -697,4 +697,20 @@ TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_re
 			"back to no indentation"
 		});
 	}
+
+	SECTION(R"(text is split on sequences of \r\n, and on separate \r and \n characters)") {
+		const std::string text =
+			"Lorem ipsum\r\ndolor sit amet\n\rconsectetur adipiscing elit\rsed do eiusmod tempor incididunt ut labore\net dolore magna\r\n\r\naliqua.";
+
+		check(text, {
+			"Lorem ipsum",
+			"dolor sit amet",
+			"",
+			"consectetur adipiscing elit",
+			"sed do eiusmod tempor incididunt ut labore",
+			"et dolore magna",
+			"",
+			"aliqua."
+		});
+	}
 }

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -656,3 +656,45 @@ TEST_CASE("Functions used for rendering articles escape '<' into `<>` for use wi
 		REQUIRE(result.first == expected);
 	}
 }
+
+TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_renderer]")
+{
+	// Verifies that render_plaintext creates the expected lines, all marked as wrappable
+	const auto check = [](const std::string input,
+	const std::vector<std::string>& expected_lines) {
+		std::vector<std::pair<LineType, std::string>> output;
+		item_renderer::render_plaintext(input, output);
+
+		REQUIRE(output.size() == expected_lines.size());
+		for (std::size_t i = 0; i < output.size(); ++i) {
+			INFO("i: " + std::to_string(i));
+			REQUIRE(output[i].first == LineType::wrappable);
+			REQUIRE(output[i].second == expected_lines[i]);
+		}
+	};
+
+	SECTION(R"(regular text is split on \r and \n)") {
+		const std::string text =
+			"Lorem ipsum dolor sit amet\nconsectetur adipiscing elit\rsed do eiusmod tempor incididunt ut labore\net dolore magna aliqua.";
+
+		check(text, {
+			"Lorem ipsum dolor sit amet",
+			"consectetur adipiscing elit",
+			"sed do eiusmod tempor incididunt ut labore",
+			"et dolore magna aliqua."
+		});
+	}
+
+	SECTION("render_plaintext keeps indentation") {
+		const std::string text =
+			"The following lines are indented:\n    hello\n    this is a test\n\nback to no indentation";
+
+		check(text, {
+			"The following lines are indented:",
+			"    hello",
+			"    this is a test",
+			"",
+			"back to no indentation"
+		});
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1010 and fixes https://github.com/newsboat/newsboat/issues/1022:
- Tested with https://dennisschagt.nl/tmp/1010-feed/feed.atom (based on archive in https://github.com/newsboat/newsboat/issues/1010#issuecomment-646866506. Removed the `<summary>` tags so the filter script from https://github.com/newsboat/newsboat/issues/1010#issuecomment-646871561 is no longer needed).

Fixes https://github.com/newsboat/newsboat/issues/468 (taken from https://github.com/newsboat/newsboat/issues/468#issuecomment-787450424):
- Tested with https://dennisschagt.nl/tmp/newsboat-issue-468.xml

I also successfully tested this plaintext rendering with some Youtube atom feeds, e.g.:
- https://www.youtube.com/feeds/videos.xml?channel_id=UCsXVk37bltHxD1rDPwtNM8Q
- https://www.youtube.com/feeds/videos.xml?channel_id=UCmxePybUpZj8RRuWz6r8uTQ
- https://www.youtube.com/feeds/videos.xml?channel_id=UCsU15yvILBmnHPeAf4SFVaQ