### PR TITLE
Guard against popping item from empty vector (list_elements_stack)

### DIFF
--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -683,7 +683,9 @@ void HtmlRenderer::render(std::istream& input,
 						tables.size() ? 0
 						: indent_level);
 				}
-				list_elements_stack.pop_back();
+				if (!list_elements_stack.empty()) {
+					list_elements_stack.pop_back();
+				}
 				add_nonempty_line(curline, tables, lines);
 				add_line("", tables, lines);
 				prepare_new_line(curline,

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -1685,3 +1685,17 @@ TEST_CASE("<div> is always rendered on a new line", "[HtmlRenderer]")
 	REQUIRE(lines[8] == p(LineType::wrappable, "hehe"));
 	REQUIRE(links.size() == 0);
 }
+
+TEST_CASE("HtmlRenderer does not crash on extra closing OL/UL tags", "[HtmlRenderer]")
+{
+	// This is a regression test for https://github.com/newsboat/newsboat/issues/1974
+
+	HtmlRenderer rnd;
+	std::vector<std::pair<LineType, std::string>> lines;
+	std::vector<LinkPair> links;
+
+	const std::string input =
+		"<ul><li>Double closed list</li></ul></ul><ol><li>Other double closed list</li></ol></ol><ul><li>Test</li></ul>";
+
+	rnd.render(input, lines, links, "");
+}


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1974