### PR TITLE
Simplify working with TZ and LC_CTYPE env vars in tests

### DIFF
--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -57,7 +57,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 	"of an RSS item, ready to be displayed to the user",
 	"[item_renderer]")
 {
-	TestHelpers::EnvVar tzEnv("TZ");
+	TestHelpers::TzEnvVar tzEnv;
 	tzEnv.set("UTC");
 
 	ConfigContainer cfg;
@@ -161,7 +161,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 	"in `text-width` setting",
 	"[item_renderer]")
 {
-	TestHelpers::EnvVar tzEnv("TZ");
+	TestHelpers::TzEnvVar tzEnv;
 	tzEnv.set("UTC");
 
 	ConfigContainer cfg;
@@ -268,7 +268,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 TEST_CASE("to_plain_text() does not escape '<' and '>' in header and body",
 	"[item_renderer]")
 {
-	TestHelpers::EnvVar tzEnv("TZ");
+	TestHelpers::TzEnvVar tzEnv;
 	tzEnv.set("UTC");
 
 	ConfigContainer cfg;
@@ -300,7 +300,7 @@ TEST_CASE("to_plain_text() does not escape '<' and '>' in header and body",
 
 TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 {
-	TestHelpers::EnvVar tzEnv("TZ");
+	TestHelpers::TzEnvVar tzEnv;
 	tzEnv.set("UTC");
 
 	ConfigContainer cfg;
@@ -416,7 +416,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 	"[item_renderer]")
 {
-	TestHelpers::EnvVar tzEnv("TZ");
+	TestHelpers::TzEnvVar tzEnv;
 	tzEnv.set("UTC");
 
 	ConfigContainer cfg;
@@ -601,7 +601,7 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed URL "
 TEST_CASE("Functions used for rendering articles escape '<' into `<>` for use with stfl",
 	"[item_renderer]")
 {
-	TestHelpers::EnvVar tzEnv("TZ");
+	TestHelpers::TzEnvVar tzEnv;
 	tzEnv.set("UTC");
 
 	ConfigContainer cfg;

--- a/test/queuemanager.cpp
+++ b/test/queuemanager.cpp
@@ -346,10 +346,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 
 	SECTION("%F, %m, %b, %d, %H, %M, %S, %y, and %Y to render items's publication date with strftime") {
 		// %H is sensitive to the timezone, so reset it to UTC for a time being
-		TestHelpers::EnvVar tzEnv("TZ");
-		tzEnv.on_change([](nonstd::optional<std::string>) {
-			::tzset();
-		});
+		TestHelpers::TzEnvVar tzEnv;
 		tzEnv.set("UTC");
 
 		cfg.set_configvalue("download-filename-format", "%F, %m, %b, %d, %H, %M, %S, %y, and %Y");

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -479,7 +479,7 @@ TEST_CASE("RssFeed contains a number of matchable attributes", "[RssFeed]")
 	}
 
 	SECTION("feeddate, feed's publication date") {
-		TestHelpers::EnvVar tzEnv("TZ");
+		TestHelpers::TzEnvVar tzEnv;
 		tzEnv.set("UTC");
 
 		f.set_pubDate(1); // one second into the Unix epoch

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -422,15 +422,7 @@ TEST_CASE("RssFeed contains a number of matchable attributes", "[RssFeed]")
 			// we can't compare results to a known-good value. Instead, we
 			// merely check that the result is *not* UTF-8.
 
-			TestHelpers::EnvVar lc_ctype("LC_CTYPE");
-			lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
-				if (new_charset.has_value()) {
-					::setlocale(LC_CTYPE, new_charset.value().c_str());
-				} else {
-					::setlocale(LC_CTYPE, "");
-				}
-			});
-
+			TestHelpers::LcCtypeEnvVar lc_ctype;
 			lc_ctype.set("C"); // This means ASCII
 
 			const auto title = "こんにちは";// "good afternoon" in Japanese
@@ -452,15 +444,7 @@ TEST_CASE("RssFeed contains a number of matchable attributes", "[RssFeed]")
 			// we can't compare results to a known-good value. Instead, we
 			// merely check that the result is *not* UTF-8.
 
-			TestHelpers::EnvVar lc_ctype("LC_CTYPE");
-			lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
-				if (new_charset.has_value()) {
-					::setlocale(LC_CTYPE, new_charset.value().c_str());
-				} else {
-					::setlocale(LC_CTYPE, "");
-				}
-			});
-
+			TestHelpers::LcCtypeEnvVar lc_ctype;
 			lc_ctype.set("C"); // This means ASCII
 
 			const auto description = "こんにちは";// "good afternoon" in Japanese

--- a/test/rssitem.cpp
+++ b/test/rssitem.cpp
@@ -51,15 +51,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 			// we can't compare results to a known-good value. Instead, we
 			// merely check that the result is *not* UTF-8.
 
-			TestHelpers::EnvVar lc_ctype("LC_CTYPE");
-			lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
-				if (new_charset.has_value()) {
-					::setlocale(LC_CTYPE, new_charset.value().c_str());
-				} else {
-					::setlocale(LC_CTYPE, "");
-				}
-			});
-
+			TestHelpers::LcCtypeEnvVar lc_ctype;
 			lc_ctype.set("C"); // This means ASCII
 
 			const auto title = "こんにちは"; // "good afternoon"
