### PR TITLE
Docs: mention that Inoreader API omits enclosures

### DIFF
--- a/doc/chapter-podcasts.asciidoc
+++ b/doc/chapter-podcasts.asciidoc
@@ -8,3 +8,9 @@ Podcast content is transported in RSS feeds via special tags called
 "enclosures". Newsboat recognizes these enclosures and stores the relevant
 information for every podcast item it finds in an RSS feed. Since version 2.0,
 it also recognizes and handles the Yahoo Media RSS extensions.
+
+Remote APIs don't always list those "enclosures", so podcasts might be missing
+from Newsboat. Such APIs are marked
+<<#_newsboat_as_a_client_for_newsreading_services,in the relevant section of our
+docs>>. If a note is missing but you still don't see enclosures in Newsboat,
+please file an issue and we'll get to the bottom of it!

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -4,6 +4,7 @@
 :sectanchors:
 :sectlinks:
 :nofooter:
+:warning-caption: pass:[<span style='font-size: 3rem'>&#x26a0;</span>]
 
 == Introduction
 
@@ -659,6 +660,9 @@ OwnCloud News' folders are converted into Newsboat tags. You can select and
 filter feeds by tags; see <<_tagging>> and <<_filter_language>> for details.
 
 === Inoreader
+
+WARNING: As of 2021-08-23, Inoreader's API doesn't list enclosures, so Newsboat
+won't display podcasts, cover images etc.
 
 https://inoreader.com/[Inoreader] is a successor to Google Reader.
 


### PR DESCRIPTION
This is inspired by https://github.com/newsboat/newsboat/issues/252#issuecomment-903343014.

The `warning-caption` thing adds a large emoji next to the warning.
Without this, Asciidoctor would use the text "WARNING" instead, which
doesn't look as eye-catching as an emoji. The recipe for this is taken
from [1] and [2]. The icon used is U+26A0 WARNING SIGN.

1. https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/#using-emoji-for-admonition-icons
2. https://github.com/asciidoctor/asciidoctor.org/issues/571

Reviews are welcome! I'll merge this once @der-lyse have taken a look and there are no unaddressed review comments.