### PR TITLE
Rust filterparser: compile regex only once

### DIFF
--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -66,9 +66,7 @@ impl Operator {
                 .apply(attr, value)
                 .map(|result| !result),
             Operator::LessThan => Ok(string_to_num(attr) < string_to_num(&value.literal())),
-            Operator::GreaterThan => {
-                Ok(dbg!(string_to_num(attr)) > dbg!(string_to_num(&value.literal())))
-            }
+            Operator::GreaterThan => Ok(string_to_num(attr) > string_to_num(&value.literal())),
             Operator::LessThanOrEquals => {
                 Ok(string_to_num(attr) <= string_to_num(&value.literal()))
             }


### PR DESCRIPTION
This repeats the approach that our C++ filterparser takes: we store *both* the string literal and the compiled regular expression. A slight difference is that Rust can also store the error; if the expression is invalid, C++ would try to re-compile it on each match, while Rust will just produce the previously generated error. I think this is fine because Rust doesn't let anyone modify the literal, so we can be sure that the stored regex/error are always relevant to the literal.

I decided not to write any new tests because this is just an optimization. The results are still checked by the more general tests for `filterparser` and `matcher`.

This fixes #1441.

Reviews are welcome! I'll merge in three days.