### PR TITLE
Don't redraw screen when returning from temporary EmptyFormAction

### DIFF
--- a/src/view.cpp
+++ b/src/view.cpp
@@ -970,11 +970,15 @@ void View::pop_current_formaction()
 			}
 			i++;
 		}
-		std::shared_ptr<FormAction> f = get_current_formaction();
-		if (f) {
-			f->set_redraw(true);
-			f->set_value("msg", "");
-			f->recalculate_widget_dimensions();
+
+		// Skip cleanup steps when returning from a transient EmptyFormAction
+		if (std::dynamic_pointer_cast<EmptyFormAction>(f) == nullptr) {
+			std::shared_ptr<FormAction> fa = get_current_formaction();
+			if (fa) {
+				fa->set_redraw(true);
+				fa->set_value("msg", "");
+				fa->recalculate_widget_dimensions();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1463 by skipping a redraw when returning from an `EmptyFormAction`.
Before https://github.com/newsboat/newsboat/pull/1259, those lines weren't hit when opening a browser because the local `f` variable would be a `nullptr`.