### PR TITLE
Use CurlHandle as much as possible

### DIFF
--- a/include/controller.h
+++ b/include/controller.h
@@ -24,8 +24,6 @@ class CliArgsParser;
 class ConfigPaths;
 class View;
 
-class CurlHandle;
-
 class Controller {
 public:
 	Controller(ConfigPaths& configpaths);

--- a/include/curlhandle.h
+++ b/include/curlhandle.h
@@ -11,22 +11,41 @@ namespace newsboat {
 class CurlHandle {
 private:
 	CURL* h;
-	CurlHandle(const CurlHandle&);
-	CurlHandle& operator=(const CurlHandle&);
+	CurlHandle(const CurlHandle&) = delete;
+	CurlHandle& operator=(const CurlHandle&) = delete;
+
+	void cleanup()
+	{
+		if (h != nullptr) {
+			curl_easy_cleanup(h);
+		}
+	}
 
 public:
 	CurlHandle()
-		: h(0)
+		: h(curl_easy_init())
 	{
-		h = curl_easy_init();
 		if (!h) {
 			throw std::runtime_error("Can't obtain curl handle");
 		}
 	}
 	~CurlHandle()
 	{
-		curl_easy_cleanup(h);
+		cleanup();
 	}
+	CurlHandle(CurlHandle&& other)
+		: h(other.h)
+	{
+		other.h = nullptr;
+	}
+	CurlHandle& operator=(CurlHandle&& other)
+	{
+		cleanup();
+		h = other.h;
+		other.h = nullptr;
+		return *this;
+	}
+
 	CURL* ptr()
 	{
 		return h;

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -275,9 +275,10 @@ src/feedcontainer.o: src/feedcontainer.cpp include/feedcontainer.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/utils.h
 src/feedhqapi.o: src/feedhqapi.cpp include/feedhqapi.h include/cache.h \
  include/configcontainer.h include/configactionhandler.h \
- include/remoteapi.h config.h include/strprintf.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
+ include/remoteapi.h config.h include/curlhandle.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/feedhqurlreader.o: src/feedhqurlreader.cpp include/feedhqurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/configcontainer.h \
@@ -380,8 +381,8 @@ src/freshrssapi.o: src/freshrssapi.cpp include/freshrssapi.h \
  include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
  include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/strprintf.h \
- include/utils.h
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/curlhandle.h \
+ include/strprintf.h include/utils.h
 src/freshrssurlreader.o: src/freshrssurlreader.cpp \
  include/freshrssurlreader.h include/urlreader.h 3rd-party/optional.hpp \
  include/configcontainer.h include/configactionhandler.h \
@@ -428,8 +429,8 @@ src/htmlrenderer.o: src/htmlrenderer.cpp include/htmlrenderer.h \
 src/inoreaderapi.o: src/inoreaderapi.cpp include/inoreaderapi.h \
  include/cache.h include/configcontainer.h include/configactionhandler.h \
  include/remoteapi.h include/urlreader.h 3rd-party/optional.hpp config.h \
- include/strprintf.h include/utils.h 3rd-party/expected.hpp \
- include/logger.h include/strprintf.h \
+ include/curlhandle.h include/strprintf.h include/utils.h \
+ 3rd-party/expected.hpp include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/inoreaderurlreader.o: src/inoreaderurlreader.cpp \
@@ -587,9 +588,10 @@ src/newsblururlreader.o: src/newsblururlreader.cpp \
  include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ocnewsapi.o: src/ocnewsapi.cpp include/ocnewsapi.h \
  include/remoteapi.h include/configcontainer.h \
- include/configactionhandler.h rss/feed.h rss/item.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h config.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
+ include/configactionhandler.h rss/feed.h rss/item.h include/curlhandle.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/ocnewsurlreader.o: src/ocnewsurlreader.cpp include/ocnewsurlreader.h \
  include/urlreader.h 3rd-party/optional.hpp include/fileurlreader.h \
@@ -600,9 +602,10 @@ src/ocnewsurlreader.o: src/ocnewsurlreader.cpp include/ocnewsurlreader.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/oldreaderapi.o: src/oldreaderapi.cpp include/oldreaderapi.h \
  include/cache.h include/configcontainer.h include/configactionhandler.h \
- include/remoteapi.h config.h include/strprintf.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
- include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
+ include/remoteapi.h config.h include/curlhandle.h include/strprintf.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/oldreaderurlreader.o: src/oldreaderurlreader.cpp \
  include/oldreaderurlreader.h include/urlreader.h 3rd-party/optional.hpp \
@@ -656,10 +659,10 @@ src/pbview.o: src/pbview.cpp include/pbview.h include/colormanager.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/poddlthread.o: src/poddlthread.cpp include/poddlthread.h \
  include/configcontainer.h include/configactionhandler.h \
- include/download.h config.h include/logger.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/utils.h \
- 3rd-party/expected.hpp 3rd-party/optional.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
+ include/download.h include/curlhandle.h config.h include/logger.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
+ include/utils.h 3rd-party/expected.hpp 3rd-party/optional.hpp \
+ include/logger.h target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/queueloader.o: src/queueloader.cpp include/queueloader.h \
  3rd-party/optional.hpp include/configcontainer.h \
  include/configactionhandler.h include/download.h config.h \

--- a/src/feedhqapi.cpp
+++ b/src/feedhqapi.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "config.h"
+#include "curlhandle.h"
 #include "strprintf.h"
 #include "utils.h"
 
@@ -45,14 +46,15 @@ static size_t my_write_data(void* buffer, size_t size, size_t nmemb,
 
 std::string FeedHqApi::retrieve_auth()
 {
-	CURL* handle = curl_easy_init();
+	CurlHandle handle;
+
 	Credentials cred = get_credentials("feedhq", "FeedHQ");
 	if (cred.user.empty() || cred.pass.empty()) {
 		return "";
 	}
 
-	char* username = curl_easy_escape(handle, cred.user.c_str(), 0);
-	char* password = curl_easy_escape(handle, cred.pass.c_str(), 0);
+	char* username = curl_easy_escape(handle.ptr(), cred.user.c_str(), 0);
+	char* password = curl_easy_escape(handle.ptr(), cred.pass.c_str(), 0);
 
 	std::string postcontent = strprintf::fmt(
 			"service=reader&Email=%s&Passwd=%s&source=%s%%2F%s&accountType="
@@ -67,15 +69,14 @@ std::string FeedHqApi::retrieve_auth()
 
 	std::string result;
 
-	utils::set_common_curl_options(handle, cfg);
-	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, my_write_data);
-	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &result);
-	curl_easy_setopt(handle, CURLOPT_POSTFIELDS, postcontent.c_str());
-	curl_easy_setopt(handle,
+	utils::set_common_curl_options(handle.ptr(), cfg);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEDATA, &result);
+	curl_easy_setopt(handle.ptr(), CURLOPT_POSTFIELDS, postcontent.c_str());
+	curl_easy_setopt(handle.ptr(),
 		CURLOPT_URL,
 		(cfg->get_configvalue("feedhq-url") + FEEDHQ_LOGIN).c_str());
-	curl_easy_perform(handle);
-	curl_easy_cleanup(handle);
+	curl_easy_perform(handle.ptr());
 
 	for (const auto& line : utils::tokenize(result)) {
 		LOG(Level::DEBUG, "FeedHqApi::retrieve_auth: line = %s", line);
@@ -92,21 +93,20 @@ std::vector<TaggedFeedUrl> FeedHqApi::get_subscribed_urls()
 {
 	std::vector<TaggedFeedUrl> urls;
 
-	CURL* handle = curl_easy_init();
+	CurlHandle handle;
 	std::string result;
 	curl_slist* custom_headers{};
 	add_custom_headers(&custom_headers);
-	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, custom_headers);
+	curl_easy_setopt(handle.ptr(), CURLOPT_HTTPHEADER, custom_headers);
 
-	utils::set_common_curl_options(handle, cfg);
-	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, my_write_data);
-	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &result);
-	curl_easy_setopt(handle,
+	utils::set_common_curl_options(handle.ptr(), cfg);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEDATA, &result);
+	curl_easy_setopt(handle.ptr(),
 		CURLOPT_URL,
 		(cfg->get_configvalue("feedhq-url") + FEEDHQ_SUBSCRIPTION_LIST)
 		.c_str());
-	curl_easy_perform(handle);
-	curl_easy_cleanup(handle);
+	curl_easy_perform(handle.ptr());
 	curl_slist_free_all(custom_headers);
 
 	LOG(Level::DEBUG,
@@ -143,7 +143,7 @@ std::vector<TaggedFeedUrl> FeedHqApi::get_subscribed_urls()
 
 		tags.push_back(std::string("~") + title);
 
-		char* escaped_id = curl_easy_escape(handle, id, 0);
+		char* escaped_id = curl_easy_escape(handle.ptr(), id, 0);
 
 		auto url = strprintf::fmt("%s%s%s?n=%u",
 				cfg->get_configvalue("feedhq-url"),
@@ -245,21 +245,20 @@ bool FeedHqApi::mark_article_read_with_token(const std::string& guid,
 
 std::string FeedHqApi::get_new_token()
 {
-	CURL* handle = curl_easy_init();
+	CurlHandle handle;
 	std::string result;
 	curl_slist* custom_headers{};
 
-	utils::set_common_curl_options(handle, cfg);
+	utils::set_common_curl_options(handle.ptr(), cfg);
 	add_custom_headers(&custom_headers);
-	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, custom_headers);
-	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, my_write_data);
-	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &result);
-	curl_easy_setopt(handle,
+	curl_easy_setopt(handle.ptr(), CURLOPT_HTTPHEADER, custom_headers);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEDATA, &result);
+	curl_easy_setopt(handle.ptr(),
 		CURLOPT_URL,
 		(cfg->get_configvalue("feedhq-url") + FEEDHQ_API_TOKEN_URL)
 		.c_str());
-	curl_easy_perform(handle);
-	curl_easy_cleanup(handle);
+	curl_easy_perform(handle.ptr());
 	curl_slist_free_all(custom_headers);
 
 	LOG(Level::DEBUG, "FeedHqApi::get_new_token: token = %s", result);
@@ -352,16 +351,15 @@ std::string FeedHqApi::post_content(const std::string& url,
 	std::string result;
 	curl_slist* custom_headers{};
 
-	CURL* handle = curl_easy_init();
-	utils::set_common_curl_options(handle, cfg);
+	CurlHandle handle;
+	utils::set_common_curl_options(handle.ptr(), cfg);
 	add_custom_headers(&custom_headers);
-	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, custom_headers);
-	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, my_write_data);
-	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &result);
-	curl_easy_setopt(handle, CURLOPT_POSTFIELDS, postdata.c_str());
-	curl_easy_setopt(handle, CURLOPT_URL, url.c_str());
-	curl_easy_perform(handle);
-	curl_easy_cleanup(handle);
+	curl_easy_setopt(handle.ptr(), CURLOPT_HTTPHEADER, custom_headers);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEDATA, &result);
+	curl_easy_setopt(handle.ptr(), CURLOPT_POSTFIELDS, postdata.c_str());
+	curl_easy_setopt(handle.ptr(), CURLOPT_URL, url.c_str());
+	curl_easy_perform(handle.ptr());
 	curl_slist_free_all(custom_headers);
 
 	LOG(Level::DEBUG,

--- a/src/oldreaderapi.cpp
+++ b/src/oldreaderapi.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "config.h"
+#include "curlhandle.h"
 #include "strprintf.h"
 #include "utils.h"
 
@@ -47,14 +48,14 @@ static size_t my_write_data(void* buffer, size_t size, size_t nmemb,
 
 std::string OldReaderApi::retrieve_auth()
 {
-	CURL* handle = curl_easy_init();
+	CurlHandle handle;
 	Credentials cred = get_credentials("oldreader", "The Old Reader");
 	if (cred.user.empty() || cred.pass.empty()) {
 		return "";
 	}
 
-	char* username = curl_easy_escape(handle, cred.user.c_str(), 0);
-	char* password = curl_easy_escape(handle, cred.pass.c_str(), 0);
+	char* username = curl_easy_escape(handle.ptr(), cred.user.c_str(), 0);
+	char* password = curl_easy_escape(handle.ptr(), cred.pass.c_str(), 0);
 
 	std::string postcontent = strprintf::fmt(
 			"service=reader&Email=%s&Passwd=%s&source=%s%%2F%s&accountType="
@@ -69,13 +70,12 @@ std::string OldReaderApi::retrieve_auth()
 
 	std::string result;
 
-	utils::set_common_curl_options(handle, cfg);
-	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, my_write_data);
-	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &result);
-	curl_easy_setopt(handle, CURLOPT_POSTFIELDS, postcontent.c_str());
-	curl_easy_setopt(handle, CURLOPT_URL, OLDREADER_LOGIN);
-	curl_easy_perform(handle);
-	curl_easy_cleanup(handle);
+	utils::set_common_curl_options(handle.ptr(), cfg);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEDATA, &result);
+	curl_easy_setopt(handle.ptr(), CURLOPT_POSTFIELDS, postcontent.c_str());
+	curl_easy_setopt(handle.ptr(), CURLOPT_URL, OLDREADER_LOGIN);
+	curl_easy_perform(handle.ptr());
 
 	std::vector<std::string> lines = utils::tokenize(result);
 	for (const auto& line : lines) {
@@ -96,17 +96,16 @@ std::vector<TaggedFeedUrl> OldReaderApi::get_subscribed_urls()
 	std::vector<TaggedFeedUrl> urls;
 	curl_slist* custom_headers{};
 
-	CURL* handle = curl_easy_init();
+	CurlHandle handle;
 	std::string result;
 	add_custom_headers(&custom_headers);
-	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, custom_headers);
+	curl_easy_setopt(handle.ptr(), CURLOPT_HTTPHEADER, custom_headers);
 
-	utils::set_common_curl_options(handle, cfg);
-	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, my_write_data);
-	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &result);
-	curl_easy_setopt(handle, CURLOPT_URL, OLDREADER_SUBSCRIPTION_LIST);
-	curl_easy_perform(handle);
-	curl_easy_cleanup(handle);
+	utils::set_common_curl_options(handle.ptr(), cfg);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEDATA, &result);
+	curl_easy_setopt(handle.ptr(), CURLOPT_URL, OLDREADER_SUBSCRIPTION_LIST);
+	curl_easy_perform(handle.ptr());
 	curl_slist_free_all(custom_headers);
 
 	LOG(Level::DEBUG,
@@ -262,18 +261,17 @@ bool OldReaderApi::mark_article_read_with_token(const std::string& guid,
 
 std::string OldReaderApi::get_new_token()
 {
-	CURL* handle = curl_easy_init();
+	CurlHandle handle;
 	std::string result;
 	curl_slist* custom_headers{};
 
-	utils::set_common_curl_options(handle, cfg);
+	utils::set_common_curl_options(handle.ptr(), cfg);
 	add_custom_headers(&custom_headers);
-	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, custom_headers);
-	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, my_write_data);
-	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &result);
-	curl_easy_setopt(handle, CURLOPT_URL, OLDREADER_API_TOKEN_URL);
-	curl_easy_perform(handle);
-	curl_easy_cleanup(handle);
+	curl_easy_setopt(handle.ptr(), CURLOPT_HTTPHEADER, custom_headers);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEDATA, &result);
+	curl_easy_setopt(handle.ptr(), CURLOPT_URL, OLDREADER_API_TOKEN_URL);
+	curl_easy_perform(handle.ptr());
 	curl_slist_free_all(custom_headers);
 
 	LOG(Level::DEBUG, "OldReaderApi::get_new_token: token = %s", result);
