### PR TITLE
Fix multi-byte characters in utils::extract_token_quoted()

### DIFF
--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -739,13 +739,13 @@ pub fn extract_token_quoted<'a>(line: &'a str, delimiters: &str) -> (Option<Stri
 
     if line.starts_with('"') {
         let mut token = String::new();
-        let mut it = line.chars().enumerate();
+        let mut it = line.chars();
         it.next(); // Ignore opening quotation mark
-        while let Some((i, c)) = it.next() {
+        while let Some(c) = it.next() {
             if c == '"' {
-                return (Some(token), &line[i + 1..]);
+                return (Some(token), it.as_str());
             } else if c == '\\' {
-                if let Some((_, escaped_char)) = it.next() {
+                if let Some(escaped_char) = it.next() {
                     token.push_str(&get_escape_value(escaped_char));
                 }
             } else {
@@ -1281,6 +1281,14 @@ mod tests {
         assert_eq!(
             tokenize_quoted(r#"one \# two three # ???"#, " "),
             vec!["one", "\\#", "two", "three"]
+        );
+    }
+
+    #[test]
+    fn t_extract_token_quoted_works_with_unicode_strings() {
+        assert_eq!(
+            extract_token_quoted(r#""привет мир" Юникода"#, " \r\n\t"),
+            (Some("привет мир".to_owned()), " Юникода")
         );
     }
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -345,6 +345,15 @@ TEST_CASE("extract_token_quoted() processes escape sequences within quoted strin
 	REQUIRE(str == " remainder");
 }
 
+TEST_CASE("extract_token_quoted() works with Unicode strings too", "[utils]")
+{
+	std::string str = R"("привет мир" Юникода)";
+	const auto token = utils::extract_token_quoted(str);
+	REQUIRE(token.has_value());
+	REQUIRE(token.value() == "привет мир");
+	REQUIRE(str == " Юникода");
+}
+
 TEST_CASE("tokenize_nl() split a string into delimiters and fields", "[utils]")
 {
 	std::vector<std::string> tokens;


### PR DESCRIPTION
@dennisschagt, please merge this after the review (if there's no comments for me to address, of course).

I low-key wonder if we should stop using English in our test strings :)