### PR TITLE
Introduce `restrict-filename` setting

### DIFF
--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -153,3 +153,4 @@ urlview-title-format||<format>||"%N %V - URLs" (localized)||Format of the title 
 use-proxy||[yes/no]||no||If set to `yes`, then the configured proxy will be used for downloading the RSS feeds.||use-proxy yes
 user-agent||<string>||""||If set to a non-zero-length string, this value will be used as HTTP User-Agent header for all HTTP requests.||user-agent "Lynx/2.8.5rel.1 libwww-FM/2.14"
 wrap-scroll||[yes/no]||no||If set to `yes`, moving down while on the last item in a list will wrap around to the top and vice versa.||wrap-scroll yes
+ascii-only-filename||[yes/no]||yes||If set to `no`, Newsboat will not limit saved article filenames to ASCII characters.||ascii-only-filename yes

--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -123,6 +123,7 @@ reload-only-visible-feeds||[yes/no]||no||If set to `yes`, then manually reloadin
 reload-threads||<number>||1||The number of parallel reload threads that shall be started when all feeds are reloaded.||reload-threads 3
 reload-time||<number>||60||The number of minutes between automatic reloads.||reload-time 120
 reset-unread-on-update||<url> [<url>...]||n/a||Specifies one or more feed URLs for whose articles the unread flag will be reset if an article has been updated, i.e. its content has been changed. This is especially useful for RSS feeds where single articles are updated after publication, and you want to be notified of the updates. This option can be specified multiple times.||reset-unread-on-update "https://blog.fefe.de/rss.xml?html"
+restrict-filename||[yes/no]||yes||If set to `no`, Newsboat will not limit saved article filenames to ASCII characters.||restrict-filename no
 run-on-startup||<list of operations>||n/a||Specifies one or more <<_newsboat_operations,Newsboat operations>>, separated by semicolons, which are executed on Newsboat startup.||run-on-startup next-unread; open; random-unread; open
 save-path||<path-to-directory>||~/||The default path where articles shall be saved to. If an invalid path is specified, the current directory is used.||save-path "~/Saved Articles"
 scrolloff||<number>||0||Keep the configured number of lines above and below the selected item in lists. Configure a high number to keep the selected item in the center of the screen.||scrolloff 5
@@ -153,4 +154,3 @@ urlview-title-format||<format>||"%N %V - URLs" (localized)||Format of the title 
 use-proxy||[yes/no]||no||If set to `yes`, then the configured proxy will be used for downloading the RSS feeds.||use-proxy yes
 user-agent||<string>||""||If set to a non-zero-length string, this value will be used as HTTP User-Agent header for all HTTP requests.||user-agent "Lynx/2.8.5rel.1 libwww-FM/2.14"
 wrap-scroll||[yes/no]||no||If set to `yes`, moving down while on the last item in a list will wrap around to the top and vice versa.||wrap-scroll yes
-ascii-only-filename||[yes/no]||yes||If set to `no`, Newsboat will not limit saved article filenames to ASCII characters.||ascii-only-filename yes

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -1101,8 +1101,6 @@ test/strprintf.o: test/strprintf.cpp include/strprintf.h \
  3rd-party/catch.hpp
 test/tagsouppullparser.o: test/tagsouppullparser.cpp \
  include/tagsouppullparser.h 3rd-party/optional.hpp 3rd-party/catch.hpp
-test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h
 test/test-helpers/chdir.o: test/test-helpers/chdir.cpp \
  test/test-helpers/chdir.h include/utils.h 3rd-party/expected.hpp \
  3rd-party/optional.hpp include/configcontainer.h \
@@ -1126,6 +1124,8 @@ test/test-helpers/tempdir.o: test/test-helpers/tempdir.cpp \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h
 test/test-helpers/tempfile.o: test/test-helpers/tempfile.cpp \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h
 test/textformatter.o: test/textformatter.cpp include/textformatter.h \
  3rd-party/catch.hpp include/regexmanager.h include/configactionhandler.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h
@@ -1138,3 +1138,23 @@ test/utils.o: test/utils.cpp include/utils.h 3rd-party/expected.hpp \
  test/test-helpers/envvar.h test/test-helpers/stringmaker/optional.h \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
  test/test-helpers/tempfile.h