@@ -364,16 +362,15 @@ std::string OldReaderApi::post_content(const std::string& url,
 	std::string result;
 	curl_slist* custom_headers{};
 
-	CURL* handle = curl_easy_init();
-	utils::set_common_curl_options(handle, cfg);
+	CurlHandle handle;
+	utils::set_common_curl_options(handle.ptr(), cfg);
 	add_custom_headers(&custom_headers);
-	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, custom_headers);
-	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, my_write_data);
-	curl_easy_setopt(handle, CURLOPT_WRITEDATA, &result);
-	curl_easy_setopt(handle, CURLOPT_POSTFIELDS, postdata.c_str());
-	curl_easy_setopt(handle, CURLOPT_URL, url.c_str());
-	curl_easy_perform(handle);
-	curl_easy_cleanup(handle);
+	curl_easy_setopt(handle.ptr(), CURLOPT_HTTPHEADER, custom_headers);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
+	curl_easy_setopt(handle.ptr(), CURLOPT_WRITEDATA, &result);
+	curl_easy_setopt(handle.ptr(), CURLOPT_POSTFIELDS, postdata.c_str());
+	curl_easy_setopt(handle.ptr(), CURLOPT_URL, url.c_str());
+	curl_easy_perform(handle.ptr());
 	curl_slist_free_all(custom_headers);
 
 	LOG(Level::DEBUG,

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -516,16 +516,16 @@ void RssParser::set_item_content(std::shared_ptr<RssItem> x,
 		cfgcont->get_configvalue_as_bool("download-full-page") &&
 		!x->link().empty()) {
 
-		CURL* easyhandle = curl_easy_init();
+		CurlHandle handle;
 		const std::string content = utils::retrieve_url(x->link(), cfgcont, "", nullptr,
-				HTTPMethod::GET, easyhandle);
+				HTTPMethod::GET, handle.ptr());
 		std::string content_mime_type;
 
 		// Determine mime-type based on Content-type header:
 		// Content-type: https://tools.ietf.org/html/rfc7231#section-3.1.1.5
 		// Format: https://tools.ietf.org/html/rfc7231#section-3.1.1.1
 		char* value = nullptr;
-		curl_easy_getinfo(easyhandle, CURLINFO_CONTENT_TYPE, &value);
+		curl_easy_getinfo(handle.ptr(), CURLINFO_CONTENT_TYPE, &value);
 		if (value != nullptr) {
 			std::string content_type(value);
 			content_mime_type = content_type.substr(0, content_type.find_first_of(";"));
@@ -534,7 +534,6 @@ void RssParser::set_item_content(std::shared_ptr<RssItem> x,
 		}
 
 		x->set_description(content, content_mime_type);
-		curl_easy_cleanup(easyhandle);
 	}
 
 	LOG(Level::DEBUG,


### PR DESCRIPTION
I tried to replace all pairs of `curl_easy_init`+`curl_easy_cleanup` with a usage of `CurlHandle` (mostly for consistency).

There are still a few places where `curl_easy_init`+`curl_easy_cleanup`  are used directly.
I would prefer to get rid of those as well, but I'm not sure how.

<details>
  <summary>Remaining occurrences</summary>

https://github.com/newsboat/newsboat/blob/3311426cdbd1eb48ed4a15d22d348765659e1794/rss/parser.cpp#L115-L219

https://github.com/newsboat/newsboat/blob/3311426cdbd1eb48ed4a15d22d348765659e1794/src/freshrssapi.cpp#L413-L432

https://github.com/newsboat/newsboat/blob/3311426cdbd1eb48ed4a15d22d348765659e1794/src/minifluxapi.cpp#L217-L240

https://github.com/newsboat/newsboat/blob/3311426cdbd1eb48ed4a15d22d348765659e1794/src/utils.cpp#L324-L395
</details>

While making these changes, I found a few occurrences where the handle was used after calling `curl_easy_cleanup`.
For example, see `handle` in first and last line of following snippet:
https://github.com/newsboat/newsboat/blob/3311426cdbd1eb48ed4a15d22d348765659e1794/src/feedhqapi.cpp#L109-L146