### PR TITLE
Fix Nextcloud "star" flag synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "fastrand",
  "gettext-rs",
  "libc",
+ "md5",
  "natord",
  "nom",
  "once_cell",
@@ -381,6 +382,12 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/include/ocnewsapi.h
+++ b/include/ocnewsapi.h
@@ -30,7 +30,6 @@ private:
 	bool query(const std::string& query,
 		json_object** result = nullptr,
 		const std::string& post = "");
-	std::string md5(const std::string& str);
 	std::string auth;
 	std::string server;
 	FeedMap known_feeds;

--- a/include/utils.h
+++ b/include/utils.h
@@ -156,6 +156,8 @@ nonstd::optional<LinkType> podcast_mime_to_link_type(const std::string&
 
 std::string get_default_browser();
 
+std::string md5hash(const std::string& input);
+
 /// The tag and Git commit ID the program was built from, or a pre-defined
 /// value from config.h if there is no Git directory.
 std::string program_version();

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -62,6 +62,7 @@ mod bridged {
         fn quote_if_necessary(input: String) -> String;
         fn make_title(rs_str: String) -> String;
         fn get_default_browser() -> String;
+        fn md5hash(input: &str) -> String;
         fn substr_with_width(string: &str, max_width: usize) -> String;
         fn substr_with_width_stfl(string: &str, max_width: usize) -> String;
         fn get_command_output(cmd: &str) -> String;

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -19,6 +19,7 @@ unicode-width = "0.1.9"
 nom = "7"
 libc = "0.2"
 natord = "1.0.9"
+md5 = "0.7.0"
 
 [dependencies.clap]
 version = "2.33"

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -4,6 +4,7 @@ use libc::{
     c_char, c_int, c_ulong, c_void, close, execvp, exit, fork, size_t, waitpid, E2BIG, EILSEQ,
     EINVAL,
 };
+use md5;
 use percent_encoding::*;
 use std::ffi::CString;
 use std::fs::DirBuilder;
@@ -150,6 +151,12 @@ pub fn get_basename(input: &str) -> String {
 pub fn get_default_browser() -> String {
     use std::env;
     env::var("BROWSER").unwrap_or_else(|_| "lynx".to_string())
+}
+
+pub fn md5hash(input: &str) -> String {
+    let digest = md5::compute(input);
+    let hash = format!("{:x}", digest);
+    hash
 }
 
 pub fn trim(rs_str: String) -> String {

--- a/src/ocnewsapi.cpp
+++ b/src/ocnewsapi.cpp
@@ -185,10 +185,16 @@ bool OcNewsApi::update_article_flags(const std::string& oldflags,
 	const std::string& newflags,
 	const std::string& guid)
 {
-	std::string star_flag = cfg->get_configvalue("ocnews-flag-star");
-	std::string query = "items/";
-	query += guid.substr(guid.find_first_of(":") + 1);
+	const auto feedIdStart = guid.find_first_of(":") + 1;
+	const auto feedIdEnd = guid.find_first_of("/");
+	const std::string feedId = guid.substr(feedIdStart, feedIdEnd - feedIdStart);
 
+	const std::string ocnewsGuid = guid.substr(guid.find_first_of("/") + 1);
+	const std::string guidHash = utils::md5hash(ocnewsGuid);
+
+	std::string query = strprintf::fmt("items/%s/%s", feedId, guidHash);
+
+	std::string star_flag = cfg->get_configvalue("ocnews-flag-star");
 	if (star_flag.length() > 0) {
 		if (strchr(oldflags.c_str(), star_flag[0]) == nullptr &&
 			strchr(newflags.c_str(), star_flag[0]) != nullptr) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -797,6 +797,11 @@ std::string utils::get_default_browser()
 	return std::string(utils::bridged::get_default_browser());
 }
 
+std::string utils::md5hash(const std::string& input)
+{
+	return std::string(utils::bridged::md5hash(input));
+}
+
 std::string utils::program_version()
 {
 	return std::string(utils::bridged::program_version());


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/743

This depends on an implementation detail of the Nextcloud News extension (computing md5 hash of `guid` for `guid_hash`).
However, it does not have the disadvantages of other approaches mentiond in https://github.com/newsboat/newsboat/issues/743#issuecomment-731252838.

Current `guid_hash` calculation in Nextcloud News:
- https://github.com/nextcloud/news/blob/c0998b27c155fd63e608cc20fd96375e75d69ace/lib/Fetcher/FeedFetcher.php#L234
- https://github.com/nextcloud/news/blob/c0998b27c155fd63e608cc20fd96375e75d69ace/lib/Db/Item.php#L150

![image](https://user-images.githubusercontent.com/4629607/137590555-0681dd48-32da-43fe-aafa-eb7e826e5d75.png)