+test/view.o: test/view.cpp include/view.h 3rd-party/optional.hpp \
+ include/colormanager.h include/configactionhandler.h \
+ include/configcontainer.h include/controller.h include/cache.h \
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/regexmanager.h include/matcher.h \
+ filter/FilterParser.h include/regexowner.h include/reloader.h \
+ include/remoteapi.h include/rssignores.h include/rssitem.h \
+ include/matchable.h include/dirbrowserformaction.h \
+ include/listformatter.h include/listwidget.h include/stflpp.h \
+ include/formaction.h include/history.h \
+ target/cxxbridge/libnewsboat-ffi/src/history.rs.h include/keymap.h \
+ include/feedlistformaction.h include/listformaction.h include/view.h \
+ include/filebrowserformaction.h include/htmlrenderer.h \
+ include/textformatter.h include/statusline.h 3rd-party/catch.hpp \
+ include/controller.h include/configpaths.h include/cliargsparser.h \
+ target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h include/logger.h \
+ config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/cache.h

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -1101,6 +1101,8 @@ test/strprintf.o: test/strprintf.cpp include/strprintf.h \
  3rd-party/catch.hpp
 test/tagsouppullparser.o: test/tagsouppullparser.cpp \
  include/tagsouppullparser.h 3rd-party/optional.hpp 3rd-party/catch.hpp
+test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h
 test/test-helpers/chdir.o: test/test-helpers/chdir.cpp \
  test/test-helpers/chdir.h include/utils.h 3rd-party/expected.hpp \
  3rd-party/optional.hpp include/configcontainer.h \
@@ -1124,8 +1126,6 @@ test/test-helpers/tempdir.o: test/test-helpers/tempdir.cpp \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h
 test/test-helpers/tempfile.o: test/test-helpers/tempfile.cpp \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
-test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h
 test/textformatter.o: test/textformatter.cpp include/textformatter.h \
  3rd-party/catch.hpp include/regexmanager.h include/configactionhandler.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -326,7 +326,7 @@ ConfigContainer::ConfigContainer()
 	{
 		"wrap-scroll",
 		ConfigData("no", ConfigDataType::BOOL)},
-	}
+}
 {
 }
 

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -324,7 +324,11 @@ ConfigContainer::ConfigContainer()
 		ConfigData(_("%N %V - URLs"), ConfigDataType::STR)},
 	{
 		"wrap-scroll",
-		ConfigData("no", ConfigDataType::BOOL)}}
+		ConfigData("no", ConfigDataType::BOOL)},
+	{
+		"ascii-only-filename",
+		ConfigData("yes", ConfigDataType::BOOL)},
+	}
 {
 }
 

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -217,6 +217,7 @@ ConfigContainer::ConfigContainer()
 		ConfigData("false", ConfigDataType::BOOL)},
 	{"reload-threads", ConfigData("1", ConfigDataType::INT)},
 	{"reload-time", ConfigData("60", ConfigDataType::INT)},