@@ -92,15 +84,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 			// we can't compare results to a known-good value. Instead, we
 			// merely check that the result is *not* UTF-8.
 
-			TestHelpers::EnvVar lc_ctype("LC_CTYPE");
-			lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
-				if (new_charset.has_value()) {
-					::setlocale(LC_CTYPE, new_charset.value().c_str());
-				} else {
-					::setlocale(LC_CTYPE, "");
-				}
-			});
-
+			TestHelpers::LcCtypeEnvVar lc_ctype;
 			lc_ctype.set("C"); // This means ASCII
 
 			const auto author = "李白"; // "Li Bai"
@@ -124,15 +108,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 			// we can't compare results to a known-good value. Instead, we
 			// merely check that the result is *not* UTF-8.
 
-			TestHelpers::EnvVar lc_ctype("LC_CTYPE");
-			lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
-				if (new_charset.has_value()) {
-					::setlocale(LC_CTYPE, new_charset.value().c_str());
-				} else {
-					::setlocale(LC_CTYPE, "");
-				}
-			});
-
+			TestHelpers::LcCtypeEnvVar lc_ctype;
 			lc_ctype.set("C"); // This means ASCII
 
 			const auto description = "こんにちは"; // "good afternoon"

--- a/test/rssitem.cpp
+++ b/test/rssitem.cpp
@@ -144,7 +144,7 @@ TEST_CASE("RssItem contains a number of matchable attributes", "[RssItem]")
 	}
 
 	SECTION("date") {
-		TestHelpers::EnvVar tzEnv("TZ");
+		TestHelpers::TzEnvVar tzEnv;
 		tzEnv.set("UTC");
 
 		const auto attr = "date";

--- a/test/rsspp_rssparser.cpp
+++ b/test/rsspp_rssparser.cpp
@@ -65,10 +65,7 @@ TEST_CASE(
 	auto input = "2008-12-30T10:03:15-08:00";
 	auto expected = "Tue, 30 Dec 2008 18:03:15 +0000";
 
-	TestHelpers::EnvVar tzEnv("TZ");
-	tzEnv.on_change([](nonstd::optional<std::string>) {
-		::tzset();
-	});
+	TestHelpers::TzEnvVar tzEnv;
 
 	// US/Pacific and Australia/Sydney have pretty much opposite DST
 	// schedules, so for any given moment in time one of the following two

--- a/test/test-helpers/envvar.cpp
+++ b/test/test-helpers/envvar.cpp
@@ -7,6 +7,8 @@ TestHelpers::EnvVar::EnvVar(std::string name_)
 {
 	if (name_ == "TZ") {
 		throw std::invalid_argument("Using EnvVar(\"TZ\") is discouraged. Try TestHelpers::TzEnvVar instead.");
+	} else if (name_ == "LC_CTYPE") {
+		throw std::invalid_argument("Using EnvVar(\"LC_CTYPE\") is discouraged. Try TestHelpers::LcCtypeEnvVar instead.");
 	}
 }
 
@@ -57,6 +59,18 @@ TestHelpers::TzEnvVar::TzEnvVar()
 {
 	on_change([](nonstd::optional<std::string>) {
 		::tzset();
+	});
+}
+
+TestHelpers::LcCtypeEnvVar::LcCtypeEnvVar()
+	: EnvVar("LC_CTYPE", true)
+{
+	on_change([](nonstd::optional<std::string> new_charset) {
+		if (new_charset.has_value()) {
+			::setlocale(LC_CTYPE, new_charset.value().c_str());
+		} else {
+			::setlocale(LC_CTYPE, "");
+		}
 	});
 }
 
@@ -407,4 +421,9 @@ TEST_CASE("EnvVar's destructor runs a function (set by on_change()) after "
 TEST_CASE("EnvVar can't be constructed for TZ variable", "[test-helpers]")
 {
 	REQUIRE_THROWS_AS(TestHelpers::EnvVar("TZ"), std::invalid_argument);
+}
+
+TEST_CASE("EnvVar can't be constructed for LC_CTYPE variable", "[test-helpers]")
+{
+	REQUIRE_THROWS_AS(TestHelpers::EnvVar("LC_CTYPE"), std::invalid_argument);
 }

--- a/test/test-helpers/envvar.h
+++ b/test/test-helpers/envvar.h
@@ -96,6 +96,21 @@ private:
 	using EnvVar::on_change;
 };
 
+/* \brief Save and restore locale charset environment variable, calling
+ * setlocale as appropriate.
+ *
+ * For details, see the docs for `EnvVar`.
+ */
+class LcCtypeEnvVar final : public EnvVar {
+public:
+	LcCtypeEnvVar();
+	virtual ~LcCtypeEnvVar() = default;
+
+private:
+	// We hide this method because we don't want users to override our handler.
+	using EnvVar::on_change;
+};
+
 } // namespace TestHelpers
 
 #endif /* NEWSBOAT_TEST_HELPERS_ENVVAR_H_ */

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1733,14 +1733,7 @@ TEST_CASE("utf8_to_locale() converts text from UTF-8 to the encoding specified "
 	"by locale in LC_CTYPE class",
 	"[utils]")
 {
-	TestHelpers::EnvVar lc_ctype("LC_CTYPE");
-	lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
-		if (new_charset.has_value()) {
-			::setlocale(LC_CTYPE, new_charset.value().c_str());
-		} else {
-			::setlocale(LC_CTYPE, "");
-		}
-	});
+	TestHelpers::LcCtypeEnvVar lc_ctype;
 	const auto set_locale = [&lc_ctype](std::string new_locale) -> bool {
 		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr)
 		{
@@ -1798,14 +1791,7 @@ TEST_CASE("utf8_to_locale() converts text from UTF-8 to the encoding specified "
 TEST_CASE("utf8_to_locale() transliterates characters unsupported by the locale's encoding",
 	"[utils]")
 {
-	TestHelpers::EnvVar lc_ctype("LC_CTYPE");
-	lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
-		if (new_charset.has_value()) {
-			::setlocale(LC_CTYPE, new_charset.value().c_str());
-		} else {
-			::setlocale(LC_CTYPE, "");
-		}
-	});
+	TestHelpers::LcCtypeEnvVar lc_ctype;
 	const auto set_locale = [&lc_ctype](std::string new_locale) -> bool {
 		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr)
 		{
@@ -1853,14 +1839,7 @@ TEST_CASE("locale_to_utf8() converts text from the encoding specified by locale 
 	"in LC_CTYPE class to UTF-8",
 	"[utils]")
 {
-	TestHelpers::EnvVar lc_ctype("LC_CTYPE");
-	lc_ctype.on_change([](nonstd::optional<std::string> new_charset) {
-		if (new_charset.has_value()) {
-			::setlocale(LC_CTYPE, new_charset.value().c_str());
-		} else {
-			::setlocale(LC_CTYPE, "");
-		}
-	});
+	TestHelpers::LcCtypeEnvVar lc_ctype;
 	const auto set_locale = [&lc_ctype](std::string new_locale) -> bool {
 		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr)
 		{


### PR DESCRIPTION
We have a test helper, `EnvVar`, which lets us automatically restore the state of the environment at the end of the test (even if the test failed). Some variables, like TZ and LC_CTYPE, require running some C function after updating it. I noticed that not all users of TZ did that. This didn't result in any bugs, but it's worrisome still.

This PR adds sub-classes of `EnvVar` that bundle the handler. The `EnvVar` constructor is updated to discourage people from using the bare `EnvVar` where a specialized version is more appropriate.

There are some more repetitive code in tests that try to set the locale, but I don't see an easy way to simplify that. Please see the commit message of https://github.com/newsboat/newsboat/commit/6bec3174c5af24fbd9dfdad3528cc94bd16e0eda for my thoughts on that.

Reviews are welcome! Will merge in three days.