### PR TITLE
Use CXX for ConfigPaths FFI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ CXX_FOR_BUILD?=$(CXX)
 DEFINES=-DLOCALEDIR='"$(localedir)"'
 
 WARNFLAGS=-Werror -Wall -Wextra -Wunreachable-code
-INCLUDES=-Iinclude -Istfl -Ifilter -I. -Irss -I$(relative_cargo_target_dir)/cxxbridge/libnewsboat-ffi/src/
+INCLUDES=-Iinclude -Istfl -Ifilter -I. -Irss -I$(relative_cargo_target_dir)/cxxbridge/
 BARE_CXXFLAGS=-std=c++11 -O2 -ggdb $(INCLUDES)
 LDFLAGS+=-L.
 

--- a/include/cliargsparser.h
+++ b/include/cliargsparser.h
@@ -79,11 +79,11 @@ public:
 
 	nonstd::optional<Level> log_level() const;
 
-	/// Returns the pointer to the Rust object.
+	/// Returns the reference to the Rust object.
 	///
 	/// This is only meant to be used in situations when one wants to pass
-	/// a pointer to CliArgsParser back to Rust.
-	void* get_rust_pointer() const;
+	/// a reference back to Rust.
+	const cliargsparser::bridged::CliArgsParser& get_rust_ref() const;
 
 private:
 	rust::Box<cliargsparser::bridged::CliArgsParser> rs_object;

--- a/include/cliargsparser.h
+++ b/include/cliargsparser.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_CLIARGSPARSER_H_
 #define NEWSBOAT_CLIARGSPARSER_H_
 
-#include "cliargsparser.rs.h"
+#include "libnewsboat-ffi/src/cliargsparser.rs.h"
 
 #include <string>
 #include <vector>

--- a/include/configpaths.h
+++ b/include/configpaths.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_CONFIGPATHS_H_
 #define NEWSBOAT_CONFIGPATHS_H_
 
-#include "configpaths.rs.h"
+#include "libnewsboat-ffi/src/configpaths.rs.h"
 
 #include <string>
 

--- a/include/configpaths.h
+++ b/include/configpaths.h
@@ -1,18 +1,17 @@
 #ifndef NEWSBOAT_CONFIGPATHS_H_
 #define NEWSBOAT_CONFIGPATHS_H_
 
+#include "configpaths.rs.h"
+
 #include <string>
 
 #include "cliargsparser.h"
 
 namespace newsboat {
 class ConfigPaths {
-	void* rs_configpaths = nullptr;
-
 public:
 	ConfigPaths();
-
-	~ConfigPaths();
+	~ConfigPaths() = default;
 
 	/// \brief Indicates if the object can be used.
 	///
@@ -71,6 +70,8 @@ public:
 
 	/// Path to the file with command-line history.
 	std::string cmdline_file() const;
+private:
+	rust::Box<configpaths::bridged::ConfigPaths> rs_object;
 };
 } // namespace newsboat
 

--- a/include/fmtstrformatter.h
+++ b/include/fmtstrformatter.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_FORMATSTRING_H_
 #define NEWSBOAT_FORMATSTRING_H_
 
-#include "fmtstrformatter.rs.h"
+#include "libnewsboat-ffi/src/fmtstrformatter.rs.h"
 
 #include <string>
 

--- a/include/fslock.h
+++ b/include/fslock.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_FSLOCK_H_
 #define NEWSBOAT_FSLOCK_H_
 
-#include "fslock.rs.h"
+#include "libnewsboat-ffi/src/fslock.rs.h"
 
 #include <string>
 #include <sys/types.h>

--- a/include/history.h
+++ b/include/history.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_HISTORY_H_
 #define NEWSBOAT_HISTORY_H_
 
-#include "history.rs.h"
+#include "libnewsboat-ffi/src/history.rs.h"
 
 #include <string>
 

