### PR TITLE
Add kitty terminfo to the Snap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Bumped minimum supported Rust version to 1.57.0
 ### Deprecated
 ### Removed
+- i386 support in Snap. The package is now based on Ubuntu 20.04, which doesn't
+    support i386.
 ### Fixed
 ### Security
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: newsboat
 version: git
-base: core18
+base: core20
 summary: An RSS/Atom feed reader for text terminals
 description: |
   Newsboat is an RSS/Atom feed reader for the text console. It's an actively
@@ -13,6 +13,7 @@ apps:
     command: usr/local/bin/newsboat
     environment:
       LOCPATH: "$SNAP/usr/lib/locale"
+      TERMINFO_DIRS: "$SNAP/lib/terminfo:$SNAP/usr/share/terminfo"
     plugs:
       - network
       - home
@@ -21,6 +22,7 @@ apps:
     command: usr/local/bin/podboat
     environment:
       LOCPATH: "$SNAP/usr/lib/locale"
+      TERMINFO_DIRS: "$SNAP/lib/terminfo:$SNAP/usr/share/terminfo"
     plugs:
       - network
       - home
@@ -56,3 +58,6 @@ parts:
       - locales-all
       - libcurl4
       - libstfl0
+      - kitty-terminfo
+      - ncurses-base
+      - ncurses-term


### PR DESCRIPTION
This also moves the snap to core20, i.e. Ubuntu 20.04, which doesn't
support i386. So no i386 builds in the Snap Store from here on.

Solution lifted from htop:
https://github.com/maxiberta/htop-snap/commit/a158b778e0e0c62a70e7693b4c3004081556e1fc

Kudos to @gdv for all the investigations and testing, and for reporting
the bug in the first place.

Fixes #2058.