### PR TITLE
Make inline code underlined in man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,8 +260,8 @@ doc/$(NEWSBOAT).1: doc/manpage-newsboat.asciidoc doc/chapter-firststeps.asciidoc
 		doc/chapter-tagging.asciidoc doc/chapter-snownews.asciidoc \
 		doc/chapter-cmdline.asciidoc \
 		doc/chapter-environment-variables.asciidoc \
-		doc/chapter-files.asciidoc
-	$(ASCIIDOCTOR) $(ASCIIDOCTOR_OPTS) --backend=manpage doc/manpage-newsboat.asciidoc
+		doc/chapter-files.asciidoc doc/man.rb
+	$(ASCIIDOCTOR) $(ASCIIDOCTOR_OPTS) --require=./doc/man.rb --backend=manpage doc/manpage-newsboat.asciidoc
 
 doc/podboat-cfgcmds.asciidoc: doc/generate doc/podboat-cmds.dsv
 	doc/generate doc/podboat-cmds.dsv 'pb-' > doc/podboat-cfgcmds.asciidoc
@@ -270,8 +270,8 @@ doc/$(PODBOAT).1: doc/manpage-podboat.asciidoc \
 		doc/chapter-podcasts.asciidoc doc/chapter-podboat.asciidoc \
 		doc/podboat-cfgcmds.asciidoc \
 		doc/chapter-environment-variables.asciidoc \
-		doc/chapter-files.asciidoc
-	$(ASCIIDOCTOR) $(ASCIIDOCTOR_OPTS) --backend=manpage doc/manpage-podboat.asciidoc
+		doc/chapter-files.asciidoc doc/man.rb
+	$(ASCIIDOCTOR) $(ASCIIDOCTOR_OPTS) --require=./doc/man.rb --backend=manpage doc/manpage-podboat.asciidoc
 
 doc/gen-example-config: doc/gen-example-config.cpp doc/split.h
 	$(CXX_FOR_BUILD) $(CXXFLAGS_FOR_BUILD) -o doc/gen-example-config doc/gen-example-config.cpp

--- a/doc/man.rb
+++ b/doc/man.rb
@@ -30,17 +30,55 @@
 # The official documentation covers the process of creating a custom converter
 # excellently: https://docs.asciidoctor.org/asciidoctor/latest/convert/custom/
 #
-# SuccessfullyTested with Asciidoctor 2.0.12.
-class ManPageConverter < (Asciidoctor::Converter.for 'manpage')
-  register_for 'manpage'
+# Successfully tested with Asciidoctor 1.5.5 and 2.0.12.
 
-  def convert_inline_quoted node
+# The following import is required for the old Asciidoctor version 1.x shipped
+# in Ubuntu 18.04, which we use in our CI/CD. Asciidoctor 2.x doesn't need it,
+# but it also doesn't hurt.
+require 'asciidoctor/converter/manpage'
+
+class ManPageConverter < Asciidoctor::Converter::ManPageConverter
+
+  def convert_inline_monospaced node
+    %[#{ESC_BS}fI<BOUNDARY>#{node.text}</BOUNDARY>#{ESC_BS}fP]
+  end
+
+  # In Asciidoctor version 1.x the method didn't have a 'convert' prefix.
+  def inline_quoted node
     case node.type
     when :monospaced
-      %[#{ESC_BS}fI<BOUNDARY>#{node.text}</BOUNDARY>#{ESC_BS}fP]
+      convert_inline_monospaced node
     else
+      # Because of this super call, we have to define the exact same method
+      # twice and cannot use an alias. Otherwise the original method name will
+      # not be found.
       super
     end
   end
+
+  # In Asciidoctor version 2.x the method got a 'convert' prefix.
+  def convert_inline_quoted node
+    case node.type
+    when :monospaced
+      convert_inline_monospaced node
+    else
+      # Because of this super call, we have to define the exact same method
+      # twice and cannot use an alias. Otherwise the original method name will
+      # not be found.
+      super
+    end
+  end
+
+end
+
+if defined? Asciidoctor::Converter::Factory.register
+  # Registering the converter in Asciidoctor version 1.x must explicitly use
+  # the 'Factory'.
+  Asciidoctor::Converter::Factory.register ManPageConverter, ['manpage']
+else
+  # Registering the converter in Asciidoctor version 2.x must not use the
+  # 'Factory'. Once support for 1.x is dropped, this can be even simplified to
+  # `register_for 'manpage'` in the class definition itself.
+  Asciidoctor::Converter.register ManPageConverter, 'manpage'
 end
 

--- a/doc/man.rb
+++ b/doc/man.rb
@@ -1,0 +1,46 @@
+# The original Asciidoctor man page converter produces a monospace font
+# ('\f(CR') for inline code fragments. The introducing merge request
+#
+#     https://github.com/asciidoctor/asciidoctor/pull/3561
+#
+# explains that this helps further transformation of the resulting man pages to
+# post script documents or PDF files. With that the inline code is then
+# rendered in a nice monospace font in PS or PDF files. This comes to a price,
+# though. Traditionally, terminals use monospace fonts exclusively. So when the
+# man page is viewed in the terminal, the dedicated monospace font of the
+# inlined code does not stand out at all. It just looks like regular text,
+# which makes reading it quite hard sometimes.
+#
+# The Newsboat and Podboat man pages are probably most often viewed in the
+# terminal. Transforming them to another document format presumably happens
+# only very rarely. Also, a dedicated HTML documentation is offered that covers
+# even more topics than the man pages. This fact is reassuring the conjecture
+# about man pages being read in the terminal most of the time.
+#
+# In order to increase the man page readability for terminal users, this custom
+# man page converter renderes inline code as underlined text instead.
+#
+# The downside, however, is, that converting the man page to post script or PDF
+# loses the original monospace font. In post script and PDF the inline code is
+# then rendered in italics. This appearance is far from the original
+# Asciidoctor source. Oh well. If one really wanted to have a nice post script
+# document from the man page, just don't use this converter to generate the man
+# page.
+#
+# The official documentation covers the process of creating a custom converter
+# excellently: https://docs.asciidoctor.org/asciidoctor/latest/convert/custom/
+#
+# SuccessfullyTested with Asciidoctor 2.0.12.
+class ManPageConverter < (Asciidoctor::Converter.for 'manpage')
+  register_for 'manpage'
+
+  def convert_inline_quoted node
+    case node.type
+    when :monospaced
+      %[#{ESC_BS}fI<BOUNDARY>#{node.text}</BOUNDARY>#{ESC_BS}fP]
+    else
+      super
+    end
+  end
+end
+


### PR DESCRIPTION
This is the promised second change in the man pages. The documentation in the ruby file says it all.

Don't be confused, I configured my `urxvt` to show underline in blue text coloe. So here's a before (top) and after (bottom):

![diff](https://user-images.githubusercontent.com/25375116/158071926-2c010031-4900-4553-b12e-9d700dd4c249.png)

Yes, it's a bit sad, that if something contains spaces (see the `<config-command> …` in the middle of the pages) the spaces themselves are not underlined. But the result is still better in my opinion. Maybe something for the future.