### PR TITLE
Check for command-dependencies

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -3,6 +3,18 @@
 FAILSTATUS=""
 PKG_CONFIG=${PKG_CONFIG:-pkg-config}
 
+check_cmd() {
+	cmd=$1
+	printf "Checking for command ${cmd}... "
+    if command -v ${cmd} &> /dev/null ; then
+        echo "found"
+    else
+        echo "not found"
+        return 1
+    fi
+    return 0
+}
+
 check_pkg() {
 	pkgname=$1
 	add_define=$2
@@ -101,6 +113,8 @@ check_pkg "sqlite3" || fail "sqlite3"
 check_pkg "libcurl" || check_custom "libcurl" "curl-config" || fail "libcurl"
 check_pkg "libxml-2.0" || check_custom "libxml2" "xml2-config" || fail "libxml2"
 check_pkg "stfl" || fail "stfl"
+check_cmd "asciidoctor" || fail "asciidoctor"
+check_cmd "cargo" || fail "cargo"
 ( check_pkg "json" "" 0.11 || check_pkg "json-c" "" 0.11 ) || fail "json-c"
 
 if [ `uname -s` = "Darwin" ]; then


### PR DESCRIPTION
Currently, `config.sh` only checks for packages through pkg-config. Some dependencies, however, don't have a pkg-config package.
This commit simply checks for `asciidoctor` and `cargo` during `make`, so it doesn't break mid-build.