### PR TITLE
CI: check for dbg! macro

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -422,3 +422,24 @@ i18nspector_task:
     # an exclamation mark. This fails the build if the log contains errors or
     # warnings.
     script: make run-i18nspector | tee i18nspector.log && ! egrep --silent "^(E|W):" i18nspector.log
+
+no_dbg_macros_task:
+    name: "No dbg! macros in Rust code"
+
+    container:
+      cpu: 1
+      memory: 512MB
+      image: alpine:3.10.2
+
+    script:
+      # Alpine uses BusyBox, so grep there doesn't support long options.
+      #
+      # -E -- extended regex, which supports beginning-of-word marker
+      # -r -- recursive
+      # -n -- show line numbers
+      #
+      # `!` in front of the command negates its exit code: this script will now
+      # exit with 0 if no matches were found, and with 1 if there are matches.
+      # We need parentheses to prevent YAML parser from eating up the
+      # exclamation mark.
+      - ( ! grep -Ern '\<dbg!' * )


### PR DESCRIPTION
This macro prints even in the release mode, so we should avoid it. For now, the check is not very constrained: it examines all files, not just the Rust code, and the simplistic regex can be triggered even by a comment. OTOH I'm pretty sure this check *can't* miss a legitimate dbg! call, so I prefer not to make it any more complicated at this time.

This fulfils the promise I made in https://github.com/newsboat/newsboat/pull/1533#discussion_r595640939.

The CI is not supposed to pass right now, because we do have a `dbg!` call in the filterparser. But once #1533 is merged, I'll rebase and then CI should pass (and I can merge this).