### PR TITLE
Make `RssIgnores` copyable

### DIFF
--- a/include/rssignores.h
+++ b/include/rssignores.h
@@ -10,12 +10,12 @@
 
 namespace newsboat {
 
-typedef std::pair<std::string, Matcher*> FeedUrlExprPair;
+typedef std::pair<std::string, std::shared_ptr<Matcher>> FeedUrlExprPair;
 
 class RssIgnores : public ConfigActionHandler {
 public:
 	RssIgnores() {}
-	~RssIgnores() override;
+	~RssIgnores() override {}
 	void handle_action(const std::string& action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -36,14 +36,14 @@ void RssIgnores::handle_action(const std::string& action,
 		}
 		std::string ignore_rssurl = params[0];
 		std::string ignore_expr = params[1];
-		Matcher m;
-		if (!m.parse(ignore_expr)) {
+		auto m = std::make_shared<Matcher>();
+		if (!m->parse(ignore_expr)) {
 			throw ConfigHandlerException(strprintf::fmt(
 					_("couldn't parse filter expression `%s': %s"),
 					ignore_expr,
-					m.get_parse_error()));
+					m->get_parse_error()));
 		}
-		ignores.push_back(FeedUrlExprPair(ignore_rssurl, new Matcher(ignore_expr)));
+		ignores.push_back(FeedUrlExprPair(ignore_rssurl, m));
 	} else if (action == "always-download") {
 		if (params.empty()) {
 			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
@@ -85,13 +85,6 @@ void RssIgnores::dump_config(std::vector<std::string>& config_output) const
 	for (const auto& rf : resetflag) {
 		config_output.push_back(strprintf::fmt(
 				"reset-unread-on-update %s", utils::quote(rf)));
-	}
-}
-
-RssIgnores::~RssIgnores()
-{
-	for (const auto& ign : ignores) {
-		delete ign.second;
 	}
 }
 


### PR DESCRIPTION
Prior to this patch, the object could (technically) be copied, but
destroying the original object would deallocate `Matcher` pointers and
break all the copies. This affected #1829.

This commit fixes the problem using `shared_ptr`, so the default copy
constructor and operator do the right thing now.

@dennisschagt please merge this if it looks all right to you. Or I'll merge this in three days myself.

Reviews from others are welcome as well!