### PR TITLE
Harmonize filter expression error messages

### DIFF
--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -433,7 +433,7 @@ REDO:
 						v->get_statusline().show_error(strprintf::fmt(
 								_("Error: couldn't "
 									"parse filter "
-									"command `%s': %s"),
+									"expression `%s': %s"),
 								newfilter,
 								matcher.get_parse_error()));
 					} else {
@@ -975,8 +975,9 @@ void FeedListFormAction::op_end_setfilter()
 	filterhistory.add_line(filtertext);
 	if (filtertext.length() > 0) {
 		if (!matcher.parse(filtertext)) {
-			v->get_statusline().show_error(
-				_("Error: couldn't parse filter command!"));
+			v->get_statusline().show_error(strprintf::fmt(
+					_("Error: couldn't parse filter expression `%s': %s"),
+					filtertext, matcher.get_parse_error()));
 		} else {
 			save_filterpos();
 			apply_filter = true;

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -632,7 +632,7 @@ bool ItemListFormAction::process_operation(Operation op,
 						v->get_statusline().show_error(strprintf::fmt(
 								_("Error: couldn't "
 									"parse filter "
-									"command `%s': %s"),
+									"expression `%s': %s"),
 								newfilter,
 								matcher.get_parse_error()));
 					} else {
@@ -842,8 +842,9 @@ void ItemListFormAction::qna_end_setfilter()
 
 	if (filtertext.length() > 0) {
 		if (!matcher.parse(filtertext)) {
-			v->get_statusline().show_error(
-				_("Error: couldn't parse filter command!"));
+			v->get_statusline().show_error(strprintf::fmt(
+					_("Error: couldn't parse filter expression `%s': %s"),
+					filtertext, matcher.get_parse_error()));
 			return;
 		}
 

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -61,8 +61,8 @@ RssFeed::RssFeed(Cache* c, const std::string& rssurl)
 		Matcher m;
 		if (!m.parse(query)) {
 			throw strprintf::fmt(
-				_("`%s' is not a valid filter expression"),
-				query);
+				_("couldn't parse filter expression `%s': %s"),
+				query, m.get_parse_error());
 		}
 
 		LOG(Level::DEBUG,


### PR DESCRIPTION
When working on the German translations for the upcoming release of Newsboat 2.24, I noticed a small imperfection regarding filters.

Previously, there had been two terms for the very same thing. The much more common "filter expression" and also a rarely used "filter command". Since the "filter expression" is not only used more often, but also sounds technically more correct, let's go with this everywhere.

Another difference was the presence or lack of details. Some places already displayed both the invalid filter as well as the exact problem, others did not. I don't see a point in hiding those details from the user in these cases, so let's always behave the same and show all the details we have.

Unfortunately, there's one potential thing left, which I won't address here. There are still two very similar messages, one of which has an "Error: " prefix, the other one doesn't. Both messages had already been present and were only reused in this commit. (To be precise, the message with the prefix originally used the deprecated "filter command" term.)

The now-unused error messages will automatically be gone with the next scheduled POT/PO files update for the following release.

**This pull request affects the original messages and their translations, so this is intended for Newsboat 2.25. Do not merge until Newsboat 2.24 is released!** Marking this as draft, to avoid accidental premature merge, although it's ready from my side.

I'm not sure whether this is the best solution or whether there's an actual reason those details weren't present in the first place. If I start Newsboat, press `F` to enter the filter `Hello = World`, I now get ``Error: couldn't parse filter expression `Hello = World': invalid stringlit``, which is very technical and certainly not the most beautiful error message in the world, but in my opinion better than before without any hints. @Minoru, @dennisschagt, you've been diving deeply in the sources for quite a long time, so please have a very critical look. ;-)

It's worth noting, the parsing error reason is not translated. Temporarily providing a German translation in the PO file, this results in `Fehler: Konnte Filterausdruck „Hello = World“ nicht parsen: invalid stringlit`. But, that's how it's been before as well at other places.