### PR TITLE
Render as HTML by default

### DIFF
--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -21,7 +21,7 @@ std::string get_feedtitle(std::shared_ptr<RssItem> item);
 
 /// \brief Splits text into lines marked as wrappable
 void render_plaintext(const std::string& source,
-	std::vector<std::pair<LineType, std::string>>& lines);
+	std::vector<std::pair<LineType, std::string>>& lines, bool raw = false);
 
 /// \brief Returns plain-text representation of the RssItem.
 ///

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -15,13 +15,19 @@ class RssItem;
 
 /// \brief Creates different textual representations of an RssItem.
 namespace item_renderer {
+
+enum class OutputFormat {
+	PlainText,
+	StflRichText,
+};
+
 /// \brief Returns feed's title of the item, or some replacement value if
 /// the title isn't available.
 std::string get_feedtitle(std::shared_ptr<RssItem> item);
 
 /// \brief Splits text into lines marked as wrappable
 void render_plaintext(const std::string& source,
-	std::vector<std::pair<LineType, std::string>>& lines, bool raw = false);
+	std::vector<std::pair<LineType, std::string>>& lines, OutputFormat format);
 
 /// \brief Returns plain-text representation of the RssItem.
 ///

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -145,7 +145,7 @@ void render_html(
 
 void item_renderer::render_plaintext(
 	const std::string& source,
-	std::vector<std::pair<LineType, std::string>>& lines, bool raw)
+	std::vector<std::pair<LineType, std::string>>& lines, OutputFormat format)
 {
 	std::string normalized = utils::replace_all(source, "\r\n", "\n");
 	normalized = utils::replace_all(normalized, "\r", "\n");
@@ -155,11 +155,14 @@ void item_renderer::render_plaintext(
 		const auto end_of_line = normalized.find_first_of("\n", pos);
 		const std::string line = normalized.substr(pos, end_of_line - pos);
 
-		if (raw) {
+		switch (format) {
+		case OutputFormat::PlainText:
 			lines.push_back(std::make_pair(LineType::wrappable, line));
-		} else {
+			break;
+		case OutputFormat::StflRichText:
 			const std::string stfl_quoted_line = utils::quote_for_stfl(line);
 			lines.push_back(std::make_pair(LineType::wrappable, stfl_quoted_line));
+			break;
 		}
 
 		if (end_of_line == std::string::npos) {
@@ -184,7 +187,7 @@ std::string item_renderer::to_plain_text(
 	if (should_render_as_html(item_description.mime)) {
 		render_html(cfg, body, lines, links, base, true);
 	} else {
-		render_plaintext(body, lines);
+		render_plaintext(body, lines, OutputFormat::PlainText);
 	}
 
 	TextFormatter txtfmt;
@@ -217,7 +220,7 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 	if (should_render_as_html(item_description.mime)) {
 		render_html(cfg, body, lines, links, baseurl, false);
 	} else {
-		render_plaintext(body, lines);
+		render_plaintext(body, lines, OutputFormat::StflRichText);
 	}
 
 	TextFormatter txtfmt;

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -13,6 +13,7 @@ namespace newsboat {
 bool should_render_as_html(const std::string mime_type)
 {
 	static const std::set<std::string> html_mime_types = {
+		"", // Render as HTML when no mime-type is provided
 		"html",
 		"xhtml",
 		"text/html",

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -144,7 +144,7 @@ void render_html(
 
 void item_renderer::render_plaintext(
 	const std::string& source,
-	std::vector<std::pair<LineType, std::string>>& lines)
+	std::vector<std::pair<LineType, std::string>>& lines, bool raw)
 {
 	std::string normalized = utils::replace_all(source, "\r\n", "\n");
 	normalized = utils::replace_all(normalized, "\r", "\n");
@@ -153,7 +153,14 @@ void item_renderer::render_plaintext(
 	while (pos < normalized.size()) {
 		const auto end_of_line = normalized.find_first_of("\n", pos);
 		const std::string line = normalized.substr(pos, end_of_line - pos);
-		lines.push_back(std::make_pair(LineType::wrappable, line));
+
+		if (raw) {
+			lines.push_back(std::make_pair(LineType::wrappable, line));
+		} else {
+			const std::string stfl_quoted_line = utils::quote_for_stfl(line);
+			lines.push_back(std::make_pair(LineType::wrappable, stfl_quoted_line));
+		}
+
 		if (end_of_line == std::string::npos) {
 			break;
 		}

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -661,9 +661,9 @@ TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_re
 {
 	// Verifies that render_plaintext creates the expected lines, all marked as wrappable
 	const auto check = [](const std::string input,
-	const std::vector<std::string>& expected_lines) {
+	const std::vector<std::string>& expected_lines, bool for_stfl = true) {
 		std::vector<std::pair<LineType, std::string>> output;
-		item_renderer::render_plaintext(input, output);
+		item_renderer::render_plaintext(input, output, !for_stfl);
 
 		REQUIRE(output.size() == expected_lines.size());
 		for (std::size_t i = 0; i < output.size(); ++i) {
@@ -712,5 +712,25 @@ TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_re
 			"",
 			"aliqua."
 		});
+	}
+
+	SECTION("render_plaintext escapes angle brackets for STFL") {
+		const std::string text = "this < should be escaped >\n<p>test text</p>";
+
+		check(text, {
+			"this <> should be escaped >",
+			"<>p>test text<>/p>"
+		});
+	}
+
+	SECTION("render_plaintext does not escape when rendering towards some plaintext output") {
+		const std::string text = "this < should *not* be escaped >\n<p>test text</p>";
+
+		const bool render_for_stfl = false;
+
+		check(text, {
+			"this < should *not* be escaped >",
+			"<p>test text</p>"
+		}, render_for_stfl);
 	}
 }

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -659,11 +659,12 @@ TEST_CASE("Functions used for rendering articles escape '<' into `<>` for use wi
 
 TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_renderer]")
 {
+	using newsboat::item_renderer::OutputFormat;
 	// Verifies that render_plaintext creates the expected lines, all marked as wrappable
 	const auto check = [](const std::string input,
-	const std::vector<std::string>& expected_lines, bool for_stfl = true) {
+	const std::vector<std::string>& expected_lines, OutputFormat format) {
 		std::vector<std::pair<LineType, std::string>> output;
-		item_renderer::render_plaintext(input, output, !for_stfl);
+		item_renderer::render_plaintext(input, output, format);
 
 		REQUIRE(output.size() == expected_lines.size());
 		for (std::size_t i = 0; i < output.size(); ++i) {
@@ -682,7 +683,7 @@ TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_re
 			"consectetur adipiscing elit",
 			"sed do eiusmod tempor incididunt ut labore",
 			"et dolore magna aliqua."
-		});
+		}, OutputFormat::StflRichText);
 	}
 
 	SECTION("render_plaintext keeps indentation") {
@@ -695,7 +696,7 @@ TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_re
 			"    this is a test",
 			"",
 			"back to no indentation"
-		});
+		}, OutputFormat::StflRichText);
 	}
 
 	SECTION(R"(text is split on sequences of \r\n, and on separate \r and \n characters)") {
@@ -711,7 +712,7 @@ TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_re
 			"et dolore magna",
 			"",
 			"aliqua."
-		});
+		}, OutputFormat::StflRichText);
 	}
 
 	SECTION("render_plaintext escapes angle brackets for STFL") {
@@ -720,17 +721,15 @@ TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_re
 		check(text, {
 			"this <> should be escaped >",
 			"<>p>test text<>/p>"
-		});
+		}, OutputFormat::StflRichText);
 	}
 
 	SECTION("render_plaintext does not escape when rendering towards some plaintext output") {
 		const std::string text = "this < should *not* be escaped >\n<p>test text</p>";
 
-		const bool render_for_stfl = false;
-
 		check(text, {
 			"this < should *not* be escaped >",
 			"<p>test text</p>"
-		}, render_for_stfl);
+		}, OutputFormat::PlainText);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1590

While looking into that issue, I noticed that `<` is not escaped for STFL when rendering using `render_plaintext()`.