### PR TITLE
Add information about missing enclosures in miniflux API

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -743,6 +743,9 @@ You can disable these feeds by setting the following configuration variable:
 
 _Supported since Newsboat 2.21._
 
+WARNING: As of 2021-10-06, Miniflux's API doesn't list enclosures, so Newsboat
+won't display podcasts, cover images etc.
+
 https://miniflux.app[Miniflux] is a "minimalist and opinionated feed reader"
 that is self-hostable.
 


### PR DESCRIPTION
Miniflux when using `get_entries` don't return enclosures: https://github.com/miniflux/v2/issues/1059

So adding information similar to this PR: https://github.com/newsboat/newsboat/pull/1760