### PR TITLE
Sort configcommands reproducibly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,8 @@ fmt:
 		*.cpp doc/*.cpp include/*.h rss/*.h rss/*.cpp src/*.cpp \
 		test/*.cpp test/test-helpers/*.h test/test-helpers/*.cpp
 	$(CARGO) fmt
-	sort -t '|' -k 1,1 -o doc/configcommands.dsv doc/configcommands.dsv
+	# We reset the locale to make the sorting reproducible.
+	LC_ALL=C sort -t '|' -k 1,1 -o doc/configcommands.dsv doc/configcommands.dsv
 
 cppcheck:
 	cppcheck -j$(CPPCHECK_JOBS) --force --enable=all --suppress=unusedFunction \


### PR DESCRIPTION
This is akin to b5ef45a3de2edd00457ade414f8c512a7e644f2f: `sort` is
controlled by the locale, so we have to set the locale to something
portable to make sure that `sort` produces the same result on all
machines.

Fixes #1790.