### PR TITLE
Fix write outside of bounds in TagSoupPullParser::decode_entity

### DIFF
--- a/src/tagsouppullparser.cpp
+++ b/src/tagsouppullparser.cpp
@@ -485,8 +485,7 @@ std::string TagSoupPullParser::decode_entity(std::string s)
 
 		const int pos = wcrtomb(mbc, static_cast<wchar_t>(wc), &mb_state);
 		if (pos > 0) {
-			mbc[pos] = '\0';
-			result.append(mbc);
+			result.append(mbc, pos);
 		}
 		LOG(Level::DEBUG,
 			"TagSoupPullParser::decode_entity: wc = %u pos = %d "


### PR DESCRIPTION
Adding terminating '\0' to the mbc results in a crash when pos == MB_LEN_MAX,
which is true for 4-byte characters and musl.

This is an attempt to fix it.