### PR TITLE
Document that # and !# don't work for tags with spaces

### DIFF
--- a/doc/chapter-tagging.asciidoc
+++ b/doc/chapter-tagging.asciidoc
@@ -29,9 +29,9 @@ Another special type of tag are tags that start with the exclamation mark (`!`).
 such a tag is found, the feed is hidden from the regular list of feeds and its 
 content can only be found through a query feed.
 
-	https://rss.orf.at/news.xml ! "World News"
-	http://feeds.bbci.co.uk/news/world/rss.xml ! "World News"
-	"query:News from around the globe:tags # \"World News\""
+	https://rss.orf.at/news.xml ! news
+	http://feeds.bbci.co.uk/news/world/rss.xml ! news
+	"query:News from around the globe:tags # \"news\""
 
 In this example, the first two feeds won't appear in the feedlist, but their
 articles will still be accessible through the query feed titled "News from

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -816,7 +816,7 @@ Attribute:Context:Meaning
 [[attr-rssurl]]<<attr-rssurl,+rssurl+>>:feed, article:RSS URL of the feed
 [[attr-unread_count]]<<attr-unread_count,+unread_count+>>:feed, article:number of unread articles in the feed
 [[attr-total_count]]<<attr-total_count,+total_count+>>:feed, article:total number of articles in the feed
-[[attr-tags]]<<attr-tags,+tags+>>:feed, article:all tags that are associated with the feed
+[[attr-tags]]<<attr-tags,+tags+>>:feed, article:space-separated list of tags that are associated with the feed. Note that for tags that have spaces in them, it's impossible to tell where they start and end, so +#+ and +!#+ operators don't work for such tags.
 [[attr-feedindex]]<<attr-feedindex,+feedindex+>>:feed, article:Index of a feed in the feed list
 |=========================================================================
 


### PR DESCRIPTION
knibbel on IRC pointed out that the example from the docs doesn't work. Turns out that in #1916 I updated the example without testing it. This commit fixes the example and adds notes about # operator not working with tags that contain spaces. The bug itself is tracked in #2039.

Reviews welcome! I'll merge this in three days, unless there is an ongoing discussion.