### PR TITLE
utils::retrieve_url: Improve error reporting of curl_easy_perform

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -370,11 +370,10 @@ std::string utils::retrieve_url(const std::string& url,
 		std::string errmsg(errbuf);
 		if (errmsg.empty()) {
 			errmsg = curl_easy_strerror(res);
-		} else {
-			if (*errmsg.crbegin() != '\n') {
-				// Prettify: end logmessage with newline if not already done by libcurl
-				errmsg += "\n";
-			}
+		}
+		if (!errmsg.empty() && errmsg.back() == '\n') {
+			// Prettify: drop superflous newlines introduced by libcurl
+			errmsg.pop_back();
 		}
 
 		if (body != nullptr) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -365,7 +365,10 @@ std::string utils::retrieve_url(const std::string& url,
 
 	CURLcode res = curl_easy_perform(easyhandle);
 
-	// Report curl errors
+	std::stringstream logprefix;
+	logprefix << "utils::retrieve_url(" << http_method_str(method) << " " << url << ")"
+	          << "[" << (body != nullptr ? body->c_str() : "-") << "]";
+
 	if (res != CURLE_OK) {
 		std::string errmsg(errbuf);
 		if (errmsg.empty()) {
@@ -376,33 +379,12 @@ std::string utils::retrieve_url(const std::string& url,
 			errmsg.pop_back();
 		}
 
-		if (body != nullptr) {
-			LOG(Level::ERROR,
-				"utils::retrieve_url(%s %s)[%s]: LibCURL error (%d): %s",
-				http_method_str(method),
-				url,
-				body,
-				res,
-				errmsg);
-		} else {
-			LOG(Level::ERROR, "utils::retrieve_url(%s)[-]: LibCURL error (%d): %s", url, res, errmsg);
-		}
-
+		LOG(Level::ERROR, "%s: LibCURL error (%d): %s", logprefix.str(), res, errmsg);
 		buf = "";
 	} else {
-		if (body != nullptr) {
-			LOG(Level::DEBUG,
-				"utils::retrieve_url(%s %s)[%s]: %s",
-				http_method_str(method),
-				url,
-				body,
-				buf);
-		} else {
-			LOG(Level::DEBUG, "utils::retrieve_url(%s)[-]: %s", url, buf);
-		}
+		LOG(Level::DEBUG, "%s: %s", logprefix.str(), buf);
 	}
 
-	// Successful query
 	if (!cached_handle) {
 		curl_easy_cleanup(easyhandle);
 	} else {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -367,7 +367,7 @@ std::string utils::retrieve_url(const std::string& url,
 
 	std::stringstream logprefix;
 	logprefix << "utils::retrieve_url(" << http_method_str(method) << " " << url << ")"
-	          << "[" << (body != nullptr ? body->c_str() : "-") << "]";
+		<< "[" << (body != nullptr ? body->c_str() : "-") << "]";
 
 	if (res != CURLE_OK) {
 		std::string errmsg(errbuf);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -389,7 +389,18 @@ std::string utils::retrieve_url(const std::string& url,
 			LOG(Level::ERROR, "utils::retrieve_url(%s)[-]: LibCURL error (%d): %s", url, res, errmsg);
 		}
 
-		return std::string("");
+		buf = "";
+	} else {
+		if (body != nullptr) {
+			LOG(Level::DEBUG,
+				"utils::retrieve_url(%s %s)[%s]: %s",
+				http_method_str(method),
+				url,
+				body,
+				buf);
+		} else {
+			LOG(Level::DEBUG, "utils::retrieve_url(%s)[-]: %s", url, buf);
+		}
 	}
 
 	// Successful query
@@ -400,17 +411,6 @@ std::string utils::retrieve_url(const std::string& url,
 		// NULL is the default value of this property according to man (3) CURLOPT_ERRORBUFFER
 		// See the clobbering note above.
 		curl_easy_setopt(easyhandle, CURLOPT_ERRORBUFFER, NULL);
-	}
-
-	if (body != nullptr) {
-		LOG(Level::DEBUG,
-			"utils::retrieve_url(%s %s)[%s]: %s",
-			http_method_str(method),
-			url,
-			body,
-			buf);
-	} else {
-		LOG(Level::DEBUG, "utils::retrieve_url(%s)[-]: %s", url, buf);
 	}
 
 	return buf;


### PR DESCRIPTION
I've recently again been bitten by the poor error-reporting, especially by the `ttrss_api`-backend in the case of curl-errors. As the backend uses `utils::retrieve_url` to do all the heavy lifitng, this is probably the place to start.

The current implementation did disregard the return value of `curl_easy_perform` and simply returned the value of `buf` in all cases. However, the value of `buf` is not really well defined in the case of transmission errors (might be a partial response, ...).

This commit therefore checks the returned `CURLcode` for errors, and further produces a meaningful error message to the log to aid debugging. The latter comes with a caveat so: To produce the errormessage, we have to clobber the value of `CURLOPT_ERRORBUFFER`, even for cached handles.

I'm not 100% content with how it interacts with our hack of cached handles, but currently, we should be fine (this is the only place we set `CURLOPT_ERRORBUFFER` in the complete codebase. (There unfortunately is no `curl(_easy)_getopt`).

Reporting an empty buffer in cases of errors somehow feels wrong as well, but this is probably a change for a different PR. Fortunately, the number of callsites seem to be quite limited, so it should be fine.
Ideally we could probably consolidate most callsites for `curl_easy_perform` as well and map them over to `retrieve_url`, so that we have a uniform use of curl within the project.

What do you think (primarily to the contemporary changes)?
Glad to do any changes, I hope I didn't mess things up :)