### PR TITLE
Add Miniflux support for min-items

### DIFF
--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -79,6 +79,7 @@ max-browser-tabs||<number>||10||Set the maximum number of articles to open in a 
 max-download-speed||<number>||0||If set to a number greater than 0, the download speed per download is set to that limit (in KB/s).||max-download-speed 50
 max-items||<number>||0||Set the number of articles to maximally keep per feed. If the number is set to 0, then all articles are kept.||max-items 100
 miniflux-login||<username>||""||Sets the username for use with Miniflux.||miniflux-login "admin"
+miniflux-min-items||<number>||100||This variable sets the number of articles that are loaded from Miniflux per feed.||miniflux-min-items 20
 miniflux-password||<password>||""||Configures the password for use with Miniflux. Double quotes and backslashes within it <<#_using_double_quotes,should be escaped>>.||miniflux-password "here_goesAquote:\""
 miniflux-passwordeval||<command>||""||A more secure alternative to the above, is providing your password from an external command that is evaluated during login. This can be used to read your password from a gpg encrypted file or your system keyring.||miniflux-passwordeval "gpg --decrypt ~/.newsboat/miniflux-password.gpg"
 miniflux-passwordfile||<path>||""||Another alternative, by storing your plaintext password elsewhere in your system.||miniflux-passwordfile "~/.newsboat/miniflux-pw.txt"

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -262,6 +262,7 @@ ConfigContainer::ConfigContainer()
 	{"ocnews-flag-star", ConfigData("", ConfigDataType::STR)},
 	{"ocnews-url", ConfigData("", ConfigDataType::STR)},
 	{"miniflux-login", ConfigData("", ConfigDataType::STR)},
+	{"miniflux-min-items", ConfigData("100", ConfigDataType::INT)},
 	{"miniflux-password", ConfigData("", ConfigDataType::STR)},
 	{"miniflux-passwordfile", ConfigData("", ConfigDataType::PATH)},
 	{"miniflux-passwordeval", ConfigData("", ConfigDataType::STR)},

--- a/src/minifluxapi.cpp
+++ b/src/minifluxapi.cpp
@@ -137,7 +137,9 @@ rsspp::Feed MinifluxApi::fetch_feed(const std::string& id, CURL* cached_handle)
 	feed.rss_version = rsspp::Feed::MINIFLUX_JSON;
 
 	const std::string query =
-		strprintf::fmt("/v1/feeds/%s/entries?order=published_at&direction=desc", id);
+		strprintf::fmt("/v1/feeds/%s/entries?order=published_at&direction=desc&limit=%u",
+			id,
+			cfg->get_configvalue_as_int("miniflux-min-items"));
 
 	const json content = run_op(query, json(), HTTPMethod::GET, cached_handle);
 	if (content.is_null()) {


### PR DESCRIPTION
For issue: https://github.com/newsboat/newsboat/issues/1814

Tested on fedora 35 and all seems fine.

Default value set as 100 to keep with current behaviour