### PR TITLE
Bump cxx to 1.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,7 +57,7 @@ freebsd_task:
     # which causes some C++ classes to be re-compiled as they depend on cxx
     # bridges.
     fake_install_script: su testuser -c 'cd ~ && mkdir fakeroot && gmake DESTDIR=fakeroot install && gmake DESTDIR=fakeroot uninstall && [ $(find fakeroot -type f -print | wc -l) -eq 0 ]'
-    clippy_script: su testuser -c 'cd ~ && cargo clippy --all-targets --all-features -- -D warnings -A unknown-lints'
+    clippy_script: su testuser -c 'cd ~ && cargo clippy --all-targets --all-features -- -D warnings -A clippy::unknown-clippy-lints -A unknown-lints'
     before_cache_script: &before_cache_script
         # Cirrus CI sometimes fails to unpack the cache. In that case, it
         # removes the "cache folder" and tries again.
@@ -91,7 +91,7 @@ freebsd_task:
         - make DESTDIR=fakeroot uninstall
         - test $(find fakeroot -type f -print | wc -l) -eq 0
     clippy_script: &clippy_script
-        - cargo clippy --all-targets --all-features -- -D warnings -A unknown-lints
+        - cargo clippy --all-targets --all-features -- -D warnings -A clippy::unknown-clippy-lints -A unknown-lints
     before_cache_script: *before_cache_script
 
 macos_task:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.9.5"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0762455306b1ed42bc651ef6a2197aabda5e1d4a43c34d5eab5c1a3634e81d"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "0.5.10"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdd48b6a265557715bbbd72e891c6d26fe0cc58d87a881892a54ae47e0a92aa"
+checksum = "0b1448d9e25a056c72d7b02c89bcc38dfba96ff37097a3d77a6c485b3d02e293"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "0.5.10"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dca43e7e9d853737dc10c2fd8f9d2daaa2ccd1c37b96056e1c492ab34a2004"
+checksum = "c30d9408ad631526e499adba8b86828d2ccc43d12b142808dc9de1de1610c72e"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -184,15 +184,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "0.5.10"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1348c4c636b17ce60fc700963326ff65b19f0e9ee151bcf0a36a165d50d5dc49"
+checksum = "138a8f7053accfd5b1e967de7861ba14d9d3671b1ef335d7446c8c6d6149a454"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "0.5.10"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f75aad3925fade3d141007be05e9e272cf7cf7bbd089d9bb0d2d5621dbb016"
+checksum = "1dedf9501abdafd2994b52595c3e2ebc7781f14d32a9da480ec671c386374993"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/libnewsboat-ffi/Cargo.toml
+++ b/rust/libnewsboat-ffi/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [dependencies]
 libnewsboat = { path="../libnewsboat" }
 libc = "0.2"
-cxx = "0.5"
+cxx = "1"
 
 [build-dependencies]
