### PR TITLE
Skip some CI tasks if no relevant files changed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -367,6 +367,7 @@ address_sanitizer_task:
 
 depslist_task:
     name: Dependencies list is up to date
+    skip: "!changesInclude('.cirrus.yml', '**.{h,cpp}')"
 
     container:
       dockerfile: docker/ubuntu_20.04-build-tools.dockerfile
@@ -415,6 +416,7 @@ undefined_behavior_sanitizer_task:
 
 asciidoctor_warnings_task:
     name: Asciidoctor with warnings-as-errors
+    skip: "!changesInclude('.cirrus.yml', 'doc/*')"
 
     container:
       cpu: 1
@@ -428,6 +430,7 @@ asciidoctor_warnings_task:
 
 i18nspector_task:
     name: .po files
+    skip: "!changesInclude('.cirrus.yml', 'po/*.{po,pot}')"
 
     container:
       cpu: 1
@@ -443,6 +446,7 @@ i18nspector_task:
 
 no_dbg_macros_task:
     name: "No dbg! macros in Rust code"
+    skip: "!changesInclude('.cirrus.yml', '**.rs')"
 
     container:
       cpu: 1

--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -1,6 +1,24 @@
 name: Coveralls
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+      - '.cirrus.yml'
+      - 'contrib/**'
+      - 'doc/**'
+      - 'docker/**'
+      - 'po/**'
+      - 'snap/**'
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - '.cirrus.yml'
+      - 'contrib/**'
+      - 'doc/**'
+      - 'docker/**'
+      - 'po/**'
+      - 'snap/**'
 
 jobs:
   gen_coverage:


### PR DESCRIPTION
This is a little step towards #1660. The heaviest jobs — the ones that compile things — are still not skipped, because Cirrus doesn't have a good function for this. [I asked for it to be added](https://github.com/cirruslabs/cirrus-ci-docs/issues/873); but even if it never happens, I can work around by writing a slightly less elegant configuration.

Reviews welcome! I'll merge in three days.