### PR TITLE
Display alt attribute of <img> in article view

### DIFF
--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -305,7 +305,7 @@ void HtmlRenderer::render(std::istream& input,
 
 			case HtmlTag::IMG: {
 				std::string img_url;
-				std::string img_title;
+				std::string img_label;
 				try {
 					img_url = xpp.get_attribute_value("src");
 				} catch (const std::invalid_argument&) {
@@ -315,16 +315,23 @@ void HtmlRenderer::render(std::istream& input,
 						"attribute");
 					img_url = "";
 				}
+				// Prefer `alt' over `title'
 				try {
-					img_title = xpp.get_attribute_value(
-							"title");
+					img_label = xpp.get_attribute_value("alt");
 				} catch (const std::invalid_argument&) {
-					img_title = "";
+					img_label = "";
+				}
+				if (img_label.empty()) {
+					try {
+						img_label = xpp.get_attribute_value("title");
+					} catch (const std::invalid_argument&) {
+						img_label = "";
+					}
 				}
 				if (!img_url.empty()) {
 					image_count++;
 					add_media_link(curline, links, url,
-						img_url, img_title, image_count,
+						img_url, img_label, image_count,
 						LinkType::IMG);
 				}
 			}

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -550,7 +550,56 @@ TEST_CASE(
 	REQUIRE(links.size() == 1);
 }
 
-TEST_CASE("title is mentioned in placeholder if <img> has `title'",
+TEST_CASE("alt is mentioned in placeholder if <img> has `alt'",
+	"[HtmlRenderer]")
+{
+	HtmlRenderer r;
+
+	const std::string input =
+		"<img src='http://example.com/image.png'"
+		"alt='Just a test image'></img>";
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	REQUIRE_NOTHROW(r.render(input, lines, links, url));
+	REQUIRE(lines.size() == 4);
+	REQUIRE(lines[0] == p(LineType::wrappable,
+			"[image 1: Just a test image (link #1)]"));
+	REQUIRE(lines[1] == p(LineType::wrappable, ""));
+	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
+	REQUIRE(lines[3] == p(LineType::softwrappable,
+			"[1]: http://example.com/image.png (image)"));
+	REQUIRE(links.size() == 1);
+	REQUIRE(links[0].first == "http://example.com/image.png");
+	REQUIRE(links[0].second == LinkType::IMG);
+}
+
+TEST_CASE("alt is mentioned in placeholder if <img> has `alt' and `title",
+	"[HtmlRenderer]")
+{
+	HtmlRenderer r;
+
+	const std::string input =
+		"<img src='http://example.com/image.png'"
+		"alt='Just a test image' title='Image title'></img>";
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	REQUIRE_NOTHROW(r.render(input, lines, links, url));
+	REQUIRE(lines.size() == 4);
+	REQUIRE(lines[0] == p(LineType::wrappable,
+			"[image 1: Just a test image (link #1)]"));
+	REQUIRE(lines[1] == p(LineType::wrappable, ""));
+	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
+	REQUIRE(lines[3] == p(LineType::softwrappable,
+			"[1]: http://example.com/image.png (image)"));
+	REQUIRE(links.size() == 1);
+	REQUIRE(links[0].first == "http://example.com/image.png");
+	REQUIRE(links[0].second == LinkType::IMG);
+}
+
+TEST_CASE(
+	"title is mentioned in placeholder if <img> has `title' but not `alt'",
 	"[HtmlRenderer]")
 {
 	HtmlRenderer r;
@@ -591,7 +640,7 @@ TEST_CASE(
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
 	REQUIRE(lines.size() == 4);
-	REQUIRE(lines[0] == p(LineType::wrappable, "[image 1 (link #1)]"));
+	REQUIRE(lines[0] == p(LineType::wrappable, "[image 1: Red dot (link #1)]"));
 	REQUIRE(lines[1] == p(LineType::wrappable, ""));
 	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
 	REQUIRE(lines[3] ==


### PR DESCRIPTION
Fixes #1505.

`alt` is preferable to `title` since [it is specific to `<img>` and its semantics are directly related to rendering](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-alt), while [the latter is not and has semantics that depend on the element](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title).