### PR TITLE
CI: warn about functions unprotected from stack smashing

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -202,7 +202,7 @@ linux_task:
                 cc: gcc-10
                 cxx: g++-10
           env: &extra_warnings_and_checks_env
-            CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
+            CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-strong -Wstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
         - name: Clang 11, more warnings and checks (Ubuntu 20.10)
           container:
             dockerfile: docker/ubuntu_20.10-build-tools.dockerfile


### PR DESCRIPTION
Adding this to avoid regressions on #1598.

Should've done this in #1601 :) Oh well.

It's a trivial change, so will merge once the CI is done.