### PR TITLE
Replace unimplemented feed tag

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1341,7 +1341,7 @@ configuration command.
 
 Example:
 
-	highlight-feed "unread > 100" white red bold
+	highlight-feed "unread_count > 100" white red bold
 
 Note the <<_using_double_quotes,use of double quotes>> to preserve spaces in
 the filter expression.


### PR DESCRIPTION
It looks like `RssFeed` does not have a "unread" attribute:
https://github.com/newsboat/newsboat/blob/28bb1cf190257f30e57807bd93f7bc6943d169b1/src/rssfeed.cpp#L175-L198

The attribute matrix already shows the correct name: [unread_count](https://newsboat.org/releases/2.25/docs/newsboat.html#attr-unread_count)