-cxx-build = "0.5"
+cxx-build = "1"
 
 [lib]
 name = "newsboat"

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -1,4 +1,8 @@
-use libnewsboat::cliargsparser::CliArgsParser;
+use libnewsboat::cliargsparser;
+
+// cxx doesn't allow to share types from other crates, so we have to wrap it
+// cf. https://github.com/dtolnay/cxx/issues/496
+struct CliArgsParser(cliargsparser::CliArgsParser);
 
 #[cxx::bridge(namespace = "newsboat::cliargsparser::bridged")]
 mod bridged {
@@ -47,62 +51,62 @@ mod bridged {
 }
 
 fn create(argv: Vec<String>) -> Box<CliArgsParser> {
-    Box::new(CliArgsParser::new(argv))
+    Box::new(CliArgsParser(cliargsparser::CliArgsParser::new(argv)))
 }
 
 fn do_import(cliargsparser: &CliArgsParser) -> bool {
-    cliargsparser.importfile.is_some()
+    cliargsparser.0.importfile.is_some()
 }
 
 fn do_export(cliargsparser: &CliArgsParser) -> bool {
-    cliargsparser.do_export
+    cliargsparser.0.do_export
 }
 
 fn do_vacuum(cliargsparser: &CliArgsParser) -> bool {
-    cliargsparser.do_vacuum
+    cliargsparser.0.do_vacuum
 }
 
 fn do_cleanup(cliargsparser: &CliArgsParser) -> bool {
-    cliargsparser.do_cleanup
+    cliargsparser.0.do_cleanup
 }
 
 fn do_show_version(cliargsparser: &CliArgsParser) -> u64 {
-    cliargsparser.show_version as u64
+    cliargsparser.0.show_version as u64
 }
 
 fn silent(cliargsparser: &CliArgsParser) -> bool {
-    cliargsparser.silent
+    cliargsparser.0.silent
 }
 
 fn using_nonstandard_configs(cliargsparser: &CliArgsParser) -> bool {
-    cliargsparser.using_nonstandard_configs()
+    cliargsparser.0.using_nonstandard_configs()
 }
 
 fn should_print_usage(cliargsparser: &CliArgsParser) -> bool {
-    cliargsparser.should_print_usage
+    cliargsparser.0.should_print_usage
 }
 
 fn refresh_on_start(cliargsparser: &CliArgsParser) -> bool {
-    cliargsparser.refresh_on_start
+    cliargsparser.0.refresh_on_start
 }
 
 fn importfile(cliargsparser: &CliArgsParser) -> String {
-    match &cliargsparser.importfile {
+    match &cliargsparser.0.importfile {
         Some(path) => path.to_string_lossy().to_string(),
         None => String::new(),
     }
 }
 
 fn program_name(cliargsparser: &CliArgsParser) -> String {
-    cliargsparser.program_name.to_string()
+    cliargsparser.0.program_name.to_string()
 }
 
 fn display_msg(cliargsparser: &CliArgsParser) -> String {
-    cliargsparser.display_msg.to_string()
+    cliargsparser.0.display_msg.to_string()
 }
 
 fn return_code(cliargsparser: &CliArgsParser, value: &mut isize) -> bool {
-    match cliargsparser.return_code {
+    match cliargsparser.0.return_code {
         Some(code) => {
             *value = code as isize;
             true
@@ -112,7 +116,7 @@ fn return_code(cliargsparser: &CliArgsParser, value: &mut isize) -> bool {
 }
 
 fn readinfo_import_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
-    match &cliargsparser.readinfo_import_file {
+    match &cliargsparser.0.readinfo_import_file {
         Some(p) => {
             *path = p.to_string_lossy().to_string();
             true
@@ -122,7 +126,7 @@ fn readinfo_import_file(cliargsparser: &CliArgsParser, path: &mut String) -> boo
 }
 
 fn readinfo_export_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
-    match &cliargsparser.readinfo_export_file {
+    match &cliargsparser.0.readinfo_export_file {
         Some(p) => {
             *path = p.to_string_lossy().to_string();
             true
@@ -132,7 +136,7 @@ fn readinfo_export_file(cliargsparser: &CliArgsParser, path: &mut String) -> boo
 }
 
 fn url_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
-    match &cliargsparser.url_file {
+    match &cliargsparser.0.url_file {
         Some(p) => {
             *path = p.to_string_lossy().to_string();
             true
@@ -142,7 +146,7 @@ fn url_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
 }
 
 fn lock_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
-    match &cliargsparser.lock_file {
+    match &cliargsparser.0.lock_file {
         Some(p) => {
             *path = p.to_string_lossy().to_string();
             true
@@ -152,7 +156,7 @@ fn lock_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
 }
 
 fn cache_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
-    match &cliargsparser.cache_file {
+    match &cliargsparser.0.cache_file {
         Some(p) => {
             *path = p.to_string_lossy().to_string();
             true
@@ -162,7 +166,7 @@ fn cache_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
 }
 
 fn config_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
-    match &cliargsparser.config_file {
+    match &cliargsparser.0.config_file {
         Some(p) => {
             *path = p.to_string_lossy().to_string();
             true
@@ -172,7 +176,7 @@ fn config_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
 }
 
 fn log_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
-    match &cliargsparser.log_file {
+    match &cliargsparser.0.log_file {
         Some(p) => {
             *path = p.to_string_lossy().to_string();
             true
@@ -182,11 +186,11 @@ fn log_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
 }
 
 fn cmds_to_execute(cliargsparser: &CliArgsParser) -> Vec<String> {
-    cliargsparser.cmds_to_execute.to_owned()
+    cliargsparser.0.cmds_to_execute.to_owned()
 }
 
 fn log_level(cliargsparser: &CliArgsParser, level: &mut i8) -> bool {
-    match cliargsparser.log_level {
+    match cliargsparser.0.log_level {
         Some(l) => {
             *level = l as i8;
             true

--- a/rust/libnewsboat-ffi/src/scopemeasure.rs
+++ b/rust/libnewsboat-ffi/src/scopemeasure.rs
@@ -1,4 +1,8 @@
-use libnewsboat::scopemeasure::ScopeMeasure;
+use libnewsboat::scopemeasure;
+
+// cxx doesn't allow to share types from other crates, so we have to wrap it
+// cf. https://github.com/dtolnay/cxx/issues/496
+struct ScopeMeasure(scopemeasure::ScopeMeasure);
 
 #[cxx::bridge(namespace = "newsboat::scopemeasure::bridged")]
 mod bridged {
@@ -6,10 +10,14 @@ mod bridged {
         type ScopeMeasure;
 
         fn create(scope_name: String) -> Box<ScopeMeasure>;
-        fn stopover(self: &ScopeMeasure, stopover_name: &str);
+        fn stopover(obj: &ScopeMeasure, stopover_name: &str);
     }
 }
 
 fn create(scope_name: String) -> Box<ScopeMeasure> {
-    Box::new(ScopeMeasure::new(scope_name))
+    Box::new(ScopeMeasure(scopemeasure::ScopeMeasure::new(scope_name)))
+}
+
+fn stopover(obj: &ScopeMeasure, stopover_name: &str) {
+    obj.0.stopover(stopover_name);
 }

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -81,7 +81,7 @@ mod bridged {
 
         fn podcast_mime_to_link_type(mime_type: &str, result: &mut i64) -> bool;
 
-        fn run_program(argv: &Vec<String>, input: &str) -> String;
+        fn run_program(argv: &[&str], input: &str) -> String;
 
         fn translit(tocode: &str, fromcode: &str) -> String;
         fn utf8_to_locale(text: &str) -> Vec<u8>;
@@ -223,20 +223,6 @@ fn podcast_mime_to_link_type(mime_type: &str, result: &mut i64) -> bool {
             false
         }
     }
-}
-
-// Ignore Clippy's suggestion to replace &Vec<_> with &[_], because cxx crate doesn't allow us to
-// pass &[String] over FFI — only &[u8] is supported.
-#[allow(clippy::ptr_arg)]
-fn run_program(argv: &Vec<String>, input: &str) -> String {
-    let argv_of_str = {
-        let mut result = Vec::<&str>::new();
-        for s in argv {
-            result.push(s);
-        }
-        result
-    };
-    utils::run_program(&argv_of_str, input)
 }
 
 #[no_mangle]

--- a/src/scopemeasure.cpp
+++ b/src/scopemeasure.cpp
@@ -9,7 +9,7 @@ ScopeMeasure::ScopeMeasure(const std::string& func)
 
 void ScopeMeasure::stopover(const std::string& son)
 {
-	rs_object->stopover(son);
+	scopemeasure::bridged::stopover(*rs_object, son);
 }
 
 } // namespace newsboat

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -270,7 +270,7 @@ std::string utils::utf8_to_locale(const std::string& text)
 std::string utils::locale_to_utf8(const std::string& text)
 {
 	const auto text_slice =
-		rust::Slice<unsigned char>(
+		rust::Slice<const unsigned char>(
 			reinterpret_cast<const unsigned char*>(text.c_str()),
 			text.length());
 	return std::string(utils::bridged::locale_to_utf8(text_slice));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -376,10 +376,13 @@ std::string utils::retrieve_url(const std::string& url,
 
 std::string utils::run_program(const char* argv[], const std::string& input)
 {
-	rust::Vec<rust::String> rs_argv;
+	std::vector<rust::Str> slices;
 	for (; *argv; ++argv) {
-		rs_argv.emplace_back(*argv);
+		slices.emplace_back(*argv);
 	}
+
+	const auto rs_argv = rust::Slice<const rust::Str>(slices.data(), slices.size());
+
 	return std::string(utils::bridged::run_program(rs_argv, input));
 }
 


### PR DESCRIPTION
The only problem was a new restriction (which should be lifted in the
future): cxx only lets us share types that are defined in the current
crate. As a result, our libnewsboat-ffi crate can't share types from the
libnewsboat crate. To work around that, we wrap the type into
a single-field struct. This makes the bindings a bit more wordy, since
we have to access the field, but it's not too bad.

Fixes #1542.

Reviews are welcome! I will merge this in three days.