### PR TITLE
Return right exit code when importing OPML

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -137,8 +137,7 @@ int Controller::run(const CliArgsParser& args)
 
 	if (args.do_import()) {
 		LOG(Level::INFO, "Importing OPML file from %s", args.importfile());
-		import_opml(args.importfile(), configpaths.url_file());
-		return EXIT_SUCCESS;
+		return import_opml(args.importfile(), configpaths.url_file());
 	}
 
 	LOG(Level::INFO, "nl_langinfo(CODESET): %s", nl_langinfo(CODESET));


### PR DESCRIPTION
Before:
```
$ ./newsboat --import-from-opml sample-opml.xml 
Error importing OPML to urls file /home/bogdasar/.newsboat/urls: Не удалось открыть файл: Нет такого файла или каталога (os error 2)
$ echo $?
0
```
what is wrong, because 0 means successful exit.

After:
```
$ ./newsboat --import-from-opml sample-opml.xml 
Error importing OPML to urls file /home/bogdasar/.newsboat/urls: Не удалось открыть файл: Нет такого файла или каталога (os error 2)
$ echo $?
1
```