### PR TITLE
CI: update FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,13 +5,9 @@ freebsd_resource_settings: &freebsd_resource_settings
 task:
     skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'docker/*', 'docker/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
     matrix:
-        - name: FreeBSD 11.4
+        - name: FreeBSD 12.3
           freebsd_instance:
-            image: freebsd-11-4-release-amd64
-            << : *freebsd_resource_settings
-        - name: FreeBSD 12.2
-          freebsd_instance:
-            image: freebsd-12-2-release-amd64
+            image: freebsd-12-3-release-amd64
             << : *freebsd_resource_settings
         - name: FreeBSD 13.0
           freebsd_instance:


### PR DESCRIPTION
1. Bump 12.2 to 12.3, as 12.2 reached EOL on March 31, 2022[1]
2. Remove 11.4, as it reached EOL on September 30, 2021[1]

1. https://www.freebsd.org/security/unsupported/