### PR TITLE
Allow regexes to select URLs in ignore-article

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -961,15 +961,18 @@ is <<ignore-article,`ignore-article`>>:
 
 	ignore-article "*" "title =~ \"Gentoo\""
 	ignore-article "https://synflood.at/blog/index.php?/feeds/index.rss2" "title =~ \"newsboat\""
+	ignore-article "regex:https?://nitter.net/.*" "title =~ \"^RT by\""
 
-It takes two parameters. The first one is either a URL of a feed, or `"*"` to
-match any feed (asterisk is _not_ a pattern, glob or regex—we simply reserve it
-to mean "all feeds").  The second argument is <<_filter_language,a filter
-expression>> for an article, probably <<_using_double_quotes,in double quotes
-to preserve spaces inside>>. If Newsboat hits an article in the specified RSS
-feed that matches the specified filter expression, then this article is ignored
-and never presented to the user. The configuration itself can contain as many
-<<ignore-article,`ignore-article`>> commands as desired.
+It takes two parameters. The first one is either a URL of a feed, a pattern 
+prefixed with `regex:`, this pattern being in the POSIX extended reg format, 
+which will be matched case-insensitive, or `"*"` to match any feed (asterisk is 
+_not_ a pattern, glob or regex—we simply reserve it to mean "all feeds"). The 
+second argument is <<_filter_language,a filter expression>> for an article, 
+probably <<_using_double_quotes,in double quotes to preserve spaces inside>>. If 
+Newsboat hits an article in the specified RSS feed that matches the specified 
+filter expression, then this article is ignored and never presented to the user. 
+The configuration itself can contain as many <<ignore-article,`ignore-article`>> 
+commands as desired.
 
 You can also specify the way an article is ignored. There are
 two ways available:

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -959,15 +959,20 @@ In Newsboat, such a "killfile" can be implemented on a per-article basis via
 the configuration file. The most important configuration command for this
 is <<ignore-article,`ignore-article`>>:
 
-	ignore-article "*" "title =~ \"Gentoo\""
 	ignore-article "https://synflood.at/blog/index.php?/feeds/index.rss2" "title =~ \"newsboat\""
 	ignore-article "regex:https?://nitter.net/.*" "title =~ \"^RT by\""
+	ignore-article "*" "title =~ \"Gentoo\""
 
-It takes two parameters. The first one is either a URL of a feed, a pattern 
-prefixed with `regex:`, this pattern being in the POSIX extended reg format, 
-which will be matched case-insensitive, or `"*"` to match any feed (asterisk is 
-_not_ a pattern, glob or regex—we simply reserve it to mean "all feeds"). The 
-second argument is <<_filter_language,a filter expression>> for an article, 
+It takes two parameters. The first one is either: 
+
+ - The URL of a feed.
+ - A pattern prefixed with `regex:`. The pattern must be
+ a https://pubs.opengroup.org/onlinepubs/9699919799.2008edition/basedefs/V1_chap09.html[POSIX
+ extended regular expression], which will be matched case-insensitive. 
+ - `"*"` to match any feed (asterisk is _not_ a pattern, glob or regex—we simply 
+ reserve it to mean "all feeds").
+
+The second argument is <<_filter_language,a filter expression>> for an article, 
 probably <<_using_double_quotes,in double quotes to preserve spaces inside>>. If 
 Newsboat hits an article in the specified RSS feed that matches the specified 
 filter expression, then this article is ignored and never presented to the user. 

--- a/include/rssignores.h
+++ b/include/rssignores.h
@@ -27,6 +27,8 @@ private:
 	std::vector<FeedUrlExprPair> ignores;
 	std::vector<std::string> ignores_lastmodified;
 	std::vector<std::string> resetflag;
+
+	static const std::string REGEX_PREFIX;
 };
 
 } // namespace newsboat

--- a/mk/mk.deps
+++ b/mk/mk.deps
@@ -756,8 +756,8 @@ src/rssignores.o: src/rssignores.cpp include/rssignores.h \
  include/textformatter.h include/logger.h include/strprintf.h \
  target/cxxbridge/libnewsboat-ffi/src/logger.rs.h include/rssfeed.h \
  include/utils.h 3rd-party/expected.hpp include/logger.h \
- target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/strprintf.h \
- include/tagsouppullparser.h include/utils.h
+ target/cxxbridge/libnewsboat-ffi/src/utils.rs.h include/regexowner.h \
+ include/strprintf.h include/tagsouppullparser.h include/utils.h
 src/rssitem.o: src/rssitem.cpp include/rssitem.h include/matchable.h \
  3rd-party/optional.hpp include/matcher.h filter/FilterParser.h \
  include/cache.h include/configcontainer.h include/configactionhandler.h \

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -99,21 +99,19 @@ bool RssIgnores::matches(RssItem* item)
 			"RssIgnores::matches: ign.first = `%s' item->feedurl = `%s'",
 			ign.first,
 			item->feedurl());
-			
-		if(!ign.first.compare(0, prefix_len, prefix)) {
+
+		if (!ign.first.compare(0, prefix_len, prefix)) {
 			std::string errorMessage;
 			std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
 			auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
 			if (regex == nullptr) {
 				throw ConfigHandlerException(strprintf::fmt(
-					_("`%s' is not a valid regular expression: %s"),
-					pattern, errorMessage));
+						_("`%s' is not a valid regular expression: %s"),
+						pattern, errorMessage));
 			}
 			const auto matches = regex->matches(item->feedurl(), 1, 0);
 			matched = !matches.empty();
