### PR TITLE
Make depslist locale-independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,11 @@ config.mk:
 xlicense.h: LICENSE
 	$(TEXTCONV) $< > $@
 
-ALL_SRCS:=$(shell ls -1 *.cpp filter/*.cpp rss/*.cpp src/*.cpp test/*.cpp test/test-helpers/*.cpp)
+# We reset the locale for the `ls` call to force it into sorting by byte value.
+# Without this, the sorting is locale-dependent, which is annoying because it
+# means the only way to pass the continuous integration check is to see it fail
+# and copy the diff.
+ALL_SRCS:=$(shell LC_ALL=C ls -1 *.cpp filter/*.cpp rss/*.cpp src/*.cpp test/*.cpp test/test-helpers/*.cpp)
 ALL_HDRS:=$(wildcard filter/*.h rss/*.h test/test-helpers/*.h 3rd-party/*.hpp) $(STFLHDRS) xlicense.h
 # This depends on NEWSBOATLIB_OUTPUT because it produces cxxbridge headers, and
 # we need to record those headers in the deps file.

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -1101,8 +1101,6 @@ test/strprintf.o: test/strprintf.cpp include/strprintf.h \
  3rd-party/catch.hpp
 test/tagsouppullparser.o: test/tagsouppullparser.cpp \
  include/tagsouppullparser.h 3rd-party/optional.hpp 3rd-party/catch.hpp
-test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h
 test/test-helpers/chdir.o: test/test-helpers/chdir.cpp \
  test/test-helpers/chdir.h include/utils.h 3rd-party/expected.hpp \
  3rd-party/optional.hpp include/configcontainer.h \
@@ -1126,6 +1124,8 @@ test/test-helpers/tempdir.o: test/test-helpers/tempdir.cpp \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h
 test/test-helpers/tempfile.o: test/test-helpers/tempfile.cpp \
  test/test-helpers/tempfile.h test/test-helpers/maintempdir.h
+test/test.o: test/test.cpp 3rd-party/catch.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h
 test/textformatter.o: test/textformatter.cpp include/textformatter.h \
  3rd-party/catch.hpp include/regexmanager.h include/configactionhandler.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h


### PR DESCRIPTION
In https://github.com/newsboat/newsboat/pull/1625, the contributor ran
`make depslist` locally, but didn't pass CI because the order of entries
was different from what CI expected. This commit makes the order
independent of the locale, which should avoid similar trouble in the
future.

I'll merge this once CI is done.