### PR TITLE
Bump gettext-rs to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "gettext-rs"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b95fa19cca70adf9888150e979839ae9bd58f85a1a42e4753699112875189e1"
+checksum = "3df4e7a9dc238dddd30f183d43e4f497990885daa211fcf01657159ade8f1610"
 dependencies = [
  "gettext-sys",
  "locale_config",
@@ -261,11 +261,12 @@ dependencies = [
 
 [[package]]
 name = "gettext-sys"
-version = "0.19.9"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e034c4ba5bb796730a6cc5eb0d654c16885006a7c3d6c6603581ed809434f153"
+checksum = "885d118016f633f99f741afe6c1433c040813a3cbc755cbfdf85f963e02fad80"
 dependencies = [
  "cc",
+ "tempfile",
 ]
 
 [[package]]
@@ -319,7 +320,6 @@ dependencies = [
  "clap",
  "curl-sys",
  "gettext-rs",
- "gettext-sys",
  "libc",
  "natord",
  "nom",

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -18,7 +18,6 @@ backtrace = "= 0.3"
 unicode-width = "0.1.8"
 nom = "6"
 libc = "0.2"
-gettext-rs = "0.5.0"
 natord = "1.0.9"
 
 [dependencies.clap]
@@ -32,8 +31,8 @@ version = "2.33"
 #   I want as little dependencies as practically possible.
 default-features = false
 
-[dependencies.gettext-sys]
-version = "0.19.9"
+[dependencies.gettext-rs]
+version = "0.6.0"
 # Don't let the crate build its own copy of gettext; force it to use the one
 # built into glibc.
 features = [ "gettext-system" ]

--- a/rust/regex-rs/Cargo.toml
+++ b/rust/regex-rs/Cargo.toml
@@ -12,4 +12,4 @@ strprintf = { path="../strprintf" }
 
 bitflags = "1.2"
 libc = ">=0.2.69"
-gettext-rs = "0.5.0"
+gettext-rs = "0.6.0"


### PR DESCRIPTION
This is to pull in a fix for a memory safety problem which never caused us any grief, but is a problem nonetheless: https://github.com/Koka/gettext-rs/issues/34

I also simplified Cargo.toml a bit: instead of toggling `gettext-system` feature directly on gettext-sys crate, I do it through the same feature in the gettext-rs crate. This rids us of direct dependency on gettext-sys, which is inconsequential but aesthetically pleasing :)

I think Dependabot didn't do this for us because gettext-rs 0.6.0 is incompatible with gettext-sys 0.19.9 that we required, and gettext-sys 0.21.0 is not compatible with gettext-rs 0.5.0 that we require. Those two crates have to be updated simultaneously. But I'm not sure that this is what tripped Dependabot up.