### PR TITLE
Podboat: Resolve performance regression (slow scrolling through downloads)

### DIFF
--- a/include/pbcontroller.h
+++ b/include/pbcontroller.h
@@ -24,14 +24,6 @@ public:
 	void initialize(int argc, char* argv[]);
 	int run(PbView& v);
 
-	bool view_update_necessary() const
-	{
-		return view_update_;
-	}
-	void set_view_update_necessary(bool b)
-	{
-		view_update_ = b;
-	}
 	std::vector<Download>& downloads()
 	{
 		return downloads_;
@@ -68,7 +60,6 @@ private:
 	std::string config_file;
 	std::string queue_file;
 	newsboat::ConfigContainer cfg;
-	bool view_update_;
 	std::vector<Download> downloads_;
 
 	std::string config_dir;

--- a/include/pbview.h
+++ b/include/pbview.h
@@ -26,6 +26,10 @@ public:
 		keys = k;
 	}
 	void apply_colors_to_all_forms();
+	void set_view_update_necessary()
+	{
+		update_view = true;
+	}
 
 private:
 	struct KeyMapHintEntry {
@@ -44,6 +48,8 @@ private:
 		const Download& dl,
 		unsigned int pos,
 		unsigned int width);
+
+	bool update_view;
 	PbController* ctrl;
 	newsboat::Stfl::Form dllist_form;
 	newsboat::Stfl::Form help_form;

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -123,7 +123,6 @@ bool PbController::setup_dirs_xdg(const char* env_home)
 PbController::PbController()
 	: config_file("config")
 	, queue_file("queue")
-	, view_update_(true)
 	, max_dls(1)
 	, lock_file("pb-lock.pid")
 	, keys(KM_PODBOAT)
@@ -291,8 +290,8 @@ int PbController::run(PbView& v)
 
 	std::cout << _("done.") << std::endl;
 
