### PR TITLE
Remove obsolete comment about lacking support of iconv on NetBSD

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -16,9 +16,6 @@ Unix-like systems such as GNU/Linux, FreeBSD or macOS.
 
 Newsboat has been tested on Linux (with glibc and musl-libc), FreeBSD and macOS.
 
-NetBSD is currently not supported, due to technical limitations in the `iconv()`
-implementation.
-
 === Why "Newsboat"?
 
 "Newsboat" is a play on the name of its ancestor, "Newsbeuter". They're spelled

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -748,12 +748,15 @@ type iconv_t = *mut c_void;
 // and WCHAR_T. This is also why we change the symbol names from "iconv" to "libiconv" below.
 #[cfg_attr(target_os = "freebsd", link(name = "iconv"))]
 #[cfg_attr(target_os = "openbsd", link(name = "iconv"))]
+#[cfg_attr(target_os = "netbsd", link(name = "iconv"))]
 extern "C" {
     #[cfg_attr(target_os = "freebsd", link_name = "libiconv_open")]
     #[cfg_attr(target_os = "openbsd", link_name = "libiconv_open")]
+    #[cfg_attr(target_os = "netbsd", link_name = "libiconv_open")]
     pub fn iconv_open(tocode: *const c_char, fromcode: *const c_char) -> iconv_t;
     #[cfg_attr(target_os = "freebsd", link_name = "libiconv")]
     #[cfg_attr(target_os = "openbsd", link_name = "libiconv")]
+    #[cfg_attr(target_os = "netbsd", link_name = "libiconv")]
     pub fn iconv(
         cd: iconv_t,
         inbuf: *mut *mut c_char,
@@ -763,6 +766,7 @@ extern "C" {
     ) -> size_t;
     #[cfg_attr(target_os = "freebsd", link_name = "libiconv_close")]
     #[cfg_attr(target_os = "openbsd", link_name = "libiconv_close")]
+    #[cfg_attr(target_os = "netbsd", link_name = "libiconv_close")]
     pub fn iconv_close(cd: iconv_t) -> c_int;
 }
 


### PR DESCRIPTION
This piece of documentation was originally introduced in https://github.com/newsboat/newsboat/commit/921ebb0f379593ba96a07802680e73480cb12c40.

I won't be able to test Newsboat on NetBSD so feel free to drop [the second commit](https://github.com/newsboat/newsboat/commit/dc56848438d8e5bdb8d3a8d44f80b773bca0aad5) from this PR.
Changes inspired by https://github.com/newsboat/newsboat/pull/1678.