### PR TITLE
Add "universal" colorscheme

### DIFF
--- a/contrib/colorschemes/universal-color
+++ b/contrib/colorschemes/universal-color
@@ -1,0 +1,20 @@
+# A simple color scheme designed to work well with pretty much any terminal:
+#   Uses the basic 16 ANSI colors
+#   Works with dark and light (inverted) terminal color schemes
+#   Avoids color-on-color text
+#   Avoids blue and yellow as those are often too bright or too dim
+#   Works with Linux framebuffer terminal despite it being weird with bold text
+
+color background         default default
+color listnormal         default default
+color listnormal_unread  color15 default bold
+color listfocus          green   default reverse
+color listfocus_unread   color10 default reverse bold
+color title              cyan    default reverse
+color info               magenta default reverse
+color hint-description   magenta default
+color article            default default
+color end-of-text-marker color8  default
+
+# Highlight URLs with regex
+highlight article "[a-z]+://[^ ]+" green default underline


### PR DESCRIPTION
As described in the file:
```
# A simple color scheme designed to work well with pretty much any terminal:
#   Uses the basic 16 ANSI colors
#   Works with dark and light (inverted) terminal color schemes
#   Avoids color-on-color text
#   Avoids blue and yellow as those are often too bright or too dim
#   Works with Linux framebuffer terminal despite it being weird with bold text
```
### XFCE terminal (default configuration)
![img](https://user-images.githubusercontent.com/5638322/150204989-7624012c-ea4b-4d53-a427-0db014bd1431.png)
![img](https://user-images.githubusercontent.com/5638322/150205130-46c39ad4-578b-4c67-b7e9-30308a79bd9b.png)
![img](https://user-images.githubusercontent.com/5638322/150205165-14a3dd2f-98ca-472e-b40f-48dfdb84d0cd.png)

### Foot terminal with One Light colorscheme
![img](https://user-images.githubusercontent.com/5638322/150207875-19b6e1ef-3712-42ec-b8a1-7e300a1355d9.png)
![img](https://user-images.githubusercontent.com/5638322/150207895-5f7af1c0-aca5-4913-bd26-19ba2df711c7.png)
![img](https://user-images.githubusercontent.com/5638322/150207967-112af03e-ccdf-4c74-8d57-e2c4eea6251c.png)

### Linux framebuffer console
![screen](https://user-images.githubusercontent.com/5638322/150208214-7dbbea2a-2dbc-41ab-a1db-52305134cbc1.png)
![screen-sel](https://user-images.githubusercontent.com/5638322/150208299-61aaba3a-f42d-4005-94a9-2f3845f9fc72.png)
![screen-art](https://user-images.githubusercontent.com/5638322/150208354-3c87be17-d90a-45f5-a204-890a235c045d.png)

### Comparison to default newsboat colorscheme
![default](https://user-images.githubusercontent.com/5638322/150208541-85b1eea4-ab1e-402a-a8f7-619d5a9ec920.png)
By default, some of the text is hard for me to read, because my colorscheme uses a darker color for yellow
