### PR TITLE
Reset STFL in top-level exception handlers to print in normal mode

### DIFF
--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -256,22 +256,22 @@ int main(int argc, char* argv[])
 	try {
 		ret = c.run(args);
 	} catch (const newsboat::DbException& e) {
+		Stfl::reset();
 		std::cerr << strprintf::fmt(
-				_("Caught newsboat::DbException with "
-					"message: %s"),
+				_("Caught newsboat::DbException with message: %s"),
 				e.what())
 			<< std::endl;
 		::exit(EXIT_FAILURE);
 	} catch (const newsboat::MatcherException& e) {
+		Stfl::reset();
 		std::cerr << strprintf::fmt(
-				_("Caught newsboat::MatcherException with "
-					"message: %s"),
+				_("Caught newsboat::MatcherException with message: %s"),
 				e.what())
 			<< std::endl;
 		::exit(EXIT_FAILURE);
 	} catch (const newsboat::Exception& e) {
-		std::cerr << strprintf::fmt(_("Caught newsboat::Exception with "
-					"message: %s"),
+		Stfl::reset();
+		std::cerr << strprintf::fmt(_("Caught newsboat::Exception with message: %s"),
 				e.what())
 			<< std::endl;
 		::exit(EXIT_FAILURE);

--- a/podboat.cpp
+++ b/podboat.cpp
@@ -37,6 +37,7 @@ int main(int argc, char* argv[])
 
 		return c.run(v);
 	} catch (const newsboat::Exception& e) {
+		Stfl::reset();
 		std::cerr << strprintf::fmt(_("Caught newsboat::Exception with "
 					"message: %s"),
 				e.what())


### PR DESCRIPTION
Related to https://github.com/newsboat/newsboat/issues/1665.

Changes output on unhandled exception to:
![image](https://user-images.githubusercontent.com/4629607/121773445-4c372e00-cb7c-11eb-8b36-e6c8100809f9.png)

Original output:
![image](https://user-images.githubusercontent.com/4629607/121773499-a7692080-cb7c-11eb-8f37-d3b8977bb2d6.png)
