### PR TITLE
include cstring in itemlisformaction

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cinttypes>
 #include <cstdio>
+#include <cstring>
 #include <langinfo.h>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Without this include, newsboat does not build on my current Fedora machine (missing `strcasestr` function definition).