### PR TITLE
Do not crash at exit if reload threads are running

### DIFF
--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -234,9 +234,9 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
-	Controller c(configpaths);
-	newsboat::View v(&c);
-	c.set_view(&v);
+	Controller *c = new Controller(configpaths);
+	newsboat::View *v = new newsboat::View(c);
+	c->set_view(v);
 	CliArgsParser args(argc, argv);
 
 	configpaths.process_args(args);
@@ -254,7 +254,7 @@ int main(int argc, char* argv[])
 
 	int ret;
 	try {
-		ret = c.run(args);
+		ret = c->run(args);
 	} catch (const newsboat::DbException& e) {
 		Stfl::reset();
 		std::cerr << strprintf::fmt(


### PR DESCRIPTION
If some of the download/reload threads are running, and if you hit 'q'
to exit the program, newsboat might segfault in libpthread.
In main(), stack variable goes out of scope and destructor for View
object is called, then another thread tries to access mtx member
of an already freed object, which could be garbage at this point, and
then tries to call std::mutex::lock().

0  __GI___pthread_mutex_lock (mutex=0x746c75617e)
1  0x0000555f942f96ba in __gthread_mutex_lock (__mutex=0x746c75617e)
2  std::mutex::lock (this=0x746c75617e)
3  std::lock_guard<std::mutex>::lock_guard (__m=..., this=<synthetic pointer>)
4  newsboat::View::set_status (this=0x746c756166, msg="")
5  0x0000555f943c867f in newsboat::Reloader::reload (this=0x555f956e9600, pos=<optimized out>, max=<optimized out>, unattended=<optimized out>, easyhandle=<optimized out>)
6  0x0000555f943c912d in newsboat::Reloader::reload_range (this=0x555f956e9600, start=<optimized out>, end=<optimized out>, size=11, unattended=false)
7  0x0000555f943c97cf in newsboat::Reloader::reload_all (this=0x555f956e9600, unattended=unattended@entry=false)
8  0x0000555f94315197 in newsboat::DownloadThread::operator() (this=0x7fa284000bb8)
9  0x00007fa28d598ed0 in std::execute_native_thread_routine (__p=0x7fa284000bb0)
10 0x00007fa28dabcea7 in start_thread (arg=<optimized out>)
11 0x00007fa28d2a2def in clone ()

Let's allocate View and Controller objects on the heap, so that
destructor for them won't be called. Everything will be cleaned up by
the kernel when process terminates.