### PR TITLE
Do not use PRI* in calls to gettext

### DIFF
--- a/rust/libnewsboat/src/filterparser.rs
+++ b/rust/libnewsboat/src/filterparser.rs
@@ -424,17 +424,17 @@ pub fn parse(expr: &str) -> Result<Expression, String> {
         Err(error) => {
             let err = match error {
                 Error::TrailingCharacters(pos, tail) => fmt!(
-                    // The "%{}" thing is a number, a zero-based offset into a string.
-                    &gettext("Parse error: trailing characters after position %{}: %s"),
-                    PRIu64,
-                    pos as u64,
+                    // The first %s is an integer offset at which trailing characters start, the
+                    // second %s is the tail itself.
+                    &gettext("Parse error: trailing characters after position %s: %s"),
+                    &pos.to_string(),
                     tail
                 ),
                 Error::AtPos(pos, expected) => fmt!(
-                    // The "%{}" thing is a number, a zero-based offset into a string.
-                    &gettext("Parse error at position %{}: expected %s"),
-                    PRIu64,
-                    pos as u64,
+                    // The first %s is a zero-based offset into the string, the second %s is the
+                    // description of what the program expected at that point.
+                    &gettext("Parse error at position %s: expected %s"),
+                    &pos.to_string(),
                     &translate_expected(expected)
                 ),
                 Error::Internal => fmt!(&gettext("Internal parse error")),

--- a/rust/libnewsboat/src/fslock.rs
+++ b/rust/libnewsboat/src/fslock.rs
@@ -109,12 +109,11 @@ impl FsLock {
                 pid
             );
             Err(fmt!(
-                &gettext("Failed to lock '%s', already locked by process with PID %{}"),
+                &gettext("Failed to lock '%s', already locked by process with PID %s"),
                 new_lock_path
                     .to_str()
                     .unwrap_or(&gettext("<filename containing invalid UTF-8 codepoint>")),
-                PRIi64,
-                *pid as i64
+                &(*pid).to_string()
             ))
         }
     }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -203,13 +203,11 @@ int Controller::run(const CliArgsParser& args)
 	std::string error;
 	if (!fslock.try_lock(configpaths.lock_file(), pid, error)) {
 		if (pid != 0) {
-			// pid_t size could vary so cast to known integer format to get correct print format
-			std::int64_t p = pid;
 			std::cout << strprintf::fmt(
 					_("Error: an instance of %s is "
-						"already running (PID: %" PRId64 ")"),
+						"already running (PID: %s)"),
 					PROGRAM_NAME,
-					p)
+					std::to_string(pid))
 				<< std::endl;
 		} else {
 			std::cout << _("Error: ") << error << std::endl;

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -238,13 +238,11 @@ void PbController::initialize(int argc, char* argv[])
 	std::string error_message;
 	if (!fslock->try_lock(lock_file, pid, error_message)) {
 		if (pid != 0) {
-			// pid_t size could vary so cast to known integer format to get correct print format
-			std::int64_t p = pid;
 			std::cout << strprintf::fmt(
 					_("Error: an instance of %s is already "
-						"running (PID: %" PRId64 ")"),
+						"running (PID: %s)"),
 					"Podboat",
-					p)
+					std::to_string(pid))
 				<< std::endl;
 		} else {
 			std::cout << _("Error: ") << error_message << std::endl;


### PR DESCRIPTION
I'm high time I fulfilled [a promise I made two weeks ago](https://github.com/newsboat/newsboat/pull/1697#issuecomment-875920449) and fixed this.

In C, it's ergonomic to write code like this:

    printf(gettext("foo" PRId32 "bar"), 42);

gettext (both the function and the tool) have support for this idiom:
the message is extracted as "foo<PRId32>bar", and the .mo files seem to
store it in annotated form as well.

Rust has no PRI* constants, and string literals are concatenated via the
`concat` macro. As a result, `xtr` (Rust's replacement for `xgettext`)
doesn't support this pattern at all.

To reconcile those differences, this commit replaces all uses of PRI*
inside gettext with code like this:

    prinln!(gettext("foo%sbar"), &42.to_string())

This is done even on the C++ side, to avoid mistakes when that code is
ported to Rust.

(There are no problem using PRI* *separately* from gettext, so we keep
doing it both in C++ and Rust.)

Reviews are welcome! I'll merge in three days.