### PR TITLE
Fix iconv linking on OpenBSD.

### DIFF
--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -747,10 +747,13 @@ type iconv_t = *mut c_void;
 // On FreeBSD, link with GNU libiconv; the iconv implementation in libc doesn't support //TRANSLIT
 // and WCHAR_T. This is also why we change the symbol names from "iconv" to "libiconv" below.
 #[cfg_attr(target_os = "freebsd", link(name = "iconv"))]
+#[cfg_attr(target_os = "openbsd", link(name = "iconv"))]
 extern "C" {
     #[cfg_attr(target_os = "freebsd", link_name = "libiconv_open")]
+    #[cfg_attr(target_os = "openbsd", link_name = "libiconv_open")]
     pub fn iconv_open(tocode: *const c_char, fromcode: *const c_char) -> iconv_t;
     #[cfg_attr(target_os = "freebsd", link_name = "libiconv")]
+    #[cfg_attr(target_os = "openbsd", link_name = "libiconv")]
     pub fn iconv(
         cd: iconv_t,
         inbuf: *mut *mut c_char,
@@ -759,6 +762,7 @@ extern "C" {
         outbytesleft: *mut size_t,
     ) -> size_t;
     #[cfg_attr(target_os = "freebsd", link_name = "libiconv_close")]
+    #[cfg_attr(target_os = "openbsd", link_name = "libiconv_close")]
     pub fn iconv_close(cd: iconv_t) -> c_int;
 }
 


### PR DESCRIPTION
OpenBSD's libc doesn't have iconv support. Link with GNU libiconv
instead as is done for FreeBSD.