### PR TITLE
Formally bump proptest to 1.0.0

### DIFF
--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -58,6 +58,5 @@ default-features = false
 
 [dev-dependencies]
 tempfile = "3"
-# 0.9.6 fixes build failures on Nightly >=2020-04-08: https://github.com/newsboat/newsboat/issues/870
-proptest = ">=0.9.6"
+proptest = "1"
 section_testing = "0.0.5"


### PR DESCRIPTION
The lockfile was updated in 31a6caa712faab2d0ccee503fb0d6947338aa13c,
now we're just formalizing this via Cargo.toml.

Closes #1486.

(This will get auto-merged because it's just upkeep, nothing to review.)