### PR TITLE
Fix perf regression in mark-all-read with remote APIs

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -486,13 +486,20 @@ bool ItemListFormAction::process_operation(Operation op,
 		try {
 			const auto message_lifetime = v->get_statusline().show_message_until_finished(
 					_("Marking feed read..."));
+
 			std::vector<std::string> guids;
 			for (const auto& item : visible_items) {
 				const std::string guid = item.first->guid();
 				guids.push_back(guid);
 			}
 			rsscache->mark_items_read_by_guid(guids);
-			v->get_ctrl()->mark_all_read(guids);
+
+			if (apply_filter) {
+				// We're only viewing a subset of items, so mark them off one by one.
+				v->get_ctrl()->mark_all_read(guids);
+			} else {
+				v->get_ctrl()->mark_all_read(pos);
+			}
 
 			if (visible_items.size() > 0) {
 				std::lock_guard<std::mutex> lock(feed->item_mutex);


### PR DESCRIPTION
516392755439d84e3cf9531b44220b03eefa5759 (PR #1558) changed
mark-all-read to mark each item individually. That made mark-all-read
aware of the filters, but also made it slower. This was especially
noticeable with remote APIs, where mark-read latency is high.

We can't speed it up in the general case, but when there is no filter,
we can fall back onto the faster mark_all_read() method which marks the
entire feed in one go. I tested that this new code is indeed faster and
doesn't re-introduce #1364.

Reported by Oneiric on IRC.

Reviews are welcome! I'll merge this in three days.