### PR TITLE
cliargsparser.{cpp,rs}: add more tests for options

### DIFF
--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -481,6 +481,65 @@ mod tests {
     }
 
     #[test]
+    fn t_supports_combined_short_options() {
+        let filename = "cache.db";
+
+        let opts = vec![
+            "newsboat".to_string(),
+            "-vc".to_string(),
+            filename.to_string(),
+        ];
+
+        let args = CliArgsParser::new(opts);
+
+        assert_eq!(args.cache_file, Some(PathBuf::from(filename)));
+        assert_eq!(
+            args.lock_file,
+            Some(PathBuf::from(filename.to_string() + LOCK_SUFFIX))
+        );
+        assert!(args.using_nonstandard_configs());
+        assert_eq!(args.show_version, 1)
+    }
+
+    #[test]
+    fn t_supports_combined_short_option_and_value() {
+        let filename = "cache.db";
+
+        let opts = vec![
+            "newsboat".to_string(),
+            "-c".to_string() + &filename.to_string(),
+        ];
+
+        let args = CliArgsParser::new(opts);
+
+        assert_eq!(args.cache_file, Some(PathBuf::from(filename)));
+        assert_eq!(
+            args.lock_file,
+            Some(PathBuf::from(filename.to_string() + LOCK_SUFFIX))
+        );
+        assert!(args.using_nonstandard_configs());
+    }
+
+    #[test]
+    fn t_supports_equals_between_combined_short_option_and_value() {
+        let filename = "cache.db";
+
+        let opts = vec![
+            "newsboat".to_string(),
+            "-c=".to_string() + &filename.to_string(),
+        ];
+
+        let args = CliArgsParser::new(opts);
+
+        assert_eq!(args.cache_file, Some(PathBuf::from(filename)));
+        assert_eq!(
+            args.lock_file,
+            Some(PathBuf::from(filename.to_string() + LOCK_SUFFIX))
+        );
+        assert!(args.using_nonstandard_configs());
+    }
+
+    #[test]
     fn t_sets_config_file_if_dash_capital_c_is_provided() {
         let filename = "config file";
 

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -250,6 +250,44 @@ TEST_CASE(
 	}
 }
 
+TEST_CASE("Supports combined short options", "[CliArgsParser]")
+{
+	const std::string filename("cache.db");
+
+	TestHelpers::Opts opts = {"newsboat", "-vc", filename};
+	CliArgsParser args(opts.argc(), opts.argv());
+
+	REQUIRE(args.cache_file() == filename);
+	REQUIRE(args.lock_file() == filename + ".lock");
+	REQUIRE(args.using_nonstandard_configs());
+	REQUIRE(args.show_version() == 1);
+}
+
+TEST_CASE("Supports combined short option and value", "[CliArgsParser]")
+{
+	const std::string filename("cache.db");
+
+	TestHelpers::Opts opts = {"newsboat", "-c" + filename};
+	CliArgsParser args(opts.argc(), opts.argv());
+
+	REQUIRE(args.cache_file() == filename);
+	REQUIRE(args.lock_file() == filename + ".lock");
+	REQUIRE(args.using_nonstandard_configs());
+}
+
+TEST_CASE("Supports `=` between combined short option and value",
+	"[CliArgsParser]")
+{
+	const std::string filename("cache.db");
+
+	TestHelpers::Opts opts = {"newsboat", "-c=" + filename};
+	CliArgsParser args(opts.argc(), opts.argv());
+
+	REQUIRE(args.cache_file() == filename);
+	REQUIRE(args.lock_file() == filename + ".lock");
+	REQUIRE(args.using_nonstandard_configs());
+}
+
 TEST_CASE("Resolves tilde to homedir in -c/--cache-file", "[CliArgsParser]")
 {
 	TestHelpers::TempDir tmp;


### PR DESCRIPTION
Add tests for:
- combined short options (e.g. `-vc /path/to/cache.db`)
- combined arguments and options (e.g. `-c/path/to/cache.db`)
- short options with `=` (e.g. `-c=/path/to/cache.db`)

See: https://github.com/newsboat/newsboat/issues/1549#issuecomment-882107413