### PR TITLE
Bring back help messages into POT file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ mo-files: $(MOFILES)
 
 extract:
 	$(RM) $(POTFILE)
-	xgettext -c/ -k_ -k_s -o po/cpp.pot *.cpp src/*.cpp rss/*.cpp
+	xgettext -c/ -k_ -k_s -ktranslatable -o po/cpp.pot *.cpp src/*.cpp rss/*.cpp
 	xtr rust/libnewsboat/src/lib.rs rust/regex-rs/src/lib.rs --omit-header -o po/rust.pot
 	cat po/cpp.pot po/rust.pot > $(POTFILE)
 	$(RM) -f po/cpp.pot po/rust.pot

--- a/po/ca.po
+++ b/po/ca.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2017-07-19 20:19+0300\n"
 "Last-Translator: Alejandro Gallo <aamsgallo@gmail.com>\n"
 "Language-Team: Alejandro Gallo <aamsgallo@gmail.com>, OmeGa <omega@mailoo."
@@ -1221,7 +1221,7 @@ msgstr "Error: no es va poder escriure l'article en l'arxiu %s"
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar l'article com no llegit: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Anar a URL #"
 
@@ -1241,6 +1241,373 @@ msgstr "Article - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Error: expressió regular invàlida!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Obrir font/article"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Tornar al diàleg anterior/Sortir"
+
+#: src/keymap.cpp:53
+#, fuzzy
+msgid "Quit program, no confirmation"
+msgstr "Sortir del programa sense confirmació"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Actualitzar la font selecionada"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Actualitzar totes las fonts"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Marcar font com llegida"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Marcar totes la fonts com llegides"
+
+#: src/keymap.cpp:82
+#, fuzzy
+msgid "Mark all above as read"
+msgstr "Marcar totes la fonts com llegides"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Guardar article"
+
+#: src/keymap.cpp:86
+#, fuzzy
+msgid "Save articles"
+msgstr "Guardar article"
+
+#: src/keymap.cpp:91
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Anar a al entrada anterior"
+
+#: src/keymap.cpp:98
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Anar a la entrada següent"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Anar al següent article no llegit"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Anar al article no llegit anterior"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Anar a un article no llegit aleatorio"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Obrir l'article en el navegador, y marcar com llegit"
+
+#: src/keymap.cpp:133
+#, fuzzy
+msgid "Open all unread items of selected feed in browser"
+msgstr "Obrir l'article en el navegador, y marcar com llegit"
+
+#: src/keymap.cpp:140
+#, fuzzy
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr "Obrir l'article en el navegador, y marcar com llegit"
+
+#: src/keymap.cpp:148
+#, fuzzy
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Obrir l'article en el navegador, y marcar com llegit"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Obrir l'article en el navegador, y marcar com llegit"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Obrir el diàleg de ajuda"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Cambiar a vista de font"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Cambiar l'estat de lectura per l'article"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Cambiar mostrar fonts/articles"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Mostrar URLs en l'article actual"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Eliminar la etiqueta actual"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Seleccionar etiqueta"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Obrir el diàleg de búsqueda"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Afegir descàrrega a la cua"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Actualitzar la llista de URLs desde la configuració"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Descarregar arxiu"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Cancelar descàrrega"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Marcar la descàrrega com eliminada"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Purgar les descàrregues finalitzades y eliminadas de la cua"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Cambiar descàrrega automàtica activada/desactivada"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Iniciar el reproductor amb la descàrrega seleccionada actualment"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Marcar arxiu com acabat (no reproduit)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Incrementar el número de descàrregues simultanies"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Disminuir el número de descàrregues simultanies"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Redibuixar pantalla"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Obrir la línea de comandos"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Establir un filtre"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Seleccionar un filtre predeterminat"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Eliminar el filtre establert actualment"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Afegir l'article/enllaç actual a marcadors"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Editar indicadors"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Anar a la següent font"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Anar a la font anterior"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Anar a la següent font no llegida"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Anar a l'anterior font no llegida"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Invocar un macro"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Eliminar article"
+
+#: src/keymap.cpp:335
+#, fuzzy
+msgid "Delete all articles"
+msgstr "Eliminar article"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Purgar articles eliminats"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Editar les URLs de subscripció"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Tancar el diàleg seleccionat actualment"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Veure la llista de diàlegs oberts"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Anar al diàleg següent"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Anar al diàleg anterior"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Encadenar article a un comando"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Ordenar la llista actual"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Ordenar la llista actual (invers)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Obrir URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Obrir URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Obrir URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Obrir URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Obrir URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Obrir URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Obrir URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Obrir URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Obrir URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Obrir URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Anar a la entrada següent"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Anar a al entrada anterior"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Anar a la pàgina anterior"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Anar a la pàgina següent"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Anar al començament de la pàgina/llista"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Anar al final de la pàgina/llista"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1622,239 +1989,6 @@ msgstr ""
 
 #~ msgid "Starting browser..."
 #~ msgstr "Iniciant el navegador..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Obrir font/article"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Tornar al diàleg anterior/Sortir"
-
-#, fuzzy
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Sortir del programa sense confirmació"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Actualitzar la font selecionada"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Actualitzar totes las fonts"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Marcar font com llegida"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Marcar totes la fonts com llegides"
-
-#, fuzzy
-#~ msgid "Mark all above as read"
-#~ msgstr "Marcar totes la fonts com llegides"
-
-#~ msgid "Save article"
-#~ msgstr "Guardar article"
-
-#, fuzzy
-#~ msgid "Save articles"
-#~ msgstr "Guardar article"
-
-#, fuzzy
-#~ msgid "Go to next entry"
-#~ msgstr "Anar a al entrada anterior"
-
-#, fuzzy
-#~ msgid "Go to previous entry"
-#~ msgstr "Anar a la entrada següent"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Anar al següent article no llegit"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Anar al article no llegit anterior"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Anar a un article no llegit aleatorio"
-
-#, fuzzy
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Obrir l'article en el navegador, y marcar com llegit"
-
-#, fuzzy
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr "Obrir l'article en el navegador, y marcar com llegit"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Obrir el diàleg de ajuda"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Cambiar a vista de font"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Cambiar l'estat de lectura per l'article"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Cambiar mostrar fonts/articles"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Mostrar URLs en l'article actual"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Eliminar la etiqueta actual"
-
-#~ msgid "Select tag"
-#~ msgstr "Seleccionar etiqueta"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Obrir el diàleg de búsqueda"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Afegir descàrrega a la cua"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Actualitzar la llista de URLs desde la configuració"
-
-#~ msgid "Download file"
-#~ msgstr "Descarregar arxiu"
-
-#~ msgid "Cancel download"
-#~ msgstr "Cancelar descàrrega"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Marcar la descàrrega com eliminada"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Purgar les descàrregues finalitzades y eliminadas de la cua"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Cambiar descàrrega automàtica activada/desactivada"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Iniciar el reproductor amb la descàrrega seleccionada actualment"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Marcar arxiu com acabat (no reproduit)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Incrementar el número de descàrregues simultanies"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Disminuir el número de descàrregues simultanies"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Redibuixar pantalla"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Obrir la línea de comandos"
-
-#~ msgid "Set a filter"
-#~ msgstr "Establir un filtre"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Seleccionar un filtre predeterminat"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Eliminar el filtre establert actualment"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Afegir l'article/enllaç actual a marcadors"
-
-#~ msgid "Edit flags"
-#~ msgstr "Editar indicadors"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Anar a la següent font"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Anar a la font anterior"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Anar a la següent font no llegida"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Anar a l'anterior font no llegida"
-
-#~ msgid "Call a macro"
-#~ msgstr "Invocar un macro"
-
-#~ msgid "Delete article"
-#~ msgstr "Eliminar article"
-
-#, fuzzy
-#~ msgid "Delete all articles"
-#~ msgstr "Eliminar article"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Purgar articles eliminats"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Editar les URLs de subscripció"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Tancar el diàleg seleccionat actualment"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Veure la llista de diàlegs oberts"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Anar al diàleg següent"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Anar al diàleg anterior"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Encadenar article a un comando"
-
-#~ msgid "Sort current list"
-#~ msgstr "Ordenar la llista actual"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Ordenar la llista actual (invers)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Obrir URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Obrir URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Obrir URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Obrir URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Obrir URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Obrir URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Obrir URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Obrir URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Obrir URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Obrir URL 10"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Anar a la entrada següent"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Anar a al entrada anterior"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Anar a la pàgina anterior"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Anar a la pàgina següent"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Anar al començament de la pàgina/llista"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Anar al final de la pàgina/llista"
 
 #~ msgid "Open article in browser"
 #~ msgstr "Obrir article en el navegador"

--- a/po/de.po
+++ b/po/de.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2020-12-07 17:34+0100\n"
 "Last-Translator: Lysander Trischler <github@lyse.isobeef.org>\n"
 "Language-Team: Andreas Krennmair <ak@newsbeuter.org>, Simon Nagl "
@@ -1217,7 +1217,7 @@ msgstr "Fehler: Konnte Artikel nicht nach %s speichern"
 msgid "Error while marking article as unread: %s"
 msgstr "Fehler beim Markieren des Artikels als ungelesen: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Gehe zu URL #"
 
@@ -1237,6 +1237,368 @@ msgstr "Artikel - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Fehler: Ungültiger regulärer Ausdruck!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Feed/Artikel öffnen"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr "Fokus zwischen Steuerelementen wechseln"
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "zum vorherigen Dialog zurückkehren/Beenden"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Programm beenden, keine Bestätigung"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "aktuell ausgewählten Feed neu laden"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "alle Feeds neu laden"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Feed als gelesen markieren"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "alle Feeds als gelesen markieren"
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr "alle obenstehenden Artikel als gelesen markieren"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Artikel speichern"
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr "Artikel speichern"
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr "zum nächsten Eintrag gehen"
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr "zum vorhergehenden Eintrag gehen"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "zum nächsten ungelesenen Artikel gehen"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "zum vorhergehenden ungelesenen Artikel gehen"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "zu einem zufälligen, ungelesenen Artikel gehen"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr ""
+"URL des Artikels oder Eintrags in der URL-Ansicht öffnen and als gelesen "
+"markieren."
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr "Alle ungelesenen Artikel des gewählten Feeds im Browser öffnen"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+"Alle ungelesenen Artikel des gewählten Feeds im Browser öffnen and als "
+"gelesen markieren"
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "URL des Artikels, Feeds oder Eintrags in der URL-Ansicht öffnen"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "URL des Artikels, Feeds oder Eintrags in der URL-Ansicht öffnen"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Hilfe-Dialog öffnen"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Quellansicht umschalten"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Gelesen-Status für Artikel umschalten"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Ansicht der gelesenen Feeds/Artikel umschalten"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "URLs im aktuellen Artikel zeigen"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "aktuellen Tag löschen"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Tag auswählen"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Suchdialog öffnen"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr "Springe zu Eintrag mit Titel"
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Download zur Warteschlange hinzufügen"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Liste der URLs aus der Konfiguration neuladen"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Datei herunterladen"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Download abbrechen"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Download als gelöscht markieren"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "fertige und gelöschte Downloads aus Warteschlange aufräumen"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "automatisches Herunterladen ein-/ausschalten"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Player mit aktuell ausgewähltem Download starten"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "markiere Datei as fertig (nicht gespielt)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Anzahl der parallelen Downloads erhöhen"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Anzahl der parallelen Downloads verringern"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Bildschirm neu zeichnen"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "die Kommandozeile öffnen"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "einen Filter setzen"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "einen vordefinierten Filter auswählen"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "aktuell gesetzten Filter löschen"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Lesezeichen für aktuellen Link/Artikel speichern"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Flags bearbeiten"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "zum nächsten Feed gehen"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "zum vorhergehenden Feed gehen"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "zum nächsten ungelesenen Feed gehen"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "zum vorhergehenden ungelesenen Feed gehen"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Makro aufrufen"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Artikel löschen"
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr "Alle Artikel löschen"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "gelöschte Artikel entfernen"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "abonnierte URLs bearbeiten"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "aktuell ausgewählten Feed schließen"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Liste von offenen Dialogen ansehen"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "zum nächsten Dialog gehen"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "zum vorherigen Dialog gehen"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Artikel zu Befehl umleiten"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "aktuelle Liste sortieren"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "aktuelle Liste sortieren (umgekehrt)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "öffne URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "öffne URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "öffne URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "öffne URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "öffne URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "öffne URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "öffne URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "öffne URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "öffne URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "öffne URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr "Kommandozeile mit 1 starten"
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr "Kommandozeile mit 2 starten"
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr "Kommandozeile mit 3 starten"
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr "Kommandozeile mit 4 starten"
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr "Kommandozeile mit 5 starten"
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr "Kommandozeile mit 6 starten"
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr "Kommandozeile mit 7 starten"
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr "Kommandozeile mit 8 starten"
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr "Kommandozeile mit 9 starten"
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "zum vorhergehenden Eintrag gehen"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "zum nächsten Eintrag gehen"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "zur vorherigen Seite gehen"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "zur nächsten Seite gehen"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "zum Anfang der Seite/Liste gehen"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "zum Ende der Seite/Liste gehen"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1624,271 +1986,3 @@ msgstr "regexec brach mit Rückgabestatus %i ab"
 
 #~ msgid "Starting browser..."
 #~ msgstr "Starte Browser..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Feed/Artikel öffnen"
-
-#~ msgid "Switch focus between widgets"
-#~ msgstr "Fokus zwischen Steuerelementen wechseln"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "zum vorherigen Dialog zurückkehren/Beenden"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Programm beenden, keine Bestätigung"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "aktuell ausgewählten Feed neu laden"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "alle Feeds neu laden"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Feed als gelesen markieren"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "alle Feeds als gelesen markieren"
-
-#~ msgid "Mark all above as read"
-#~ msgstr "alle obenstehenden Artikel als gelesen markieren"
-
-#~ msgid "Save article"
-#~ msgstr "Artikel speichern"
-
-#~ msgid "Save articles"
-#~ msgstr "Artikel speichern"
-
-#~ msgid "Go to next entry"
-#~ msgstr "zum nächsten Eintrag gehen"
-
-#~ msgid "Go to previous entry"
-#~ msgstr "zum vorhergehenden Eintrag gehen"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "zum nächsten ungelesenen Artikel gehen"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "zum vorhergehenden ungelesenen Artikel gehen"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "zu einem zufälligen, ungelesenen Artikel gehen"
-
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr ""
-#~ "URL des Artikels oder Eintrags in der URL-Ansicht öffnen and als gelesen "
-#~ "markieren."
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr "Alle ungelesenen Artikel des gewählten Feeds im Browser öffnen"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr ""
-#~ "Alle ungelesenen Artikel des gewählten Feeds im Browser öffnen and als "
-#~ "gelesen markieren"
-
-#~ msgid "Open URL of article, feed, or entry in URL view"
-#~ msgstr "URL des Artikels, Feeds oder Eintrags in der URL-Ansicht öffnen"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Hilfe-Dialog öffnen"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Quellansicht umschalten"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Gelesen-Status für Artikel umschalten"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Ansicht der gelesenen Feeds/Artikel umschalten"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "URLs im aktuellen Artikel zeigen"
-
-#~ msgid "Clear current tag"
-#~ msgstr "aktuellen Tag löschen"
-
-#~ msgid "Select tag"
-#~ msgstr "Tag auswählen"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Suchdialog öffnen"
-
-#~ msgid "Goto item with title"
-#~ msgstr "Springe zu Eintrag mit Titel"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Download zur Warteschlange hinzufügen"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Liste der URLs aus der Konfiguration neuladen"
-
-#~ msgid "Download file"
-#~ msgstr "Datei herunterladen"
-
-#~ msgid "Cancel download"
-#~ msgstr "Download abbrechen"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Download als gelöscht markieren"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "fertige und gelöschte Downloads aus Warteschlange aufräumen"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "automatisches Herunterladen ein-/ausschalten"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Player mit aktuell ausgewähltem Download starten"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "markiere Datei as fertig (nicht gespielt)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Anzahl der parallelen Downloads erhöhen"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Anzahl der parallelen Downloads verringern"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Bildschirm neu zeichnen"
-
-#~ msgid "Open the commandline"
-#~ msgstr "die Kommandozeile öffnen"
-
-#~ msgid "Set a filter"
-#~ msgstr "einen Filter setzen"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "einen vordefinierten Filter auswählen"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "aktuell gesetzten Filter löschen"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Lesezeichen für aktuellen Link/Artikel speichern"
-
-#~ msgid "Edit flags"
-#~ msgstr "Flags bearbeiten"
-
-#~ msgid "Go to next feed"
-#~ msgstr "zum nächsten Feed gehen"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "zum vorhergehenden Feed gehen"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "zum nächsten ungelesenen Feed gehen"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "zum vorhergehenden ungelesenen Feed gehen"
-
-#~ msgid "Call a macro"
-#~ msgstr "Makro aufrufen"
-
-#~ msgid "Delete article"
-#~ msgstr "Artikel löschen"
-
-#~ msgid "Delete all articles"
-#~ msgstr "Alle Artikel löschen"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "gelöschte Artikel entfernen"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "abonnierte URLs bearbeiten"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "aktuell ausgewählten Feed schließen"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Liste von offenen Dialogen ansehen"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "zum nächsten Dialog gehen"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "zum vorherigen Dialog gehen"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Artikel zu Befehl umleiten"
-
-#~ msgid "Sort current list"
-#~ msgstr "aktuelle Liste sortieren"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "aktuelle Liste sortieren (umgekehrt)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "öffne URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "öffne URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "öffne URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "öffne URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "öffne URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "öffne URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "öffne URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "öffne URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "öffne URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "öffne URL 10"
-
-#~ msgid "Start cmdline with 1"
-#~ msgstr "Kommandozeile mit 1 starten"
-
-#~ msgid "Start cmdline with 2"
-#~ msgstr "Kommandozeile mit 2 starten"
-
-#~ msgid "Start cmdline with 3"
-#~ msgstr "Kommandozeile mit 3 starten"
-
-#~ msgid "Start cmdline with 4"
-#~ msgstr "Kommandozeile mit 4 starten"
-
-#~ msgid "Start cmdline with 5"
-#~ msgstr "Kommandozeile mit 5 starten"
-
-#~ msgid "Start cmdline with 6"
-#~ msgstr "Kommandozeile mit 6 starten"
-
-#~ msgid "Start cmdline with 7"
-#~ msgstr "Kommandozeile mit 7 starten"
-
-#~ msgid "Start cmdline with 8"
-#~ msgstr "Kommandozeile mit 8 starten"
-
-#~ msgid "Start cmdline with 9"
-#~ msgstr "Kommandozeile mit 9 starten"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "zum vorhergehenden Eintrag gehen"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "zum nächsten Eintrag gehen"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "zur vorherigen Seite gehen"
-
-#~ msgid "Move to the next page"
-#~ msgstr "zur nächsten Seite gehen"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "zum Anfang der Seite/Liste gehen"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "zum Ende der Seite/Liste gehen"

--- a/po/es.po
+++ b/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2020-04-21 23:43+0200\n"
 "Last-Translator: Marcos Cruz <github@programandala.net>\n"
 "Language-Team: ROOT <epsilon@correoe.no-ip.org>, OmeGa <omega@mailoo.org>, "
@@ -1212,7 +1212,7 @@ msgstr "Error: no se pudo escribir el artículo en el archivo %s"
 msgid "Error while marking article as unread: %s"
 msgstr "Error al marcar el artículo como no leído: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Ir a URL #"
 
@@ -1232,6 +1232,371 @@ msgstr "Artículo - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Error: expresión regular incorrecta."
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Abrir fuente/artículo"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Volver al diálogo anterior/Salir"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Salir del programa sin confirmación"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Recargar la fuente seleccionada"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Recargar todas las fuentes"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Marcar la fuente como leída"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Marcar todas las fuentes como leídas"
+
+#: src/keymap.cpp:82
+#, fuzzy
+msgid "Mark all above as read"
+msgstr "Marcar todo lo de arriba como leído"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Guardar artículo"
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr "Guardar artículos"
+
+#: src/keymap.cpp:91
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Ir a al entrada siguiente"
+
+#: src/keymap.cpp:98
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Ir a la entrada anterior"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Ir al siguiente artículo no leído"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Ir al artículo anterior no leído"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Ir a un artículo no leído aleatorio"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Abrir el artículo en el navegador y marcarlo como leído"
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr ""
+"Abrir en el navegador los artículos no leídos de la fuente seleccionada"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+"Abrir en el navegador los artículos no leídos de la fuente seleccionada y "
+"marcarlos como leídos"
+
+#: src/keymap.cpp:148
+#, fuzzy
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Abrir el artículo en el navegador y marcarlo como leído"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Abrir el artículo en el navegador y marcarlo como leído"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Abrir el diálogo de ayuda"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Conmutar la vista de fuente"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Conmutar la marca de lectura del artículo"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Conmutar la visualización de fuentes y artículos leídos"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Mostrar las URL del artículo actual"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Borrar la etiqueta actual"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Seleccionar etiqueta"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Abrir el diálogo de búsqueda"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Añadir descarga a la cola"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Recargar la lista de las URL desde la configuración"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Descargar archivo"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Cancelar descarga"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Marcar la descarga como eliminada"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Limpiar las descargas terminadas y borradas de la cola"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Conmutar la descarga automática"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Iniciar el reproductor con la descarga seleccionada"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Marcar archivo como finalizado (no reproducido)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Incrementar el número de descargas simultáneas"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Reducir el número de descargas simultáneas"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Redibujar la pantalla"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Abrir la línea de comandos"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Establecer un filtro"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Seleccionar un filtro predefinido"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Borrar el filtro actual"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Añadir el artículo o enlace actual a los marcadores"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Editar marcas"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Ir a la siguiente fuente"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Ir a la fuente anterior"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Ir a la siguiente fuente no leída"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Ir a la anterior fuente no leída"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Ejecutar una macro"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Borrar artículo"
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr "Borrar todos los artículos"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Eliminar definitivamente los artículos borrados"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Editar las URL suscritas"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Cerrar el diálogo seleccionado"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Ver la lista de diálogos abiertos"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Ir al diálogo siguiente"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Ir al diálogo anterior"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Enviar el artículo a un comando"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Ordenar la lista actual"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Ordenar decrecientemente la lista actual"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Abrir URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Abrir URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Abrir URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Abrir URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Abrir URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Abrir URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Abrir URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Abrir URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Abrir URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Abrir URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Ir a la entrada anterior"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Ir a al entrada siguiente"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Ir a la página anterior"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Ir a la página siguiente"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Ir al comienzo de la página o lista"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Ir al final de la página o lista"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1616,241 +1981,6 @@ msgstr "El navegador devolvió el código de error %i"
 
 #~ msgid "Starting browser..."
 #~ msgstr "Iniciando el navegador..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Abrir fuente/artículo"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Volver al diálogo anterior/Salir"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Salir del programa sin confirmación"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Recargar la fuente seleccionada"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Recargar todas las fuentes"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Marcar la fuente como leída"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Marcar todas las fuentes como leídas"
-
-#, fuzzy
-#~ msgid "Mark all above as read"
-#~ msgstr "Marcar todo lo de arriba como leído"
-
-#~ msgid "Save article"
-#~ msgstr "Guardar artículo"
-
-#~ msgid "Save articles"
-#~ msgstr "Guardar artículos"
-
-#, fuzzy
-#~ msgid "Go to next entry"
-#~ msgstr "Ir a al entrada siguiente"
-
-#, fuzzy
-#~ msgid "Go to previous entry"
-#~ msgstr "Ir a la entrada anterior"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Ir al siguiente artículo no leído"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Ir al artículo anterior no leído"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Ir a un artículo no leído aleatorio"
-
-#, fuzzy
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Abrir el artículo en el navegador y marcarlo como leído"
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr ""
-#~ "Abrir en el navegador los artículos no leídos de la fuente seleccionada"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr ""
-#~ "Abrir en el navegador los artículos no leídos de la fuente seleccionada y "
-#~ "marcarlos como leídos"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Abrir el diálogo de ayuda"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Conmutar la vista de fuente"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Conmutar la marca de lectura del artículo"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Conmutar la visualización de fuentes y artículos leídos"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Mostrar las URL del artículo actual"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Borrar la etiqueta actual"
-
-#~ msgid "Select tag"
-#~ msgstr "Seleccionar etiqueta"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Abrir el diálogo de búsqueda"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Añadir descarga a la cola"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Recargar la lista de las URL desde la configuración"
-
-#~ msgid "Download file"
-#~ msgstr "Descargar archivo"
-
-#~ msgid "Cancel download"
-#~ msgstr "Cancelar descarga"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Marcar la descarga como eliminada"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Limpiar las descargas terminadas y borradas de la cola"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Conmutar la descarga automática"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Iniciar el reproductor con la descarga seleccionada"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Marcar archivo como finalizado (no reproducido)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Incrementar el número de descargas simultáneas"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Reducir el número de descargas simultáneas"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Redibujar la pantalla"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Abrir la línea de comandos"
-
-#~ msgid "Set a filter"
-#~ msgstr "Establecer un filtro"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Seleccionar un filtro predefinido"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Borrar el filtro actual"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Añadir el artículo o enlace actual a los marcadores"
-
-#~ msgid "Edit flags"
-#~ msgstr "Editar marcas"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Ir a la siguiente fuente"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Ir a la fuente anterior"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Ir a la siguiente fuente no leída"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Ir a la anterior fuente no leída"
-
-#~ msgid "Call a macro"
-#~ msgstr "Ejecutar una macro"
-
-#~ msgid "Delete article"
-#~ msgstr "Borrar artículo"
-
-#~ msgid "Delete all articles"
-#~ msgstr "Borrar todos los artículos"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Eliminar definitivamente los artículos borrados"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Editar las URL suscritas"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Cerrar el diálogo seleccionado"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Ver la lista de diálogos abiertos"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Ir al diálogo siguiente"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Ir al diálogo anterior"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Enviar el artículo a un comando"
-
-#~ msgid "Sort current list"
-#~ msgstr "Ordenar la lista actual"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Ordenar decrecientemente la lista actual"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Abrir URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Abrir URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Abrir URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Abrir URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Abrir URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Abrir URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Abrir URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Abrir URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Abrir URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Abrir URL 10"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Ir a la entrada anterior"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Ir a al entrada siguiente"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Ir a la página anterior"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Ir a la página siguiente"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Ir al comienzo de la página o lista"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Ir al final de la página o lista"
 
 #~ msgid ""
 #~ "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:"

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.6\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2020-12-10 21:26+0100\n"
 "Last-Translator: Tanguy Kerdoncuff <t.kerdonc@gmail.com>\n"
 "Language-Team: Nicolas Martyanoff <khaelin@gmail.com, Tanguy Kerdoncuff <t."
@@ -1222,7 +1222,7 @@ msgstr "Erreur : échec lors de l'enregistrement vers %s"
 msgid "Error while marking article as unread: %s"
 msgstr "Erreur en marquant l'article comme lu : %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Aller à l'addresse #"
 
@@ -1242,6 +1242,367 @@ msgstr "Article - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Erreur : expression régulière incorrecte !"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Ouvrir le fil/article"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr "Changer de widget actif"
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Retourner à la vue précédente/Quitter"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Quitter le programme immédiatement"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Recharger le fil"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Recharger tous les fils"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Marquer le fil comme étant lu"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Marquer tous les fils comme étant lus"
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr "Marquer tous les éléments ci dessys comme étant lus"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Enregistrer article"
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr "Enregistrer les articles"
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr "Passer au prochain élément"
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr "Passer à l'élément précédent"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Passer au prochain article à lire"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Passer au précédent article à lire"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Lire un article au hasard"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr ""
+"Ouvrir l'article ou l'élément dans le navigateur et le marquer comme lu"
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr "Ouvrir tous les articles à lire du fil dans le navigateur"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+"Ouvrir tous les articles à lire du fil dans le navigateur, puis les marquer "
+"comme lus"
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Ouvrir l'URL de l'article, fil ou élément en vue URL"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Ouvrir l'URL de l'article, fil ou élément en vue URL"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Ouvrir cette aide"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Voir la source"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Intervertir l'état de lecture de l'article"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Intervertir l'affichage exclusif des fils/articles déjà lus"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Afficher les liens contenus dans l'article actuel"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Retirer l'étiquette"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Appliquer une étiquette"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Lancer une recherche"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr "Aller à l'élément avec titre"
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Ajouter un téléchargement à la file d'attente"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Recharger les liens depuis la configuration"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Télécharger le fichier"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Annuler le téléchargement"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Marquer le téléchargement comme supprimé"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Retirer les téléchargements terminés/supprimés de la file"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Intervertir le mode de téléchargement automatique"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Lancer la lecture du téléchargement actuel"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Marquer le fichier comme terminé (à lire)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Augmenter le nombre de téléchargements possibles en parallèle"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Diminuer le nombre de téléchargements possibles en parallèle"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Rafraîchir l'affichage"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Ouvrir la ligne de commande"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Appliquer un filtre"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Choisir un filtre prédéfini"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Retirer le filtre"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Créer un signet à partir du lien/article actuel"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Éditer les signaux"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Passer au fil suivant"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Passer au fil précédent"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Passer au fil à lire suivant"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Passer au fil à lire précédent"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Lancer une macro-commande"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Supprimer l'article"
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr "Supprimer tout les articles"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Retirer les articles supprimés"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Modifier les abonnements"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Fermer la vue sélectionnée"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Afficher la liste des vues actives"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Passer à la vue suivante"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Passer à la vue précédente"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Passer l'article à la commande"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Trier la liste"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Trier la liste (sens inverse)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Ouvrir le lien n°1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Ouvrir le lien n°2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Ouvrir le lien n°3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Ouvrir le lien n°4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Ouvrir le lien n°5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Ouvrir le lien n°6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Ouvrir le lien n°7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Ouvrir le lien n°8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Ouvrir le lien n°9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Ouvrir le lien n°10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr "Lancer cmdline avec 1"
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr "Lancer cmdline avec 2"
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr "Lancer cmdline avec 3"
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr "Lancer cmdline avec 4"
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr "Lancer cmdline avec 5"
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr "Lancer cmdline avec 6"
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr "Lancer cmdline avec 7"
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr "Lancer cmdline avec 8"
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr "Lancer cmdline avec 9"
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Passer à l'élément précédent"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Passer au prochain élément"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Passer à la page précédente"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Passer à la page suivante"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Aller au début de la page/liste"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Aller à la fin de la page/liste"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1631,273 +1992,6 @@ msgstr "regexec a retourné le code %i"
 
 #~ msgid "Starting browser..."
 #~ msgstr "Lancement du navigateur..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Ouvrir le fil/article"
-
-#~ msgid "Switch focus between widgets"
-#~ msgstr "Changer de widget actif"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Retourner à la vue précédente/Quitter"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Quitter le programme immédiatement"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Recharger le fil"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Recharger tous les fils"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Marquer le fil comme étant lu"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Marquer tous les fils comme étant lus"
-
-#~ msgid "Mark all above as read"
-#~ msgstr "Marquer tous les éléments ci dessys comme étant lus"
-
-#~ msgid "Save article"
-#~ msgstr "Enregistrer article"
-
-#~ msgid "Save articles"
-#~ msgstr "Enregistrer les articles"
-
-#~ msgid "Go to next entry"
-#~ msgstr "Passer au prochain élément"
-
-#~ msgid "Go to previous entry"
-#~ msgstr "Passer à l'élément précédent"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Passer au prochain article à lire"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Passer au précédent article à lire"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Lire un article au hasard"
-
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr ""
-#~ "Ouvrir l'article ou l'élément dans le navigateur et le marquer comme lu"
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr "Ouvrir tous les articles à lire du fil dans le navigateur"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr ""
-#~ "Ouvrir tous les articles à lire du fil dans le navigateur, puis les "
-#~ "marquer comme lus"
-
-#~ msgid "Open URL of article, feed, or entry in URL view"
-#~ msgstr "Ouvrir l'URL de l'article, fil ou élément en vue URL"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Ouvrir cette aide"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Voir la source"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Intervertir l'état de lecture de l'article"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Intervertir l'affichage exclusif des fils/articles déjà lus"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Afficher les liens contenus dans l'article actuel"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Retirer l'étiquette"
-
-#~ msgid "Select tag"
-#~ msgstr "Appliquer une étiquette"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Lancer une recherche"
-
-#~ msgid "Goto item with title"
-#~ msgstr "Aller à l'élément avec titre"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Ajouter un téléchargement à la file d'attente"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Recharger les liens depuis la configuration"
-
-#~ msgid "Download file"
-#~ msgstr "Télécharger le fichier"
-
-#~ msgid "Cancel download"
-#~ msgstr "Annuler le téléchargement"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Marquer le téléchargement comme supprimé"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Retirer les téléchargements terminés/supprimés de la file"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Intervertir le mode de téléchargement automatique"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Lancer la lecture du téléchargement actuel"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Marquer le fichier comme terminé (à lire)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Augmenter le nombre de téléchargements possibles en parallèle"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Diminuer le nombre de téléchargements possibles en parallèle"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Rafraîchir l'affichage"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Ouvrir la ligne de commande"
-
-#~ msgid "Set a filter"
-#~ msgstr "Appliquer un filtre"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Choisir un filtre prédéfini"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Retirer le filtre"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Créer un signet à partir du lien/article actuel"
-
-#~ msgid "Edit flags"
-#~ msgstr "Éditer les signaux"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Passer au fil suivant"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Passer au fil précédent"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Passer au fil à lire suivant"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Passer au fil à lire précédent"
-
-#~ msgid "Call a macro"
-#~ msgstr "Lancer une macro-commande"
-
-#~ msgid "Delete article"
-#~ msgstr "Supprimer l'article"
-
-#~ msgid "Delete all articles"
-#~ msgstr "Supprimer tout les articles"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Retirer les articles supprimés"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Modifier les abonnements"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Fermer la vue sélectionnée"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Afficher la liste des vues actives"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Passer à la vue suivante"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Passer à la vue précédente"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Passer l'article à la commande"
-
-#~ msgid "Sort current list"
-#~ msgstr "Trier la liste"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Trier la liste (sens inverse)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Ouvrir le lien n°1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Ouvrir le lien n°2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Ouvrir le lien n°3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Ouvrir le lien n°4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Ouvrir le lien n°5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Ouvrir le lien n°6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Ouvrir le lien n°7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Ouvrir le lien n°8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Ouvrir le lien n°9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Ouvrir le lien n°10"
-
-#~ msgid "Start cmdline with 1"
-#~ msgstr "Lancer cmdline avec 1"
-
-#~ msgid "Start cmdline with 2"
-#~ msgstr "Lancer cmdline avec 2"
-
-#~ msgid "Start cmdline with 3"
-#~ msgstr "Lancer cmdline avec 3"
-
-#~ msgid "Start cmdline with 4"
-#~ msgstr "Lancer cmdline avec 4"
-
-#~ msgid "Start cmdline with 5"
-#~ msgstr "Lancer cmdline avec 5"
-
-#~ msgid "Start cmdline with 6"
-#~ msgstr "Lancer cmdline avec 6"
-
-#~ msgid "Start cmdline with 7"
-#~ msgstr "Lancer cmdline avec 7"
-
-#~ msgid "Start cmdline with 8"
-#~ msgstr "Lancer cmdline avec 8"
-
-#~ msgid "Start cmdline with 9"
-#~ msgstr "Lancer cmdline avec 9"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Passer à l'élément précédent"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Passer au prochain élément"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Passer à la page précédente"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Passer à la page suivante"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Aller au début de la page/liste"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Aller à la fin de la page/liste"
 
 #~ msgid "Open article in browser"
 #~ msgstr "Ouvrir l'article dans le navigateur"

--- a/po/hu.po
+++ b/po/hu.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2008-01-28 10:00+0100\n"
 "Last-Translator: Zsolt Udvari <udvzsolt@gmail.com>\n"
 "Language-Team: \n"
@@ -1217,7 +1217,7 @@ msgstr "Hiba: nem tudtam a cikket a(z) %s file-ba menteni"
 msgid "Error while marking article as unread: %s"
 msgstr "Hiba a cikk olvasatlanná tétele közben: %s "
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Ugrás: URL #"
 
@@ -1237,6 +1237,375 @@ msgstr "Cikk %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Hiba: érvénytelen reguláris kifejezés!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Forrás/cikk megnyitása"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Vissza az előzőhöz/Kilépés"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Kilépés a programból, megerősítés nélkül"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Az aktuális forrás újratöltése"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Összes forrás újratöltése"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Forrás olvasottá"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Összes forrás olvasottá"
+
+#: src/keymap.cpp:82
+#, fuzzy
+msgid "Mark all above as read"
+msgstr "Összes forrás olvasottá"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Cikk mentése"
+
+#: src/keymap.cpp:86
+#, fuzzy
+msgid "Save articles"
+msgstr "Cikk mentése"
+
+#: src/keymap.cpp:91
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Következő bejegyzés"
+
+#: src/keymap.cpp:98
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Előző bejegyzés"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Következő olvasatlan cikk"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Elõző olvasatlan cikk"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Véletlenszerű olvasatlan cikk"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Cikk megnyitása böngészőben"
+
+#: src/keymap.cpp:133
+#, fuzzy
+msgid "Open all unread items of selected feed in browser"
+msgstr "Cikk megnyitása böngészőben"
+
+#: src/keymap.cpp:140
+#, fuzzy
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr "Cikk megnyitása böngészőben"
+
+#: src/keymap.cpp:148
+#, fuzzy
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Cikk megnyitása böngészőben"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Cikk megnyitása böngészőben"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Súgó megnyitása"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Forrás nézet"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Olvasott státusz ki/beállítása a cikkre"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Olvasott források mutatása"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "URL-ek az aktuális cikkben"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Aktuális cimke törlése"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Cimke kijelölése"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Keresés megnyitása"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Letöltési listához hozzáad"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Az URL-ek listájának újratöltése"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Fájl letöltése"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Letöltés megszakítása"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Letöltés töröltnek nyilvánítása"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Befejezett és törölt letöltések ürítése a listából"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Automatikus letöltés be/ki"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Lejátszó indítása a kijelölt letöltéssel"
+
+#: src/keymap.cpp:247
+#, fuzzy
+msgid "Mark file as finished (not played)"
+msgstr "Takarítás befejezve"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Párhuzamos letöltések számának növelése"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Párhuzamos letöltések számának csökkentése"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Képernyő újrarajzolása"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Parancssor nyitása"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Szűrő állítása"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Előredefiniált szűrő kiválasztása"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Aktuális szűrő törlése"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Aktuális link/cikk könyvjelzőbe"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Jelzők szerkesztése"
+
+#: src/keymap.cpp:301
+#, fuzzy
+msgid "Go to next feed"
+msgstr "Következő olvasatlan forrás"
+
+#: src/keymap.cpp:306
+#, fuzzy
+msgid "Go to previous feed"
+msgstr "Előző olvasatlan forrás"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Következő olvasatlan forrás"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Előző olvasatlan forrás"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Makró hívása"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Cikk törlése"
+
+#: src/keymap.cpp:335
+#, fuzzy
+msgid "Delete all articles"
+msgstr "Cikk törlése"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Végleges törlés"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Feliratkozott URL-ek szerkesztése"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Az aktuálisan kijelölt dialógus bezárása"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Megnyitott dialógusok listája"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Következő dialógus"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Előző dialógus"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Cikk pipe-olása parancsnak"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Aktuális lista rendezése"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Aktuális lista rendezése (fordított)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "1. URL megnyitása"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "2. URL megnyitása"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "3. URL megnyitása"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "4. URL megnyitása"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "5. URL megnyitása"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "6. URL megnyitása"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "7. URL megnyitása"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "8. URL megnyitása"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "9. URL megnyitása"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "10. URL megnyitása"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Előző bejegyzés"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Következő bejegyzés"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Az előző oldalra"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "A következő oldalra"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Mozgatás az oldal/lista elejére"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Mozgatás az oldal/lista végére"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1617,237 +1986,6 @@ msgstr ""
 
 #~ msgid "Starting browser..."
 #~ msgstr "Böngésző indítása..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Forrás/cikk megnyitása"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Vissza az előzőhöz/Kilépés"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Kilépés a programból, megerősítés nélkül"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Az aktuális forrás újratöltése"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Összes forrás újratöltése"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Forrás olvasottá"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Összes forrás olvasottá"
-
-#, fuzzy
-#~ msgid "Mark all above as read"
-#~ msgstr "Összes forrás olvasottá"
-
-#~ msgid "Save article"
-#~ msgstr "Cikk mentése"
-
-#, fuzzy
-#~ msgid "Save articles"
-#~ msgstr "Cikk mentése"
-
-#, fuzzy
-#~ msgid "Go to next entry"
-#~ msgstr "Következő bejegyzés"
-
-#, fuzzy
-#~ msgid "Go to previous entry"
-#~ msgstr "Előző bejegyzés"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Következő olvasatlan cikk"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Elõző olvasatlan cikk"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Véletlenszerű olvasatlan cikk"
-
-#, fuzzy
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Cikk megnyitása böngészőben"
-
-#, fuzzy
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr "Cikk megnyitása böngészőben"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Súgó megnyitása"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Forrás nézet"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Olvasott státusz ki/beállítása a cikkre"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Olvasott források mutatása"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "URL-ek az aktuális cikkben"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Aktuális cimke törlése"
-
-#~ msgid "Select tag"
-#~ msgstr "Cimke kijelölése"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Keresés megnyitása"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Letöltési listához hozzáad"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Az URL-ek listájának újratöltése"
-
-#~ msgid "Download file"
-#~ msgstr "Fájl letöltése"
-
-#~ msgid "Cancel download"
-#~ msgstr "Letöltés megszakítása"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Letöltés töröltnek nyilvánítása"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Befejezett és törölt letöltések ürítése a listából"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Automatikus letöltés be/ki"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Lejátszó indítása a kijelölt letöltéssel"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Párhuzamos letöltések számának növelése"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Párhuzamos letöltések számának csökkentése"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Képernyő újrarajzolása"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Parancssor nyitása"
-
-#~ msgid "Set a filter"
-#~ msgstr "Szűrő állítása"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Előredefiniált szűrő kiválasztása"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Aktuális szűrő törlése"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Aktuális link/cikk könyvjelzőbe"
-
-#~ msgid "Edit flags"
-#~ msgstr "Jelzők szerkesztése"
-
-#, fuzzy
-#~ msgid "Go to next feed"
-#~ msgstr "Következő olvasatlan forrás"
-
-#, fuzzy
-#~ msgid "Go to previous feed"
-#~ msgstr "Előző olvasatlan forrás"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Következő olvasatlan forrás"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Előző olvasatlan forrás"
-
-#~ msgid "Call a macro"
-#~ msgstr "Makró hívása"
-
-#~ msgid "Delete article"
-#~ msgstr "Cikk törlése"
-
-#, fuzzy
-#~ msgid "Delete all articles"
-#~ msgstr "Cikk törlése"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Végleges törlés"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Feliratkozott URL-ek szerkesztése"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Az aktuálisan kijelölt dialógus bezárása"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Megnyitott dialógusok listája"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Következő dialógus"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Előző dialógus"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Cikk pipe-olása parancsnak"
-
-#~ msgid "Sort current list"
-#~ msgstr "Aktuális lista rendezése"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Aktuális lista rendezése (fordított)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "1. URL megnyitása"
-
-#~ msgid "Open URL 2"
-#~ msgstr "2. URL megnyitása"
-
-#~ msgid "Open URL 3"
-#~ msgstr "3. URL megnyitása"
-
-#~ msgid "Open URL 4"
-#~ msgstr "4. URL megnyitása"
-
-#~ msgid "Open URL 5"
-#~ msgstr "5. URL megnyitása"
-
-#~ msgid "Open URL 6"
-#~ msgstr "6. URL megnyitása"
-
-#~ msgid "Open URL 7"
-#~ msgstr "7. URL megnyitása"
-
-#~ msgid "Open URL 8"
-#~ msgstr "8. URL megnyitása"
-
-#~ msgid "Open URL 9"
-#~ msgstr "9. URL megnyitása"
-
-#~ msgid "Open URL 10"
-#~ msgstr "10. URL megnyitása"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Előző bejegyzés"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Következő bejegyzés"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Az előző oldalra"
-
-#~ msgid "Move to the next page"
-#~ msgstr "A következő oldalra"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Mozgatás az oldal/lista elejére"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Mozgatás az oldal/lista végére"
 
 #~ msgid "Open article in browser"
 #~ msgstr "Cikk megnyitása böngészőben"

--- a/po/it.po
+++ b/po/it.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2020-12-13 21:15+0100\n"
 "Last-Translator: Mauro Scomparin <scompo@gmail.com>\n"
 "Language-Team: Claudio M. Alessi <somppy@gmail.com>, Leandro Noferini "
@@ -1213,7 +1213,7 @@ msgstr "Errore: impossibile scrivere l'articolo sul file %s"
 msgid "Error while marking article as unread: %s"
 msgstr "Errore contrassegnando l'articolo come non letto: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Vai a URL #"
 
@@ -1233,6 +1233,364 @@ msgstr "Articolo - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Errore: espressione regolare non valida!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Apri feed/articolo"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr "Cambia fuoco tra widgets"
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Torna alla schermata precedente/Esci"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Programma in uscita, nessuna conferma"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Ricarica il feed attualmente selezionato"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Ricarica tutti i feed"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Segna feed come letto"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Segna tutti i feed come letti"
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr "Contrassegna i feed al di sopra come letti"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Salva articolo"
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr "Salva articolo"
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr "Spostati all'elemento successivo"
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr "Spostati all'elemento precedente"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Vai al prossimo articolo non letto"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Vai al precedente articolo non letto"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Vai su un articolo non letto a caso"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Apri l'URL dell'articolo nel browser e segnalo come letto"
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr "Apri tutte le voci non lette del feed nel browser"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr "Apri tutti gli articoli del feed nel browser e segnali come letti"
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Apri URL articolo, feed, o elemento in visualizzatore URL"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Apri URL articolo, feed, o elemento in visualizzatore URL"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Apri schermata di aiuto"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Attiva/Disattiva la visualizzazione del sorgente"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Attiva/Disattiva lo stato di \"letto\" per l'articolo"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Attiva/Disattiva la visualizzazione dei feed/articoli letti"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Mostra gli URL nell'articolo corrente"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Pulisci il tag corrente"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Seleziona tag"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Apri la schermata di ricerca"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr "Vai a elemento con titolo"
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Aggiungi il download in coda"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Ricarica la lista degli URL dalla configurazione"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Scarica file"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Cancella download"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Segna il download come eliminato"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Elimina finiti e cancella i download dalla coda"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Attiva/Disattiva download automatico on/off"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Avvia il player con il download correntemente selezionato"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Contrassegna il file come concluso (non eseguito)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Incrementa il numero di download paralleli"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Decrementa il numero di download paralleli"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Ridisegna lo schermo"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Apri la riga di comando"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Imposta un filtro"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Seleziona un filtro predefinito"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Pulisci il filtro correntemente impostato"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Aggiungi il collegamento/l'articolo corrente ai segnalibri"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Modifica le flag"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Vai al prossimo feed"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Vai al feed non letto precedente"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Vai al prossimo feed non letto"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Vai al precedente feed non letto"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Richiama una macro"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Cancella articolo"
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr "Cancella articolo"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Pulisce gli articoli cancellati"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Modifica gli URL sottoscritti"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Chiude la schermata selezionata correntemente"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Mostra la lista delle schermate aperte"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Vai alla prossima schermata"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Vai alla schermata precedente"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Metti in pipe l'articolo con un comando"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Ordina la lista corrente"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Ordina la lista corrente (inverso)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Apri URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Apri URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Apri URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Apri URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Apri URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Apri URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Apri URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Apri URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Apri URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Apri URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr "Avvia linea di comando con 1"
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr "Avvia linea di comando con 2"
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr "Avvia linea di comando con 3"
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr "Avvia linea di comando con 4"
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr "Avvia linea di comando con 5"
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr "Avvia linea di comando con 6"
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr "Avvia linea di comando con 7"
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr "Avvia linea di comando con 8"
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr "Avvia linea di comando con 9"
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Spostati alla voce precedente"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Spostati alla voce successiva"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Spostati alla pagina precedente"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Spostati alla pagina successiva"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Spostati all'inizio della pagina/lista"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Spostati alla fine della pagina/lista"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1614,267 +1972,3 @@ msgstr "regexec ha ritornato codice %i"
 
 #~ msgid "Starting browser..."
 #~ msgstr "Sto avviando il browser..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Apri feed/articolo"
-
-#~ msgid "Switch focus between widgets"
-#~ msgstr "Cambia fuoco tra widgets"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Torna alla schermata precedente/Esci"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Programma in uscita, nessuna conferma"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Ricarica il feed attualmente selezionato"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Ricarica tutti i feed"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Segna feed come letto"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Segna tutti i feed come letti"
-
-#~ msgid "Mark all above as read"
-#~ msgstr "Contrassegna i feed al di sopra come letti"
-
-#~ msgid "Save article"
-#~ msgstr "Salva articolo"
-
-#~ msgid "Save articles"
-#~ msgstr "Salva articolo"
-
-#~ msgid "Go to next entry"
-#~ msgstr "Spostati all'elemento successivo"
-
-#~ msgid "Go to previous entry"
-#~ msgstr "Spostati all'elemento precedente"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Vai al prossimo articolo non letto"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Vai al precedente articolo non letto"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Vai su un articolo non letto a caso"
-
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Apri l'URL dell'articolo nel browser e segnalo come letto"
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr "Apri tutte le voci non lette del feed nel browser"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr "Apri tutti gli articoli del feed nel browser e segnali come letti"
-
-#~ msgid "Open URL of article, feed, or entry in URL view"
-#~ msgstr "Apri URL articolo, feed, o elemento in visualizzatore URL"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Apri schermata di aiuto"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Attiva/Disattiva la visualizzazione del sorgente"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Attiva/Disattiva lo stato di \"letto\" per l'articolo"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Attiva/Disattiva la visualizzazione dei feed/articoli letti"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Mostra gli URL nell'articolo corrente"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Pulisci il tag corrente"
-
-#~ msgid "Select tag"
-#~ msgstr "Seleziona tag"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Apri la schermata di ricerca"
-
-#~ msgid "Goto item with title"
-#~ msgstr "Vai a elemento con titolo"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Aggiungi il download in coda"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Ricarica la lista degli URL dalla configurazione"
-
-#~ msgid "Download file"
-#~ msgstr "Scarica file"
-
-#~ msgid "Cancel download"
-#~ msgstr "Cancella download"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Segna il download come eliminato"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Elimina finiti e cancella i download dalla coda"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Attiva/Disattiva download automatico on/off"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Avvia il player con il download correntemente selezionato"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Contrassegna il file come concluso (non eseguito)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Incrementa il numero di download paralleli"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Decrementa il numero di download paralleli"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Ridisegna lo schermo"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Apri la riga di comando"
-
-#~ msgid "Set a filter"
-#~ msgstr "Imposta un filtro"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Seleziona un filtro predefinito"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Pulisci il filtro correntemente impostato"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Aggiungi il collegamento/l'articolo corrente ai segnalibri"
-
-#~ msgid "Edit flags"
-#~ msgstr "Modifica le flag"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Vai al prossimo feed"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Vai al feed non letto precedente"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Vai al prossimo feed non letto"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Vai al precedente feed non letto"
-
-#~ msgid "Call a macro"
-#~ msgstr "Richiama una macro"
-
-#~ msgid "Delete article"
-#~ msgstr "Cancella articolo"
-
-#~ msgid "Delete all articles"
-#~ msgstr "Cancella articolo"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Pulisce gli articoli cancellati"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Modifica gli URL sottoscritti"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Chiude la schermata selezionata correntemente"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Mostra la lista delle schermate aperte"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Vai alla prossima schermata"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Vai alla schermata precedente"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Metti in pipe l'articolo con un comando"
-
-#~ msgid "Sort current list"
-#~ msgstr "Ordina la lista corrente"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Ordina la lista corrente (inverso)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Apri URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Apri URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Apri URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Apri URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Apri URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Apri URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Apri URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Apri URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Apri URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Apri URL 10"
-
-#~ msgid "Start cmdline with 1"
-#~ msgstr "Avvia linea di comando con 1"
-
-#~ msgid "Start cmdline with 2"
-#~ msgstr "Avvia linea di comando con 2"
-
-#~ msgid "Start cmdline with 3"
-#~ msgstr "Avvia linea di comando con 3"
-
-#~ msgid "Start cmdline with 4"
-#~ msgstr "Avvia linea di comando con 4"
-
-#~ msgid "Start cmdline with 5"
-#~ msgstr "Avvia linea di comando con 5"
-
-#~ msgid "Start cmdline with 6"
-#~ msgstr "Avvia linea di comando con 6"
-
-#~ msgid "Start cmdline with 7"
-#~ msgstr "Avvia linea di comando con 7"
-
-#~ msgid "Start cmdline with 8"
-#~ msgstr "Avvia linea di comando con 8"
-
-#~ msgid "Start cmdline with 9"
-#~ msgstr "Avvia linea di comando con 9"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Spostati alla voce precedente"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Spostati alla voce successiva"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Spostati alla pagina precedente"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Spostati alla pagina successiva"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Spostati all'inizio della pagina/lista"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Spostati alla fine della pagina/lista"

--- a/po/ja.po
+++ b/po/ja.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.9\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2015-04-26 05:55+0900\n"
 "Last-Translator: Grady Martin <GradyMartin@gmail.com>\n"
 "Language-Team: \n"
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr ""
 
@@ -1187,6 +1187,367 @@ msgstr ""
 
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
+msgstr ""
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr ""
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr ""
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr ""
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr ""
+
+#: src/keymap.cpp:63
+#, fuzzy
+msgid "Reload all feeds"
+msgstr "全フィードを同期"
+
+#: src/keymap.cpp:68
+#, fuzzy
+msgid "Mark feed read"
+msgstr "既読にする"
+
+#: src/keymap.cpp:75
+#, fuzzy
+msgid "Mark all feeds read"
+msgstr "全件を既読にする"
+
+#: src/keymap.cpp:82
+#, fuzzy
+msgid "Mark all above as read"
+msgstr "全件を既読にする"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr ""
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr ""
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr ""
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr ""
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr ""
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr ""
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr ""
+
+#: src/keymap.cpp:126
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr ""
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr ""
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr ""
+
+#: src/keymap.cpp:155
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr ""
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr ""
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr ""
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr ""
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr ""
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr ""
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr ""
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr ""
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr ""
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+#, fuzzy
+msgid "Add download to queue"
+msgstr "%sのダウンロードを予約しました。"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr ""
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr ""
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr ""
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr ""
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr ""
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr ""
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr ""
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr ""
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr ""
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr ""
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr ""
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr ""
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr ""
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr ""
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr ""
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr ""
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr ""
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr ""
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr ""
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr ""
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr ""
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr ""
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr ""
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr ""
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr ""
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr ""
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr ""
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr ""
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr ""
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr ""
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr ""
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr ""
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr ""
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr ""
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr ""
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr ""
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr ""
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr ""
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr ""
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr ""
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr ""
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr ""
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr ""
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr ""
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr ""
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr ""
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr ""
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr ""
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
 msgstr ""
 
 #: src/keymap.cpp:710
@@ -1557,10 +1918,6 @@ msgstr ""
 
 #~ msgid "Starting browser..."
 #~ msgstr "ブラウザーを起動中…"
-
-#, fuzzy
-#~ msgid "Mark all above as read"
-#~ msgstr "全件を既読にする"
 
 #, fuzzy
 #~ msgid "config"

--- a/po/nb.po
+++ b/po/nb.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2012-08-08 20:07+0100\n"
 "Last-Translator: Daniel Aleksandersen <code@daniel.priv.no>\n"
 "Language-Team: \n"
@@ -1222,7 +1222,7 @@ msgstr "Feil: kunne ikke skrive artikkelen til filen %s"
 msgid "Error while marking article as unread: %s"
 msgstr "Feil mens artikkelen ble markert som lest: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Gå til URL #"
 
@@ -1242,6 +1242,373 @@ msgstr "Artikkel - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Feil: ugyldig regulært uttrykk!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Åpne nyhetsstrøm/artikkel"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Vend tilbake til forrige dialog/avslutt"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Avslutt programmet uten bekreftelse"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Oppdater den markerte nyhetsstrømmen"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Oppdater alle nyhetsstrømmer"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Marker nyhetsstrømmen som lest"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Marker alle nyhetsstrømmer som lest"
+
+#: src/keymap.cpp:82
+#, fuzzy
+msgid "Mark all above as read"
+msgstr "Marker alle nyhetsstrømmer som lest"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Lagre artikkel"
+
+#: src/keymap.cpp:86
+#, fuzzy
+msgid "Save articles"
+msgstr "Lagre artikkel"
+
+#: src/keymap.cpp:91
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Gå til neste innlegg"
+
+#: src/keymap.cpp:98
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Gå til forrige innlegg"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Gå til neste uleste artikkel"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Gå til forrige uleste artikkel"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Gå til en tilfeldig ulest artikkel"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Åpne artikkel i en nettleser og marker som lest"
+
+#: src/keymap.cpp:133
+#, fuzzy
+msgid "Open all unread items of selected feed in browser"
+msgstr "Åpne artikkel i en nettleser og marker som lest"
+
+#: src/keymap.cpp:140
+#, fuzzy
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr "Åpne artikkel i en nettleser og marker som lest"
+
+#: src/keymap.cpp:148
+#, fuzzy
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Åpne artikkel i en nettleser og marker som lest"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Åpne artikkel i en nettleser og marker som lest"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Åpne hjelpedialog"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Kildevisning [av/på]"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Leststatus for artikkel [av/på]"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Vis leste nyhetsstrømmer/artikler [av/på]"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Vis artikkelens URLer"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Tøm valgte etikett"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Velg etikett"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Åpne søkedialog"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Legg til i nedlastingskøen"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Oppdater listen over URLer fra oppsettet"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Last ned filen"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Avbryt nedlastingen"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Merk nedlastingen som slettet"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Fjern ferdige og slettede nedlastinger fra køen"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Automatisk nedlasting [av/på]"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Start markerte nedlasting i avspilleren"
+
+#: src/keymap.cpp:247
+#, fuzzy
+msgid "Mark file as finished (not played)"
+msgstr "Fjern fullførte"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Øk antallet samtidige nedlastinger"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Reduser antallet samtidige nedlastinger"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Tegn skjermen på nytt"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Åpne kommandolinjen"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Velg et filter"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Velg et eksisterende filter"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Tøm gjeldende filtrering"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Sett bokmerke på denne lenken/artikkelen"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Endre flagg"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Gå til neste nyhetsstrøm"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Gå til forrige nyhetsstrøm"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Gå til neste uleste nyhetsstrøm"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Gå til forrige uleste nyhetsstrøm"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Bruk en makro"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Slett artikkel"
+
+#: src/keymap.cpp:335
+#, fuzzy
+msgid "Delete all articles"
+msgstr "Slett artikkel"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Fjern slettede artikkler"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Endre abonnements-URLene"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Lukk den markerte dialogen"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Vis listen over åpne dialoger"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Gå til neste dialog"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Vend tilbake til forrige dialog"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Send artikkel til kommando"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Sorter denne listen stigende"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Sorter denne listen synkende"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Åpne URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Åpne URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Åpne URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Åpne URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Åpne URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Åpne URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Åpne URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Åpne URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Åpne URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Åpne URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Gå til forrige innlegg"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Gå til neste innlegg"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Gå til forrige side"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Gå til neste side"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Gå til starten av siden/listen"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Gå til slutten av siden/listen"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1622,235 +1989,6 @@ msgstr ""
 
 #~ msgid "Starting browser..."
 #~ msgstr "Åpner nettleseren..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Åpne nyhetsstrøm/artikkel"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Vend tilbake til forrige dialog/avslutt"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Avslutt programmet uten bekreftelse"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Oppdater den markerte nyhetsstrømmen"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Oppdater alle nyhetsstrømmer"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Marker nyhetsstrømmen som lest"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Marker alle nyhetsstrømmer som lest"
-
-#, fuzzy
-#~ msgid "Mark all above as read"
-#~ msgstr "Marker alle nyhetsstrømmer som lest"
-
-#~ msgid "Save article"
-#~ msgstr "Lagre artikkel"
-
-#, fuzzy
-#~ msgid "Save articles"
-#~ msgstr "Lagre artikkel"
-
-#, fuzzy
-#~ msgid "Go to next entry"
-#~ msgstr "Gå til neste innlegg"
-
-#, fuzzy
-#~ msgid "Go to previous entry"
-#~ msgstr "Gå til forrige innlegg"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Gå til neste uleste artikkel"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Gå til forrige uleste artikkel"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Gå til en tilfeldig ulest artikkel"
-
-#, fuzzy
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Åpne artikkel i en nettleser og marker som lest"
-
-#, fuzzy
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr "Åpne artikkel i en nettleser og marker som lest"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Åpne hjelpedialog"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Kildevisning [av/på]"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Leststatus for artikkel [av/på]"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Vis leste nyhetsstrømmer/artikler [av/på]"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Vis artikkelens URLer"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Tøm valgte etikett"
-
-#~ msgid "Select tag"
-#~ msgstr "Velg etikett"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Åpne søkedialog"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Legg til i nedlastingskøen"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Oppdater listen over URLer fra oppsettet"
-
-#~ msgid "Download file"
-#~ msgstr "Last ned filen"
-
-#~ msgid "Cancel download"
-#~ msgstr "Avbryt nedlastingen"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Merk nedlastingen som slettet"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Fjern ferdige og slettede nedlastinger fra køen"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Automatisk nedlasting [av/på]"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Start markerte nedlasting i avspilleren"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Øk antallet samtidige nedlastinger"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Reduser antallet samtidige nedlastinger"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Tegn skjermen på nytt"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Åpne kommandolinjen"
-
-#~ msgid "Set a filter"
-#~ msgstr "Velg et filter"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Velg et eksisterende filter"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Tøm gjeldende filtrering"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Sett bokmerke på denne lenken/artikkelen"
-
-#~ msgid "Edit flags"
-#~ msgstr "Endre flagg"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Gå til neste nyhetsstrøm"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Gå til forrige nyhetsstrøm"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Gå til neste uleste nyhetsstrøm"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Gå til forrige uleste nyhetsstrøm"
-
-#~ msgid "Call a macro"
-#~ msgstr "Bruk en makro"
-
-#~ msgid "Delete article"
-#~ msgstr "Slett artikkel"
-
-#, fuzzy
-#~ msgid "Delete all articles"
-#~ msgstr "Slett artikkel"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Fjern slettede artikkler"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Endre abonnements-URLene"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Lukk den markerte dialogen"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Vis listen over åpne dialoger"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Gå til neste dialog"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Vend tilbake til forrige dialog"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Send artikkel til kommando"
-
-#~ msgid "Sort current list"
-#~ msgstr "Sorter denne listen stigende"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Sorter denne listen synkende"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Åpne URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Åpne URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Åpne URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Åpne URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Åpne URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Åpne URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Åpne URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Åpne URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Åpne URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Åpne URL 10"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Gå til forrige innlegg"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Gå til neste innlegg"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Gå til forrige side"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Gå til neste side"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Gå til starten av siden/listen"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Gå til slutten av siden/listen"
 
 #~ msgid "Open article in browser"
 #~ msgstr "Åpne artikkel i en nettleser"

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Error while marking article as unread: %s"
 msgstr ""
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr ""
 
@@ -1180,6 +1180,362 @@ msgstr ""
 
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
+msgstr ""
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr ""
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr ""
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr ""
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr ""
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr ""
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr ""
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr ""
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr ""
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr ""
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr ""
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr ""
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr ""
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr ""
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr ""
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr ""
+
+#: src/keymap.cpp:126
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr ""
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr ""
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr ""
+
+#: src/keymap.cpp:155
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr ""
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr ""
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr ""
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr ""
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr ""
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr ""
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr ""
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr ""
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr ""
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr ""
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr ""
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr ""
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr ""
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr ""
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr ""
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr ""
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr ""
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr ""
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr ""
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr ""
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr ""
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr ""
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr ""
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr ""
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr ""
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr ""
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr ""
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr ""
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr ""
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr ""
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr ""
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr ""
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr ""
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr ""
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr ""
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr ""
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr ""
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr ""
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr ""
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr ""
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr ""
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr ""
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr ""
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr ""
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr ""
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr ""
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr ""
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr ""
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr ""
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr ""
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr ""
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr ""
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr ""
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr ""
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr ""
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr ""
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr ""
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr ""
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
 msgstr ""
 
 #: src/keymap.cpp:710

--- a/po/nl.po
+++ b/po/nl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2020-12-09 01:22+0100\n"
 "Last-Translator: Dennis van der Schagt <dennisschagt@gmail.com>\n"
 "Language-Team: Dutch <vertalen@vrijschrift.org>, Erwin Poeze <donnut@outlook."
@@ -1219,7 +1219,7 @@ msgstr "Fout: artikel opslaan in bestand ‘%s’ is mislukt"
 msgid "Error while marking article as unread: %s"
 msgstr "Het als ongelezen markeren van het artikel ‘%s’ is mislukt"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Ga naar URL #"
 
@@ -1239,6 +1239,364 @@ msgstr "Artikel - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Fout: ongeldige reguliere expressie!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Open feed/artikel"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr "Wissel tussen widgets"
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Naar vorige dialoogvenster terugkeren/afsluiten"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Programma afsluiten zonder bevestiging"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Geselecteerde feed vernieuwen"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Alle feeds vernieuwen"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Feed als gelezen markeren"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Alle feeds als gelezen markeren"
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr "Markeer alle voorgaande feeds als gelezen"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Artikel opslaan"
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr "Artikelen opslaan"
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr "Ga naar volgende item"
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr "Ga naar vorige item"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Ga naar volgend ongelezen artikel"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Ga naar vorig ongelezen artikel"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Ga naar willekeurig ongelezen artikel"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Open URL van artikel in browser en markeer als gelezen."
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr "Open alle ongelezen artikelen van de huidige feed in de browser"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr "Open alle ongelezen artikelen in de browser en markeer als gelezen"
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Open URL van artikel, feed, of item in het URL overzicht"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Open URL van artikel, feed, of item in het URL overzicht"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Open het hulpvenster"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Broncodeweergave omschakelen"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Gelezen status voor artikel omschakelen"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Wissel tussen tonen/niet tonen van gelezen feeds/artikelen"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "URLs in huidige artikelen tonen"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Huidige tag wissen"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Tag selecteren"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Zoekvenster openen"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr "Ga naar item met titel"
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Download toevoegen aan wachtrij"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Lijst van URLs opnieuw uit de configuratie lezen"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Bestand downloaden"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Download annuleren"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Download als verwijderd markeren"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Afgeronde en verwijderde downloads uit de wachtrij verwijderen"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Automatisch downloaden omschakelen"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Speler starten met huidig geselecteerde download"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Bestand als afgerond markeren (niet afgespeeld)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Aantal gelijktijdige downloads verhogen"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Aantal gelijktijdige downloads verminderen"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Scherm verversen"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Opdrachtregel openen"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Filter instellen"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Voorgedefinieerde filter selecteren"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Huidig geselecteerde filter wissen"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Bladwijzer op huidig(e) koppeling/artikel zetten"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Wijzig vlaggen"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Ga naar volgende feed"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Ga naar vorige feed"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Ga naar volgende ongelezen feed"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Ga naar vorige ongelezen feed"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Macro uitvoeren"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Artikel verwijderen"
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr "Alle artikelen verwijderen"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Verwijderde artikelen definitief opruimen"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Geabonneerde URLs wijzigen"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Huidig geselecteerd dialoogvenster sluiten"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Toon lijst van open dialoogvensters"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Ga naar volgend dialoogvenster"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Ga naar vorig dialoogvenster"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Artikel naar commando doorsturen"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Huidige lijst sorteren"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Huidige lijst omgekeerd sorteren"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Open URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Open URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Open URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Open URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Open URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Open URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Open URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Open URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Open URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Open URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr "Open opdrachtregel met 1"
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr "Open opdrachtregel met 2"
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr "Open opdrachtregel met 3"
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr "Open opdrachtregel met 4"
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr "Open opdrachtregel met 5"
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr "Open opdrachtregel met 6"
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr "Open opdrachtregel met 7"
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr "Open opdrachtregel met 8"
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr "Open opdrachtregel met 9"
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Ga naar vorig ongelezen element"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Ga naar volgend ongelezen element"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Ga naar vorige pagina"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Ga naar volgende pagina"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Ga naar begin van pagina/lijst"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Ga naar einde van pagina/lijst"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1623,270 +1981,6 @@ msgstr "regexec gaf error code %i terug"
 
 #~ msgid "Starting browser..."
 #~ msgstr "Bezig met starten van browser..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Open feed/artikel"
-
-#~ msgid "Switch focus between widgets"
-#~ msgstr "Wissel tussen widgets"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Naar vorige dialoogvenster terugkeren/afsluiten"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Programma afsluiten zonder bevestiging"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Geselecteerde feed vernieuwen"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Alle feeds vernieuwen"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Feed als gelezen markeren"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Alle feeds als gelezen markeren"
-
-#~ msgid "Mark all above as read"
-#~ msgstr "Markeer alle voorgaande feeds als gelezen"
-
-#~ msgid "Save article"
-#~ msgstr "Artikel opslaan"
-
-#~ msgid "Save articles"
-#~ msgstr "Artikelen opslaan"
-
-#~ msgid "Go to next entry"
-#~ msgstr "Ga naar volgende item"
-
-#~ msgid "Go to previous entry"
-#~ msgstr "Ga naar vorige item"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Ga naar volgend ongelezen artikel"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Ga naar vorig ongelezen artikel"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Ga naar willekeurig ongelezen artikel"
-
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Open URL van artikel in browser en markeer als gelezen."
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr "Open alle ongelezen artikelen van de huidige feed in de browser"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr "Open alle ongelezen artikelen in de browser en markeer als gelezen"
-
-#~ msgid "Open URL of article, feed, or entry in URL view"
-#~ msgstr "Open URL van artikel, feed, of item in het URL overzicht"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Open het hulpvenster"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Broncodeweergave omschakelen"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Gelezen status voor artikel omschakelen"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Wissel tussen tonen/niet tonen van gelezen feeds/artikelen"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "URLs in huidige artikelen tonen"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Huidige tag wissen"
-
-#~ msgid "Select tag"
-#~ msgstr "Tag selecteren"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Zoekvenster openen"
-
-#~ msgid "Goto item with title"
-#~ msgstr "Ga naar item met titel"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Download toevoegen aan wachtrij"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Lijst van URLs opnieuw uit de configuratie lezen"
-
-#~ msgid "Download file"
-#~ msgstr "Bestand downloaden"
-
-#~ msgid "Cancel download"
-#~ msgstr "Download annuleren"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Download als verwijderd markeren"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Afgeronde en verwijderde downloads uit de wachtrij verwijderen"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Automatisch downloaden omschakelen"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Speler starten met huidig geselecteerde download"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Bestand als afgerond markeren (niet afgespeeld)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Aantal gelijktijdige downloads verhogen"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Aantal gelijktijdige downloads verminderen"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Scherm verversen"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Opdrachtregel openen"
-
-#~ msgid "Set a filter"
-#~ msgstr "Filter instellen"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Voorgedefinieerde filter selecteren"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Huidig geselecteerde filter wissen"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Bladwijzer op huidig(e) koppeling/artikel zetten"
-
-#~ msgid "Edit flags"
-#~ msgstr "Wijzig vlaggen"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Ga naar volgende feed"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Ga naar vorige feed"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Ga naar volgende ongelezen feed"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Ga naar vorige ongelezen feed"
-
-#~ msgid "Call a macro"
-#~ msgstr "Macro uitvoeren"
-
-#~ msgid "Delete article"
-#~ msgstr "Artikel verwijderen"
-
-#~ msgid "Delete all articles"
-#~ msgstr "Alle artikelen verwijderen"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Verwijderde artikelen definitief opruimen"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Geabonneerde URLs wijzigen"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Huidig geselecteerd dialoogvenster sluiten"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Toon lijst van open dialoogvensters"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Ga naar volgend dialoogvenster"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Ga naar vorig dialoogvenster"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Artikel naar commando doorsturen"
-
-#~ msgid "Sort current list"
-#~ msgstr "Huidige lijst sorteren"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Huidige lijst omgekeerd sorteren"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Open URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Open URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Open URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Open URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Open URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Open URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Open URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Open URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Open URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Open URL 10"
-
-#~ msgid "Start cmdline with 1"
-#~ msgstr "Open opdrachtregel met 1"
-
-#~ msgid "Start cmdline with 2"
-#~ msgstr "Open opdrachtregel met 2"
-
-#~ msgid "Start cmdline with 3"
-#~ msgstr "Open opdrachtregel met 3"
-
-#~ msgid "Start cmdline with 4"
-#~ msgstr "Open opdrachtregel met 4"
-
-#~ msgid "Start cmdline with 5"
-#~ msgstr "Open opdrachtregel met 5"
-
-#~ msgid "Start cmdline with 6"
-#~ msgstr "Open opdrachtregel met 6"
-
-#~ msgid "Start cmdline with 7"
-#~ msgstr "Open opdrachtregel met 7"
-
-#~ msgid "Start cmdline with 8"
-#~ msgstr "Open opdrachtregel met 8"
-
-#~ msgid "Start cmdline with 9"
-#~ msgstr "Open opdrachtregel met 9"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Ga naar vorig ongelezen element"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Ga naar volgend ongelezen element"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Ga naar vorige pagina"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Ga naar volgende pagina"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Ga naar begin van pagina/lijst"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Ga naar einde van pagina/lijst"
 
 #~ msgid ""
 #~ "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:"

--- a/po/pl.po
+++ b/po/pl.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.5\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2020-12-11 19:36+0100\n"
 "Last-Translator: Michal Siemek <carnophage@dobramama.pl>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -1218,7 +1218,7 @@ msgstr "Błąd: nie można zapisać artykułu do pliku %s"
 msgid "Error while marking article as unread: %s"
 msgstr "Błąd podczas oznaczania artykułu jako nieprzeczytanego: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Idź do adresu URL #"
 
@@ -1238,6 +1238,368 @@ msgstr "Artykuł - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Błąd: nieprawidłowe wyrażenie regularne!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Otwórz kanał/artykuł"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr "Przełącz między aktywnymi widżetami"
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Powrót do poprzedniego okna/Wyjście"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Wyjście z programu, bez potwierdzenia"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Odśwież aktualnie wybrany kanał"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Odśwież wszystkie kanały"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Oznacz kanał jako przeczytany"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Oznacz wszystkie kanały jako przeczytane"
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr "Oznacz powyższe jako przeczytane"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Zapisz artykuł"
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr "Zapisz artykuły"
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr "Przejdź do następnego wpisu"
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr "Przejdź do poprzedniego wpisu"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Przejdź do następnego nieprzeczytanego artykułu"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Przejdź do poprzedniego nieprzeczytanego artykułu"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Przejdź do losowo wybranego artykułu"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr ""
+"Otwórz odnośnik artykułu, lub wpis w widoku odnośników. Oznacz jako "
+"przeczytany."
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr ""
+"Otwórz wszystkie nieprzeczytane pozycje wybranego kanału w przyglądarce"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+"Otwórz nieprzeczytane artykuły w przeglądarce i oznacz jako przeczytane"
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Otwórz odnośnik artykułu, lub wpis w widoku odnośników"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Otwórz odnośnik artykułu, lub wpis w widoku odnośników"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Otwórz okno pomocy"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Przełącz widok źródła"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Przełącz status przeczytania artykułu"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Przełącz pokazywanie przeczytanych kanałów/artykułów"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Pokaż odnośniki w aktualnym artykule"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Wyczyść aktualny tag"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Wybierz tag"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Otwórz dialog wyszukiwania"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr "Idź do elementu o tytule"
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Dodaj pobieranie do kolejki"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Odśwież listę adresów kanałów z pliku konfiguracyjnego"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Pobierz plik"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Anuluj pobieranie"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Oznacz pobieranie jako usunięte"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Wyczyść zakończone i usunięte pobierania z kolejki"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Przełącz automatyczne pobieranie"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Uruchom odtwarzacz z wybranym pobieraniem"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Oznacz plik jako zakończony (nieodtwarzany)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Zwiększ ilość równoczesnych pobrań"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Zmniejsz ilość równoczesnych pobrań"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Odśwież ekran"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Otwórz linię poleceń"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Ustaw filtr"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Wybierz przygotowany filtr"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Wyzeruj aktualny filtr"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Dodaj aktualny odsyłacz/artykuł do zakładek"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Edytuj znaczniki"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Idź do następnego kanału"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Idź do poprzedniego kanału"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Idź do następnego nieprzeczytanego kanału"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Idź do poprzedniego nieprzeczytanego kanału"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Wywołaj makro"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Usuń artykuł"
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr "Usuń wszystkie artykuły"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Wyczyść usunięte artykuły"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Edytuj subskrybowane adresy URL"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Zamknij wybrane okno dialogowe"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Pokaż listę otwartych okien dialogowych"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Przejdź do następnego okna dialogowego"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Powrót do poprzedniego okna dialogowego"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Przekaż artykuł do polecenia"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Posortuj obecną listę"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Posortuj obecną listę (odwrotnie)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Otwórz URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Otwórz URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Otwórz URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Otwórz URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Otwórz URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Otwórz URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Otwórz URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Otwórz URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Otwórz URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Otwórz URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr "Uruchom wiersz poleceń z 1"
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr "Uruchom wiersz poleceń z 2"
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr "Uruchom wiersz poleceń z 3"
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr "Uruchom wiersz poleceń z 4"
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr "Uruchom wiersz poleceń z 5"
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr "Uruchom wiersz poleceń z 6"
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr "Uruchom wiersz poleceń z 7"
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr "Uruchom wiersz poleceń z 8"
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr "Uruchom wiersz poleceń z 9"
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Idź do poprzedniego wpisu"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Przejdź do następnego wpisu"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Powrót do poprzedniej strony"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Przejdź do następnej strony"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Przejdź do początku strony/listy"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Przejdź do końca strony/listy"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1621,274 +1983,6 @@ msgstr "regexc zwrócił kod błędu %s"
 
 #~ msgid "Starting browser..."
 #~ msgstr "Uruchamiam przeglądarkę..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Otwórz kanał/artykuł"
-
-#~ msgid "Switch focus between widgets"
-#~ msgstr "Przełącz między aktywnymi widżetami"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Powrót do poprzedniego okna/Wyjście"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Wyjście z programu, bez potwierdzenia"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Odśwież aktualnie wybrany kanał"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Odśwież wszystkie kanały"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Oznacz kanał jako przeczytany"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Oznacz wszystkie kanały jako przeczytane"
-
-#~ msgid "Mark all above as read"
-#~ msgstr "Oznacz powyższe jako przeczytane"
-
-#~ msgid "Save article"
-#~ msgstr "Zapisz artykuł"
-
-#~ msgid "Save articles"
-#~ msgstr "Zapisz artykuły"
-
-#~ msgid "Go to next entry"
-#~ msgstr "Przejdź do następnego wpisu"
-
-#~ msgid "Go to previous entry"
-#~ msgstr "Przejdź do poprzedniego wpisu"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Przejdź do następnego nieprzeczytanego artykułu"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Przejdź do poprzedniego nieprzeczytanego artykułu"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Przejdź do losowo wybranego artykułu"
-
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr ""
-#~ "Otwórz odnośnik artykułu, lub wpis w widoku odnośników. Oznacz jako "
-#~ "przeczytany."
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr ""
-#~ "Otwórz wszystkie nieprzeczytane pozycje wybranego kanału w przyglądarce"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr ""
-#~ "Otwórz nieprzeczytane artykuły w przeglądarce i oznacz jako przeczytane"
-
-#~ msgid "Open URL of article, feed, or entry in URL view"
-#~ msgstr "Otwórz odnośnik artykułu, lub wpis w widoku odnośników"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Otwórz okno pomocy"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Przełącz widok źródła"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Przełącz status przeczytania artykułu"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Przełącz pokazywanie przeczytanych kanałów/artykułów"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Pokaż odnośniki w aktualnym artykule"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Wyczyść aktualny tag"
-
-#~ msgid "Select tag"
-#~ msgstr "Wybierz tag"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Otwórz dialog wyszukiwania"
-
-#~ msgid "Goto item with title"
-#~ msgstr "Idź do elementu o tytule"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Dodaj pobieranie do kolejki"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Odśwież listę adresów kanałów z pliku konfiguracyjnego"
-
-#~ msgid "Download file"
-#~ msgstr "Pobierz plik"
-
-#~ msgid "Cancel download"
-#~ msgstr "Anuluj pobieranie"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Oznacz pobieranie jako usunięte"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Wyczyść zakończone i usunięte pobierania z kolejki"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Przełącz automatyczne pobieranie"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Uruchom odtwarzacz z wybranym pobieraniem"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Oznacz plik jako zakończony (nieodtwarzany)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Zwiększ ilość równoczesnych pobrań"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Zmniejsz ilość równoczesnych pobrań"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Odśwież ekran"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Otwórz linię poleceń"
-
-#~ msgid "Set a filter"
-#~ msgstr "Ustaw filtr"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Wybierz przygotowany filtr"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Wyzeruj aktualny filtr"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Dodaj aktualny odsyłacz/artykuł do zakładek"
-
-#~ msgid "Edit flags"
-#~ msgstr "Edytuj znaczniki"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Idź do następnego kanału"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Idź do poprzedniego kanału"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Idź do następnego nieprzeczytanego kanału"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Idź do poprzedniego nieprzeczytanego kanału"
-
-#~ msgid "Call a macro"
-#~ msgstr "Wywołaj makro"
-
-#~ msgid "Delete article"
-#~ msgstr "Usuń artykuł"
-
-#~ msgid "Delete all articles"
-#~ msgstr "Usuń wszystkie artykuły"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Wyczyść usunięte artykuły"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Edytuj subskrybowane adresy URL"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Zamknij wybrane okno dialogowe"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Pokaż listę otwartych okien dialogowych"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Przejdź do następnego okna dialogowego"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Powrót do poprzedniego okna dialogowego"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Przekaż artykuł do polecenia"
-
-#~ msgid "Sort current list"
-#~ msgstr "Posortuj obecną listę"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Posortuj obecną listę (odwrotnie)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Otwórz URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Otwórz URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Otwórz URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Otwórz URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Otwórz URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Otwórz URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Otwórz URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Otwórz URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Otwórz URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Otwórz URL 10"
-
-#~ msgid "Start cmdline with 1"
-#~ msgstr "Uruchom wiersz poleceń z 1"
-
-#~ msgid "Start cmdline with 2"
-#~ msgstr "Uruchom wiersz poleceń z 2"
-
-#~ msgid "Start cmdline with 3"
-#~ msgstr "Uruchom wiersz poleceń z 3"
-
-#~ msgid "Start cmdline with 4"
-#~ msgstr "Uruchom wiersz poleceń z 4"
-
-#~ msgid "Start cmdline with 5"
-#~ msgstr "Uruchom wiersz poleceń z 5"
-
-#~ msgid "Start cmdline with 6"
-#~ msgstr "Uruchom wiersz poleceń z 6"
-
-#~ msgid "Start cmdline with 7"
-#~ msgstr "Uruchom wiersz poleceń z 7"
-
-#~ msgid "Start cmdline with 8"
-#~ msgstr "Uruchom wiersz poleceń z 8"
-
-#~ msgid "Start cmdline with 9"
-#~ msgstr "Uruchom wiersz poleceń z 9"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Idź do poprzedniego wpisu"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Przejdź do następnego wpisu"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Powrót do poprzedniej strony"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Przejdź do następnej strony"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Przejdź do początku strony/listy"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Przejdź do końca strony/listy"
 
 #~ msgid ""
 #~ "Overwrite `%s' in `%s'? There are no more conflicts like this (y:Yes a:"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.8\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2018-03-06 20:35-0300\n"
 "Last-Translator: Alexandre Erwin Ittner <alexandre@ittner.com.br>\n"
 "Language-Team: \n"
@@ -1224,7 +1224,7 @@ msgstr "Erro: não foi possível gravar o artigo no arquivo %s"
 msgid "Error while marking article as unread: %s"
 msgstr "Erro marcando artigo como não lido: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Ir para a URL #"
 
@@ -1244,6 +1244,372 @@ msgstr "Artigo - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Erro: expressão regular inválida!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Abrir fonte/artigo"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Retornar à tela anterior/Sair"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Fechar o programa, sem confirmação"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Atualizar a fonte selecionada"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Atualizar todas fontes"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Marcar fonte como lida"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Marcar todas fontes como lidas"
+
+#: src/keymap.cpp:82
+#, fuzzy
+msgid "Mark all above as read"
+msgstr "Marcar todas fontes como lidas"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Salvar artigo"
+
+#: src/keymap.cpp:86
+#, fuzzy
+msgid "Save articles"
+msgstr "Salvar artigo"
+
+#: src/keymap.cpp:91
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Ir para o próximo item"
+
+#: src/keymap.cpp:98
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Ir para o item anterior "
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Ir para o próximo artigo não lido"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Ir para o artigo não lido anterior"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Pular para um artigo não lido aleatório"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Abrir artigo no navegador e marca-o como lido"
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr "Abrir todos os itens não lidos da fonte selecionada no navegador"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+"Abrir todos os itens não lidos da fonte selecionada no navegador e marcar "
+"como lidos"
+
+#: src/keymap.cpp:148
+#, fuzzy
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Abrir artigo no navegador e marca-o como lido"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Abrir artigo no navegador e marca-o como lido"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Abrir a tela de ajuda"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Alternar a visualização do código-fonte"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Alternar o estado lido/não lido do artigo"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Alternar a visualização de fontes RSS/artigos não lidos"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Mostrar URLs no artigo atual"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Limpar etiqueta atual"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Selecionar etiqueta"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Abrir tela de procura"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Adicionar à fila para ser baixado"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Atualizar a lista de URLs a partir da configuração"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Baixar arquivo"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Cancelar a transferência"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Marcar transferência como excluída"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Eliminar transferências concluídas ou excluídas da fila"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Ativar/desativar transferência automática"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Iniciar tocador com a transferência selecionada"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Marcar o arquivo como concluído (não tocado)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Aumentar número de transferências simultâneas"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Diminuir o número de transferências simultâneas"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Redesenhar tela"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Abrir a linha de comando"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Definir um filtro"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Selecionar um filtro pré-definido"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Limpar o filtro atual"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Adicionar marcador ao link ou artigo atual"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Editar sinalizações"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Ir para a próxima fonte"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Ir para a fonte anterior"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Ir para a próxima fonte não lida"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Ir para a fonte não lida anterior"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Chamar uma macro"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Excluir artigo"
+
+#: src/keymap.cpp:335
+#, fuzzy
+msgid "Delete all articles"
+msgstr "Excluir artigo"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Eliminar artigos excluídos"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Editar lista de URLs assinadas"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Fechar a tela atualmente selecionada"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Ver lista de telas abertos"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Ir para a próxima tela"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Retornar à tela anterior"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Passar artigo por pipe a um comando"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Ordenar a lista atual"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Ordenar a lista atual (inversamente)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Abrir URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Abrir URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Abrir URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Abrir URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Abrir URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Abrir URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Abrir URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Abrir URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Abrir URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Abrir URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Ir para o item anterior "
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Ir para o próximo item"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Ir para a página anterior"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Ir para a próxima página"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Ir para o início da página/lista"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Ir para o fim da página/lista"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1622,242 +1988,6 @@ msgstr ""
 
 #~ msgid "Starting browser..."
 #~ msgstr "Iniciando navegador..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Abrir fonte/artigo"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Retornar à tela anterior/Sair"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Fechar o programa, sem confirmação"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Atualizar a fonte selecionada"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Atualizar todas fontes"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Marcar fonte como lida"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Marcar todas fontes como lidas"
-
-#, fuzzy
-#~ msgid "Mark all above as read"
-#~ msgstr "Marcar todas fontes como lidas"
-
-#~ msgid "Save article"
-#~ msgstr "Salvar artigo"
-
-#, fuzzy
-#~ msgid "Save articles"
-#~ msgstr "Salvar artigo"
-
-#, fuzzy
-#~ msgid "Go to next entry"
-#~ msgstr "Ir para o próximo item"
-
-#, fuzzy
-#~ msgid "Go to previous entry"
-#~ msgstr "Ir para o item anterior "
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Ir para o próximo artigo não lido"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Ir para o artigo não lido anterior"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Pular para um artigo não lido aleatório"
-
-#, fuzzy
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Abrir artigo no navegador e marca-o como lido"
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr "Abrir todos os itens não lidos da fonte selecionada no navegador"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr ""
-#~ "Abrir todos os itens não lidos da fonte selecionada no navegador e marcar "
-#~ "como lidos"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Abrir a tela de ajuda"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Alternar a visualização do código-fonte"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Alternar o estado lido/não lido do artigo"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Alternar a visualização de fontes RSS/artigos não lidos"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Mostrar URLs no artigo atual"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Limpar etiqueta atual"
-
-#~ msgid "Select tag"
-#~ msgstr "Selecionar etiqueta"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Abrir tela de procura"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Adicionar à fila para ser baixado"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Atualizar a lista de URLs a partir da configuração"
-
-#~ msgid "Download file"
-#~ msgstr "Baixar arquivo"
-
-#~ msgid "Cancel download"
-#~ msgstr "Cancelar a transferência"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Marcar transferência como excluída"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Eliminar transferências concluídas ou excluídas da fila"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Ativar/desativar transferência automática"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Iniciar tocador com a transferência selecionada"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Marcar o arquivo como concluído (não tocado)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Aumentar número de transferências simultâneas"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Diminuir o número de transferências simultâneas"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Redesenhar tela"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Abrir a linha de comando"
-
-#~ msgid "Set a filter"
-#~ msgstr "Definir um filtro"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Selecionar um filtro pré-definido"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Limpar o filtro atual"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Adicionar marcador ao link ou artigo atual"
-
-#~ msgid "Edit flags"
-#~ msgstr "Editar sinalizações"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Ir para a próxima fonte"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Ir para a fonte anterior"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Ir para a próxima fonte não lida"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Ir para a fonte não lida anterior"
-
-#~ msgid "Call a macro"
-#~ msgstr "Chamar uma macro"
-
-#~ msgid "Delete article"
-#~ msgstr "Excluir artigo"
-
-#, fuzzy
-#~ msgid "Delete all articles"
-#~ msgstr "Excluir artigo"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Eliminar artigos excluídos"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Editar lista de URLs assinadas"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Fechar a tela atualmente selecionada"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Ver lista de telas abertos"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Ir para a próxima tela"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Retornar à tela anterior"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Passar artigo por pipe a um comando"
-
-#~ msgid "Sort current list"
-#~ msgstr "Ordenar a lista atual"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Ordenar a lista atual (inversamente)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Abrir URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Abrir URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Abrir URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Abrir URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Abrir URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Abrir URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Abrir URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Abrir URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Abrir URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Abrir URL 10"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Ir para o item anterior "
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Ir para o próximo item"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Ir para a página anterior"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Ir para a próxima página"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Ir para o início da página/lista"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Ir para o fim da página/lista"
 
 #~ msgid "Open article in browser"
 #~ msgstr "Abrir artigo no navegador"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2020-12-07 10:35+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Konstantin Shakhnov <kastian@mail.ru>, Alexander Batischev "
@@ -1218,7 +1218,7 @@ msgstr "Ошибка: невозможно записать заметку в ф
 msgid "Error while marking article as unread: %s"
 msgstr "Ошибка во время пометки заметки как непрочитанной: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Открыть ссылку №"
 
@@ -1238,6 +1238,367 @@ msgstr "Заметка - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Ошибка: неправильное регулярное выражение!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Открыть ленту/заметку"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr "Переключить фокус между виджетами"
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Вернуться в предыдущий диалог/Выйти"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Закрыть программу без подтверждения"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Обновить выбранную ленту"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Обновить все ленты"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Отметить ленту как прочитанную"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Отметить все ленты как прочитанные"
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr "Отметить все, что выше, как прочитанные"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Сохранить заметку"
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr "Сохранить заметки"
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr "Перейти к следующей заметке"
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr "Перейти к предыдущей заметке"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Перейти к следующей непрочитанной заметке"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Перейти к предыдущей непрочитанной заметке"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Перейти к случайной непрочитанной заметке"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr ""
+"Открыть URL статьи, ленты, или записи в диалоге URL. Отметить прочтённым."
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr "Открыть все непрочитанные статьи из выбранной ленты в браузере"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+"Открыть все непрочитанные статьи из выбранной ленты в браузере и пометить "
+"прочитанными"
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Открыть URL статьи, ленты, или записи в диалоге URL"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Открыть URL статьи, ленты, или записи в диалоге URL"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Открыть диалог помощи"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Переключиться на просмотр исходных данных"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Переключить статус прочтения заметки"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Включить показ прочитанных лент"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Показывать ссылки в текущей заметке"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Очистить текущую метку"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Выбрать метку"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Открыть диалог поиска"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr "Открыть запись с названием"
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Добавить загрузку в очередь"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Обновить список ссылок из файла настроек"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Загрузить файл"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Отменить загрузку"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Отметить загрузку как удаленную"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Очистить очередь от законченных и удалённых загрузок"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Переключить автоматическую загрузку вкл/выкл"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Запустить проигрыватель с текущей выбранной закачкой"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Отметить файл как завершённый (не проигрывался)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Увеличить количество одновременных загрузок"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Уменьшить количество одновременных загрузок"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Обновить экран"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Открыть командную строку"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Установить фильтр"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Выбрать предопределённый фильтр"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Очистить текущий фильтр"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Занести в закладки текущую ссылку/заметку"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Редактировать флаги"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Перейти к следующей ленте"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Перейти к предыдущей ленте"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Перейти к следующей непрочитанной ленте"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Перейти к предыдущей непрочитанной ленте"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Вызвать макрос"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Удалить заметку"
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr "Удалить все заметки"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Очистить от удаленных заметок"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Изменить подписанные ссылки"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Закрыть текущий диалог"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Просмотреть список открытых окон"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Перейти к следующему диалогу"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Вернуться в предыдущий диалог"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Обработать заметку командой"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Отсортировать текущий список"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Отсортировать список в обратном порядке"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Открыть ссылку 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Открыть ссылку 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Открыть ссылку 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Открыть ссылку 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Открыть ссылку 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Открыть ссылку 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Открыть ссылку 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Открыть ссылку 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Открыть ссылку 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Открыть ссылку 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr "Начать командную строку с единицы"
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr "Начать командную строку с двойки"
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr "Начать командную строку с тройки"
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr "Начать командную строку с четвёрки"
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr "Начать командную строку с пятёрки"
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr "Начать командную строку с шестёрки"
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr "Начать командную строку с семёрки"
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr "Начать командную строку с восьмёрки"
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr "Начать командную строку с девятки"
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Перейти к предыдущей заметке"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Перейти к следующей заметке"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Вернуться на предыдущую страницу"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Перейти к следующей странице"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Перейти к началу страницы/списка"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Перейти к концу страницы/списка"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1617,270 +1978,3 @@ msgstr "regexec вернула код %i"
 
 #~ msgid "Starting browser..."
 #~ msgstr "Запускаю браузер..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Открыть ленту/заметку"
-
-#~ msgid "Switch focus between widgets"
-#~ msgstr "Переключить фокус между виджетами"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Вернуться в предыдущий диалог/Выйти"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Закрыть программу без подтверждения"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Обновить выбранную ленту"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Обновить все ленты"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Отметить ленту как прочитанную"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Отметить все ленты как прочитанные"
-
-#~ msgid "Mark all above as read"
-#~ msgstr "Отметить все, что выше, как прочитанные"
-
-#~ msgid "Save article"
-#~ msgstr "Сохранить заметку"
-
-#~ msgid "Save articles"
-#~ msgstr "Сохранить заметки"
-
-#~ msgid "Go to next entry"
-#~ msgstr "Перейти к следующей заметке"
-
-#~ msgid "Go to previous entry"
-#~ msgstr "Перейти к предыдущей заметке"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Перейти к следующей непрочитанной заметке"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Перейти к предыдущей непрочитанной заметке"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Перейти к случайной непрочитанной заметке"
-
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr ""
-#~ "Открыть URL статьи, ленты, или записи в диалоге URL. Отметить прочтённым."
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr "Открыть все непрочитанные статьи из выбранной ленты в браузере"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr ""
-#~ "Открыть все непрочитанные статьи из выбранной ленты в браузере и пометить "
-#~ "прочитанными"
-
-#~ msgid "Open URL of article, feed, or entry in URL view"
-#~ msgstr "Открыть URL статьи, ленты, или записи в диалоге URL"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Открыть диалог помощи"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Переключиться на просмотр исходных данных"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Переключить статус прочтения заметки"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Включить показ прочитанных лент"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Показывать ссылки в текущей заметке"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Очистить текущую метку"
-
-#~ msgid "Select tag"
-#~ msgstr "Выбрать метку"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Открыть диалог поиска"
-
-#~ msgid "Goto item with title"
-#~ msgstr "Открыть запись с названием"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Добавить загрузку в очередь"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Обновить список ссылок из файла настроек"
-
-#~ msgid "Download file"
-#~ msgstr "Загрузить файл"
-
-#~ msgid "Cancel download"
-#~ msgstr "Отменить загрузку"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Отметить загрузку как удаленную"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Очистить очередь от законченных и удалённых загрузок"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Переключить автоматическую загрузку вкл/выкл"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Запустить проигрыватель с текущей выбранной закачкой"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Отметить файл как завершённый (не проигрывался)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Увеличить количество одновременных загрузок"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Уменьшить количество одновременных загрузок"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Обновить экран"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Открыть командную строку"
-
-#~ msgid "Set a filter"
-#~ msgstr "Установить фильтр"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Выбрать предопределённый фильтр"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Очистить текущий фильтр"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Занести в закладки текущую ссылку/заметку"
-
-#~ msgid "Edit flags"
-#~ msgstr "Редактировать флаги"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Перейти к следующей ленте"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Перейти к предыдущей ленте"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Перейти к следующей непрочитанной ленте"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Перейти к предыдущей непрочитанной ленте"
-
-#~ msgid "Call a macro"
-#~ msgstr "Вызвать макрос"
-
-#~ msgid "Delete article"
-#~ msgstr "Удалить заметку"
-
-#~ msgid "Delete all articles"
-#~ msgstr "Удалить все заметки"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Очистить от удаленных заметок"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Изменить подписанные ссылки"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Закрыть текущий диалог"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Просмотреть список открытых окон"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Перейти к следующему диалогу"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Вернуться в предыдущий диалог"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Обработать заметку командой"
-
-#~ msgid "Sort current list"
-#~ msgstr "Отсортировать текущий список"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Отсортировать список в обратном порядке"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Открыть ссылку 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Открыть ссылку 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Открыть ссылку 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Открыть ссылку 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Открыть ссылку 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Открыть ссылку 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Открыть ссылку 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Открыть ссылку 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Открыть ссылку 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Открыть ссылку 10"
-
-#~ msgid "Start cmdline with 1"
-#~ msgstr "Начать командную строку с единицы"
-
-#~ msgid "Start cmdline with 2"
-#~ msgstr "Начать командную строку с двойки"
-
-#~ msgid "Start cmdline with 3"
-#~ msgstr "Начать командную строку с тройки"
-
-#~ msgid "Start cmdline with 4"
-#~ msgstr "Начать командную строку с четвёрки"
-
-#~ msgid "Start cmdline with 5"
-#~ msgstr "Начать командную строку с пятёрки"
-
-#~ msgid "Start cmdline with 6"
-#~ msgstr "Начать командную строку с шестёрки"
-
-#~ msgid "Start cmdline with 7"
-#~ msgstr "Начать командную строку с семёрки"
-
-#~ msgid "Start cmdline with 8"
-#~ msgstr "Начать командную строку с восьмёрки"
-
-#~ msgid "Start cmdline with 9"
-#~ msgstr "Начать командную строку с девятки"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Перейти к предыдущей заметке"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Перейти к следующей заметке"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Вернуться на предыдущую страницу"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Перейти к следующей странице"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Перейти к началу страницы/списка"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Перейти к концу страницы/списка"

--- a/po/sk.po
+++ b/po/sk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.10.1\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2017-12-25 00:38+0100\n"
 "Last-Translator: František Hájik <ferko.hajik@gmail.com>\n"
 "Language-Team: \n"
@@ -1212,7 +1212,7 @@ msgstr "Chyba: nemožno zapísať článok do súboru %s"
 msgid "Error while marking article as unread: %s"
 msgstr "Chyba pri označovaní článku ako neprečítaného: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Choď na URL #"
 
@@ -1232,6 +1232,374 @@ msgstr "Článok - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Chyba: neplatný regulárny výraz!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Otvoriť informačný kanál/článok"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Návrat do predchádzajúceho dialógového okna/Ukončiť"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Ukončiť program, bez potvrdenia"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Aktualizovať aktuálne vybraný informačný kanál (zdroj)"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Znovu načítať všetky informačné kanály"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Označ informačný kanál ako prečítaný"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Označ všetky informačné kanály ako prečítané"
+
+#: src/keymap.cpp:82
+#, fuzzy
+msgid "Mark all above as read"
+msgstr "Označ všetky informačné kanály ako prečítané"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Uložiť článok"
+
+#: src/keymap.cpp:86
+#, fuzzy
+msgid "Save articles"
+msgstr "Uložiť článok"
+
+#: src/keymap.cpp:91
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Prejsť na ďalšiu položku"
+
+#: src/keymap.cpp:98
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Prejsť na predchádzajúcu položku"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Choď na nasledujúci neprečítaný článok"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Choď na predchádzajúci neprečítaný článok"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Choď na náhodný neprečítaný článok"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Otvoriť článok v prehliadači a označ ho ako prečítaný"
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr ""
+"Otvoriť všetky neprečítané položky vybratého informačného kanála v "
+"prehliadači"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+"Otvoriť všetky neprečítané položky vybratého informačného kanála v "
+"prehliadači a označ ako prečítané"
+
+#: src/keymap.cpp:148
+#, fuzzy
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Otvoriť článok v prehliadači a označ ho ako prečítaný"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Otvoriť článok v prehliadači a označ ho ako prečítaný"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Otvor dialóg pomocníka"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Prepnúť zobrazenie zdroja"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Prepnúť status čítania článku"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Prepnúť zobrazenie informačných kanálov/článkov"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Zobraziť adresy URL v aktuálnom článku"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Vymazať aktuálnu značku (tag)"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Vybrať značku (tag)"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Otvoriť dialógové okno vyhľadávania"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Pridať sťahovanie do fronty"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Znova načítať zoznam adries URL z konfigurácie"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Stiahnuť súbor"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Zrušiť sťahovanie"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Označiť stiahnuté ako odstránené"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Vyčistiť dokončené a odstrániť stiahnuté z fronty"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Prepnúť automatické preberanie zapnuté/vypnuté"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Spustiť prehrávač s aktuálne vybratým sťahovaním"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Označiť súbor ako dokončený (neprehraný)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Zvýšenie počtu paralelných sťahovaní"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Znížiť počet paralelných sťahovaní"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Prepísať obrazovku"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Otvoriť príkazový riadok (cli)"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Nastav fitler"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Vybrať preddefinovaný filter"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Vymazať aktuálne nastavený filter"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Záložka aktuálneho odkazu/článku"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Upraviť príznaky"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Prejsť na ďalší informačný kanál"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Prejsť na predchádzajúci informačný kanál"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Prejsť na ďalší neprečítaný informačný kanál"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Prejsť na predchádzajúci neprečítaný informačný kanál"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Vyvolať makro"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Zmazať článok"
+
+#: src/keymap.cpp:335
+#, fuzzy
+msgid "Delete all articles"
+msgstr "Zmazať článok"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Vyčistiť odstránené články"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Upraviť vybrané URL adresy"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Zatvoriť aktuálne vybratý dialóg"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Zobraziť zoznam otvorených dialógov"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Prejsť na ďalší dialóg"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Prejsť na predchádzajúci dialóg"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "\"Pipe\" článok do príkazu"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Zoradiť aktuálny zoznam"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Zoradiť aktuálny zoznam (spätne)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Otvor URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Otvor URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Otvor URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Otvor URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Otvor URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Otvor URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Otvor URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Otvor URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Otvor URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Otvor URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Prejsť na predchádzajúcu položku"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Prejsť na ďalšiu položku"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Prejsť na predchádzajúcu stránku"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Prejsť na ďalšiu stránku"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Prejsť na začiatok stránky / zoznamu"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Prejsť na koniec stránky/zoznamu"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1610,244 +1978,6 @@ msgstr ""
 
 #~ msgid "Starting browser..."
 #~ msgstr "Spustenie prehliadača..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Otvoriť informačný kanál/článok"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Návrat do predchádzajúceho dialógového okna/Ukončiť"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Ukončiť program, bez potvrdenia"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Aktualizovať aktuálne vybraný informačný kanál (zdroj)"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Znovu načítať všetky informačné kanály"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Označ informačný kanál ako prečítaný"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Označ všetky informačné kanály ako prečítané"
-
-#, fuzzy
-#~ msgid "Mark all above as read"
-#~ msgstr "Označ všetky informačné kanály ako prečítané"
-
-#~ msgid "Save article"
-#~ msgstr "Uložiť článok"
-
-#, fuzzy
-#~ msgid "Save articles"
-#~ msgstr "Uložiť článok"
-
-#, fuzzy
-#~ msgid "Go to next entry"
-#~ msgstr "Prejsť na ďalšiu položku"
-
-#, fuzzy
-#~ msgid "Go to previous entry"
-#~ msgstr "Prejsť na predchádzajúcu položku"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Choď na nasledujúci neprečítaný článok"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Choď na predchádzajúci neprečítaný článok"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Choď na náhodný neprečítaný článok"
-
-#, fuzzy
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Otvoriť článok v prehliadači a označ ho ako prečítaný"
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr ""
-#~ "Otvoriť všetky neprečítané položky vybratého informačného kanála v "
-#~ "prehliadači"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr ""
-#~ "Otvoriť všetky neprečítané položky vybratého informačného kanála v "
-#~ "prehliadači a označ ako prečítané"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Otvor dialóg pomocníka"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Prepnúť zobrazenie zdroja"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Prepnúť status čítania článku"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Prepnúť zobrazenie informačných kanálov/článkov"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Zobraziť adresy URL v aktuálnom článku"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Vymazať aktuálnu značku (tag)"
-
-#~ msgid "Select tag"
-#~ msgstr "Vybrať značku (tag)"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Otvoriť dialógové okno vyhľadávania"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Pridať sťahovanie do fronty"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Znova načítať zoznam adries URL z konfigurácie"
-
-#~ msgid "Download file"
-#~ msgstr "Stiahnuť súbor"
-
-#~ msgid "Cancel download"
-#~ msgstr "Zrušiť sťahovanie"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Označiť stiahnuté ako odstránené"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Vyčistiť dokončené a odstrániť stiahnuté z fronty"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Prepnúť automatické preberanie zapnuté/vypnuté"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Spustiť prehrávač s aktuálne vybratým sťahovaním"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Označiť súbor ako dokončený (neprehraný)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Zvýšenie počtu paralelných sťahovaní"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Znížiť počet paralelných sťahovaní"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Prepísať obrazovku"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Otvoriť príkazový riadok (cli)"
-
-#~ msgid "Set a filter"
-#~ msgstr "Nastav fitler"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Vybrať preddefinovaný filter"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Vymazať aktuálne nastavený filter"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Záložka aktuálneho odkazu/článku"
-
-#~ msgid "Edit flags"
-#~ msgstr "Upraviť príznaky"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Prejsť na ďalší informačný kanál"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Prejsť na predchádzajúci informačný kanál"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Prejsť na ďalší neprečítaný informačný kanál"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Prejsť na predchádzajúci neprečítaný informačný kanál"
-
-#~ msgid "Call a macro"
-#~ msgstr "Vyvolať makro"
-
-#~ msgid "Delete article"
-#~ msgstr "Zmazať článok"
-
-#, fuzzy
-#~ msgid "Delete all articles"
-#~ msgstr "Zmazať článok"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Vyčistiť odstránené články"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Upraviť vybrané URL adresy"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Zatvoriť aktuálne vybratý dialóg"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Zobraziť zoznam otvorených dialógov"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Prejsť na ďalší dialóg"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Prejsť na predchádzajúci dialóg"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "\"Pipe\" článok do príkazu"
-
-#~ msgid "Sort current list"
-#~ msgstr "Zoradiť aktuálny zoznam"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Zoradiť aktuálny zoznam (spätne)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Otvor URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Otvor URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Otvor URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Otvor URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Otvor URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Otvor URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Otvor URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Otvor URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Otvor URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Otvor URL 10"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Prejsť na predchádzajúcu položku"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Prejsť na ďalšiu položku"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Prejsť na predchádzajúcu stránku"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Prejsť na ďalšiu stránku"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Prejsť na začiatok stránky / zoznamu"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Prejsť na koniec stránky/zoznamu"
 
 #~ msgid "Open article in browser"
 #~ msgstr "Otvoriť článok v prehliadači"

--- a/po/sv.po
+++ b/po/sv.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat-2.12\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2018-08-08 10:17+0200\n"
 "Last-Translator: Dennis Öberg <contact@dennisoberg.se>\n"
 "Language-Team: Niklas Grahn <terra.unknown@yahoo.com>\n"
@@ -1217,7 +1217,7 @@ msgstr "Fel: kunde inte skriva artikel till fil %s"
 msgid "Error while marking article as unread: %s"
 msgstr "Fel vid markering av artikel som oläst: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Gå till URL #"
 
@@ -1237,6 +1237,371 @@ msgstr "Artikel - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Fel: ogiltigt reguljärt uttryck!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Öppna webbflöde/artikel"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Återvänd till föregående dialogruta/Avsluta"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Avsluta program utan att begära bekräftelse"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Läs om markerat webbflöde"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Läs om alla webbflöden"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Markera webbflöde som läst"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Markera alla webbflöden som lästa"
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr "Markera allt ovanför som läst"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Spara artikel"
+
+#: src/keymap.cpp:86
+#, fuzzy
+msgid "Save articles"
+msgstr "Spara artikel"
+
+#: src/keymap.cpp:91
+#, fuzzy
+msgid "Go to next entry"
+msgstr "Flytta till nästa post"
+
+#: src/keymap.cpp:98
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "Flytta till föregående post"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Gå till nästa olästa artikel"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Gå till föregående olästa artikel"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Gå till en slumpmässigt vald oläst artikel"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Öppna artikel i webbläsare och markera som läst"
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr "Öppna alla olästa artiklar i markerat webbflöde i webbläsare"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+"Öppna alla olästa artiklar i markerat webbflöde i webbläsare och markera som "
+"lästa"
+
+#: src/keymap.cpp:148
+#, fuzzy
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Öppna artikel i webbläsare och markera som läst"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Öppna artikel i webbläsare och markera som läst"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Öppna hjälpdialogruta"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Växla källvy"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Växla lässtatus för artikel"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Växla visa lästa webbflöden/artiklar"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Visa URL:er i nuvarande artikel"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Töm nuvarande tagg"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Välj tagg"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Öppna sökdialogrutan"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Lägg till hämtning i kö"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Läs om listan över URL:er från konfigurationen"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Hämta fil"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Avbryt hämtning"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Markera hämtning som borttagen"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Rensa färdiga och borttagna hämtningar från kö"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Växla automatisk hämtning på/av"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Starta spelaren med den markerade hämtningen"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Markera fil som klar (inte spelad)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Öka antalet samtidiga hämtningar"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Minska antalet samtidiga hämtningar"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Rita om skärm"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Öppna kommandoraden"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Ställ in ett filter"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Välj ett förinställt filter"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Töm aktuellt inställt filter"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Bokmarkera aktuell länk/artikel"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Redigera flaggor"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Gå till nästa webbflöde"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Gå till föregående webbflöde"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Gå till nästa olästa webbflöde"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Gå till föregående olästa webbflöde"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Anropa ett makro"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Ta bort artikel"
+
+#: src/keymap.cpp:335
+#, fuzzy
+msgid "Delete all articles"
+msgstr "Ta bort artikel"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Rensa borttagna artiklar"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Redigera prenumererade URL:er"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Stäng markerad dialogruta"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Se lista över öppna dialogrutor"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Gå till nästa dialogruta"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Gå till föregående dialogruta"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Skicka artikel genom pipe till kommando"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Sortera aktuell lista"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Sortera aktuell lista (omvänt)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Öppna url 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Öppna url 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Öppna url 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Öppna url 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Öppna url 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Öppna url 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Öppna url 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Öppna url 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Öppna url 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Öppna url 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Flytta till föregående post"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Flytta till nästa post"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Flytta till föregående sida"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Flytta till nästa sida"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Flytta till början av sida/lista"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Flytta till slutet av sida/lista"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1613,241 +1978,6 @@ msgstr ""
 
 #~ msgid "Starting browser..."
 #~ msgstr "Startar webbläsare..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Öppna webbflöde/artikel"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Återvänd till föregående dialogruta/Avsluta"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Avsluta program utan att begära bekräftelse"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Läs om markerat webbflöde"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Läs om alla webbflöden"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Markera webbflöde som läst"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Markera alla webbflöden som lästa"
-
-#~ msgid "Mark all above as read"
-#~ msgstr "Markera allt ovanför som läst"
-
-#~ msgid "Save article"
-#~ msgstr "Spara artikel"
-
-#, fuzzy
-#~ msgid "Save articles"
-#~ msgstr "Spara artikel"
-
-#, fuzzy
-#~ msgid "Go to next entry"
-#~ msgstr "Flytta till nästa post"
-
-#, fuzzy
-#~ msgid "Go to previous entry"
-#~ msgstr "Flytta till föregående post"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Gå till nästa olästa artikel"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Gå till föregående olästa artikel"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Gå till en slumpmässigt vald oläst artikel"
-
-#, fuzzy
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Öppna artikel i webbläsare och markera som läst"
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr "Öppna alla olästa artiklar i markerat webbflöde i webbläsare"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr ""
-#~ "Öppna alla olästa artiklar i markerat webbflöde i webbläsare och markera "
-#~ "som lästa"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Öppna hjälpdialogruta"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Växla källvy"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Växla lässtatus för artikel"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Växla visa lästa webbflöden/artiklar"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Visa URL:er i nuvarande artikel"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Töm nuvarande tagg"
-
-#~ msgid "Select tag"
-#~ msgstr "Välj tagg"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Öppna sökdialogrutan"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Lägg till hämtning i kö"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Läs om listan över URL:er från konfigurationen"
-
-#~ msgid "Download file"
-#~ msgstr "Hämta fil"
-
-#~ msgid "Cancel download"
-#~ msgstr "Avbryt hämtning"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Markera hämtning som borttagen"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Rensa färdiga och borttagna hämtningar från kö"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Växla automatisk hämtning på/av"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Starta spelaren med den markerade hämtningen"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Markera fil som klar (inte spelad)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Öka antalet samtidiga hämtningar"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Minska antalet samtidiga hämtningar"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Rita om skärm"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Öppna kommandoraden"
-
-#~ msgid "Set a filter"
-#~ msgstr "Ställ in ett filter"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Välj ett förinställt filter"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Töm aktuellt inställt filter"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Bokmarkera aktuell länk/artikel"
-
-#~ msgid "Edit flags"
-#~ msgstr "Redigera flaggor"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Gå till nästa webbflöde"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Gå till föregående webbflöde"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Gå till nästa olästa webbflöde"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Gå till föregående olästa webbflöde"
-
-#~ msgid "Call a macro"
-#~ msgstr "Anropa ett makro"
-
-#~ msgid "Delete article"
-#~ msgstr "Ta bort artikel"
-
-#, fuzzy
-#~ msgid "Delete all articles"
-#~ msgstr "Ta bort artikel"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Rensa borttagna artiklar"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Redigera prenumererade URL:er"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Stäng markerad dialogruta"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Se lista över öppna dialogrutor"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Gå till nästa dialogruta"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Gå till föregående dialogruta"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Skicka artikel genom pipe till kommando"
-
-#~ msgid "Sort current list"
-#~ msgstr "Sortera aktuell lista"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Sortera aktuell lista (omvänt)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Öppna url 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Öppna url 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Öppna url 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Öppna url 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Öppna url 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Öppna url 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Öppna url 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Öppna url 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Öppna url 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Öppna url 10"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Flytta till föregående post"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Flytta till nästa post"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Flytta till föregående sida"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Flytta till nästa sida"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Flytta till början av sida/lista"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Flytta till slutet av sida/lista"
 
 #~ msgid "Open article in browser"
 #~ msgstr "Öppna artikel i webbläsare"

--- a/po/tr.po
+++ b/po/tr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2020-12-07 19:00+0300\n"
 "Last-Translator: Emir SARI <bitigchi@me.com>, 2020\n"
 "Language-Team: https://github.com/bitigchi/newsboat\n"
@@ -1217,7 +1217,7 @@ msgstr "Hata: Yazı %s' konumuna kaydedilemedi"
 msgid "Error while marking article as unread: %s"
 msgstr "Yazı yeni olarak imlenirken hata oluştu: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "URL'ye git: #"
 
@@ -1237,6 +1237,364 @@ msgstr "Yazı - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Hata: Geçersiz düzenli ifade!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Beslemeyi/Yazıyı aç"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr "Araç takımları arasındaki odağı değiştir"
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Önceki diyaloğa dön/Çık"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Programdan onay olmadan çık"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Seçilen beslemeyi yeniden yükle"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Tüm beslemeleri yeniden yükle"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Beslemeyi okundu olarak işaretle"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Tüm beslemeleri okundu olarak imle"
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr "Yukarıdakilerin tümünü okundu olarak imle"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Yazıyı kaydet"
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr "Yazıları kaydet"
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr "Sonraki girdiye git"
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr "Önceki girdiye git"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Sonraki okunmamış yazıya git"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Önceki okunmamış yazıya git"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Rastgele okunmamış bir yazıya git"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "Yazının URL'sini veya URL görünümündeki girdiyi aç. Okundu imle."
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr "Seçili beslemenin tüm okunmamış ögelerini tarayıcıda aç"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr "Seçili beslemenin tüm ögelerini tarayıcıda aç ve okundu olarak imle"
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Yazının, beslemenin veya girdinin URL'sini URL görünümünde aç"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Yazının, beslemenin veya girdinin URL'sini URL görünümünde aç"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Yardım diyaloğunu aç"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Kaynak gösterimini aç/kapat"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Durum okuma özelliğini aç/kapat"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Yazı okumayı aç/kapat"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Adresleri mevcut yazı içinde göster"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Mevcut etiketi temizle"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Etiket seç"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Arama diyaloğunu aç"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr "Başlıklı ögeye git"
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "İndirmeyi kuyruğa ekle"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Ayar dosyasında adreslerin listesini yeniden yükle"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Dosyayı indir"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "İndirmeyi iptal et"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "İndirmeyi silindi olarak imle"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Tamamlanan ve silinen indirmeleri kuyruktan temizle"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Otomatik indirmeyi aç/kapat"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Oynatıcı seçilen indirme ile başlat"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Dosyayı bitmiş olarak imle (oynatılmadı)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Eşzamanlı indirmelerin sayısını artır"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Eşzamanlı indirmelerin sayısını azalt"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Ekranı yeniden çiz"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Komut satırını aç"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Süzgeç ayarla"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Önceden tanımlanmış bir süzgeç seç"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Mevcut süzgeci temizle"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Mevcut yazıyı yerimlerine ekle"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Bayrakları düzenle"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Sonraki beslemeye git"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Önceki beslemeye git"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Sonraki okunmamış beslemeye git"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Önceki okunmamış beslemeye git"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Makro çağır"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Yazıyı sil"
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr "Tüm yazıları sil"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Silinen yazıları temizle"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Abone olunan adresleri düzenle"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Seçilen diyalogu kapat"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Açık diyalogların listesini görüntüle"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Sonraki diyaloga git"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Önceki diyaloğa dön/Çık"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Yazıyı komuta kanalla"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Mevcut listeyi sırala"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Mevcut listeyi sırala (tersten)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "URL 1'i aç"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "URL 2'yi aç"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "URL 3'ü aç"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "URL 4'ü aç"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "URL 5'i aç"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "URL 6'yı aç"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "URL 7'yi aç"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "URL 8'i aç"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "URL 9'u aç"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "URL 10'u aç"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr "Komut satırını 1 ile başlat"
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr "Komut satırını 2 ile başlat"
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr "Komut satırını 3 ile başlat"
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr "Komut satırını 4 ile başlat"
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr "Komut satırını 5 ile başlat"
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr "Komut satırını 6 ile başlat"
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr "Komut satırını 7 ile başlat"
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr "Komut satırını 8 ile başlat"
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr "Komut satırını 9 ile başlat"
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Önceki girdiye taşı"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Sonraki girdiye taşı"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Önceki sayfaya taşı"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Sonraki sayfaya taşı"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Sayfanın/listenin başına taşı"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Sayfanın/listenin sonuna taşı"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1614,267 +1972,3 @@ msgstr "regexec %i kodunu döndürdü"
 
 #~ msgid "Starting browser..."
 #~ msgstr "Tarayıcı başlatılıyor..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Beslemeyi/Yazıyı aç"
-
-#~ msgid "Switch focus between widgets"
-#~ msgstr "Araç takımları arasındaki odağı değiştir"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Önceki diyaloğa dön/Çık"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Programdan onay olmadan çık"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Seçilen beslemeyi yeniden yükle"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Tüm beslemeleri yeniden yükle"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Beslemeyi okundu olarak işaretle"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Tüm beslemeleri okundu olarak imle"
-
-#~ msgid "Mark all above as read"
-#~ msgstr "Yukarıdakilerin tümünü okundu olarak imle"
-
-#~ msgid "Save article"
-#~ msgstr "Yazıyı kaydet"
-
-#~ msgid "Save articles"
-#~ msgstr "Yazıları kaydet"
-
-#~ msgid "Go to next entry"
-#~ msgstr "Sonraki girdiye git"
-
-#~ msgid "Go to previous entry"
-#~ msgstr "Önceki girdiye git"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Sonraki okunmamış yazıya git"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Önceki okunmamış yazıya git"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Rastgele okunmamış bir yazıya git"
-
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "Yazının URL'sini veya URL görünümündeki girdiyi aç. Okundu imle."
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr "Seçili beslemenin tüm okunmamış ögelerini tarayıcıda aç"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr "Seçili beslemenin tüm ögelerini tarayıcıda aç ve okundu olarak imle"
-
-#~ msgid "Open URL of article, feed, or entry in URL view"
-#~ msgstr "Yazının, beslemenin veya girdinin URL'sini URL görünümünde aç"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Yardım diyaloğunu aç"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Kaynak gösterimini aç/kapat"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Durum okuma özelliğini aç/kapat"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Yazı okumayı aç/kapat"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Adresleri mevcut yazı içinde göster"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Mevcut etiketi temizle"
-
-#~ msgid "Select tag"
-#~ msgstr "Etiket seç"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Arama diyaloğunu aç"
-
-#~ msgid "Goto item with title"
-#~ msgstr "Başlıklı ögeye git"
-
-#~ msgid "Add download to queue"
-#~ msgstr "İndirmeyi kuyruğa ekle"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Ayar dosyasında adreslerin listesini yeniden yükle"
-
-#~ msgid "Download file"
-#~ msgstr "Dosyayı indir"
-
-#~ msgid "Cancel download"
-#~ msgstr "İndirmeyi iptal et"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "İndirmeyi silindi olarak imle"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Tamamlanan ve silinen indirmeleri kuyruktan temizle"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Otomatik indirmeyi aç/kapat"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Oynatıcı seçilen indirme ile başlat"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Dosyayı bitmiş olarak imle (oynatılmadı)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Eşzamanlı indirmelerin sayısını artır"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Eşzamanlı indirmelerin sayısını azalt"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Ekranı yeniden çiz"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Komut satırını aç"
-
-#~ msgid "Set a filter"
-#~ msgstr "Süzgeç ayarla"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Önceden tanımlanmış bir süzgeç seç"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Mevcut süzgeci temizle"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Mevcut yazıyı yerimlerine ekle"
-
-#~ msgid "Edit flags"
-#~ msgstr "Bayrakları düzenle"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Sonraki beslemeye git"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Önceki beslemeye git"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Sonraki okunmamış beslemeye git"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Önceki okunmamış beslemeye git"
-
-#~ msgid "Call a macro"
-#~ msgstr "Makro çağır"
-
-#~ msgid "Delete article"
-#~ msgstr "Yazıyı sil"
-
-#~ msgid "Delete all articles"
-#~ msgstr "Tüm yazıları sil"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Silinen yazıları temizle"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Abone olunan adresleri düzenle"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Seçilen diyalogu kapat"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Açık diyalogların listesini görüntüle"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Sonraki diyaloga git"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Önceki diyaloğa dön/Çık"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Yazıyı komuta kanalla"
-
-#~ msgid "Sort current list"
-#~ msgstr "Mevcut listeyi sırala"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Mevcut listeyi sırala (tersten)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "URL 1'i aç"
-
-#~ msgid "Open URL 2"
-#~ msgstr "URL 2'yi aç"
-
-#~ msgid "Open URL 3"
-#~ msgstr "URL 3'ü aç"
-
-#~ msgid "Open URL 4"
-#~ msgstr "URL 4'ü aç"
-
-#~ msgid "Open URL 5"
-#~ msgstr "URL 5'i aç"
-
-#~ msgid "Open URL 6"
-#~ msgstr "URL 6'yı aç"
-
-#~ msgid "Open URL 7"
-#~ msgstr "URL 7'yi aç"
-
-#~ msgid "Open URL 8"
-#~ msgstr "URL 8'i aç"
-
-#~ msgid "Open URL 9"
-#~ msgstr "URL 9'u aç"
-
-#~ msgid "Open URL 10"
-#~ msgstr "URL 10'u aç"
-
-#~ msgid "Start cmdline with 1"
-#~ msgstr "Komut satırını 1 ile başlat"
-
-#~ msgid "Start cmdline with 2"
-#~ msgstr "Komut satırını 2 ile başlat"
-
-#~ msgid "Start cmdline with 3"
-#~ msgstr "Komut satırını 3 ile başlat"
-
-#~ msgid "Start cmdline with 4"
-#~ msgstr "Komut satırını 4 ile başlat"
-
-#~ msgid "Start cmdline with 5"
-#~ msgstr "Komut satırını 5 ile başlat"
-
-#~ msgid "Start cmdline with 6"
-#~ msgstr "Komut satırını 6 ile başlat"
-
-#~ msgid "Start cmdline with 7"
-#~ msgstr "Komut satırını 7 ile başlat"
-
-#~ msgid "Start cmdline with 8"
-#~ msgstr "Komut satırını 8 ile başlat"
-
-#~ msgid "Start cmdline with 9"
-#~ msgstr "Komut satırını 9 ile başlat"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Önceki girdiye taşı"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Sonraki girdiye taşı"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Önceki sayfaya taşı"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Sonraki sayfaya taşı"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Sayfanın/listenin başına taşı"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Sayfanın/listenin sonuna taşı"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 2.11\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2020-12-07 10:48+0300\n"
 "Last-Translator: Alexander Batischev <eual.jp@gmail.com>\n"
 "Language-Team: Ivan Kovnatsky <sevenfourk@gmail.com>, Alexander Batischev "
@@ -1219,7 +1219,7 @@ msgstr "Помилка: не можу записати статтю у файл 
 msgid "Error while marking article as unread: %s"
 msgstr "Помилка при позначенні статті як непрочитано: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "Перейти за посиланням №"
 
@@ -1239,6 +1239,367 @@ msgstr "Стаття - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "Помилка: неправильний вираз!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "Відкрити тему/статтю"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr "Перемкнути фокус між віджетами"
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "Повернутись до попереднього діалогу/Вийти"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "Вийти з програми без підтвердження"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "Перезавантажити вибрану тему"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "Перезавантажити усі теми"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "Позначити теми як прочитані"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "Позначити усі теми як прочитані"
+
+#: src/keymap.cpp:82
+msgid "Mark all above as read"
+msgstr "Позначити усе, що вище, як прочитані"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "Зберегти статтю"
+
+#: src/keymap.cpp:86
+msgid "Save articles"
+msgstr "Зберегти статті"
+
+#: src/keymap.cpp:91
+msgid "Go to next entry"
+msgstr "Перейти до наступного рядка"
+
+#: src/keymap.cpp:98
+msgid "Go to previous entry"
+msgstr "Перейти до попереднього рядка"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "Перейти до наступної непрочитаної статті"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "Перейти до попередньої непрочитаної статті"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "Перейти до будь-якої непрочитаної статті"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr ""
+"Відкрити URL статті, теми, чи рядка у діалозі URL. Позначити прочитаним."
+
+#: src/keymap.cpp:133
+msgid "Open all unread items of selected feed in browser"
+msgstr "Відкрити усі непрочитані статті обраної теми в браузері"
+
+#: src/keymap.cpp:140
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr ""
+"Відкрити усі непрочитані статті обраної теми в браузері і позначити "
+"прочитаними"
+
+#: src/keymap.cpp:148
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "Відкрити URL статті, теми, чи рядка у діалозі URL"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "Відкрити URL статті, теми, чи рядка у діалозі URL"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "Відкрити діалог довідки"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "Переключитись на перегляд сирців"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "Переключити статус прочитано для статті"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "Переключити перегляд прочитаних тем/статей"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "Показати URLs в поточній статті"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "Очистити поточну мітку"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "Вибрати мітку"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "Відкрити діалог пошуку"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr "Перейти до статті із заголовком"
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "Додати завантаження у чергу"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "Перезавантажити список URLs з налаштувань"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "Завантажити файл"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "Відмінити завантаження"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "Позначити завантаження як видалено"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "Очистити закінчені та видалені завантаження з черги"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "Переключити автоматичне завантаження Ув/В"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "Запустити програвач з вибраним завантаженням"
+
+#: src/keymap.cpp:247
+msgid "Mark file as finished (not played)"
+msgstr "Помітити файл як завершений (не програний)"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "Збільшити число одночасних завантажень"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "Зменшити число одночасних завантажень"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "Поновити екран"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "Відкрити командний рядок"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "Встановити фільтр"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "Вибрати попередньо визначений фільтр"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "Очистити поточно встановлений фільтр"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "Додати закладку на посилання/статтю"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "Редагувати флаги"
+
+#: src/keymap.cpp:301
+msgid "Go to next feed"
+msgstr "Перейти до наступної теми"
+
+#: src/keymap.cpp:306
+msgid "Go to previous feed"
+msgstr "Перейти до попередньої теми"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "Перейти до наступної непрочитаної теми"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "Перейти до попередньої непрочитаної теми"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "Викликати макрос"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "Видалити статтю"
+
+#: src/keymap.cpp:335
+msgid "Delete all articles"
+msgstr "Видалити усі статті"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "Очистити видалені статті"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "Редагувати підписані URLs"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "Закрити вибране меню"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "Дивитись список відкритих меню"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "Перейти до наступного меню"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "Повернутись до попереднього меню"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Пайпувати статтю до каманди"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "Сортувати поточний список"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "Сортувати поточний список (реверсно)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "Відкрити URL 1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "Відкрити URL 2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "Відкрити URL 3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "Відкрити URL 4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "Відкрити URL 5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "Відкрити URL 6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "Відкрити URL 7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "Відкрити URL 8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "Відкрити URL 9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "Відкрити URL 10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr "Почати команду з одиниці"
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr "Почати команду з двійки"
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr "Почати команду з трійки"
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr "Почати команду з четвірки"
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr "Почати команду з п'ятірки"
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr "Почати команду з шестірки"
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr "Почати команду з семірки"
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr "Почати команду з вісьмірки"
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr "Почати команду з дев'ятки"
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "Перейти до попереднього рядка"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "Перемістити до наступного рядка"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "Перемістити до попередньої сторінки"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "Перемістити до наступної сторінки"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "Перемістити до початку сторінки/списку"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "Перемістити до кінця сторінки/списку"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1618,270 +1979,3 @@ msgstr "regexec повернула код помилки %i"
 
 #~ msgid "Starting browser..."
 #~ msgstr "Запускаю браузер..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "Відкрити тему/статтю"
-
-#~ msgid "Switch focus between widgets"
-#~ msgstr "Перемкнути фокус між віджетами"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "Повернутись до попереднього діалогу/Вийти"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "Вийти з програми без підтвердження"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "Перезавантажити вибрану тему"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "Перезавантажити усі теми"
-
-#~ msgid "Mark feed read"
-#~ msgstr "Позначити теми як прочитані"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "Позначити усі теми як прочитані"
-
-#~ msgid "Mark all above as read"
-#~ msgstr "Позначити усе, що вище, як прочитані"
-
-#~ msgid "Save article"
-#~ msgstr "Зберегти статтю"
-
-#~ msgid "Save articles"
-#~ msgstr "Зберегти статті"
-
-#~ msgid "Go to next entry"
-#~ msgstr "Перейти до наступного рядка"
-
-#~ msgid "Go to previous entry"
-#~ msgstr "Перейти до попереднього рядка"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "Перейти до наступної непрочитаної статті"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "Перейти до попередньої непрочитаної статті"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "Перейти до будь-якої непрочитаної статті"
-
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr ""
-#~ "Відкрити URL статті, теми, чи рядка у діалозі URL. Позначити прочитаним."
-
-#~ msgid "Open all unread items of selected feed in browser"
-#~ msgstr "Відкрити усі непрочитані статті обраної теми в браузері"
-
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr ""
-#~ "Відкрити усі непрочитані статті обраної теми в браузері і позначити "
-#~ "прочитаними"
-
-#~ msgid "Open URL of article, feed, or entry in URL view"
-#~ msgstr "Відкрити URL статті, теми, чи рядка у діалозі URL"
-
-#~ msgid "Open help dialog"
-#~ msgstr "Відкрити діалог довідки"
-
-#~ msgid "Toggle source view"
-#~ msgstr "Переключитись на перегляд сирців"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "Переключити статус прочитано для статті"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "Переключити перегляд прочитаних тем/статей"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "Показати URLs в поточній статті"
-
-#~ msgid "Clear current tag"
-#~ msgstr "Очистити поточну мітку"
-
-#~ msgid "Select tag"
-#~ msgstr "Вибрати мітку"
-
-#~ msgid "Open search dialog"
-#~ msgstr "Відкрити діалог пошуку"
-
-#~ msgid "Goto item with title"
-#~ msgstr "Перейти до статті із заголовком"
-
-#~ msgid "Add download to queue"
-#~ msgstr "Додати завантаження у чергу"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "Перезавантажити список URLs з налаштувань"
-
-#~ msgid "Download file"
-#~ msgstr "Завантажити файл"
-
-#~ msgid "Cancel download"
-#~ msgstr "Відмінити завантаження"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "Позначити завантаження як видалено"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "Очистити закінчені та видалені завантаження з черги"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "Переключити автоматичне завантаження Ув/В"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "Запустити програвач з вибраним завантаженням"
-
-#~ msgid "Mark file as finished (not played)"
-#~ msgstr "Помітити файл як завершений (не програний)"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "Збільшити число одночасних завантажень"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "Зменшити число одночасних завантажень"
-
-#~ msgid "Redraw screen"
-#~ msgstr "Поновити екран"
-
-#~ msgid "Open the commandline"
-#~ msgstr "Відкрити командний рядок"
-
-#~ msgid "Set a filter"
-#~ msgstr "Встановити фільтр"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "Вибрати попередньо визначений фільтр"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "Очистити поточно встановлений фільтр"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "Додати закладку на посилання/статтю"
-
-#~ msgid "Edit flags"
-#~ msgstr "Редагувати флаги"
-
-#~ msgid "Go to next feed"
-#~ msgstr "Перейти до наступної теми"
-
-#~ msgid "Go to previous feed"
-#~ msgstr "Перейти до попередньої теми"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "Перейти до наступної непрочитаної теми"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "Перейти до попередньої непрочитаної теми"
-
-#~ msgid "Call a macro"
-#~ msgstr "Викликати макрос"
-
-#~ msgid "Delete article"
-#~ msgstr "Видалити статтю"
-
-#~ msgid "Delete all articles"
-#~ msgstr "Видалити усі статті"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "Очистити видалені статті"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "Редагувати підписані URLs"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "Закрити вибране меню"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "Дивитись список відкритих меню"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "Перейти до наступного меню"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "Повернутись до попереднього меню"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Пайпувати статтю до каманди"
-
-#~ msgid "Sort current list"
-#~ msgstr "Сортувати поточний список"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "Сортувати поточний список (реверсно)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "Відкрити URL 1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "Відкрити URL 2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "Відкрити URL 3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "Відкрити URL 4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "Відкрити URL 5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "Відкрити URL 6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "Відкрити URL 7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "Відкрити URL 8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "Відкрити URL 9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "Відкрити URL 10"
-
-#~ msgid "Start cmdline with 1"
-#~ msgstr "Почати команду з одиниці"
-
-#~ msgid "Start cmdline with 2"
-#~ msgstr "Почати команду з двійки"
-
-#~ msgid "Start cmdline with 3"
-#~ msgstr "Почати команду з трійки"
-
-#~ msgid "Start cmdline with 4"
-#~ msgstr "Почати команду з четвірки"
-
-#~ msgid "Start cmdline with 5"
-#~ msgstr "Почати команду з п'ятірки"
-
-#~ msgid "Start cmdline with 6"
-#~ msgstr "Почати команду з шестірки"
-
-#~ msgid "Start cmdline with 7"
-#~ msgstr "Почати команду з семірки"
-
-#~ msgid "Start cmdline with 8"
-#~ msgstr "Почати команду з вісьмірки"
-
-#~ msgid "Start cmdline with 9"
-#~ msgstr "Почати команду з дев'ятки"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "Перейти до попереднього рядка"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "Перемістити до наступного рядка"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "Перемістити до попередньої сторінки"
-
-#~ msgid "Move to the next page"
-#~ msgstr "Перемістити до наступної сторінки"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "Перемістити до початку сторінки/списку"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "Перемістити до кінця сторінки/списку"

--- a/po/zh.po
+++ b/po/zh.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 0.7\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2007-11-21 22:51+0100\n"
 "Last-Translator: josh yu <joshyupeng@gmail.com>\n"
 "Language-Team: \n"
@@ -1196,7 +1196,7 @@ msgstr "错误：无法将文章写至 %s"
 msgid "Error while marking article as unread: %s"
 msgstr "当标记文章为未读的时候出错: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr ""
 
@@ -1217,6 +1217,388 @@ msgstr "把文章保存到 %s"
 #, fuzzy
 msgid "Error: invalid regular expression!"
 msgstr "错误:无效的种子!"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "打开种子/文章"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "返回到前一个对话框/退出"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr ""
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "重新加载当前选择的种子"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "重新加载所有种子"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "标记当前种子为已读"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "标记所有种子为已读"
+
+#: src/keymap.cpp:82
+#, fuzzy
+msgid "Mark all above as read"
+msgstr "标记所有种子为已读"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "保存文章"
+
+#: src/keymap.cpp:86
+#, fuzzy
+msgid "Save articles"
+msgstr "保存文章"
+
+#: src/keymap.cpp:91
+#, fuzzy
+msgid "Go to next entry"
+msgstr "转到下一篇未读的种子"
+
+#: src/keymap.cpp:98
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "转到前一篇未读的种子"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "转到下一篇未读文章"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "转到前一篇未读文章"
+
+#: src/keymap.cpp:119
+#, fuzzy
+msgid "Go to a random unread article"
+msgstr "转到下一篇未读文章"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "在浏览器里打开文章"
+
+#: src/keymap.cpp:133
+#, fuzzy
+msgid "Open all unread items of selected feed in browser"
+msgstr "在浏览器里打开文章"
+
+#: src/keymap.cpp:140
+#, fuzzy
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr "在浏览器里打开文章"
+
+#: src/keymap.cpp:148
+#, fuzzy
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "在浏览器里打开文章"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "在浏览器里打开文章"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "打开帮助对话框"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "切换源代码显示"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "切换文章的阅读状态（已读/未读）"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "切换显示已读种子/文章"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "列出当前文章里的所有链接"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "清除当前标签"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "选择标签"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "打开搜索对话框"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "将该下载项目加入队列"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "重新加载配置文件里的链接列表"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "下载文件"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "取消下载"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "将下载的项目标记为已删除"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "清除队列中已完成的和已删除的下载项目"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "切换是否自动下载"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "播放当前所选的下载项目"
+
+#: src/keymap.cpp:247
+#, fuzzy
+msgid "Mark file as finished (not played)"
+msgstr "清除完毕的项目"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "增加同步下载的进程数目"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "减少同步下载的进程数目"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "刷新屏显"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "打开命令行"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "设置一个过滤器"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "选择一个预设置的过滤器"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "清除当前所选的过滤器"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "将当前文章/链接加入书签"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "编辑标记"
+
+#: src/keymap.cpp:301
+#, fuzzy
+msgid "Go to next feed"
+msgstr "转到下一篇未读的种子"
+
+#: src/keymap.cpp:306
+#, fuzzy
+msgid "Go to previous feed"
+msgstr "转到前一篇未读的种子"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "转到下一篇未读的种子"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "转到前一篇未读的种子"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "调用一个宏命令"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "删除文章"
+
+#: src/keymap.cpp:335
+#, fuzzy
+msgid "Delete all articles"
+msgstr "删除文章"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "压缩已删除文章"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "编辑已提交链接"
+
+#: src/keymap.cpp:356
+#, fuzzy
+msgid "Close currently selected dialog"
+msgstr "重新加载当前选择的种子"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr ""
+
+#: src/keymap.cpp:370
+#, fuzzy
+msgid "Go to next dialog"
+msgstr "转到下一篇未读文章"
+
+#: src/keymap.cpp:377
+#, fuzzy
+msgid "Go to previous dialog"
+msgstr "返回到前一个对话框/退出"
+
+#: src/keymap.cpp:384
+#, fuzzy
+msgid "Pipe article to command"
+msgstr "把文章保存到 %s"
+
+#: src/keymap.cpp:391
+#, fuzzy
+msgid "Sort current list"
+msgstr "清除当前标签"
+
+#: src/keymap.cpp:398
+#, fuzzy
+msgid "Sort current list (reverse)"
+msgstr "清除当前标签"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "打开链接1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "打开链接2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "打开链接3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "打开链接4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "打开链接5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "打开链接6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "打开链接7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "打开链接8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "打开链接9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "打开链接10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+#, fuzzy
+msgid "Move to the previous entry"
+msgstr "转到前一篇未读的种子"
+
+#: src/keymap.cpp:424
+#, fuzzy
+msgid "Move to the next entry"
+msgstr "转到下一篇未读文章"
+
+#: src/keymap.cpp:429
+#, fuzzy
+msgid "Move to the previous page"
+msgstr "返回到前一个对话框/退出"
+
+#: src/keymap.cpp:436
+#, fuzzy
+msgid "Move to the next page"
+msgstr "转到下一篇未读文章"
+
+#: src/keymap.cpp:444
+#, fuzzy
+msgid "Move to the start of page/list"
+msgstr "转到下一篇未读文章"
+
+#: src/keymap.cpp:451
+#, fuzzy
+msgid "Move to the end of page/list"
+msgstr "转到下一篇未读文章"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1597,236 +1979,6 @@ msgstr ""
 
 #~ msgid "Starting browser..."
 #~ msgstr "启动浏览器..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "打开种子/文章"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "返回到前一个对话框/退出"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "重新加载当前选择的种子"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "重新加载所有种子"
-
-#~ msgid "Mark feed read"
-#~ msgstr "标记当前种子为已读"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "标记所有种子为已读"
-
-#, fuzzy
-#~ msgid "Mark all above as read"
-#~ msgstr "标记所有种子为已读"
-
-#~ msgid "Save article"
-#~ msgstr "保存文章"
-
-#, fuzzy
-#~ msgid "Save articles"
-#~ msgstr "保存文章"
-
-#, fuzzy
-#~ msgid "Go to next entry"
-#~ msgstr "转到下一篇未读的种子"
-
-#, fuzzy
-#~ msgid "Go to previous entry"
-#~ msgstr "转到前一篇未读的种子"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "转到下一篇未读文章"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "转到前一篇未读文章"
-
-#, fuzzy
-#~ msgid "Go to a random unread article"
-#~ msgstr "转到下一篇未读文章"
-
-#, fuzzy
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "在浏览器里打开文章"
-
-#, fuzzy
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr "在浏览器里打开文章"
-
-#~ msgid "Open help dialog"
-#~ msgstr "打开帮助对话框"
-
-#~ msgid "Toggle source view"
-#~ msgstr "切换源代码显示"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "切换文章的阅读状态（已读/未读）"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "切换显示已读种子/文章"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "列出当前文章里的所有链接"
-
-#~ msgid "Clear current tag"
-#~ msgstr "清除当前标签"
-
-#~ msgid "Select tag"
-#~ msgstr "选择标签"
-
-#~ msgid "Open search dialog"
-#~ msgstr "打开搜索对话框"
-
-#~ msgid "Add download to queue"
-#~ msgstr "将该下载项目加入队列"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "重新加载配置文件里的链接列表"
-
-#~ msgid "Download file"
-#~ msgstr "下载文件"
-
-#~ msgid "Cancel download"
-#~ msgstr "取消下载"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "将下载的项目标记为已删除"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "清除队列中已完成的和已删除的下载项目"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "切换是否自动下载"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "播放当前所选的下载项目"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "增加同步下载的进程数目"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "减少同步下载的进程数目"
-
-#~ msgid "Redraw screen"
-#~ msgstr "刷新屏显"
-
-#~ msgid "Open the commandline"
-#~ msgstr "打开命令行"
-
-#~ msgid "Set a filter"
-#~ msgstr "设置一个过滤器"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "选择一个预设置的过滤器"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "清除当前所选的过滤器"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "将当前文章/链接加入书签"
-
-#~ msgid "Edit flags"
-#~ msgstr "编辑标记"
-
-#, fuzzy
-#~ msgid "Go to next feed"
-#~ msgstr "转到下一篇未读的种子"
-
-#, fuzzy
-#~ msgid "Go to previous feed"
-#~ msgstr "转到前一篇未读的种子"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "转到下一篇未读的种子"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "转到前一篇未读的种子"
-
-#~ msgid "Call a macro"
-#~ msgstr "调用一个宏命令"
-
-#~ msgid "Delete article"
-#~ msgstr "删除文章"
-
-#, fuzzy
-#~ msgid "Delete all articles"
-#~ msgstr "删除文章"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "压缩已删除文章"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "编辑已提交链接"
-
-#, fuzzy
-#~ msgid "Close currently selected dialog"
-#~ msgstr "重新加载当前选择的种子"
-
-#, fuzzy
-#~ msgid "Go to next dialog"
-#~ msgstr "转到下一篇未读文章"
-
-#, fuzzy
-#~ msgid "Go to previous dialog"
-#~ msgstr "返回到前一个对话框/退出"
-
-#, fuzzy
-#~ msgid "Pipe article to command"
-#~ msgstr "把文章保存到 %s"
-
-#, fuzzy
-#~ msgid "Sort current list"
-#~ msgstr "清除当前标签"
-
-#~ msgid "Open URL 1"
-#~ msgstr "打开链接1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "打开链接2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "打开链接3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "打开链接4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "打开链接5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "打开链接6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "打开链接7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "打开链接8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "打开链接9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "打开链接10"
-
-#, fuzzy
-#~ msgid "Move to the previous entry"
-#~ msgstr "转到前一篇未读的种子"
-
-#, fuzzy
-#~ msgid "Move to the previous page"
-#~ msgstr "返回到前一个对话框/退出"
-
-#, fuzzy
-#~ msgid "Move to the next page"
-#~ msgstr "转到下一篇未读文章"
-
-#, fuzzy
-#~ msgid "Move to the start of page/list"
-#~ msgstr "转到下一篇未读文章"
-
-#, fuzzy
-#~ msgid "Move to the end of page/list"
-#~ msgstr "转到下一篇未读文章"
 
 #~ msgid "Open article in browser"
 #~ msgstr "在浏览器里打开文章"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: newsboat 1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
-"POT-Creation-Date: 2021-03-09 19:02+0300\n"
+"POT-Creation-Date: 2021-03-09 22:46+0300\n"
 "PO-Revision-Date: 2010-03-03 16:55+0800\n"
 "Last-Translator: Aeglos <aeglos.lin@gmail.com>\n"
 "Language-Team: \n"
@@ -1196,7 +1196,7 @@ msgstr "錯誤：無法將文章寫至 %s"
 msgid "Error while marking article as unread: %s"
 msgstr "將文章標為未讀時發生錯誤: %s"
 
-#: src/itemviewformaction.cpp:466
+#: src/itemviewformaction.cpp:466 src/keymap.cpp:203
 msgid "Goto URL #"
 msgstr "前往網址 #"
 
@@ -1216,6 +1216,375 @@ msgstr "文章 - %s"
 #: src/itemviewformaction.cpp:722
 msgid "Error: invalid regular expression!"
 msgstr "錯誤:無效的正規表示式！"
+
+#: src/keymap.cpp:37
+msgid "Open feed/article"
+msgstr "打開來源/文章"
+
+#: src/keymap.cpp:45
+msgid "Switch focus between widgets"
+msgstr ""
+
+#: src/keymap.cpp:48
+msgid "Return to previous dialog/Quit"
+msgstr "返回到前一個對話框/退出"
+
+#: src/keymap.cpp:53
+msgid "Quit program, no confirmation"
+msgstr "不經確認，直接離開程式"
+
+#: src/keymap.cpp:60
+msgid "Reload currently selected feed"
+msgstr "重新載入選擇的來源"
+
+#: src/keymap.cpp:63
+msgid "Reload all feeds"
+msgstr "重新載入所有來源"
+
+#: src/keymap.cpp:68
+msgid "Mark feed read"
+msgstr "將來源標為已讀"
+
+#: src/keymap.cpp:75
+msgid "Mark all feeds read"
+msgstr "將所有來源標為已讀"
+
+#: src/keymap.cpp:82
+#, fuzzy
+msgid "Mark all above as read"
+msgstr "將所有來源標為已讀"
+
+#: src/keymap.cpp:85
+msgid "Save article"
+msgstr "保存文章"
+
+#: src/keymap.cpp:86
+#, fuzzy
+msgid "Save articles"
+msgstr "保存文章"
+
+#: src/keymap.cpp:91
+#, fuzzy
+msgid "Go to next entry"
+msgstr "跳到下一項"
+
+#: src/keymap.cpp:98
+#, fuzzy
+msgid "Go to previous entry"
+msgstr "跳到前一項"
+
+#: src/keymap.cpp:105
+msgid "Go to next unread article"
+msgstr "轉到下一篇未讀文章"
+
+#: src/keymap.cpp:112
+msgid "Go to previous unread article"
+msgstr "轉到前一篇未讀文章"
+
+#: src/keymap.cpp:119
+msgid "Go to a random unread article"
+msgstr "隨機跳到未讀的文章"
+
+#: src/keymap.cpp:126
+#, fuzzy
+msgid "Open URL of article, or entry in URL view. Mark read"
+msgstr "在瀏覽器裡打開文章"
+
+#: src/keymap.cpp:133
+#, fuzzy
+msgid "Open all unread items of selected feed in browser"
+msgstr "在瀏覽器裡打開文章"
+
+#: src/keymap.cpp:140
+#, fuzzy
+msgid "Open all unread items of selected feed in browser and mark read"
+msgstr "在瀏覽器裡打開文章"
+
+#: src/keymap.cpp:148
+#, fuzzy
+msgid "Open URL of article, feed, or entry in URL view"
+msgstr "在瀏覽器裡打開文章"
+
+#: src/keymap.cpp:155
+#, fuzzy
+msgid "Open URL of article, feed, or entry in a browser, non-interactively"
+msgstr "在瀏覽器裡打開文章"
+
+#: src/keymap.cpp:162
+msgid "Open help dialog"
+msgstr "打開說明對話框"
+
+#: src/keymap.cpp:169
+msgid "Toggle source view"
+msgstr "切換原始碼顯示"
+
+#: src/keymap.cpp:176
+msgid "Toggle read status for article"
+msgstr "切換文章的閱讀狀態（已讀/未讀）"
+
+#: src/keymap.cpp:183
+msgid "Toggle show read feeds/articles"
+msgstr "切換顯示已讀來源/文章"
+
+#: src/keymap.cpp:190
+msgid "Show URLs in current article"
+msgstr "列出當前文章裡的所有鏈結"
+
+#: src/keymap.cpp:193
+msgid "Clear current tag"
+msgstr "清除當前標籤"
+
+#: src/keymap.cpp:194 src/keymap.cpp:195
+msgid "Select tag"
+msgstr "選擇標籤"
+
+#: src/keymap.cpp:200
+msgid "Open search dialog"
+msgstr "打開搜尋對話框"
+
+#: src/keymap.cpp:204
+msgid "Goto item with title"
+msgstr ""
+
+#: src/keymap.cpp:205
+msgid "Add download to queue"
+msgstr "將該下載項目加入隊列"
+
+#: src/keymap.cpp:210
+msgid "Reload the list of URLs from the configuration"
+msgstr "重新載入配置文件裡的鏈結列表"
+
+#: src/keymap.cpp:213
+msgid "Download file"
+msgstr "下載檔案"
+
+#: src/keymap.cpp:214
+msgid "Cancel download"
+msgstr "取消下載"
+
+#: src/keymap.cpp:219
+msgid "Mark download as deleted"
+msgstr "將下載的項目標記為已刪除"
+
+#: src/keymap.cpp:226
+msgid "Purge finished and deleted downloads from queue"
+msgstr "清除隊列中已完成的和已刪除的下載項目"
+
+#: src/keymap.cpp:233
+msgid "Toggle automatic download on/off"
+msgstr "切換是否自動下載"
+
+#: src/keymap.cpp:240
+msgid "Start player with currently selected download"
+msgstr "播放當前所選的下載項目"
+
+#: src/keymap.cpp:247
+#, fuzzy
+msgid "Mark file as finished (not played)"
+msgstr "清除完畢的項目"
+
+#: src/keymap.cpp:254
+msgid "Increase the number of concurrent downloads"
+msgstr "增加同時下載的數目"
+
+#: src/keymap.cpp:261
+msgid "Decrease the number of concurrent downloads"
+msgstr "減少同時下載的數目"
+
+#: src/keymap.cpp:264
+msgid "Redraw screen"
+msgstr "更新畫面"
+
+#: src/keymap.cpp:265
+msgid "Open the commandline"
+msgstr "打開命令列"
+
+#: src/keymap.cpp:270
+msgid "Set a filter"
+msgstr "設置一個過濾器"
+
+#: src/keymap.cpp:277
+msgid "Select a predefined filter"
+msgstr "選擇一個預先設定的過濾器"
+
+#: src/keymap.cpp:284
+msgid "Clear currently set filter"
+msgstr "清除目前的過濾器"
+
+#: src/keymap.cpp:291
+msgid "Bookmark current link/article"
+msgstr "將目前的文章/鏈結加入書籤"
+
+#: src/keymap.cpp:298
+msgid "Edit flags"
+msgstr "編輯標記"
+
+#: src/keymap.cpp:301
+#, fuzzy
+msgid "Go to next feed"
+msgstr "跳到下一篇未讀文章"
+
+#: src/keymap.cpp:306
+#, fuzzy
+msgid "Go to previous feed"
+msgstr "跳到前一篇未讀文章"
+
+#: src/keymap.cpp:313
+msgid "Go to next unread feed"
+msgstr "跳到下一篇未讀文章"
+
+#: src/keymap.cpp:320
+msgid "Go to previous unread feed"
+msgstr "跳到前一篇未讀文章"
+
+#: src/keymap.cpp:323
+msgid "Call a macro"
+msgstr "呼叫巨集"
+
+#: src/keymap.cpp:328
+msgid "Delete article"
+msgstr "刪除文章"
+
+#: src/keymap.cpp:335
+#, fuzzy
+msgid "Delete all articles"
+msgstr "刪除文章"
+
+#: src/keymap.cpp:342
+msgid "Purge deleted articles"
+msgstr "清空被刪除的文章"
+
+#: src/keymap.cpp:349
+msgid "Edit subscribed URLs"
+msgstr "編緝已訂閱的鏈結"
+
+#: src/keymap.cpp:356
+msgid "Close currently selected dialog"
+msgstr "關閉目前選擇的對話窗"
+
+#: src/keymap.cpp:363
+msgid "View list of open dialogs"
+msgstr "檢視已開啟對話窗列表"
+
+#: src/keymap.cpp:370
+msgid "Go to next dialog"
+msgstr "跳到下一個對話窗"
+
+#: src/keymap.cpp:377
+msgid "Go to previous dialog"
+msgstr "跳到前一個對話窗"
+
+#: src/keymap.cpp:384
+msgid "Pipe article to command"
+msgstr "Pipe article to command"
+
+#: src/keymap.cpp:391
+msgid "Sort current list"
+msgstr "排序列表"
+
+#: src/keymap.cpp:398
+msgid "Sort current list (reverse)"
+msgstr "排序列表(反向)"
+
+#: src/keymap.cpp:402
+msgid "Open URL 1"
+msgstr "打開網址1"
+
+#: src/keymap.cpp:403
+msgid "Open URL 2"
+msgstr "打開網址2"
+
+#: src/keymap.cpp:404
+msgid "Open URL 3"
+msgstr "打開網址3"
+
+#: src/keymap.cpp:405
+msgid "Open URL 4"
+msgstr "打開網址4"
+
+#: src/keymap.cpp:406
+msgid "Open URL 5"
+msgstr "打開網址5"
+
+#: src/keymap.cpp:407
+msgid "Open URL 6"
+msgstr "打開網址6"
+
+#: src/keymap.cpp:408
+msgid "Open URL 7"
+msgstr "打開網址7"
+
+#: src/keymap.cpp:409
+msgid "Open URL 8"
+msgstr "打開網址8"
+
+#: src/keymap.cpp:410
+msgid "Open URL 9"
+msgstr "打開網址9"
+
+#: src/keymap.cpp:411
+msgid "Open URL 10"
+msgstr "打開網址10"
+
+#: src/keymap.cpp:413
+msgid "Start cmdline with 1"
+msgstr ""
+
+#: src/keymap.cpp:414
+msgid "Start cmdline with 2"
+msgstr ""
+
+#: src/keymap.cpp:415
+msgid "Start cmdline with 3"
+msgstr ""
+
+#: src/keymap.cpp:416
+msgid "Start cmdline with 4"
+msgstr ""
+
+#: src/keymap.cpp:417
+msgid "Start cmdline with 5"
+msgstr ""
+
+#: src/keymap.cpp:418
+msgid "Start cmdline with 6"
+msgstr ""
+
+#: src/keymap.cpp:419
+msgid "Start cmdline with 7"
+msgstr ""
+
+#: src/keymap.cpp:420
+msgid "Start cmdline with 8"
+msgstr ""
+
+#: src/keymap.cpp:421
+msgid "Start cmdline with 9"
+msgstr ""
+
+#: src/keymap.cpp:423
+msgid "Move to the previous entry"
+msgstr "跳到前一項"
+
+#: src/keymap.cpp:424
+msgid "Move to the next entry"
+msgstr "跳到下一項"
+
+#: src/keymap.cpp:429
+msgid "Move to the previous page"
+msgstr "回到前一頁"
+
+#: src/keymap.cpp:436
+msgid "Move to the next page"
+msgstr "跳到下一頁"
+
+#: src/keymap.cpp:444
+msgid "Move to the start of page/list"
+msgstr "跳到頁面/列表的開始"
+
+#: src/keymap.cpp:451
+msgid "Move to the end of page/list"
+msgstr "跳到頁面/列表的最後"
 
 #: src/keymap.cpp:710
 #, c-format
@@ -1592,237 +1961,6 @@ msgstr ""
 
 #~ msgid "Starting browser..."
 #~ msgstr "啟動瀏覽器..."
-
-#~ msgid "Open feed/article"
-#~ msgstr "打開來源/文章"
-
-#~ msgid "Return to previous dialog/Quit"
-#~ msgstr "返回到前一個對話框/退出"
-
-#~ msgid "Quit program, no confirmation"
-#~ msgstr "不經確認，直接離開程式"
-
-#~ msgid "Reload currently selected feed"
-#~ msgstr "重新載入選擇的來源"
-
-#~ msgid "Reload all feeds"
-#~ msgstr "重新載入所有來源"
-
-#~ msgid "Mark feed read"
-#~ msgstr "將來源標為已讀"
-
-#~ msgid "Mark all feeds read"
-#~ msgstr "將所有來源標為已讀"
-
-#, fuzzy
-#~ msgid "Mark all above as read"
-#~ msgstr "將所有來源標為已讀"
-
-#~ msgid "Save article"
-#~ msgstr "保存文章"
-
-#, fuzzy
-#~ msgid "Save articles"
-#~ msgstr "保存文章"
-
-#, fuzzy
-#~ msgid "Go to next entry"
-#~ msgstr "跳到下一項"
-
-#, fuzzy
-#~ msgid "Go to previous entry"
-#~ msgstr "跳到前一項"
-
-#~ msgid "Go to next unread article"
-#~ msgstr "轉到下一篇未讀文章"
-
-#~ msgid "Go to previous unread article"
-#~ msgstr "轉到前一篇未讀文章"
-
-#~ msgid "Go to a random unread article"
-#~ msgstr "隨機跳到未讀的文章"
-
-#, fuzzy
-#~ msgid "Open URL of article, or entry in URL view. Mark read."
-#~ msgstr "在瀏覽器裡打開文章"
-
-#, fuzzy
-#~ msgid "Open all unread items of selected feed in browser and mark read"
-#~ msgstr "在瀏覽器裡打開文章"
-
-#~ msgid "Open help dialog"
-#~ msgstr "打開說明對話框"
-
-#~ msgid "Toggle source view"
-#~ msgstr "切換原始碼顯示"
-
-#~ msgid "Toggle read status for article"
-#~ msgstr "切換文章的閱讀狀態（已讀/未讀）"
-
-#~ msgid "Toggle show read feeds/articles"
-#~ msgstr "切換顯示已讀來源/文章"
-
-#~ msgid "Show URLs in current article"
-#~ msgstr "列出當前文章裡的所有鏈結"
-
-#~ msgid "Clear current tag"
-#~ msgstr "清除當前標籤"
-
-#~ msgid "Select tag"
-#~ msgstr "選擇標籤"
-
-#~ msgid "Open search dialog"
-#~ msgstr "打開搜尋對話框"
-
-#~ msgid "Add download to queue"
-#~ msgstr "將該下載項目加入隊列"
-
-#~ msgid "Reload the list of URLs from the configuration"
-#~ msgstr "重新載入配置文件裡的鏈結列表"
-
-#~ msgid "Download file"
-#~ msgstr "下載檔案"
-
-#~ msgid "Cancel download"
-#~ msgstr "取消下載"
-
-#~ msgid "Mark download as deleted"
-#~ msgstr "將下載的項目標記為已刪除"
-
-#~ msgid "Purge finished and deleted downloads from queue"
-#~ msgstr "清除隊列中已完成的和已刪除的下載項目"
-
-#~ msgid "Toggle automatic download on/off"
-#~ msgstr "切換是否自動下載"
-
-#~ msgid "Start player with currently selected download"
-#~ msgstr "播放當前所選的下載項目"
-
-#~ msgid "Increase the number of concurrent downloads"
-#~ msgstr "增加同時下載的數目"
-
-#~ msgid "Decrease the number of concurrent downloads"
-#~ msgstr "減少同時下載的數目"
-
-#~ msgid "Redraw screen"
-#~ msgstr "更新畫面"
-
-#~ msgid "Open the commandline"
-#~ msgstr "打開命令列"
-
-#~ msgid "Set a filter"
-#~ msgstr "設置一個過濾器"
-
-#~ msgid "Select a predefined filter"
-#~ msgstr "選擇一個預先設定的過濾器"
-
-#~ msgid "Clear currently set filter"
-#~ msgstr "清除目前的過濾器"
-
-#~ msgid "Bookmark current link/article"
-#~ msgstr "將目前的文章/鏈結加入書籤"
-
-#~ msgid "Edit flags"
-#~ msgstr "編輯標記"
-
-#, fuzzy
-#~ msgid "Go to next feed"
-#~ msgstr "跳到下一篇未讀文章"
-
-#, fuzzy
-#~ msgid "Go to previous feed"
-#~ msgstr "跳到前一篇未讀文章"
-
-#~ msgid "Go to next unread feed"
-#~ msgstr "跳到下一篇未讀文章"
-
-#~ msgid "Go to previous unread feed"
-#~ msgstr "跳到前一篇未讀文章"
-
-#~ msgid "Call a macro"
-#~ msgstr "呼叫巨集"
-
-#~ msgid "Delete article"
-#~ msgstr "刪除文章"
-
-#, fuzzy
-#~ msgid "Delete all articles"
-#~ msgstr "刪除文章"
-
-#~ msgid "Purge deleted articles"
-#~ msgstr "清空被刪除的文章"
-
-#~ msgid "Edit subscribed URLs"
-#~ msgstr "編緝已訂閱的鏈結"
-
-#~ msgid "Close currently selected dialog"
-#~ msgstr "關閉目前選擇的對話窗"
-
-#~ msgid "View list of open dialogs"
-#~ msgstr "檢視已開啟對話窗列表"
-
-#~ msgid "Go to next dialog"
-#~ msgstr "跳到下一個對話窗"
-
-#~ msgid "Go to previous dialog"
-#~ msgstr "跳到前一個對話窗"
-
-#~ msgid "Pipe article to command"
-#~ msgstr "Pipe article to command"
-
-#~ msgid "Sort current list"
-#~ msgstr "排序列表"
-
-#~ msgid "Sort current list (reverse)"
-#~ msgstr "排序列表(反向)"
-
-#~ msgid "Open URL 1"
-#~ msgstr "打開網址1"
-
-#~ msgid "Open URL 2"
-#~ msgstr "打開網址2"
-
-#~ msgid "Open URL 3"
-#~ msgstr "打開網址3"
-
-#~ msgid "Open URL 4"
-#~ msgstr "打開網址4"
-
-#~ msgid "Open URL 5"
-#~ msgstr "打開網址5"
-
-#~ msgid "Open URL 6"
-#~ msgstr "打開網址6"
-
-#~ msgid "Open URL 7"
-#~ msgstr "打開網址7"
-
-#~ msgid "Open URL 8"
-#~ msgstr "打開網址8"
-
-#~ msgid "Open URL 9"
-#~ msgstr "打開網址9"
-
-#~ msgid "Open URL 10"
-#~ msgstr "打開網址10"
-
-#~ msgid "Move to the previous entry"
-#~ msgstr "跳到前一項"
-
-#~ msgid "Move to the next entry"
-#~ msgstr "跳到下一項"
-
-#~ msgid "Move to the previous page"
-#~ msgstr "回到前一頁"
-
-#~ msgid "Move to the next page"
-#~ msgstr "跳到下一頁"
-
-#~ msgid "Move to the start of page/list"
-#~ msgstr "跳到頁面/列表的開始"
-
-#~ msgid "Move to the end of page/list"
-#~ msgstr "跳到頁面/列表的最後"
 
 #~ msgid "Open article in browser"
 #~ msgstr "在瀏覽器裡打開文章"


### PR DESCRIPTION
Help messages are now wrapped in a new macro, `translatable()`, but I forgot to update the Makefile to account for that. See https://github.com/newsboat/newsboat/pull/1489

Issue spotted by @bitigchi: https://github.com/newsboat/newsboat/pull/1519#issuecomment-794357520