### PR TITLE
Coveralls: pin Rust to 2021-03-04

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Rust
         uses: ATiltedTree/setup-rust@v1
         with:
-          rust-version: nightly
+          rust-version: nightly-2021-03-04
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This fixes SIGSEGVs in the C++ test suite. I'll investigate separately why newer Nightlies break the tests.