### PR TITLE
Changelog: note that 2.14+ removes whitespace around URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -686,6 +686,8 @@ Nestler, Thanga Ayyanar A.
 - Hangs when `highlight` rule matches an empty string (zaowen)
 - Article disappearing from the pager upon feed reload (zaowen)
     (https://github.com/akrennmair/newsbeuter/issues/534)
+- Leading and trailing spaces not stripped from the URLs in <A> tags (Raphael
+    Nestler)
 
 
 

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -2026,6 +2026,39 @@ mod tests {
             "http://test:test@foobar:33/bla2.html".to_owned()
         );
         assert_eq!(absolute_url("foo", "bar"), "bar".to_owned());
+
+        // Strips ASCII whitespace: tab, line feed, form feed, carriage return, and space
+        assert_eq!(
+            absolute_url(" \t https://example.com/page1", "page2"),
+            "https://example.com/page2".to_owned()
+        );
+        assert_eq!(
+            absolute_url("https://example.com/page3  \n ", "page4"),
+            "https://example.com/page4".to_owned()
+        );
+        assert_eq!(
+            absolute_url("  \rhttps://example.com/page5  \x0c ", "page6"),
+            "https://example.com/page6".to_owned()
+        );
+        assert_eq!(
+            absolute_url("https://example.com/base", " \n replacement"),
+            "https://example.com/replacement".to_owned()
+        );
+        assert_eq!(
+            absolute_url("https://example.com/different", "   another\t"),
+            "https://example.com/another".to_owned()
+        );
+        assert_eq!(
+            absolute_url("https://example.com/~joe/", " \rhello\x0c"),
+            "https://example.com/~joe/hello".to_owned()
+        );
+        assert_eq!(
+            absolute_url(
+                "\x0c\n\rhttps://example.com/misc/\t    ",
+                "   \t\x0ceverything_at_once\n\r"
+            ),
+            "https://example.com/misc/everything_at_once".to_owned()
+        );
     }
 
     #[test]

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -858,6 +858,27 @@ TEST_CASE("absolute_url()", "[utils]")
 			"bla2.html") == "http://test:test@foobar:33/bla2.html");
 }
 
+TEST_CASE("absolute_url() strips ASCII whitespace", "[utils]")
+{
+	// ASCII whitespace characters are: tab, line feed, form feed, carriage
+	// return, and space
+
+	REQUIRE(utils::absolute_url(" \t https://example.com/page1",
+			"page2") == "https://example.com/page2");
+	REQUIRE(utils::absolute_url("https://example.com/page3  \n ",
+			"page4") == "https://example.com/page4");
+	REQUIRE(utils::absolute_url("  \rhttps://example.com/page5  \f ",
+			"page6") == "https://example.com/page6");
+	REQUIRE(utils::absolute_url("https://example.com/base",
+			" \n replacement") == "https://example.com/replacement");
+	REQUIRE(utils::absolute_url("https://example.com/different",
+			"   another\t") == "https://example.com/another");
+	REQUIRE(utils::absolute_url("https://example.com/~joe/",
+			" \rhello\f") == "https://example.com/~joe/hello");
+	REQUIRE(utils::absolute_url( "\f\n\rhttps://example.com/misc/\t    ",
+			"   \t\feverything_at_once\n\r") == "https://example.com/misc/everything_at_once");
+}
+
 TEST_CASE("quote_for_stfl() adds a \'>\' after every \'<\'", "[utils]")
 {
 	REQUIRE(utils::quote_for_stfl("<<><><><") == "<><>><>><>><>");


### PR DESCRIPTION
A recently published a new post in Newsboat's Atom feed, and since
I write the feed by hand, I accidentally put a space inside the <a>
tag's `href` property:

    <a href=" https://newsboat.org/...">hey</a>

@der-lyse reported that Newsboat 2.13 rendered this space, but
I couldn't see it in 2.23. Turns out we accidentally fixed this in 2.14
when we started handling URLs using Rust's `url` crate instead of
calling into libxml2.