+	{"restrict-filename", ConfigData("yes", ConfigDataType::BOOL)},
 	{"save-path", ConfigData("~/", ConfigDataType::PATH)},
 	{"scrolloff", ConfigData("0", ConfigDataType::INT)},
 	{
@@ -325,9 +326,6 @@ ConfigContainer::ConfigContainer()
 	{
 		"wrap-scroll",
 		ConfigData("no", ConfigDataType::BOOL)},
-	{
-		"ascii-only-filename",
-		ConfigData("yes", ConfigDataType::BOOL)},
 	}
 {
 }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -289,11 +289,11 @@ std::string View::get_filename_suggestion(const std::string& s)
 {
 	/*
 	 * With this function, we generate normalized filenames for saving
-	 * articles to files if the setting `ascii-only-filename` is enabled.
+	 * articles to files if the setting `restrict-filename` is enabled.
 	 */
 	std::string retval;
 
-	if (cfg->get_configvalue_as_bool("ascii-only-filename")) {
+	if (cfg->get_configvalue_as_bool("restrict-filename")) {
 		for (unsigned int i = 0; i < s.length(); ++i) {
 			if (isalnum(s[i])) {
 				retval.push_back(s[i]);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -289,17 +289,23 @@ std::string View::get_filename_suggestion(const std::string& s)
 {
 	/*
 	 * With this function, we generate normalized filenames for saving
-	 * articles to files.
+	 * articles to files if the setting `ascii-only-filename` is enabled.
 	 */
 	std::string retval;
-	for (unsigned int i = 0; i < s.length(); ++i) {
-		if (isalnum(s[i])) {
-			retval.push_back(s[i]);
-		} else if (s[i] == '/' || s[i] == ' ' || s[i] == '\r' ||
-			s[i] == '\n') {
-			retval.push_back('_');
+
+	if (cfg->get_configvalue_as_bool("ascii-only-filename")) {
+		for (unsigned int i = 0; i < s.length(); ++i) {
+			if (isalnum(s[i])) {
+				retval.push_back(s[i]);
+			} else if (s[i] == '/' || s[i] == ' ' || s[i] == '\r' ||
+				s[i] == '\n') {
+				retval.push_back('_');
+			}
 		}
+	} else {
+		retval = s;
 	}
+
 	if (retval.length() == 0) {
 		retval = "article.txt";
 	} else {

--- a/test/view.cpp
+++ b/test/view.cpp
@@ -12,12 +12,10 @@ using namespace newsboat;
 TEST_CASE("get_filename_suggestion() normalizes filenames for saving articles", "[View]")
 {
 
-	std::string
-	example_ru("Инженеры из MIT придумали остроумный способ очистки металлов от соли и грязи");
-	std::string example_fr("Les mathématiques ont-elles pris le pouvoir sur le réel ?");
+	const std::string example_ru("Инженеры из MIT");
+	const std::string example_fr("Les mathématiques");
 
-	std::string example_en("Comparing Visual Reasoning in Humans and AI");
-	std::string example_en_default("Comparing_Visual_Reasoning_in_Humans_and_AI.txt");
+	const std::string example_en("Comparing Visual");
 
 	ConfigPaths paths{};
 	Controller c(paths);
@@ -30,13 +28,16 @@ TEST_CASE("get_filename_suggestion() normalizes filenames for saving articles", 
 	c.set_view(&v);
 
 	// Default case is exclusively ASCII characters. Should never fail.
-	REQUIRE(v.get_filename_suggestion(example_en).compare(example_en_default) == 0);
+	REQUIRE(v.get_filename_suggestion(example_en).compare("Comparing_Visual.txt") ==
+		0);
 
-	REQUIRE(v.get_filename_suggestion(example_ru).compare(example_ru.append(".txt")) != 0);
-	REQUIRE(v.get_filename_suggestion(example_fr).compare(example_fr.append(".txt")) != 0);
+	REQUIRE(v.get_filename_suggestion(
+			example_ru).compare("Инженеры_из_MIT.txt") != 0);
+	REQUIRE(v.get_filename_suggestion(example_fr).compare("Les_mathématiques.txt") != 0);
 
 	cfg.toggle("restrict-filename");
 
-	REQUIRE(v.get_filename_suggestion(example_ru).compare(example_ru.append(".txt")) == 0);
-	REQUIRE(v.get_filename_suggestion(example_fr).compare(example_fr.append(".txt")) == 0);
+	REQUIRE(v.get_filename_suggestion(
+			example_ru).compare("Инженеры из MIT.txt") == 0);
+	REQUIRE(v.get_filename_suggestion(example_fr).compare("Les mathématiques.txt") == 0);
 }

--- a/test/view.cpp
+++ b/test/view.cpp
@@ -1,0 +1,40 @@
+#include "view.h"
+
+#include <string>
+
+#include "3rd-party/catch.hpp"
+#include "controller.h"
+#include "configpaths.h"
+#include "cache.h"
+
+using namespace newsboat;
+
+TEST_CASE("get_filename_suggestion() normalizes filenames for saving articles", "[View]") {
+
+    std::string example_ru("Инженеры из MIT придумали остроумный способ очистки металлов от соли и грязи");
+    std::string example_fr("Les mathématiques ont-elles pris le pouvoir sur le réel ?");
+
+    std::string example_en("Comparing Visual Reasoning in Humans and AI");
+    std::string example_en_default("Comparing_Visual_Reasoning_in_Humans_and_AI.txt");
+
+    ConfigPaths paths{};
+    Controller c(paths);
+    newsboat::View v(&c);
+
+    ConfigContainer cfg{};
+    Cache rsscache(":memory:", &cfg);
+
+    v.set_config_container(&cfg);
+    c.set_view(&v);
+
+    // Default case is exclusively ASCII characters. Should never fail.
+    REQUIRE(v.get_filename_suggestion(example_en).compare(example_en_default) == 0);
+
+    REQUIRE(v.get_filename_suggestion(example_ru).compare(example_ru.append(".txt")) != 0);
+    REQUIRE(v.get_filename_suggestion(example_fr).compare(example_fr.append(".txt")) != 0);
+
+    cfg.toggle("restrict-filename");
+
+    REQUIRE(v.get_filename_suggestion(example_ru).compare(example_ru.append(".txt")) == 0);
+    REQUIRE(v.get_filename_suggestion(example_fr).compare(example_fr.append(".txt")) == 0);
+}

--- a/test/view.cpp
+++ b/test/view.cpp
@@ -9,32 +9,34 @@
 
 using namespace newsboat;
 
-TEST_CASE("get_filename_suggestion() normalizes filenames for saving articles", "[View]") {
+TEST_CASE("get_filename_suggestion() normalizes filenames for saving articles", "[View]")
+{
 
-    std::string example_ru("Инженеры из MIT придумали остроумный способ очистки металлов от соли и грязи");
-    std::string example_fr("Les mathématiques ont-elles pris le pouvoir sur le réel ?");
+	std::string
+	example_ru("Инженеры из MIT придумали остроумный способ очистки металлов от соли и грязи");
+	std::string example_fr("Les mathématiques ont-elles pris le pouvoir sur le réel ?");
 
-    std::string example_en("Comparing Visual Reasoning in Humans and AI");
-    std::string example_en_default("Comparing_Visual_Reasoning_in_Humans_and_AI.txt");
+	std::string example_en("Comparing Visual Reasoning in Humans and AI");
+	std::string example_en_default("Comparing_Visual_Reasoning_in_Humans_and_AI.txt");
 
-    ConfigPaths paths{};
-    Controller c(paths);
-    newsboat::View v(&c);
+	ConfigPaths paths{};
+	Controller c(paths);
+	newsboat::View v(&c);
 
-    ConfigContainer cfg{};
-    Cache rsscache(":memory:", &cfg);
+	ConfigContainer cfg{};
+	Cache rsscache(":memory:", &cfg);
 
-    v.set_config_container(&cfg);
-    c.set_view(&v);
+	v.set_config_container(&cfg);
+	c.set_view(&v);
 
-    // Default case is exclusively ASCII characters. Should never fail.
-    REQUIRE(v.get_filename_suggestion(example_en).compare(example_en_default) == 0);
+	// Default case is exclusively ASCII characters. Should never fail.
+	REQUIRE(v.get_filename_suggestion(example_en).compare(example_en_default) == 0);
 
-    REQUIRE(v.get_filename_suggestion(example_ru).compare(example_ru.append(".txt")) != 0);
-    REQUIRE(v.get_filename_suggestion(example_fr).compare(example_fr.append(".txt")) != 0);
+	REQUIRE(v.get_filename_suggestion(example_ru).compare(example_ru.append(".txt")) != 0);
+	REQUIRE(v.get_filename_suggestion(example_fr).compare(example_fr.append(".txt")) != 0);
 
-    cfg.toggle("restrict-filename");
+	cfg.toggle("restrict-filename");
 
-    REQUIRE(v.get_filename_suggestion(example_ru).compare(example_ru.append(".txt")) == 0);
-    REQUIRE(v.get_filename_suggestion(example_fr).compare(example_fr.append(".txt")) == 0);
+	REQUIRE(v.get_filename_suggestion(example_ru).compare(example_ru.append(".txt")) == 0);
+	REQUIRE(v.get_filename_suggestion(example_fr).compare(example_fr.append(".txt")) == 0);
 }


### PR DESCRIPTION
This setting allows toggling the default behavior of normalizing article names when saving to disk.
When set to `no`, Newsboat will use the name of the article as it is without making any modifications, except adding the `.txt` extension. Defaults to `yes`.

Fixes #1110.