-	ql.reset(new QueueLoader(queue_file, cfg, [this]() {
-		this->set_view_update_necessary(true);
+	ql.reset(new QueueLoader(queue_file, cfg, [&]() {
+		v.set_view_update_necessary();
 	}));
 	ql->reload(downloads_);
 

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -68,20 +68,15 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 					ctrl->get_maxdownloads());
 			}
 
-			char buf[1024];
-			snprintf(buf,
-				sizeof(buf),
-				_("Queue (%u downloads in progress, %u total) "
-					"- %.2f %s total%s"),
-				static_cast<unsigned int>(
-					ctrl->downloads_in_progress()),
-				static_cast<unsigned int>(
-					ctrl->downloads().size()),
-				speed.first,
-				speed.second.c_str(),
-				parbuf);
+			const auto title = strprintf::fmt(
+					_("Queue (%u downloads in progress, %u total) - %.2f %s total%s"),
+					static_cast<unsigned int>(ctrl->downloads_in_progress()),
+					static_cast<unsigned int>(ctrl->downloads().size()),
+					speed.first,
+					speed.second,
+					parbuf);
 
-			dllist_form.set("head", buf);
+			dllist_form.set("head", title);
 
 			LOG(Level::DEBUG,
 				"PbView::run: updating view... "

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -60,21 +60,16 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			const double total_kbps = ctrl->get_total_kbps();
 			const auto speed = get_speed_human_readable(total_kbps);
 
-			char parbuf[128] = "";
-			if (ctrl->get_maxdownloads() > 1) {
-				snprintf(parbuf,
-					sizeof(parbuf),
-					_(" - %u parallel downloads"),
-					ctrl->get_maxdownloads());
-			}
-
-			const auto title = strprintf::fmt(
-					_("Queue (%u downloads in progress, %u total) - %.2f %s total%s"),
+			auto title = strprintf::fmt(
+					_("Queue (%u downloads in progress, %u total) - %.2f %s total"),
 					static_cast<unsigned int>(ctrl->downloads_in_progress()),
 					static_cast<unsigned int>(ctrl->downloads().size()),
 					speed.first,
-					speed.second,
-					parbuf);
+					speed.second);
+
+			if (ctrl->get_maxdownloads() > 1) {
+				title += strprintf::fmt(_(" - %u parallel downloads"), ctrl->get_maxdownloads());
+			}
 
 			dllist_form.set("head", title);
 

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -24,7 +24,8 @@ using namespace newsboat;
 namespace podboat {
 
 PbView::PbView(PbController* c)
-	: ctrl(c)
+	: update_view(true)
+	, ctrl(c)
 	, dllist_form(dllist_str)
 	, help_form(help_str)
 	, keys(0)
@@ -55,7 +56,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 	set_dllist_keymap_hint();
 
 	do {
-		if (ctrl->view_update_necessary()) {
+		if (update_view) {
 			const double total_kbps = ctrl->get_total_kbps();
 			const auto speed = get_speed_human_readable(total_kbps);
 
@@ -111,7 +112,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 				dllist_form.set("msg", ctrl->downloads()[idx].status_msg());
 			}
 
-			ctrl->set_view_update_necessary(false);
+			update_view = false;
 		}
 
 		const char* event = dllist_form.run(500);
@@ -136,7 +137,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 
 		if (dllist_form.get("msg").length() > 0) {
 			dllist_form.set("msg", "");
-			ctrl->set_view_update_necessary(true);
+			update_view = true;
 		}
 
 		switch (op) {
@@ -146,28 +147,28 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		case OP_PREV:
 		case OP_SK_UP:
 			downloads_list.move_up(wrap_scroll);
-			ctrl->set_view_update_necessary(true);
+			update_view = true;
 			break;
 		case OP_NEXT:
 		case OP_SK_DOWN:
 			downloads_list.move_down(wrap_scroll);
-			ctrl->set_view_update_necessary(true);
+			update_view = true;
 			break;
 		case OP_SK_HOME:
 			downloads_list.move_to_first();
-			ctrl->set_view_update_necessary(true);
+			update_view = true;
 			break;
 		case OP_SK_END:
 			downloads_list.move_to_last();
-			ctrl->set_view_update_necessary(true);
+			update_view = true;
 			break;
 		case OP_SK_PGUP:
 			downloads_list.move_page_up(wrap_scroll);
-			ctrl->set_view_update_necessary(true);
+			update_view = true;
 			break;
 		case OP_SK_PGDOWN:
 			downloads_list.move_page_down(wrap_scroll);
-			ctrl->set_view_update_necessary(true);
+			update_view = true;
 			break;
 		case OP_PB_TOGGLE_DLALL:
 			auto_download = !auto_download;
@@ -175,10 +176,8 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		case OP_HARDQUIT:
 		case OP_QUIT:
 			if (ctrl->downloads_in_progress() > 0) {
-				dllist_form.set("msg",
-					_("Error: can't quit: download(s) in "
-						"progress."));
-				ctrl->set_view_update_necessary(true);
+				dllist_form.set("msg", _("Error: can't quit: download(s) in progress."));
+				update_view = true;
 			} else {
 				quit = true;
 			}
@@ -268,7 +267,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			} else {
 				ctrl->purge_queue();
 			}
-			ctrl->set_view_update_necessary(true);
+			update_view = true;
 			break;
 		case OP_HELP:
 			run_help();
@@ -286,7 +285,7 @@ void PbView::handle_resize()
 	for (const auto& form : forms) {
 		form.get().run(-3);
 	}
-	ctrl->set_view_update_necessary(true);
+	update_view = true;
 }
 
 void PbView::apply_colors_to_all_forms()

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -95,14 +95,14 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 
 			downloads_list.stfl_replace_lines(listfmt);
 
-			// If there's no status message, we know there's no error to show
-			// Thus, it's safe to replace with the download's status
-			if (i >= 1 && dllist_form.get("msg").empty()) {
-				const auto idx = downloads_list.get_position();
-				dllist_form.set("msg", ctrl->downloads()[idx].status_msg());
-			}
-
 			update_view = false;
+		}
+
+		// If there's no status message, we know there's no error to show
+		// Thus, it's safe to replace with the download's status
+		if (dllist_form.get("msg").empty() && ctrl->downloads().size() > 0) {
+			const auto idx = downloads_list.get_position();
+			dllist_form.set("msg", ctrl->downloads()[idx].status_msg());
 		}
 
 		const char* event = dllist_form.run(500);
@@ -137,28 +137,22 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		case OP_PREV:
 		case OP_SK_UP:
 			downloads_list.move_up(wrap_scroll);
-			update_view = true;
 			break;
 		case OP_NEXT:
 		case OP_SK_DOWN:
 			downloads_list.move_down(wrap_scroll);
-			update_view = true;
 			break;
 		case OP_SK_HOME:
 			downloads_list.move_to_first();
-			update_view = true;
 			break;
 		case OP_SK_END:
 			downloads_list.move_to_last();
-			update_view = true;
 			break;
 		case OP_SK_PGUP:
 			downloads_list.move_page_up(wrap_scroll);
-			update_view = true;
 			break;
 		case OP_SK_PGDOWN:
 			downloads_list.move_page_down(wrap_scroll);
-			update_view = true;
 			break;
 		case OP_PB_TOGGLE_DLALL:
 			auto_download = !auto_download;


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1375

https://github.com/newsboat/newsboat/commit/edf1949750db681323ec68393d1eb713ce4d4d83 contains the fix. The other commits only contain some readability improvements.