### PR TITLE
Do not skip Coveralls job, ever

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -1,24 +1,6 @@
 name: Coveralls
 
-on:
-  push:
-    paths-ignore:
-      - '*.md'
-      - '.cirrus.yml'
-      - 'contrib/**'
-      - 'doc/**'
-      - 'docker/**'
-      - 'po/**'
-      - 'snap/**'
-  pull_request:
-    paths-ignore:
-      - '*.md'
-      - '.cirrus.yml'
-      - 'contrib/**'
-      - 'doc/**'
-      - 'docker/**'
-      - 'po/**'
-      - 'snap/**'
+on: [push, pull_request]
 
 jobs:
   gen_coverage:


### PR DESCRIPTION
This rolls back a part of 8722d689955a859d6b7a81b7369b3f81fcd4cedf. The
problem is that `on.push.paths-ignore` doesn't just skip the job, it
doesn't even start it (that's a documented behaviour, nothing wrong
here). This doesn't play well with the fact that Coveralls job is
required, i.e. a PR can't be merged without it.

The default `job.<name>.if` mechanism would let us skip the job
properly, but it doesn't provide a ready-made way to check which paths
changed. Third-party actions don't seem to cover this either.

I ran out of interest looking into this, so I'm just rolling back the
changes. Perhaps I'll revisit this later.