### PR TITLE
Do not exit when preparing invalid query feed

### DIFF
--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -684,8 +684,9 @@ src/reloader.o: src/reloader.cpp include/reloader.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
  include/rssitem.h include/matchable.h include/curlhandle.h \
  include/dbexception.h include/downloadthread.h include/fmtstrformatter.h \
- include/reloadrangethread.h include/reloadthread.h include/controller.h \
- rss/exception.h include/rssfeed.h include/utils.h 3rd-party/expected.hpp \
+ include/matcherexception.h include/reloadrangethread.h \
+ include/reloadthread.h include/controller.h rss/exception.h \
+ include/rssfeed.h include/utils.h 3rd-party/expected.hpp \
  include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/rssparser.h \

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -11,6 +11,7 @@
 #include "dbexception.h"
 #include "downloadthread.h"
 #include "fmtstrformatter.h"
+#include "matcherexception.h"
 #include "reloadrangethread.h"
 #include "reloadthread.h"
 #include "rss/exception.h"
@@ -179,8 +180,12 @@ void Reloader::reload_all(bool unattended)
 	LOG(Level::DEBUG, "Reloader::reload_all: refresh query feeds");
 	for (const auto& feed : ctrl->get_feedcontainer()->get_all_feeds()) {
 		if (feed->is_query_feed()) {
-			ctrl->get_view()->prepare_query_feed(feed);
-			feed->set_status(DlStatus::SUCCESS);
+			try {
+				ctrl->get_view()->prepare_query_feed(feed);
+				feed->set_status(DlStatus::SUCCESS);
+			} catch (const MatcherException& /* e */) {
+				feed->set_status(DlStatus::DL_ERROR);
+			}
 		}
 	}
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -455,7 +455,13 @@ std::shared_ptr<ItemListFormAction> View::push_itemlist(
 
 	feed->purge_deleted_items();
 
-	prepare_query_feed(feed);
+	try {
+		prepare_query_feed(feed);
+	} catch (const MatcherException& e) {
+		const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+		status_line.show_error(msg);
+		return nullptr;
+	}
 
 	if (feed->total_item_count() > 0) {
 		auto itemlist = std::make_shared<ItemListFormAction>(
@@ -700,7 +706,13 @@ bool View::get_random_unread(ItemListFormAction& itemlist,
 		LOG(Level::DEBUG,
 			"View::get_random_unread: found feed with unread "
 			"articles");
-		prepare_query_feed(feedlist_form->get_feed());
+		try {
+			prepare_query_feed(feedlist_form->get_feed());
+		} catch (const MatcherException& e) {
+			const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+			status_line.show_error(msg);
+			return false;
+		}
 		itemlist.set_feed(feedlist_form->get_feed());
 		itemlist.set_pos(feedpos);
 		itemlist.init();
@@ -741,7 +753,13 @@ bool View::get_previous_unread(ItemListFormAction& itemlist,
 		LOG(Level::DEBUG,
 			"View::get_previous_unread: found feed with unread "
 			"articles");
-		prepare_query_feed(feedlist_form->get_feed());
+		try {
+			prepare_query_feed(feedlist_form->get_feed());
+		} catch (const MatcherException& e) {
+			const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+			status_line.show_error(msg);
+			return false;
+		}
 		itemlist.set_feed(feedlist_form->get_feed());
 		itemlist.set_pos(feedpos);
 		itemlist.init();
@@ -761,7 +779,13 @@ bool View::get_next_unread_feed(ItemListFormAction& itemlist)
 {
 	unsigned int feedpos;
 	if (feedlist_form->jump_to_next_unread_feed(feedpos)) {
-		prepare_query_feed(feedlist_form->get_feed());
+		try {
+			prepare_query_feed(feedlist_form->get_feed());
+		} catch (const MatcherException& e) {
+			const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+			status_line.show_error(msg);
+			return false;
+		}
 		itemlist.set_feed(feedlist_form->get_feed());
 		itemlist.set_pos(feedpos);
 		itemlist.init();
@@ -774,7 +798,13 @@ bool View::get_prev_unread_feed(ItemListFormAction& itemlist)
 {
 	unsigned int feedpos;
 	if (feedlist_form->jump_to_previous_unread_feed(feedpos)) {
-		prepare_query_feed(feedlist_form->get_feed());
+		try {
+			prepare_query_feed(feedlist_form->get_feed());
+		} catch (const MatcherException& e) {
+			const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+			status_line.show_error(msg);
+			return false;
+		}
 		itemlist.set_feed(feedlist_form->get_feed());
 		itemlist.set_pos(feedpos);
 		itemlist.init();
@@ -806,7 +836,13 @@ bool View::get_next_unread(ItemListFormAction& itemlist,
 		LOG(Level::DEBUG,
 			"View::get_next_unread: found feed with unread "
 			"articles");
-		prepare_query_feed(feedlist_form->get_feed());
+		try {
+			prepare_query_feed(feedlist_form->get_feed());
+		} catch (const MatcherException& e) {
+			const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+			status_line.show_error(msg);
+			return false;
+		}
 		itemlist.set_feed(feedlist_form->get_feed());
 		itemlist.set_pos(feedpos);
 		itemlist.init();
@@ -839,7 +875,13 @@ bool View::get_previous(ItemListFormAction& itemlist,
 		status_line.show_error(_("Already on first item."));
 	} else if (feedlist_form->jump_to_previous_feed(feedpos)) {
 		LOG(Level::DEBUG, "View::get_previous: previous feed");
-		prepare_query_feed(feedlist_form->get_feed());
+		try {
+			prepare_query_feed(feedlist_form->get_feed());
+		} catch (const MatcherException& e) {
+			const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+			status_line.show_error(msg);
+			return false;
+		}
 		itemlist.set_feed(feedlist_form->get_feed());
 		itemlist.set_pos(feedpos);
 		itemlist.init();
@@ -871,7 +913,13 @@ bool View::get_next(ItemListFormAction& itemlist, ItemViewFormAction* itemview)
 		status_line.show_error(_("Already on last item."));
 	} else if (feedlist_form->jump_to_next_feed(feedpos)) {
 		LOG(Level::DEBUG, "View::get_next: next feed");
-		prepare_query_feed(feedlist_form->get_feed());
+		try {
+			prepare_query_feed(feedlist_form->get_feed());
+		} catch (const MatcherException& e) {
+			const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+			status_line.show_error(msg);
+			return false;
+		}
 		itemlist.set_feed(feedlist_form->get_feed());
 		itemlist.set_pos(feedpos);
 		itemlist.init();
@@ -891,7 +939,13 @@ bool View::get_next_feed(ItemListFormAction& itemlist)
 {
 	unsigned int feedpos;
 	if (feedlist_form->jump_to_next_feed(feedpos)) {
-		prepare_query_feed(feedlist_form->get_feed());
+		try {
+			prepare_query_feed(feedlist_form->get_feed());
+		} catch (const MatcherException& e) {
+			const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+			status_line.show_error(msg);
+			return false;
+		}
 		itemlist.set_feed(feedlist_form->get_feed());
 		itemlist.set_pos(feedpos);
 		itemlist.init();
@@ -904,7 +958,13 @@ bool View::get_prev_feed(ItemListFormAction& itemlist)
 {
 	unsigned int feedpos;
 	if (feedlist_form->jump_to_previous_feed(feedpos)) {
-		prepare_query_feed(feedlist_form->get_feed());
+		try {
+			prepare_query_feed(feedlist_form->get_feed());
+		} catch (const MatcherException& e) {
+			const auto msg = strprintf::fmt(_("Error: couldn't prepare query feed: %s"), e.what());
+			status_line.show_error(msg);
+			return false;
+		}
 		itemlist.set_feed(feedlist_form->get_feed());
 		itemlist.set_pos(feedpos);
 		itemlist.init();


### PR DESCRIPTION
Fixes #1665.

This can't be merged right now because it introduces a new translatable string. However, @dennisschagt provided a good stopgap solution in #1666, so it's not a very big deal. I'll merge after the 2.24 release.