### PR TITLE
Speed up Rust tests by turning doctests into unit tests

### DIFF
--- a/doc/internal/code-style.markdown
+++ b/doc/internal/code-style.markdown
@@ -97,3 +97,14 @@ the same header as the class they're helping.
 If a big group of classes are sufficiently isolated from the rest, they can be
 stored in a separate directory and compiled into a static library. Examples:
 "filter" and "rss" directories.
+
+
+
+## Rust
+
+
+### Documentation tests (doctests)
+
+Each doctest is linked as a separate binary, which is slow. Use them to
+document the general API of the module, and mark them `no_run`. Do actual
+testing with unit tests inside the `tests` sub-module.

--- a/rust/libnewsboat/src/fmtstrformatter/mod.rs
+++ b/rust/libnewsboat/src/fmtstrformatter/mod.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 /// Since Newsboat contains a number of different format strings with different specifiers, we need
 /// an object to encapsulate the common part: the act of formatting. That way, the above example
 /// with titles and authors can be implemented very easily:
-/// ```
+/// ```no_run
 /// use libnewsboat::fmtstrformatter::*;
 ///
 /// let format = "%t (%a)";

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -89,7 +89,7 @@ struct LogFiles {
 /// This is meant to be a long-lived, shared object that exists for the duration of the program.
 /// Users would call its `log` method to add messages to the log file, like this:
 ///
-/// ```
+/// ```no_run
 /// use libnewsboat::logger::{Logger, Level};
 ///
 /// // Create and configure the logger

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -111,43 +111,6 @@ pub fn is_exec_url(url: &str) -> bool {
 }
 
 /// Censor URLs by replacing username and password with '*'
-/// ```
-/// use libnewsboat::utils::censor_url;
-/// assert_eq!(&censor_url(""), "");
-/// assert_eq!(&censor_url("foobar"), "foobar");
-/// assert_eq!(&censor_url("foobar://xyz/"), "foobar://xyz/");
-/// assert_eq!(&censor_url("http://newsbeuter.org/"),
-///     "http://newsbeuter.org/");
-/// assert_eq!(&censor_url("https://newsbeuter.org/"),
-///     "https://newsbeuter.org/");
-///
-/// assert_eq!(&censor_url("http://@newsbeuter.org/"),
-///         "http://newsbeuter.org/");
-/// assert_eq!(&censor_url("https://@newsbeuter.org/"),
-///         "https://newsbeuter.org/");
-///
-/// assert_eq!(&censor_url("http://foo:bar@newsbeuter.org/"),
-///     "http://*:*@newsbeuter.org/");
-/// assert_eq!(&censor_url("https://foo:bar@newsbeuter.org/"),
-///     "https://*:*@newsbeuter.org/");
-///
-/// assert_eq!(&censor_url("http://aschas@newsbeuter.org/"),
-///     "http://*:*@newsbeuter.org/");
-/// assert_eq!(&censor_url("https://aschas@newsbeuter.org/"),
-///     "https://*:*@newsbeuter.org/");
-///
-/// assert_eq!(&censor_url("xxx://aschas@newsbeuter.org/"),
-///     "xxx://*:*@newsbeuter.org/");
-///
-/// assert_eq!(&censor_url("http://foobar"), "http://foobar/");
-/// assert_eq!(&censor_url("https://foobar"), "https://foobar/");
-///
-/// assert_eq!(&censor_url("http://aschas@host"), "http://*:*@host/");
-/// assert_eq!(&censor_url("https://aschas@host"), "https://*:*@host/");
-///
-/// assert_eq!(&censor_url("query:name:age between 1:10"),
-///     "query:name:age between 1:10");
-/// ```
 pub fn censor_url(url: &str) -> String {
     if !url.is_empty() && !is_special_url(url) {
         Url::parse(url)
@@ -2119,5 +2082,63 @@ mod tests {
             "http://test:test@foobar:33/bla2.html".to_owned()
         );
         assert_eq!(absolute_url("foo", "bar"), "bar".to_owned());
+    }
+
+    #[test]
+    fn t_censor_url() {
+        assert_eq!(&censor_url(""), "");
+        assert_eq!(&censor_url("foobar"), "foobar");
+        assert_eq!(&censor_url("foobar://xyz/"), "foobar://xyz/");
+        assert_eq!(
+            &censor_url("http://newsbeuter.org/"),
+            "http://newsbeuter.org/"
+        );
+        assert_eq!(
+            &censor_url("https://newsbeuter.org/"),
+            "https://newsbeuter.org/"
+        );
+
+        assert_eq!(
+            &censor_url("http://@newsbeuter.org/"),
+            "http://newsbeuter.org/"
+        );
+        assert_eq!(
+            &censor_url("https://@newsbeuter.org/"),
+            "https://newsbeuter.org/"
+        );
+
+        assert_eq!(
+            &censor_url("http://foo:bar@newsbeuter.org/"),
+            "http://*:*@newsbeuter.org/"
+        );
+        assert_eq!(
+            &censor_url("https://foo:bar@newsbeuter.org/"),
+            "https://*:*@newsbeuter.org/"
+        );
+
+        assert_eq!(
+            &censor_url("http://aschas@newsbeuter.org/"),
+            "http://*:*@newsbeuter.org/"
+        );
+        assert_eq!(
+            &censor_url("https://aschas@newsbeuter.org/"),
+            "https://*:*@newsbeuter.org/"
+        );
+
+        assert_eq!(
+            &censor_url("xxx://aschas@newsbeuter.org/"),
+            "xxx://*:*@newsbeuter.org/"
+        );
+
+        assert_eq!(&censor_url("http://foobar"), "http://foobar/");
+        assert_eq!(&censor_url("https://foobar"), "https://foobar/");
+
+        assert_eq!(&censor_url("http://aschas@host"), "http://*:*@host/");
+        assert_eq!(&censor_url("https://aschas@host"), "https://*:*@host/");
+
+        assert_eq!(
+            &censor_url("query:name:age between 1:10"),
+            "query:name:age between 1:10"
+        );
     }
 }

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -289,13 +289,6 @@ pub fn strwidth(rs_str: &str) -> usize {
 ///
 /// STFL tags (e.g. `<b>`, `<foobar>`, `</>`) are counted as having 0 width.
 /// Escaped less-than sign (`<` escaped as `<>`) is counted as having a width of 1 character.
-/// ```
-/// use libnewsboat::utils::strwidth_stfl;
-/// assert_eq!(strwidth_stfl("a"), 1);
-/// assert_eq!(strwidth_stfl("abc<tag>def"), 6);
-/// assert_eq!(strwidth_stfl("less-than: <>"), 12);
-/// assert_eq!(strwidth_stfl("ＡＢＣＤＥＦ"), 12);
-///```
 pub fn strwidth_stfl(mut s: &str) -> usize {
     let mut width = 0;
     loop {
@@ -1321,6 +1314,10 @@ mod tests {
         assert_eq!(strwidth_stfl("\u{F91F}"), 2);
         assert_eq!(strwidth_stfl("\u{0007}"), 0);
         assert_eq!(strwidth_stfl("<a"), 0); // #415
+        assert_eq!(strwidth_stfl("a"), 1);
+        assert_eq!(strwidth_stfl("abc<tag>def"), 6);
+        assert_eq!(strwidth_stfl("less-than: <>"), 12);
+        assert_eq!(strwidth_stfl("ＡＢＣＤＥＦ"), 12);
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -551,18 +551,6 @@ pub fn make_title(rs_str: String) -> String {
 
 /// Run the given command interactively with inherited stdin and stdout/stderr. Return the lowest
 /// 8 bits of its exit code, or `None` if the command failed to start.
-/// ```
-/// use libnewsboat::utils::run_interactively;
-///
-/// let result = run_interactively("echo true", "test");
-/// assert_eq!(result, Some(0));
-///
-/// let result = run_interactively("exit 1", "test");
-/// assert_eq!(result, Some(1));
-///
-/// // Unfortunately, there is no easy way to provoke this function to return `None`, nor to test
-/// // that it returns just the lowest 8 bits.
-/// ```
 pub fn run_interactively(command: &str, caller: &str) -> Option<u8> {
     log!(Level::Debug, &format!("{}: running `{}'", caller, command));
     Command::new("sh")
@@ -2076,6 +2064,18 @@ mod tests {
             "http://test:test@foobar:33/bla2.html".to_owned()
         );
         assert_eq!(absolute_url("foo", "bar"), "bar".to_owned());
+    }
+
+    #[test]
+    fn t_run_interactively() {
+        let result = run_interactively("echo true", "test");
+        assert_eq!(result, Some(0));
+
+        let result = run_interactively("exit 1", "test");
+        assert_eq!(result, Some(1));
+
+        // Unfortunately, there is no easy way to provoke this function to return `None`, nor to test
+        // that it returns just the lowest 8 bits.
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -248,14 +248,6 @@ pub fn strwidth_stfl(mut s: &str) -> usize {
 ///
 /// Each chararacter width is calculated with UnicodeWidthChar::width. If UnicodeWidthChar::width()
 /// returns None, the character width is treated as 0.
-/// ```
-/// use libnewsboat::utils::substr_with_width;
-/// assert_eq!(substr_with_width("a", 1), "a");
-/// assert_eq!(substr_with_width("a", 2), "a");
-/// assert_eq!(substr_with_width("ab", 1), "a");
-/// assert_eq!(substr_with_width("abc", 1), "a");
-/// assert_eq!(substr_with_width("A\u{3042}B\u{3044}C\u{3046}", 5), "A\u{3042}B")
-///```
 pub fn substr_with_width(string: &str, max_width: usize) -> String {
     let mut result = String::new();
     let mut width = 0;
@@ -1248,6 +1240,18 @@ mod tests {
         assert_eq!(strwidth_stfl("abc<tag>def"), 6);
         assert_eq!(strwidth_stfl("less-than: <>"), 12);
         assert_eq!(strwidth_stfl("ＡＢＣＤＥＦ"), 12);
+    }
+
+    #[test]
+    fn t_substr_with_width() {
+        assert_eq!(substr_with_width("a", 1), "a");
+        assert_eq!(substr_with_width("a", 2), "a");
+        assert_eq!(substr_with_width("ab", 1), "a");
+        assert_eq!(substr_with_width("abc", 1), "a");
+        assert_eq!(
+            substr_with_width("A\u{3042}B\u{3044}C\u{3046}", 5),
+            "A\u{3042}B"
+        )
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -137,14 +137,6 @@ pub fn quote_for_stfl(string: &str) -> String {
 }
 
 /// Get basename from a URL if available else return an empty string
-/// ```
-/// use libnewsboat::utils::get_basename;
-/// assert_eq!(get_basename("https://example.com/"), "");
-/// assert_eq!(get_basename("https://example.org/?param=value#fragment"), "");
-/// assert_eq!(get_basename("https://example.org/path/to/?param=value#fragment"), "");
-/// assert_eq!(get_basename("https://example.org/file.mp3"), "file.mp3");
-/// assert_eq!(get_basename("https://example.org/path/to/file.mp3?param=value#fragment"), "file.mp3");
-/// ```
 pub fn get_basename(input: &str) -> String {
     match Url::parse(input) {
         Ok(url) => match url.path_segments() {
@@ -2076,6 +2068,24 @@ mod tests {
             "http://test:test@foobar:33/bla2.html".to_owned()
         );
         assert_eq!(absolute_url("foo", "bar"), "bar".to_owned());
+    }
+
+    #[test]
+    fn t_get_basename() {
+        assert_eq!(get_basename("https://example.com/"), "");
+        assert_eq!(
+            get_basename("https://example.org/?param=value#fragment"),
+            ""
+        );
+        assert_eq!(
+            get_basename("https://example.org/path/to/?param=value#fragment"),
+            ""
+        );
+        assert_eq!(get_basename("https://example.org/file.mp3"), "file.mp3");
+        assert_eq!(
+            get_basename("https://example.org/path/to/file.mp3?param=value#fragment"),
+            "file.mp3"
+        );
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -109,11 +109,6 @@ pub fn is_special_url(url: &str) -> bool {
 }
 
 /// Check if the given URL is a http(s) URL
-/// # Example
-/// ```
-/// use libnewsboat::utils::is_http_url;
-/// assert!(is_http_url("http://example.com"));
-/// ```
 pub fn is_http_url(url: &str) -> bool {
     url.starts_with("https://") || url.starts_with("http://")
 }
@@ -1200,6 +1195,7 @@ mod tests {
 
     #[test]
     fn t_is_http_url() {
+        assert!(is_http_url("http://example.com"));
         assert!(is_http_url("https://foo.bar"));
         assert!(is_http_url("http://"));
         assert!(is_http_url("https://"));

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -269,14 +269,6 @@ pub fn substr_with_width(string: &str, max_width: usize) -> String {
 /// Each chararacter width is calculated with UnicodeWidthChar::width. If UnicodeWidthChar::width()
 /// returns None, the character width is treated as 0. A STFL tag (e.g. `<b>`, `<foobar>`, `</>`)
 /// width is treated as 0, but escaped less-than (`<>`) width is treated as 1.
-/// ```
-/// use libnewsboat::utils::substr_with_width_stfl;
-/// assert_eq!(substr_with_width_stfl("a", 1), "a");
-/// assert_eq!(substr_with_width_stfl("a", 2), "a");
-/// assert_eq!(substr_with_width_stfl("ab", 1), "a");
-/// assert_eq!(substr_with_width_stfl("abc", 1), "a");
-/// assert_eq!(substr_with_width_stfl("A\u{3042}B\u{3044}C\u{3046}", 5), "A\u{3042}B")
-///```
 pub fn substr_with_width_stfl(string: &str, max_width: usize) -> String {
     let mut result = String::new();
     let mut in_bracket = false;
@@ -1293,6 +1285,18 @@ mod tests {
     #[test]
     fn t_substr_with_width_max_width_non_printable() {
         assert_eq!(substr_with_width("\x01\x02abc", 1), "\x01\x02a");
+    }
+
+    #[test]
+    fn t_substr_with_width_stfl() {
+        assert_eq!(substr_with_width_stfl("a", 1), "a");
+        assert_eq!(substr_with_width_stfl("a", 2), "a");
+        assert_eq!(substr_with_width_stfl("ab", 1), "a");
+        assert_eq!(substr_with_width_stfl("abc", 1), "a");
+        assert_eq!(
+            substr_with_width_stfl("A\u{3042}B\u{3044}C\u{3046}", 5),
+            "A\u{3042}B"
+        )
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -2031,7 +2031,7 @@ mod tests {
     #[test]
     fn t_gentabs() {
         fn genstring(len: usize) -> String {
-            return std::iter::repeat("a").take(len).collect::<String>();
+            std::iter::repeat("a").take(len).collect::<String>()
         }
 
         assert_eq!(gentabs(""), 4);

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -132,12 +132,6 @@ pub fn censor_url(url: &str) -> String {
 }
 
 /// Quote a string for use with stfl by replacing all occurences of "<" with "<>"
-/// ```
-/// use libnewsboat::utils::quote_for_stfl;
-/// assert_eq!(&quote_for_stfl("<"), "<>");
-/// assert_eq!(&quote_for_stfl("<<><><><"), "<><>><>><>><>");
-/// assert_eq!(&quote_for_stfl("test"), "test");
-/// ```
 pub fn quote_for_stfl(string: &str) -> String {
     string.replace("<", "<>")
 }
@@ -2082,6 +2076,13 @@ mod tests {
             "http://test:test@foobar:33/bla2.html".to_owned()
         );
         assert_eq!(absolute_url("foo", "bar"), "bar".to_owned());
+    }
+
+    #[test]
+    fn t_quote_for_stfl() {
+        assert_eq!(&quote_for_stfl("<"), "<>");
+        assert_eq!(&quote_for_stfl("<<><><><"), "<><>><>><>><>");
+        assert_eq!(&quote_for_stfl("test"), "test");
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -570,18 +570,6 @@ pub fn run_interactively(command: &str, caller: &str) -> Option<u8> {
 
 /// Run the given command non-interactively with closed stdin and stdout/stderr. Return the lowest
 /// 8 bits of its exit code, or `None` if the command failed to start.
-/// ```
-/// use libnewsboat::utils::run_non_interactively;
-///
-/// let result = run_non_interactively("echo true", "test");
-/// assert_eq!(result, Some(0));
-///
-/// let result = run_non_interactively("exit 1", "test");
-/// assert_eq!(result, Some(1));
-///
-/// // Unfortunately, there is no easy way to provoke this function to return `None`, nor to test
-/// // that it returns just the lowest 8 bits.
-/// ```
 pub fn run_non_interactively(command: &str, caller: &str) -> Option<u8> {
     log!(Level::Debug, &format!("{}: running `{}'", caller, command));
     Command::new("sh")
@@ -2064,6 +2052,18 @@ mod tests {
             "http://test:test@foobar:33/bla2.html".to_owned()
         );
         assert_eq!(absolute_url("foo", "bar"), "bar".to_owned());
+    }
+
+    #[test]
+    fn t_run_non_interactively() {
+        let result = run_non_interactively("echo true", "test");
+        assert_eq!(result, Some(0));
+
+        let result = run_non_interactively("exit 1", "test");
+        assert_eq!(result, Some(1));
+
+        // Unfortunately, there is no easy way to provoke this function to return `None`, nor to test
+        // that it returns just the lowest 8 bits.
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -635,32 +635,6 @@ pub fn strnaturalcmp(a: &str, b: &str) -> std::cmp::Ordering {
 ///
 /// The number of tabs will be adjusted by the width of the given string.  Usually, a column will
 /// consist of 4 tabs, 8 characters each.  Each column will consist of at least one tab.
-///
-/// ```
-/// use libnewsboat::utils::gentabs;
-///
-/// fn genstring(len: usize) -> String {
-///     return std::iter::repeat("a").take(len).collect::<String>();
-/// }
-///
-/// assert_eq!(gentabs(""), 4);
-/// assert_eq!(gentabs("a"), 4);
-/// assert_eq!(gentabs("aa"), 4);
-/// assert_eq!(gentabs("aaa"), 4);
-/// assert_eq!(gentabs("aaaa"), 4);
-/// assert_eq!(gentabs("aaaaa"), 4);
-/// assert_eq!(gentabs("aaaaaa"), 4);
-/// assert_eq!(gentabs("aaaaaaa"), 4);
-/// assert_eq!(gentabs("aaaaaaaa"), 3);
-/// assert_eq!(gentabs(&genstring(8)), 3);
-/// assert_eq!(gentabs(&genstring(9)), 3);
-/// assert_eq!(gentabs(&genstring(15)), 3);
-/// assert_eq!(gentabs(&genstring(16)), 2);
-/// assert_eq!(gentabs(&genstring(20)), 2);
-/// assert_eq!(gentabs(&genstring(24)), 1);
-/// assert_eq!(gentabs(&genstring(32)), 1);
-/// assert_eq!(gentabs(&genstring(100)), 1);
-/// ```
 pub fn gentabs(string: &str) -> usize {
     let tabcount = strwidth(string) / 8;
     if tabcount >= 4 {
@@ -2052,6 +2026,31 @@ mod tests {
             "http://test:test@foobar:33/bla2.html".to_owned()
         );
         assert_eq!(absolute_url("foo", "bar"), "bar".to_owned());
+    }
+
+    #[test]
+    fn t_gentabs() {
+        fn genstring(len: usize) -> String {
+            return std::iter::repeat("a").take(len).collect::<String>();
+        }
+
+        assert_eq!(gentabs(""), 4);
+        assert_eq!(gentabs("a"), 4);
+        assert_eq!(gentabs("aa"), 4);
+        assert_eq!(gentabs("aaa"), 4);
+        assert_eq!(gentabs("aaaa"), 4);
+        assert_eq!(gentabs("aaaaa"), 4);
+        assert_eq!(gentabs("aaaaaa"), 4);
+        assert_eq!(gentabs("aaaaaaa"), 4);
+        assert_eq!(gentabs("aaaaaaaa"), 3);
+        assert_eq!(gentabs(&genstring(8)), 3);
+        assert_eq!(gentabs(&genstring(9)), 3);
+        assert_eq!(gentabs(&genstring(15)), 3);
+        assert_eq!(gentabs(&genstring(16)), 2);
+        assert_eq!(gentabs(&genstring(20)), 2);
+        assert_eq!(gentabs(&genstring(24)), 1);
+        assert_eq!(gentabs(&genstring(32)), 1);
+        assert_eq!(gentabs(&genstring(100)), 1);
     }
 
     #[test]

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -49,21 +49,6 @@ pub fn to_u(rs_str: String, default_value: u32) -> u32 {
 
 /// Combine a base URL and a link to a new absolute URL.
 /// If the base URL is malformed or joining with the link fails, link will be returned.
-/// # Examples
-/// ```
-/// use libnewsboat::utils::absolute_url;
-/// assert_eq!(absolute_url("http://foobar/hello/crook/", "bar.html"),
-///     "http://foobar/hello/crook/bar.html".to_owned());
-/// assert_eq!(absolute_url("https://foobar/foo/", "/bar.html"),
-///     "https://foobar/bar.html".to_owned());
-/// assert_eq!(absolute_url("https://foobar/foo/", "http://quux/bar.html"),
-///     "http://quux/bar.html".to_owned());
-/// assert_eq!(absolute_url("http://foobar", "bla.html"),
-///     "http://foobar/bla.html".to_owned());
-/// assert_eq!(absolute_url("http://test:test@foobar:33", "bla2.html"),
-///     "http://test:test@foobar:33/bla2.html".to_owned());
-/// assert_eq!(absolute_url("foo", "bar"), "bar".to_owned());
-/// ```
 pub fn absolute_url(base_url: &str, link: &str) -> String {
     Url::parse(base_url)
         .and_then(|url| url.join(link))
@@ -2109,5 +2094,30 @@ mod tests {
             0xc3, 0x8b, 0xc3, 0x8c, 0xc3, 0x8d, 0xc3, 0x8e, 0xc3, 0x8f,
         ];
         assert_eq!(convert_text(&input, "UTF-8", "ISO-8859-1"), expected);
+    }
+
+    #[test]
+    fn t_absolute_url() {
+        assert_eq!(
+            absolute_url("http://foobar/hello/crook/", "bar.html"),
+            "http://foobar/hello/crook/bar.html".to_owned()
+        );
+        assert_eq!(
+            absolute_url("https://foobar/foo/", "/bar.html"),
+            "https://foobar/bar.html".to_owned()
+        );
+        assert_eq!(
+            absolute_url("https://foobar/foo/", "http://quux/bar.html"),
+            "http://quux/bar.html".to_owned()
+        );
+        assert_eq!(
+            absolute_url("http://foobar", "bla.html"),
+            "http://foobar/bla.html".to_owned()
+        );
+        assert_eq!(
+            absolute_url("http://test:test@foobar:33", "bla2.html"),
+            "http://test:test@foobar:33/bla2.html".to_owned()
+        );
+        assert_eq!(absolute_url("foo", "bar"), "bar".to_owned());
     }
 }

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -916,6 +916,7 @@ TEST_CASE("strwidth_stfl()", "[utils]")
 
 TEST_CASE("is_http_url()", "[utils]")
 {
+	REQUIRE(utils::is_http_url("http://example.com"));
 	REQUIRE(utils::is_http_url("http://foo.bar"));
 	REQUIRE(utils::is_http_url("https://foo.bar"));
 	REQUIRE(utils::is_http_url("http://"));

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -906,6 +906,12 @@ TEST_CASE("strwidth_stfl()", "[utils]")
 	const auto input1 = utils::wstr2str(L"\uF91F");
 	REQUIRE(utils::strwidth_stfl(input1) == 2);
 	REQUIRE(utils::strwidth_stfl("\07") == 0);
+
+	REQUIRE(utils::strwidth_stfl("<a") == 0); // #415
+	REQUIRE(utils::strwidth_stfl("a") == 1);
+	REQUIRE(utils::strwidth_stfl("abc<tag>def") == 6);
+	REQUIRE(utils::strwidth_stfl("less-than: <>") ==  12);
+	REQUIRE(utils::strwidth_stfl("ＡＢＣＤＥＦ") == 12);
 }
 
 TEST_CASE("is_http_url()", "[utils]")


### PR DESCRIPTION
For the rationale, please see e4f99a6ed4ca90dccf7c47aae1d436a5bdb9ad7e. If that doesn't convince you, leave a comment below :)

Some numbers:

```
$ git checkout --quiet d9580c8cf97d276e74ed6c1c805f368f83d469d2 \
  && cargo test --no-run \
  && sync \
  && TMPDIR=/dev/shm hyperfine --warmup 5 --min-runs 20 --command-name 'Prior to these changes' 'cargo test' \
  && git checkout --quiet e4f99a6ed4ca90dccf7c47aae1d436a5bdb9ad7e \
  && cargo test --no-run \
  && sync \
  && TMPDIR=/dev/shm hyperfine --warmup 5 --min-runs 20 --command-name 'After these changes' 'cargo test'
   Compiling libnewsboat v2.23.0 (/home/minoru/src/newsboat/rust/libnewsboat)
   Compiling libnewsboat-ffi v2.23.0 (/home/minoru/src/newsboat/rust/libnewsboat-ffi)
    Finished test [unoptimized + debuginfo] target(s) in 4.88s
Benchmark #1: Prior to these changes
  Time (mean ± σ):      5.331 s ±  0.022 s    [User: 26.051 s, System: 2.829 s]
  Range (min … max):    5.291 s …  5.380 s    20 runs

   Compiling libnewsboat v2.23.0 (/home/minoru/src/newsboat/rust/libnewsboat)
   Compiling libnewsboat-ffi v2.23.0 (/home/minoru/src/newsboat/rust/libnewsboat-ffi)
    Finished test [unoptimized + debuginfo] target(s) in 4.95s
Benchmark #1: After these changes
  Time (mean ± σ):      1.503 s ±  0.018 s    [User: 3.847 s, System: 0.239 s]
  Range (min … max):    1.473 s …  1.535 s    20 runs
```

That's with Intel Core i7-7700HQ, 4 cores, 8 threads. The working directory is on an SSD; `sync` ensures that all the executables are written onto disk before the testing starts. I decided against using tmpfs for the working directory because I wanted numbers that are close to real life. The first `git checkout` moves to `master` at the time of writing.

So yeah, (1-1.503/5.331)*100 = 72% reduction in runtime. Even if we take re-compilation into account, that's still (1 - (4.95+1.503)/(4.95+5.331))*100 = 37% reduction, which isn't great but is already noticeable.

Reviews are welcome! Don't fear the amount of commits — they're tiny, and purely to help with reviewing. I'll squash them when I merge this in three days.