### PR TITLE
Simple fix to let exportOPMLWithTags.py handle comments

### DIFF
--- a/contrib/exportOPMLWithTags.py
+++ b/contrib/exportOPMLWithTags.py
@@ -64,8 +64,9 @@ try:
 
     for line in lines:
 
-        if len(line)<2:
-            # lines must be `url "tag"`, so ignore this line
+        if len(line)<2 or line[0].startswith("#"):
+            # Ignore lines that are not `url "tag"` (at least 2 parts)
+            # and ignore all comments in the file
             print(f"ignoring this line:\n{' '.join(line)}", file=sys.stderr)
             continue
 


### PR DESCRIPTION
https://github.com/newsboat/newsboat/issues/1770

According to the [test file](https://github.com/newsboat/newsboat/blob/master/test/data/test-urls.txt), the urls can contain comments.

This minor addition can let this export script handle it properly.

I tested on my local urls file, and it works great.

_Python will stop eval once it finds a true from left to right  in `or`, thus the line[0] will always be valid._