### PR TITLE
Use newer dockerfile for build

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -19,7 +19,7 @@ one that we use for Continuous Integration:
         --file=docker/ubuntu_20.10-build-tools.dockerfile \
         docker
 
-This will use the description from "docker/ubuntu_18.04-build-tools.dockerfile"
+This will use the description from "docker/ubuntu_20.10-build-tools.dockerfile"
 to build an image named "newsboat-build-tools". That image contains all the
 compilers and libraries that one needs to build Newsboat from source.
 

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -16,7 +16,7 @@ one that we use for Continuous Integration:
     # In the root of Newsboat's repository
     $ docker build \
         --tag=newsboat-build-tools \
-        --file=docker/ubuntu_18.04-build-tools.dockerfile \
+        --file=docker/ubuntu_20.10-build-tools.dockerfile \
         docker
 
 This will use the description from "docker/ubuntu_18.04-build-tools.dockerfile"


### PR DESCRIPTION
Using the [current docker-based build doc](https://github.com/newsboat/newsboat/blob/master/doc/docker.md), i.e. with `ubuntu_18.04-build-tools.dockerfile`, I get:

```
src/view.cpp:7:10: fatal error: curses.h: No such file or directory
 #include <curses.h>
          ^~~~~~~~~~
compilation terminated.
```

So I tried with the newer `ubuntu_20.10-build-tools.dockerfile`, and it works better:

```sh
docker build --tag=newsboat-build-tools --file=docker/ubuntu_20.10-build-tools.dockerfile docker

docker run --rm --mount type=bind,source=$(pwd),target=/home/builder/src --user $(id -u):$(id -g) newsboat-build-tools make -j

docker run --rm -it --mount type=bind,source=$(pwd),target=/home/builder/src newsboat-build-tools ./newsboat
```