### PR TITLE
Include string.h instead of string

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -6,7 +6,7 @@
 #include <cstring>
 #include <langinfo.h>
 #include <sstream>
-#include <string>
+#include <string.h>
 #include <sys/stat.h>
 
 #include "config.h"


### PR DESCRIPTION
When building with gcc12 I get:
```
[   61s] src/itemlistformaction.cpp:1142:21: error: 'strcasestr' was not declared in this scope; did you mean 'xmlStrcasestr'?
[   61s]  1142 |                 if (strcasestr(visible_items[i].first->title().c_str(),
[   61s]       |                     ^~~~~~~~~~
[   61s]       |                     xmlStrcasestr
[   61s] src/itemlistformaction.cpp:1149:21: error: 'strcasestr' was not declared in this scope; did you mean 'xmlStrcasestr'?
[   61s]  1149 |                 if (strcasestr(visible_items[i].first->title().c_str(),
[   61s]       |                     ^~~~~~~~~~
[   61s]       |                     xmlStrcasestr
[   61s] make: *** [Makefile:177: src/itemlistformaction.o] Error 1
```

I assume this has to do with `strcasestr()` being a non standard
function.