### PR TITLE
Create database indices for unread items and deleted urls

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -387,6 +387,14 @@ static const schema_patches schemaPatches{
 
 			"ALTER TABLE rss_item ADD COLUMN content_mime_type VARCHAR(255) NOT NULL DEFAULT \"\";"
 		}
+	},
+	{	{2, 27},
+		{
+			"UPDATE metadata SET db_schema_version_major = 2, db_schema_version_minor = 27;",
+
+			"CREATE INDEX idx_feedurl_deleted ON rss_item(feedurl, deleted);",
+			"CREATE INDEX idx_unread ON rss_item(unread);"
+		}
 	}
 
 	// Note: schema changes should use the version number of the release that introduced them.


### PR DESCRIPTION
As reported by user Evil_Bob on IRC, we have several SQL queries on our
critical startup path that query the rss_items table on 1) unread
items and 2) a combination of feedurl and the deleted flag.
He suggests that this can be speed up significantly by introducing two
additional indices which this commit adds.

Some initial (not very scientific) measurements on my personal database:
(`for i in {0..9}; do time newsboat -x print-unread; done`):

Without indices:
```
newsboat -x print-unread  5,46s user 5,80s system 95% cpu 11,830 total
newsboat -x print-unread  5,44s user 5,83s system 95% cpu 11,827 total
newsboat -x print-unread  5,37s user 5,76s system 95% cpu 11,691 total
newsboat -x print-unread  5,33s user 5,84s system 95% cpu 11,748 total
newsboat -x print-unread  5,54s user 5,77s system 95% cpu 11,889 total
newsboat -x print-unread  5,36s user 5,86s system 94% cpu 11,931 total
newsboat -x print-unread  5,32s user 6,02s system 95% cpu 11,912 total
newsboat -x print-unread  5,22s user 5,95s system 95% cpu 11,735 total
newsboat -x print-unread  5,48s user 5,82s system 95% cpu 11,854 total
newsboat -x print-unread  5,34s user 5,85s system 95% cpu 11,756 total
```

With indices:
```
newsboat -x print-unread  1,27s user 0,34s system 74% cpu 2,179 total
newsboat -x print-unread  1,22s user 0,35s system 74% cpu 2,113 total
newsboat -x print-unread  1,21s user 0,34s system 73% cpu 2,099 total
newsboat -x print-unread  1,22s user 0,34s system 73% cpu 2,120 total
newsboat -x print-unread  1,24s user 0,35s system 72% cpu 2,201 total
newsboat -x print-unread  1,25s user 0,31s system 73% cpu 2,125 total
newsboat -x print-unread  1,19s user 0,38s system 74% cpu 2,124 total
newsboat -x print-unread  1,23s user 0,32s system 73% cpu 2,115 total
newsboat -x print-unread  1,21s user 0,33s system 73% cpu 2,095 total
newsboat -x print-unread  1,19s user 0,36s system 73% cpu 2,099 total
```

Of course on the other hand the indices consume a bit more space in the
.db file:

Before: `./cache.db: 911M`
After:  `./cache.db: 924M`

Still, this seems like an adequate trade-off to make.

Please note: The release number embedded in the sql-migration has to be bumped on the next release. I don't know what the release engineering process is at this point :)