### PR TITLE
Bump Rust to 1.56.0

### DIFF
--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.55.0 by default.
+# and Rust 1.56.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-8
-# - rust_version -- Rust version to install. Default: 1.55.0
+# - rust_version -- Rust version to install. Default: 1.56.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-8
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.55.0
+ARG rust_version=1.56.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -82,7 +82,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain 1.55.0 \
+        --default-toolchain 1.56.0 \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 9 and Rust 1.55.0 by default.
+# compilers. Contains GCC 9 and Rust 1.56.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.55.0
+# - rust_version -- Rust version to install. Default: 1.56.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.55.0
+ARG rust_version=1.56.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_20.10-build-tools.dockerfile
+++ b/docker/ubuntu_20.10-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 10 and Rust 1.55.0 by default.
+# compilers. Contains GCC 10 and Rust 1.56.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-10
-# - rust_version -- Rust version to install. Default: 1.55.0
+# - rust_version -- Rust version to install. Default: 1.56.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-10
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.55.0
+ARG rust_version=1.56.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_21.04-build-tools.dockerfile
+++ b/docker/ubuntu_21.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 10 and Rust 1.55.0 by default.
+# compilers. Contains GCC 10 and Rust 1.56.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-10
-# - rust_version -- Rust version to install. Default: 1.55.0
+# - rust_version -- Rust version to install. Default: 1.56.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-10
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -100,7 +100,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.55.0
+ARG rust_version=1.56.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \


### PR DESCRIPTION
1.56.0 also introduces a new Rust edition, but we can't use it just yet — our minimum supported Rust version is 1.53.0. We'll bump it in December, and *then* we can migrate.