### PR TITLE
Correctly escape %2F in remote APIs

### DIFF
--- a/src/feedhqapi.cpp
+++ b/src/feedhqapi.cpp
@@ -55,7 +55,7 @@ std::string FeedHqApi::retrieve_auth()
 	char* password = curl_easy_escape(handle, cred.pass.c_str(), 0);
 
 	std::string postcontent = strprintf::fmt(
-			"service=reader&Email=%s&Passwd=%s&source=%s%2F%s&accountType="
+			"service=reader&Email=%s&Passwd=%s&source=%s%%2F%s&accountType="
 			"HOSTED_OR_GOOGLE&continue=http://www.google.com/",
 			username,
 			password,

--- a/src/oldreaderapi.cpp
+++ b/src/oldreaderapi.cpp
@@ -57,7 +57,7 @@ std::string OldReaderApi::retrieve_auth()
 	char* password = curl_easy_escape(handle, cred.pass.c_str(), 0);
 
 	std::string postcontent = strprintf::fmt(
-			"service=reader&Email=%s&Passwd=%s&source=%s%2F%s&accountType="
+			"service=reader&Email=%s&Passwd=%s&source=%s%%2F%s&accountType="
 			"HOSTED_OR_GOOGLE&continue=http://www.google.com/",
 			username,
 			password,


### PR DESCRIPTION
%2F is percent-encoded space, but when passed into snprintf, it's interpreted as a floating-point field. As a result, the program's version is formatted as a floating point. To avoid that, we escape the percent sign: %%2F.

This bug was found while reviewing FreshRSS integration: https://github.com/newsboat/newsboat/pull/1559#discussion_r605192829

I don't expect any reviews on this, so I'll auto-merge once the CI pass. But if you have thoughts of where similar bugs might lurk, let's hear them!