--- a/include/logger.h
+++ b/include/logger.h
@@ -4,7 +4,7 @@
 #include "config.h"
 #include "strprintf.h"
 
-#include "logger.rs.h"
+#include "libnewsboat-ffi/src/logger.rs.h"
 
 namespace newsboat {
 

--- a/include/scopemeasure.h
+++ b/include/scopemeasure.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "scopemeasure.rs.h"
+#include "libnewsboat-ffi/src/scopemeasure.rs.h"
 
 namespace newsboat {
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -16,7 +16,7 @@
 #include "configcontainer.h"
 #include "logger.h"
 
-#include "utils.rs.h"
+#include "libnewsboat-ffi/src/utils.rs.h"
 
 namespace newsboat {
 

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -13,9 +13,11 @@ newsboat.o: newsboat.cpp include/cache.h include/configcontainer.h \
  target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h \
  3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h config.h \
- include/configpaths.h include/cliargsparser.h include/controller.h \
- include/cache.h include/colormanager.h include/configparser.h \
- include/feedcontainer.h include/filtercontainer.h include/fslock.h \
+ include/configpaths.h \
+ target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
+ include/cliargsparser.h include/controller.h include/cache.h \
+ include/colormanager.h include/configparser.h include/feedcontainer.h \
+ include/filtercontainer.h include/fslock.h \
  target/cxxbridge/libnewsboat-ffi/src/fslock.rs.h include/opml.h \
  include/fileurlreader.h include/urlreader.h include/queuemanager.h \
  include/regexmanager.h include/matcher.h filter/FilterParser.h \
@@ -164,11 +166,11 @@ src/configparser.o: src/configparser.cpp include/configparser.h \
  3rd-party/expected.hpp include/configcontainer.h include/logger.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/configpaths.o: src/configpaths.cpp include/configpaths.h \
+ target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
  include/cliargsparser.h \
  target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h \
  3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/globals.h \
- include/ruststring.h include/strprintf.h
+ target/cxxbridge/libnewsboat-ffi/src/logger.rs.h
 src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/configcontainer.h include/configactionhandler.h \
  include/colormanager.h include/configparser.h include/feedcontainer.h \
@@ -183,10 +185,12 @@ src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/colormanager.h \
  include/configcontainer.h include/configexception.h \
- include/configpaths.h include/cliargsparser.h include/dbexception.h \
- include/downloadthread.h include/exception.h include/feedhqapi.h \
- include/feedhqurlreader.h include/freshrssapi.h rss/feed.h rss/item.h \
- 3rd-party/json.hpp include/utils.h 3rd-party/expected.hpp \
+ include/configpaths.h \
+ target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
+ include/cliargsparser.h include/dbexception.h include/downloadthread.h \
+ include/exception.h include/feedhqapi.h include/feedhqurlreader.h \
+ include/freshrssapi.h rss/feed.h rss/item.h 3rd-party/json.hpp \
+ include/utils.h 3rd-party/expected.hpp \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h \
  include/freshrssurlreader.h include/fileurlreader.h include/globals.h \
  include/inoreaderapi.h include/inoreaderurlreader.h \
@@ -942,6 +946,7 @@ test/configparser.o: test/configparser.cpp include/configparser.h \
  3rd-party/optional.hpp test/test-helpers/tempfile.h \
  test/test-helpers/maintempdir.h
 test/configpaths.o: test/configpaths.cpp include/configpaths.h \
+ target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
  include/cliargsparser.h \
  target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h \
  3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
@@ -1007,7 +1012,9 @@ test/itemlistformaction.o: test/itemlistformaction.cpp \
  include/filesystembrowser.h include/feedlistformaction.h \
  include/filebrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h include/statusline.h 3rd-party/catch.hpp \
- include/cache.h include/configpaths.h include/cliargsparser.h \
+ include/cache.h include/configpaths.h \
+ target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
+ include/cliargsparser.h \
  target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h include/logger.h \
  config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
@@ -1187,7 +1194,9 @@ test/view.o: test/view.cpp include/view.h 3rd-party/optional.hpp \
  include/feedlistformaction.h include/listformaction.h include/view.h \
  include/filebrowserformaction.h include/htmlrenderer.h \
  include/textformatter.h include/statusline.h 3rd-party/catch.hpp \
- include/controller.h include/configpaths.h include/cliargsparser.h \
+ include/controller.h include/configpaths.h \
+ target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
+ include/cliargsparser.h \
  target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h include/logger.h \
  config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/cache.h

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -167,10 +167,9 @@ src/configparser.o: src/configparser.cpp include/configparser.h \
  target/cxxbridge/libnewsboat-ffi/src/utils.rs.h
 src/configpaths.o: src/configpaths.cpp include/configpaths.h \
  target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
- include/cliargsparser.h \
  target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h \
- 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/logger.rs.h
+ include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h
 src/controller.o: src/controller.cpp include/controller.h include/cache.h \
  include/configcontainer.h include/configactionhandler.h \
  include/colormanager.h include/configparser.h include/feedcontainer.h \
@@ -947,11 +946,10 @@ test/configparser.o: test/configparser.cpp include/configparser.h \
  test/test-helpers/maintempdir.h
 test/configpaths.o: test/configpaths.cpp include/configpaths.h \
  target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
- include/cliargsparser.h \
  target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h \
- 3rd-party/optional.hpp include/logger.h config.h include/strprintf.h \
- target/cxxbridge/libnewsboat-ffi/src/logger.rs.h 3rd-party/catch.hpp \
- test/test-helpers/chmod.h test/test-helpers/envvar.h \
+ include/cliargsparser.h 3rd-party/optional.hpp include/logger.h config.h \
+ include/strprintf.h target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
+ 3rd-party/catch.hpp test/test-helpers/chmod.h test/test-helpers/envvar.h \
  test/test-helpers/misc.h test/test-helpers/opts.h \
  test/test-helpers/tempdir.h test/test-helpers/maintempdir.h \
  include/utils.h 3rd-party/expected.hpp include/configcontainer.h \
@@ -1014,9 +1012,8 @@ test/itemlistformaction.o: test/itemlistformaction.cpp \
  include/textformatter.h include/statusline.h 3rd-party/catch.hpp \
  include/cache.h include/configpaths.h \
  target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
- include/cliargsparser.h \
- target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h include/logger.h \
- config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h \
+ include/cliargsparser.h include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h \
  include/feedlistformaction.h stfl/itemlist.h include/keymap.h \
  include/regexmanager.h include/rssfeed.h include/utils.h \
@@ -1196,7 +1193,6 @@ test/view.o: test/view.cpp include/view.h 3rd-party/optional.hpp \
  include/textformatter.h include/statusline.h 3rd-party/catch.hpp \
  include/controller.h include/configpaths.h \
  target/cxxbridge/libnewsboat-ffi/src/configpaths.rs.h \
- include/cliargsparser.h \
- target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h include/logger.h \
- config.h include/strprintf.h \
+ target/cxxbridge/libnewsboat-ffi/src/cliargsparser.rs.h \
+ include/cliargsparser.h include/logger.h config.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/cache.h

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -11,6 +11,7 @@ fn add_cxxbridge(module: &str) {
 
 fn main() {
     add_cxxbridge("cliargsparser");
+    add_cxxbridge("configpaths");
     add_cxxbridge("fmtstrformatter");
     add_cxxbridge("fslock");
     add_cxxbridge("history");

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -1,8 +1,15 @@
+use cxx::{type_id, ExternType};
+
 use libnewsboat::cliargsparser;
 
 // cxx doesn't allow to share types from other crates, so we have to wrap it
 // cf. https://github.com/dtolnay/cxx/issues/496
-struct CliArgsParser(cliargsparser::CliArgsParser);
+pub struct CliArgsParser(pub cliargsparser::CliArgsParser);
+
+unsafe impl ExternType for CliArgsParser {
+    type Id = type_id!("newsboat::cliargsparser::bridged::CliArgsParser");
+    type Kind = cxx::kind::Opaque;
+}
 
 #[cxx::bridge(namespace = "newsboat::cliargsparser::bridged")]
 mod bridged {

--- a/rust/libnewsboat-ffi/src/configpaths.rs
+++ b/rust/libnewsboat-ffi/src/configpaths.rs
@@ -1,156 +1,95 @@
-use crate::abort_on_panic;
-use libc::{c_char, c_void};
-use libnewsboat::cliargsparser::CliArgsParser;
-use libnewsboat::configpaths::ConfigPaths;
-use std::ffi::{CStr, CString};
-use std::mem;
-use std::panic::{RefUnwindSafe, UnwindSafe};
+use libnewsboat::cliargsparser;
+use libnewsboat::configpaths;
 use std::path::Path;
-use std::ptr;
 
-#[no_mangle]
-pub extern "C" fn create_rs_configpaths() -> *mut c_void {
-    abort_on_panic(|| Box::into_raw(Box::new(ConfigPaths::new())) as *mut c_void)
+// cxx doesn't allow to share types from other crates, so we have to wrap it
+// cf. https://github.com/dtolnay/cxx/issues/496
+pub struct ConfigPaths(configpaths::ConfigPaths);
+
+// cxx doesn't allow to share types from other crates, so we have to wrap it
+// cf. https://github.com/dtolnay/cxx/issues/496
+pub struct FfiCliArgsParser(cliargsparser::CliArgsParser);
+
+#[cxx::bridge(namespace = "newsboat::configpaths::bridged")]
+mod bridged {
+    extern "Rust" {
+        type ConfigPaths;
+        type FfiCliArgsParser;
+
+        fn create() -> Box<ConfigPaths>;
+
+        fn create_dirs(configpaths: &ConfigPaths) -> bool;
+
+        fn initialized(configpaths: &ConfigPaths) -> bool;
+        fn error_message(configpaths: &ConfigPaths) -> String;
+
+        fn process_args(configpaths: &mut ConfigPaths, args: &FfiCliArgsParser);
+
+        fn try_migrate_from_newsbeuter(configpaths: &mut ConfigPaths) -> bool;
+
+        fn url_file(configpaths: &ConfigPaths) -> String;
+        fn cache_file(configpaths: &ConfigPaths) -> String;
+        fn set_cache_file(configpaths: &mut ConfigPaths, path: &str);
+        fn config_file(configpaths: &ConfigPaths) -> String;
+        fn lock_file(configpaths: &ConfigPaths) -> String;
+        fn queue_file(configpaths: &ConfigPaths) -> String;
+        fn search_file(configpaths: &ConfigPaths) -> String;
+        fn cmdline_file(configpaths: &ConfigPaths) -> String;
+    }
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn destroy_rs_configpaths(object: *mut c_void) {
-    abort_on_panic(|| {
-        if object.is_null() {
-            return;
-        };
-        Box::from_raw(object as *mut ConfigPaths);
-    })
+fn create() -> Box<ConfigPaths> {
+    Box::new(ConfigPaths(configpaths::ConfigPaths::new()))
 }
 
-unsafe fn with_configpaths<F, T>(object: *mut c_void, action: F, default: T) -> T
-where
-    F: RefUnwindSafe + Fn(&mut ConfigPaths) -> T,
-    T: UnwindSafe,
-{
-    abort_on_panic(|| {
-        if object.is_null() {
-            return default;
-        }
-
-        let mut object = Box::from_raw(object as *mut ConfigPaths);
-        let result = action(&mut object);
-
-        // Don't destroy the object when the function finishes
-        mem::forget(object);
-
-        result
-    })
+fn create_dirs(configpaths: &ConfigPaths) -> bool {
+    configpaths.0.create_dirs()
 }
 
-unsafe fn with_configpaths_string<F>(object: *mut c_void, action: F) -> *mut c_char
-where
-    F: RefUnwindSafe + Fn(&mut ConfigPaths) -> String,
-{
-    with_configpaths(
-        object,
-        |o| CString::new(action(o)).unwrap().into_raw(),
-        ptr::null_mut(),
-    )
+fn initialized(configpaths: &ConfigPaths) -> bool {
+    configpaths.0.initialized()
 }
 
-unsafe fn with_configpaths_path<F>(object: *mut c_void, action: F) -> *mut c_char
-where
-    F: RefUnwindSafe + Fn(&mut ConfigPaths) -> &Path,
-{
-    with_configpaths_string(object, |o| action(o).to_string_lossy().into_owned())
+fn error_message(configpaths: &ConfigPaths) -> String {
+    configpaths.0.error_message().to_owned()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_initialized(object: *mut c_void) -> bool {
-    with_configpaths(object, |o| o.initialized(), false)
+fn process_args(configpaths: &mut ConfigPaths, args: &FfiCliArgsParser) {
+    configpaths.0.process_args(&args.0);
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_error_message(object: *mut c_void) -> *mut c_char {
-    with_configpaths_string(object, |o| o.error_message().to_owned())
+fn try_migrate_from_newsbeuter(configpaths: &mut ConfigPaths) -> bool {
+    configpaths.0.try_migrate_from_newsbeuter()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_process_args(
-    object: *mut c_void,
-    rs_cliargsparser: *mut c_void,
-) {
-    abort_on_panic(|| {
-        if rs_cliargsparser.is_null() {
-            return;
-        }
-
-        let cliargsparser = Box::from_raw(rs_cliargsparser as *mut CliArgsParser);
-
-        with_configpaths(object, |o| o.process_args(&cliargsparser), ());
-
-        // Don't destroy the object when the function finishes
-        mem::forget(cliargsparser);
-    })
+fn url_file(configpaths: &ConfigPaths) -> String {
+    configpaths.0.url_file().to_string_lossy().into_owned()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_try_migrate_from_newsbeuter(object: *mut c_void) -> bool {
-    with_configpaths(object, |o| o.try_migrate_from_newsbeuter(), false)
+fn cache_file(configpaths: &ConfigPaths) -> String {
+    configpaths.0.cache_file().to_string_lossy().into_owned()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_create_dirs(object: *mut c_void) -> bool {
-    with_configpaths(object, |o| o.create_dirs(), false)
+fn set_cache_file(configpaths: &mut ConfigPaths, path: &str) {
+    configpaths.0.set_cache_file(Path::new(path).to_owned());
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_url_file(object: *mut c_void) -> *mut c_char {
-    with_configpaths_path(object, |o| o.url_file())
+fn config_file(configpaths: &ConfigPaths) -> String {
+    configpaths.0.config_file().to_string_lossy().into_owned()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_cache_file(object: *mut c_void) -> *mut c_char {
-    with_configpaths_path(object, |o| o.cache_file())
+fn lock_file(configpaths: &ConfigPaths) -> String {
+    configpaths.0.lock_file().to_string_lossy().into_owned()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_set_cache_file(
-    object: *mut c_void,
-    cstr_path: *const c_char,
-) {
-    abort_on_panic(|| {
-        let path = {
-            assert!(!cstr_path.is_null());
-            CStr::from_ptr(cstr_path)
-        }
-        .to_string_lossy()
-        .into_owned();
-        with_configpaths(
-            object,
-            |o| o.set_cache_file(Path::new(&path).to_owned()),
-            (),
-        )
-    })
+fn queue_file(configpaths: &ConfigPaths) -> String {
+    configpaths.0.queue_file().to_string_lossy().into_owned()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_config_file(object: *mut c_void) -> *mut c_char {
-    with_configpaths_path(object, |o| o.config_file())
+fn search_file(configpaths: &ConfigPaths) -> String {
+    configpaths.0.search_file().to_string_lossy().into_owned()
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_lock_file(object: *mut c_void) -> *mut c_char {
-    with_configpaths_path(object, |o| o.lock_file())
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_queue_file(object: *mut c_void) -> *mut c_char {
-    with_configpaths_path(object, |o| o.queue_file())
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_search_file(object: *mut c_void) -> *mut c_char {
-    with_configpaths_path(object, |o| o.search_file())
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn rs_configpaths_cmdline_file(object: *mut c_void) -> *mut c_char {
-    with_configpaths_path(object, |o| o.cmdline_file())
+fn cmdline_file(configpaths: &ConfigPaths) -> String {
+    configpaths.0.cmdline_file().to_string_lossy().into_owned()
 }

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -178,9 +178,9 @@ nonstd::optional<Level> CliArgsParser::log_level() const
 	return nonstd::nullopt;
 }
 
-void* CliArgsParser::get_rust_pointer() const
+const cliargsparser::bridged::CliArgsParser& CliArgsParser::get_rust_ref() const
 {
-	return (void*)&*rs_object;
+	return *rs_object;
 }
 
 } // namespace newsboat

--- a/src/configpaths.cpp
+++ b/src/configpaths.cpp
@@ -19,8 +19,7 @@ std::string ConfigPaths::error_message() const
 
 void ConfigPaths::process_args(const CliArgsParser& args)
 {
-	newsboat::configpaths::bridged::process_args(*rs_object,
-		*(newsboat::configpaths::bridged::FfiCliArgsParser*)args.get_rust_pointer());
+	newsboat::configpaths::bridged::process_args(*rs_object, args.get_rust_ref());
 }
 
 bool ConfigPaths::try_migrate_from_newsbeuter()

--- a/src/configpaths.cpp
+++ b/src/configpaths.cpp
@@ -1,151 +1,76 @@
 #include "configpaths.h"
 
-#include <cstring>
-#include <fstream>
-#include <iostream>
-#include <pwd.h>
-#include <string>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#include "config.h"
-#include "globals.h"
-#include "ruststring.h"
-#include "strprintf.h"
-
-extern "C" {
-	void* create_rs_configpaths();
-
-	void destroy_rs_configpaths(void* rs_configpaths);
-
-	bool rs_configpaths_initialized(void* rs_configpaths);
-
-	char* rs_configpaths_error_message(void* rs_configpaths);
-
-	void rs_configpaths_process_args(void* rs_configpaths, void* rs_cliargsparser);
-
-	bool rs_configpaths_try_migrate_from_newsbeuter(void* rs_configpaths);
-
-	bool rs_configpaths_create_dirs(void* rs_configpaths);
-
-	char* rs_configpaths_url_file(void* rs_configpaths);
-
-	char* rs_configpaths_cache_file(void* rs_configpaths);
-
-	void rs_configpaths_set_cache_file(void* rs_configpaths, const char*);
-
-	char* rs_configpaths_config_file(void* rs_configpaths);
-
-	char* rs_configpaths_lock_file(void* rs_configpaths);
-
-	char* rs_configpaths_queue_file(void* rs_configpaths);
-
-	char* rs_configpaths_search_file(void* rs_configpaths);
-
-	char* rs_configpaths_cmdline_file(void* rs_configpaths);
-}
-
-#define SIMPLY_RUN(NAME) \
-	if (rs_configpaths) { \
-		rs_configpaths_ ## NAME (rs_configpaths); \
-	}
-
-#define GET_VALUE(NAME, DEFAULT) \
-	if (rs_configpaths) { \
-		return rs_configpaths_ ## NAME (rs_configpaths); \
-	} else { \
-		return DEFAULT; \
-	}
-
-#define GET_STRING(NAME) \
-	if (rs_configpaths) { \
-		return RustString(rs_configpaths_ ## NAME (rs_configpaths)); \
-	} else { \
-		return {}; \
-	}
-
 namespace newsboat {
 
 ConfigPaths::ConfigPaths()
+	: rs_object(configpaths::bridged::create())
 {
-	rs_configpaths = create_rs_configpaths();
-}
-
-ConfigPaths::~ConfigPaths()
-{
-	if (rs_configpaths) {
-		destroy_rs_configpaths(rs_configpaths);
-	}
 }
 
 bool ConfigPaths::initialized() const
 {
-	GET_VALUE(initialized, false);
+	return newsboat::configpaths::bridged::initialized(*rs_object);
 }
 
 std::string ConfigPaths::error_message() const
 {
-	GET_STRING(error_message);
+	return std::string(newsboat::configpaths::bridged::error_message(*rs_object));
 }
 
 void ConfigPaths::process_args(const CliArgsParser& args)
 {
-	if (rs_configpaths) {
-		rs_configpaths_process_args(rs_configpaths, args.get_rust_pointer());
-	}
+	newsboat::configpaths::bridged::process_args(*rs_object,
+		*(newsboat::configpaths::bridged::FfiCliArgsParser*)args.get_rust_pointer());
 }
 
 bool ConfigPaths::try_migrate_from_newsbeuter()
 {
-	GET_VALUE(try_migrate_from_newsbeuter, false);
+	return newsboat::configpaths::bridged::try_migrate_from_newsbeuter(*rs_object);
 }
 
 bool ConfigPaths::create_dirs() const
 {
-	GET_VALUE(create_dirs, false);
+	return newsboat::configpaths::bridged::create_dirs(*rs_object);
 }
 
 void ConfigPaths::set_cache_file(const std::string& new_cachefile)
 {
-	if (rs_configpaths) {
-		rs_configpaths_set_cache_file(rs_configpaths, new_cachefile.c_str());
-	}
+	newsboat::configpaths::bridged::set_cache_file(*rs_object, new_cachefile);
 }
 
 std::string ConfigPaths::url_file() const
 {
-	GET_STRING(url_file);
+	return std::string(newsboat::configpaths::bridged::url_file(*rs_object));
 }
 
 std::string ConfigPaths::cache_file() const
 {
-	GET_STRING(cache_file);
+	return std::string(newsboat::configpaths::bridged::cache_file(*rs_object));
 }
 
 std::string ConfigPaths::config_file() const
 {
-	GET_STRING(config_file);
+	return std::string(newsboat::configpaths::bridged::config_file(*rs_object));
 }
 
 std::string ConfigPaths::lock_file() const
 {
-	GET_STRING(lock_file);
+	return std::string(newsboat::configpaths::bridged::lock_file(*rs_object));
 }
 
 std::string ConfigPaths::queue_file() const
 {
-	GET_STRING(queue_file);
+	return std::string(newsboat::configpaths::bridged::queue_file(*rs_object));
 }
 
 std::string ConfigPaths::search_file() const
 {
-	GET_STRING(search_file);
+	return std::string(newsboat::configpaths::bridged::search_file(*rs_object));
 }
 
 std::string ConfigPaths::cmdline_file() const
 {
-	GET_STRING(cmdline_file);
+	return std::string(newsboat::configpaths::bridged::cmdline_file(*rs_object));
 }
 
 } // namespace newsboat

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -13,7 +13,7 @@
 #include "strprintf.h"
 #include "utils.h"
 
-#include "keymap.rs.h"
+#include "libnewsboat-ffi/src/keymap.rs.h"
 
 namespace newsboat {
 


### PR DESCRIPTION
Related to https://github.com/newsboat/newsboat/issues/1383

I had some trouble passing the `CliArgsParser` as an argument to `ConfigPaths::process_args()`.
It looks like types in `extern "Rust"` scopes cannot be shared (maybe it is possible, but I couldn't find out how).
I worked around it by introducing `FfiCliArgsParser` and casting on the C++ side.