### PR TITLE
Document comments in urls file

### DIFF
--- a/doc/chapter-firststeps.asciidoc
+++ b/doc/chapter-firststeps.asciidoc
@@ -53,6 +53,12 @@ You can also configure local files as feeds, by prefixing the local path with
 
 	file:///var/log/rss_eventlog.xml
 
+The _urls_ file can also contain comments: lines that start with `#` can
+contain anything you want. Comments are ignored by Newsboat, but can serve as
+documentation for you. Please note, that commenting out URLs for debugging
+purposes might lead to unexpected data loss, see the
+<<cleanup-on-quit,`cleanup-on-quit`>> setting below for details.
+
 Now you can run Newsboat again, and it will present you with a controllable
 list of the URLs that you configured previously. You can now start downloading
 the feeds, either by pressing "R" to download all feeds, or by pressing "r" to


### PR DESCRIPTION
Not sure whether we should emphasize this hazard more. I hesitated, because it's in the introduction and I don't want to scare people away. In the future we're probably better off to spend dedicated subsections on both configuration files at section "3.4 Files".

My wording might be off today, I'm happy for suggestions. @zounp would this have helped you?