### PR TITLE
Use cxx for FmtStrFormatter C++/rust bindings

### DIFF
--- a/include/fmtstrformatter.h
+++ b/include/fmtstrformatter.h
@@ -1,7 +1,8 @@
 #ifndef NEWSBOAT_FORMATSTRING_H_
 #define NEWSBOAT_FORMATSTRING_H_
 
-#include <map>
+#include "fmtstrformatter.rs.h"
+
 #include <string>
 
 namespace newsboat {
@@ -9,12 +10,12 @@ namespace newsboat {
 class FmtStrFormatter {
 public:
 	FmtStrFormatter();
-	~FmtStrFormatter();
+	~FmtStrFormatter() = default;
 	void register_fmt(char f, const std::string& value);
 	std::string do_format(const std::string& fmt, unsigned int width = 0);
 
 private:
-	void* rs_fmt = nullptr;
+	rust::Box<fmtstrformatter::bridged::FmtStrFormatter> rs_object;
 };
 
 } // namespace newsboat

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -212,9 +212,11 @@ src/dialogsformaction.o: src/dialogsformaction.cpp \
  include/configactionhandler.h include/stflpp.h include/listwidget.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h config.h \
- include/fmtstrformatter.h include/listformatter.h include/strprintf.h \
- include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h include/strprintf.h \
+ include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
+ include/listformatter.h include/strprintf.h include/utils.h \
+ 3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
+ include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
@@ -234,20 +236,21 @@ src/dirbrowserformaction.o: src/dirbrowserformaction.cpp \
  target/cxxbridge/libnewsboat-ffi/src/history.rs.h include/keymap.h \
  include/stflpp.h include/listformatter.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
- include/listwidget.h config.h include/fmtstrformatter.h include/logger.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
- include/strprintf.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
- include/view.h include/colormanager.h include/controller.h \
- include/cache.h include/configparser.h include/feedcontainer.h \
- include/filtercontainer.h include/fslock.h \
- target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
- include/fileurlreader.h include/urlreader.h include/queuemanager.h \
- include/reloader.h include/remoteapi.h include/rssignores.h \
- include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
- include/feedlistformaction.h include/listformaction.h include/view.h \
- include/filebrowserformaction.h include/htmlrenderer.h \
- include/textformatter.h include/statusline.h
+ include/listwidget.h config.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
+ include/logger.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp include/logger.h \
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
+ include/colormanager.h include/controller.h include/cache.h \
+ include/configparser.h include/feedcontainer.h include/filtercontainer.h \
+ include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
+ include/opml.h include/fileurlreader.h include/urlreader.h \
+ include/queuemanager.h include/reloader.h include/remoteapi.h \
+ include/rssignores.h include/rssitem.h include/matchable.h \
+ include/dirbrowserformaction.h include/feedlistformaction.h \
+ include/listformaction.h include/view.h include/filebrowserformaction.h \
+ include/htmlrenderer.h include/textformatter.h include/statusline.h
 src/download.o: src/download.cpp include/download.h config.h \
  include/pbcontroller.h include/colormanager.h \
  include/configactionhandler.h include/configcontainer.h \
@@ -301,6 +304,7 @@ src/feedlistformaction.o: src/feedlistformaction.cpp \
  include/filebrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h include/statusline.h config.h \
  include/dbexception.h include/feedcontainer.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
  include/listformatter.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/reloader.h \
  include/rssfeed.h include/utils.h 3rd-party/expected.hpp \
@@ -316,6 +320,7 @@ src/filebrowserformaction.o: src/filebrowserformaction.cpp \
  include/stflpp.h include/listformatter.h include/regexmanager.h \
  include/matcher.h filter/FilterParser.h include/regexowner.h \
  include/listwidget.h config.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
  include/listformatter.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/strprintf.h \
  include/utils.h 3rd-party/expected.hpp include/logger.h \
@@ -345,6 +350,7 @@ src/filtercontainer.o: src/filtercontainer.cpp include/filtercontainer.h \
  include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/fmtstrformatter.o: src/fmtstrformatter.cpp include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
  include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/ruststring.h
 src/formaction.o: src/formaction.cpp include/formaction.h \
@@ -391,12 +397,13 @@ src/helpformaction.o: src/helpformaction.cpp include/helpformaction.h \
  include/formaction.h include/history.h \
  target/cxxbridge/libnewsboat-ffi/src/history.rs.h include/keymap.h \
  include/configactionhandler.h include/stflpp.h include/textviewwidget.h \
- config.h include/fmtstrformatter.h include/keymap.h \
- include/listformatter.h include/regexmanager.h include/matcher.h \
- filter/FilterParser.h include/regexowner.h include/strprintf.h \
- include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
- include/configcontainer.h include/logger.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
+ config.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
+ include/keymap.h include/listformatter.h include/regexmanager.h \
+ include/matcher.h filter/FilterParser.h include/regexowner.h \
+ include/strprintf.h include/utils.h 3rd-party/expected.hpp \
+ 3rd-party/optional.hpp include/configcontainer.h include/logger.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/view.h \
  include/colormanager.h include/controller.h include/cache.h \
  include/configparser.h include/feedcontainer.h include/filtercontainer.h \
@@ -450,6 +457,7 @@ src/itemlistformaction.o: src/itemlistformaction.cpp \
  include/filebrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h include/statusline.h config.h \
  include/controller.h include/dbexception.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
  include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  include/matcherexception.h include/rssfeed.h include/utils.h \
@@ -473,22 +481,24 @@ src/itemviewformaction.o: src/itemviewformaction.cpp \
  include/textformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h include/textviewwidget.h \
  config.h include/confighandlerexception.h include/dbexception.h \
- include/fmtstrformatter.h include/itemlistformaction.h \
- 3rd-party/optional.hpp include/listformaction.h include/listwidget.h \
- include/listformatter.h include/view.h include/colormanager.h \
- include/configcontainer.h include/controller.h include/cache.h \
- include/configparser.h include/feedcontainer.h include/filtercontainer.h \
- include/fslock.h target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h \
- include/opml.h include/fileurlreader.h include/urlreader.h \
- include/queuemanager.h include/reloader.h include/remoteapi.h \
- include/rssignores.h include/rssitem.h include/matchable.h \
- include/dirbrowserformaction.h include/filesystembrowser.h \
- include/feedlistformaction.h include/filebrowserformaction.h \
- include/statusline.h include/itemrenderer.h include/htmlrenderer.h \
- include/logger.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/rssfeed.h \
- include/utils.h 3rd-party/expected.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/scopemeasure.h \
+ include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
+ include/itemlistformaction.h 3rd-party/optional.hpp \
+ include/listformaction.h include/listwidget.h include/listformatter.h \
+ include/view.h include/colormanager.h include/configcontainer.h \
+ include/controller.h include/cache.h include/configparser.h \
+ include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
+ include/fileurlreader.h include/urlreader.h include/queuemanager.h \
+ include/reloader.h include/remoteapi.h include/rssignores.h \
+ include/rssitem.h include/matchable.h include/dirbrowserformaction.h \
+ include/filesystembrowser.h include/feedlistformaction.h \
+ include/filebrowserformaction.h include/statusline.h \
+ include/itemrenderer.h include/htmlrenderer.h include/logger.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
+ include/rssfeed.h include/utils.h 3rd-party/expected.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
+ include/scopemeasure.h \
  target/cxxbridge/libnewsboat-ffi/src/scopemeasure.rs.h \
  include/strprintf.h include/textformatter.h include/utils.h \
  include/view.h
@@ -635,7 +645,8 @@ src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
  include/listformatter.h include/regexmanager.h include/matcher.h \
  filter/FilterParser.h include/regexowner.h include/stflpp.h \
  include/textviewwidget.h config.h include/configcontainer.h \
- stfl/dllist.h include/download.h include/fmtstrformatter.h stfl/help.h \
+ stfl/dllist.h include/download.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h stfl/help.h \
  include/listformatter.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/pbcontroller.h \
  include/configcontainer.h include/download.h include/fslock.h \
@@ -657,12 +668,13 @@ src/queueloader.o: src/queueloader.cpp include/queueloader.h \
  include/strprintf.h include/utils.h 3rd-party/expected.hpp \
  include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/queuemanager.o: src/queuemanager.cpp include/queuemanager.h \
- include/fmtstrformatter.h include/rssfeed.h include/matchable.h \
- 3rd-party/optional.hpp include/rssitem.h include/matcher.h \
- filter/FilterParser.h include/utils.h 3rd-party/expected.hpp \
- include/configcontainer.h include/configactionhandler.h include/logger.h \
- config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
+ include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
+ include/rssfeed.h include/matchable.h 3rd-party/optional.hpp \
+ include/rssitem.h include/matcher.h filter/FilterParser.h \
+ include/utils.h 3rd-party/expected.hpp include/configcontainer.h \
+ include/configactionhandler.h include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/utils.h
 src/regexmanager.o: src/regexmanager.cpp include/regexmanager.h \
  include/configactionhandler.h include/matcher.h filter/FilterParser.h \
@@ -684,6 +696,7 @@ src/reloader.o: src/reloader.cpp include/reloader.h \
  include/reloader.h include/remoteapi.h include/rssignores.h \
  include/rssitem.h include/matchable.h include/curlhandle.h \
  include/dbexception.h include/downloadthread.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
  include/matcherexception.h include/reloadrangethread.h \
  include/reloadthread.h include/controller.h rss/exception.h \
  include/rssfeed.h include/utils.h 3rd-party/expected.hpp \
@@ -774,6 +787,7 @@ src/selectformaction.o: src/selectformaction.cpp \
  include/stflpp.h include/listwidget.h include/listformatter.h \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h config.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
  include/listformatter.h include/strprintf.h include/utils.h \
  3rd-party/expected.hpp 3rd-party/optional.hpp include/configcontainer.h \
  include/logger.h include/strprintf.h \
@@ -840,6 +854,7 @@ src/urlviewformaction.o: src/urlviewformaction.cpp \
  include/textformatter.h include/listwidget.h include/listformatter.h \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
  include/regexowner.h config.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
  include/listformatter.h include/rssfeed.h include/matchable.h \
  3rd-party/optional.hpp include/rssitem.h include/utils.h \
  3rd-party/expected.hpp include/configcontainer.h include/logger.h \
@@ -880,6 +895,7 @@ src/view.o: src/view.cpp include/view.h 3rd-party/optional.hpp \
  include/dbexception.h stfl/dialogs.h include/dialogsformaction.h \
  include/emptyformaction.h stfl/empty.h include/exception.h \
  stfl/feedlist.h stfl/filebrowser.h include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
  include/formaction.h stfl/help.h include/helpformaction.h \
  include/textviewwidget.h include/htmlrenderer.h stfl/itemlist.h \
  include/itemlistformaction.h stfl/itemview.h \
@@ -954,7 +970,9 @@ test/filtercontainer.o: test/filtercontainer.cpp \
 test/filterparser.o: test/filterparser.cpp filter/FilterParser.h \
  3rd-party/catch.hpp
 test/fmtstrformatter.o: test/fmtstrformatter.cpp \
- include/fmtstrformatter.h 3rd-party/catch.hpp
+ include/fmtstrformatter.h \
+ target/cxxbridge/libnewsboat-ffi/src/fmtstrformatter.rs.h \
+ 3rd-party/catch.hpp
 test/fslock.o: test/fslock.cpp include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h 3rd-party/catch.hpp \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -11,6 +11,7 @@ fn add_cxxbridge(module: &str) {
 
 fn main() {
     add_cxxbridge("cliargsparser");
+    add_cxxbridge("fmtstrformatter");
     add_cxxbridge("fslock");
     add_cxxbridge("history");
     add_cxxbridge("keymap");

--- a/rust/libnewsboat-ffi/src/fmtstrformatter.rs
+++ b/rust/libnewsboat-ffi/src/fmtstrformatter.rs
@@ -1,4 +1,3 @@
-use cxx::CxxString;
 use libnewsboat::fmtstrformatter;
 
 // cxx doesn't allow to share types from other crates, so we have to wrap it
@@ -12,8 +11,8 @@ mod bridged {
 
         fn create() -> Box<FmtStrFormatter>;
 
-        fn register_fmt(fmt: &mut FmtStrFormatter, key: u8, value: &CxxString);
-        fn do_format(fmt: &mut FmtStrFormatter, format: &CxxString, width: u32) -> String;
+        fn register_fmt(fmt: &mut FmtStrFormatter, key: u8, value: &str);
+        fn do_format(fmt: &mut FmtStrFormatter, format: &str, width: u32) -> String;
     }
 }
 
@@ -21,14 +20,10 @@ fn create() -> Box<FmtStrFormatter> {
     Box::new(FmtStrFormatter(fmtstrformatter::FmtStrFormatter::new()))
 }
 
-fn register_fmt(fmt: &mut FmtStrFormatter, key: u8, value: &CxxString) {
-    let value = value.to_string_lossy().into_owned();
-
-    fmt.0.register_fmt(key as char, value);
+fn register_fmt(fmt: &mut FmtStrFormatter, key: u8, value: &str) {
+    fmt.0.register_fmt(key as char, value.to_string());
 }
 
-fn do_format(fmt: &mut FmtStrFormatter, format: &CxxString, width: u32) -> String {
-    let format = format.to_string_lossy().into_owned();
-
+fn do_format(fmt: &mut FmtStrFormatter, format: &str, width: u32) -> String {
     fmt.0.do_format(&format, width)
 }

--- a/rust/libnewsboat-ffi/src/fmtstrformatter.rs
+++ b/rust/libnewsboat-ffi/src/fmtstrformatter.rs
@@ -12,7 +12,7 @@ mod bridged {
 
         fn create() -> Box<FmtStrFormatter>;
 
-        fn register_fmt(fmt: &mut FmtStrFormatter, key: &CxxString, value: &CxxString);
+        fn register_fmt(fmt: &mut FmtStrFormatter, key: u8, value: &CxxString);
         fn do_format(fmt: &mut FmtStrFormatter, format: &CxxString, width: u32) -> String;
     }
 }
@@ -21,14 +21,10 @@ fn create() -> Box<FmtStrFormatter> {
     Box::new(FmtStrFormatter(fmtstrformatter::FmtStrFormatter::new()))
 }
 
-// key should contain exactly 1 char
-fn register_fmt(fmt: &mut FmtStrFormatter, key: &CxxString, value: &CxxString) {
-    let key = key.to_string_lossy().into_owned();
+fn register_fmt(fmt: &mut FmtStrFormatter, key: u8, value: &CxxString) {
     let value = value.to_string_lossy().into_owned();
 
-    if let Some(key) = key.chars().next() {
-        fmt.0.register_fmt(key, value);
-    }
+    fmt.0.register_fmt(key as char, value);
 }
 
 fn do_format(fmt: &mut FmtStrFormatter, format: &CxxString, width: u32) -> String {

--- a/rust/libnewsboat-ffi/src/history.rs
+++ b/rust/libnewsboat-ffi/src/history.rs
@@ -1,4 +1,3 @@
-use cxx::CxxString;
 use libnewsboat::history;
 
 // cxx doesn't allow to share types from other crates, so we have to wrap it
@@ -12,11 +11,11 @@ mod bridged {
 
         fn create() -> Box<History>;
 
-        fn add_line(history: &mut History, line: &CxxString);
+        fn add_line(history: &mut History, line: &str);
         fn previous_line(history: &mut History) -> String;
         fn next_line(history: &mut History) -> String;
-        fn load_from_file(history: &mut History, file: &CxxString);
-        fn save_to_file(history: &mut History, file: &CxxString, limit: usize);
+        fn load_from_file(history: &mut History, file: &str);
+        fn save_to_file(history: &mut History, file: &str, limit: usize);
     }
 }
 
@@ -24,9 +23,8 @@ fn create() -> Box<History> {
     Box::new(History(history::History::new()))
 }
 
-fn add_line(history: &mut History, line: &CxxString) {
-    let line = line.to_string_lossy().into_owned();
-    history.0.add_line(line);
+fn add_line(history: &mut History, line: &str) {
+    history.0.add_line(line.to_string());
 }
 
 fn previous_line(history: &mut History) -> String {
@@ -37,17 +35,13 @@ fn next_line(history: &mut History) -> String {
     history.0.next_line()
 }
 
-fn load_from_file(history: &mut History, file: &CxxString) {
-    let file = file.to_string_lossy().into_owned();
-
+fn load_from_file(history: &mut History, file: &str) {
     // Original C++ code did nothing if it failed to open file.
     // Returns a [must_use] type so safely ignoring the value.
     let _ = history.0.load_from_file(file);
 }
 
-fn save_to_file(history: &mut History, file: &CxxString, limit: usize) {
-    let file = file.to_string_lossy().into_owned();
-
+fn save_to_file(history: &mut History, file: &str, limit: usize) {
     // Original C++ code did nothing if it failed to open file.
     // Returns a [must_use] type so safely ignoring the value.
     let _ = history.0.save_to_file(file, limit);

--- a/src/fmtstrformatter.cpp
+++ b/src/fmtstrformatter.cpp
@@ -16,8 +16,7 @@ FmtStrFormatter::FmtStrFormatter()
 
 void FmtStrFormatter::register_fmt(char f, const std::string& value)
 {
-	std::string key(1, f);
-	fmtstrformatter::bridged::register_fmt(*rs_object, key, value);
+	fmtstrformatter::bridged::register_fmt(*rs_object, f, value);
 }
 
 std::string FmtStrFormatter::do_format(const std::string& fmt,

--- a/src/fmtstrformatter.cpp
+++ b/src/fmtstrformatter.cpp
@@ -7,43 +7,24 @@
 #include "logger.h"
 #include "ruststring.h"
 
-extern "C" {
-	void* rs_fmtstrformatter_new();
-
-	void rs_fmtstrformatter_free(void* fmt);
-
-	void rs_fmtstrformatter_register_fmt(
-		void* fmt,
-		char key,
-		const char* value);
-
-	char* rs_fmtstrformatter_do_format(
-		void* fmt,
-		const char* format,
-		std::uint32_t width);
-}
-
 namespace newsboat {
 
 FmtStrFormatter::FmtStrFormatter()
+	: rs_object(fmtstrformatter::bridged::create())
 {
-	rs_fmt = rs_fmtstrformatter_new();
-}
-
-FmtStrFormatter::~FmtStrFormatter()
-{
-	rs_fmtstrformatter_free(rs_fmt);
 }
 
 void FmtStrFormatter::register_fmt(char f, const std::string& value)
 {
-	rs_fmtstrformatter_register_fmt(rs_fmt, f, value.c_str());
+	std::string key(1, f);
+	fmtstrformatter::bridged::register_fmt(*rs_object, key, value);
 }
 
 std::string FmtStrFormatter::do_format(const std::string& fmt,
 	unsigned int width)
 {
-	return RustString(rs_fmtstrformatter_do_format(rs_fmt, fmt.c_str(), width));
+	auto formatted = fmtstrformatter::bridged::do_format(*rs_object, fmt, width);
+	return std::string(formatted);
 }
 
 } // namespace newsboat

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -4,29 +4,6 @@
 
 #include "ruststring.h"
 
-extern "C" {
-	void* rs_history_new();
-
-	void rs_history_free(void* hst);
-
-	void rs_history_add_line(
-		void* hst,
-		const char* line);
-
-	char* rs_history_previous_line(void* hst);
-
-	char* rs_history_next_line(void* hst);
-
-	void rs_history_load_from_file(
-		void* hst,
-		const char* file);
-
-	void rs_history_save_to_file(
-		void* fmt,
-		const char* file,
-		unsigned int limit);
-}
-
 namespace newsboat {
 
 History::History()


### PR DESCRIPTION
Related issue: https://github.com/newsboat/newsboat/issues/1383

If preferred, feel free to postpone merging until after the r2.24 release.