-		}
-		else 
-		{
+		} else {
 			matched = ign.first == "*" || item->feedurl() == ign.first;
 		}
 

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -11,6 +11,7 @@
 #include <sys/utsname.h>
 #include <string.h>
 #include <time.h>
+#include <regex>
 
 #include "cache.h"
 #include "config.h"
@@ -91,11 +92,12 @@ void RssIgnores::dump_config(std::vector<std::string>& config_output) const
 bool RssIgnores::matches(RssItem* item)
 {
 	for (const auto& ign : ignores) {
+		auto matched = regex_match (item->feedurl(), std::regex(ign.first));
 		LOG(Level::DEBUG,
-			"RssIgnores::matches: ign.first = `%s' item->feedurl = `%s'",
+			"RssIgnores::matches: ign.first = `%s' item->feedurl = `%s': %d",
 			ign.first,
-			item->feedurl());
-		if (ign.first == "*" || item->feedurl() == ign.first) {
+			item->feedurl(), matched);
+		if (matched) {
 			if (ign.second->matches(item)) {
 				LOG(Level::DEBUG,
 					"RssIgnores::matches: found match");

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -118,7 +118,7 @@ bool RssIgnores::matches(RssItem* item)
 		if (!ign.first.compare(0, prefix_len, REGEX_PREFIX)) {
 			const std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
 			std::string errorMessage;
-			auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
+			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
 			const auto matches = regex->matches(item->feedurl(), 1, 0);
 			matched = !matches.empty();
 		} else {

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -47,12 +47,12 @@ void RssIgnores::handle_action(const std::string& action,
 					m->get_parse_error()));
 		}
 
-		int prefix_len = REGEX_PREFIX.length();
+		const int prefix_len = REGEX_PREFIX.length();
 		if (!ignore_rssurl.compare(0, prefix_len, REGEX_PREFIX)) {
 			std::string errorMessage;
-			std::string pattern = ignore_rssurl.substr(prefix_len,
+			const std::string pattern = ignore_rssurl.substr(prefix_len,
 					ignore_rssurl.length() - prefix_len);
-			auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
+			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
 			if (regex == nullptr) {
 				throw ConfigHandlerException(strprintf::fmt(
 						_("`%s' is not a valid regular expression: %s"),
@@ -107,7 +107,7 @@ void RssIgnores::dump_config(std::vector<std::string>& config_output) const
 
 bool RssIgnores::matches(RssItem* item)
 {
-	int prefix_len = REGEX_PREFIX.length();
+	const int prefix_len = REGEX_PREFIX.length();
 	for (const auto& ign : ignores) {
 		bool matched = false;
 		LOG(Level::DEBUG,
@@ -116,7 +116,7 @@ bool RssIgnores::matches(RssItem* item)
 			item->feedurl());
 
 		if (!ign.first.compare(0, prefix_len, REGEX_PREFIX)) {
-			std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
+			const std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
 			std::string errorMessage;
 			auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
 			const auto matches = regex->matches(item->feedurl(), 1, 0);

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -274,6 +274,11 @@ TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
 
 			REQUIRE(ignores.matches(&item));
 		}
+
+		SECTION("Throws ConfigHandlerException if second param can't be parsed as filter expression") {
+			REQUIRE_THROWS_AS(ignores.handle_action("ignore-article", {"regex:a{1z", "author = \"John Doe\""}),
+				ConfigHandlerException);
+		}
 	}
 
 	SECTION("Rules with URL of \"*\" match any feed") {

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -66,6 +66,11 @@ TEST_CASE("RssIgnores::handle_action() handles `ignore-article`",
 		REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "more"}));
 		REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "way", "more different", "parameters"}));
 	}
+
+	SECTION("Throws ConfigHandlerException if second param can't be parsed as a filter expression") {
+		REQUIRE_THROWS_AS(ignores.handle_action("ignore-article", {"regex:a{1z", "author = \"John Doe\""}),
+			ConfigHandlerException);
+	}
 }
 
 TEST_CASE("RssIgnores::handle_action() handles `always-download`",
@@ -273,11 +278,6 @@ TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
 			ignores.handle_action("ignore-article", {"regex:.*example.com/.*\\.xml", "author = \"John Doe\""});
 
 			REQUIRE(ignores.matches(&item));
-		}
-
-		SECTION("Throws ConfigHandlerException if second param can't be parsed as filter expression") {
-			REQUIRE_THROWS_AS(ignores.handle_action("ignore-article", {"regex:a{1z", "author = \"John Doe\""}),
-				ConfigHandlerException);
 		}
 	}
 

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -262,6 +262,20 @@ TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
 		}
 	}
 
+	SECTION("Pattern matching rules prefixed with \"regex:\"") {
+		SECTION("Matching feeds starting with https://") {
+			ignores.handle_action("ignore-article", {"regex:^https://.*", "author = \"John Doe\""});
+
+			REQUIRE(ignores.matches(&item));
+		}
+
+		SECTION("Matching feeds containing example.com and ending with xml") {
+			ignores.handle_action("ignore-article", {"regex:.*example.com/.*\\.xml", "author = \"John Doe\""});
+
+			REQUIRE(ignores.matches(&item));
+		}
+	}
+
 	SECTION("Rules with URL of \"*\" match any feed") {
 		ignores.handle_action("ignore-article", {"*", "author = \"John Doe\""});
 


### PR DESCRIPTION
for #1913,
adds regex matching for ignore-article if and only if the pattern is prefixed with 'regex:', otherwise the previous behaviour is used.