### PR TITLE
Check for `NULL` before calling `json_object_get_string()`

### DIFF
--- a/src/feedhqapi.cpp
+++ b/src/feedhqapi.cpp
@@ -136,12 +136,20 @@ std::vector<TaggedFeedUrl> FeedHqApi::get_subscribed_urls()
 		json_object* id_str{};
 		json_object_object_get_ex(sub, "id", &id_str);
 		const char* id = json_object_get_string(id_str);
+		if (id == nullptr) {
+			LOG(Level::WARN, "Skipping a subscription without an id");
+			continue;
+		}
 
 		json_object* title_str{};
 		json_object_object_get_ex(sub, "title", &title_str);
 		const char* title = json_object_get_string(title_str);
-
-		tags.push_back(std::string("~") + title);
+		if (title != nullptr) {
+			tags.push_back(std::string("~") + title);
+		} else {
+			LOG(Level::WARN, "Subscription has no title, so let's call it \"%i\"", i);
+			tags.push_back(std::string("~") + std::to_string(i));
+		}
 
 		char* escaped_id = curl_easy_escape(handle.ptr(), id, 0);
 

--- a/src/feedhqapi.cpp
+++ b/src/feedhqapi.cpp
@@ -130,8 +130,7 @@ std::vector<TaggedFeedUrl> FeedHqApi::get_subscribed_urls()
 
 	for (int i = 0; i < len; i++) {
 		std::vector<std::string> tags;
-		json_object* sub =
-			json_object_array_get_idx(subscription_obj, i);
+		json_object* sub = json_object_array_get_idx(subscription_obj, i);
 
 		json_object* id_str{};
 		json_object_object_get_ex(sub, "id", &id_str);

--- a/src/newsblurapi.cpp
+++ b/src/newsblurapi.cpp
@@ -165,17 +165,12 @@ std::map<std::string, std::vector<std::string>> NewsBlurApi::mk_feeds_to_tags(
 
 		// invariant: `tag_to_feed_ids` is a JSON object
 
-		json_object_object_foreach(
-			tag_to_feed_ids, key, feeds_with_tag_obj) {
+		json_object_object_foreach(tag_to_feed_ids, key, feeds_with_tag_obj) {
 			std::string std_key(key);
-			array_list* feeds_with_tag_arr =
-				json_object_get_array(feeds_with_tag_obj);
-			int feeds_with_tag_len =
-				array_list_length(feeds_with_tag_arr);
+			array_list* feeds_with_tag_arr = json_object_get_array(feeds_with_tag_obj);
+			int feeds_with_tag_len = array_list_length(feeds_with_tag_arr);
 			for (int j = 0; j < feeds_with_tag_len; ++j) {
-				json_object* feed_id_obj =
-					json_object_array_get_idx(
-						feeds_with_tag_obj, j);
+				json_object* feed_id_obj = json_object_array_get_idx(feeds_with_tag_obj, j);
 				const auto id = json_object_get_string(feed_id_obj);
 				if (id == nullptr) {
 					LOG(Level::WARN, "Skipping subscription's tag whose name is a null value");
@@ -294,8 +289,7 @@ rsspp::Feed NewsBlurApi::fetch_feed(const std::string& id)
 			items_size);
 
 		for (int i = 0; i < items_size; i++) {
-			json_object* item_obj =
-				(json_object*)array_list_get_idx(items, i);
+			json_object* item_obj = (json_object*)array_list_get_idx(items, i);
 
 			rsspp::Item item;
 
@@ -330,19 +324,14 @@ rsspp::Feed NewsBlurApi::fetch_feed(const std::string& id)
 			}
 
 			const char* article_id{};
-			if (json_object_object_get_ex(item_obj, "id", &node) ==
-				TRUE) {
+			if (json_object_object_get_ex(item_obj, "id", &node) == TRUE) {
 				article_id = json_object_get_string(node);
 			}
-			item.guid = id + ID_SEPARATOR +
-				(article_id ? article_id : "");
+			item.guid = id + ID_SEPARATOR + (article_id ? article_id : "");
 
-			if (json_object_object_get_ex(
-					item_obj, "read_status", &node) == TRUE) {
-				if (!static_cast<bool>(
-						json_object_get_int(node))) {
-					item.labels.push_back(
-						"newsblur:unread");
+			if (json_object_object_get_ex(item_obj, "read_status", &node) == TRUE) {
+				if (!static_cast<bool>(json_object_get_int(node))) {
+					item.labels.push_back("newsblur:unread");
 				} else {
 					item.labels.push_back("newsblur:read");
 				}

--- a/src/newsblurapi.cpp
+++ b/src/newsblurapi.cpp
@@ -109,10 +109,21 @@ std::vector<TaggedFeedUrl> NewsBlurApi::get_subscribed_urls()
 
 		json_object* feed_json = json_object_iter_peek_value(&it);
 		json_object_object_get_ex(feed_json, "feed_title", &node);
-		current_feed.title = json_object_get_string(node);
+		const auto title = json_object_get_string(node);
+		if (title != nullptr) {
+			current_feed.title = title;
+		} else {
+			LOG(Level::WARN, "Subscription has no title, so let's call it \"%s\"", feed_id);
+			current_feed.title = feed_id;
+		}
 		json_object_object_get_ex(feed_json, "feed_link", &node);
 		if (node) {
-			current_feed.link = json_object_get_string(node);
+			const auto link = json_object_get_string(node);
+			if (link == nullptr) {
+				LOG(Level::WARN, "Skipping a subscription without a link");
+				continue;
+			}
+			current_feed.link = link;
 
 			known_feeds[feed_id] = current_feed;
 			std::string std_feed_id(feed_id);
@@ -152,6 +163,8 @@ std::map<std::string, std::vector<std::string>> NewsBlurApi::mk_feeds_to_tags(
 			continue;
 		}
 
+		// invariant: `tag_to_feed_ids` is a JSON object
+
 		json_object_object_foreach(
 			tag_to_feed_ids, key, feeds_with_tag_obj) {
 			std::string std_key(key);
@@ -163,9 +176,12 @@ std::map<std::string, std::vector<std::string>> NewsBlurApi::mk_feeds_to_tags(
 				json_object* feed_id_obj =
 					json_object_array_get_idx(
 						feeds_with_tag_obj, j);
-				std::string feed_id(
-					json_object_get_string(feed_id_obj));
-				result[feed_id].push_back(std_key);
+				const auto id = json_object_get_string(feed_id_obj);
+				if (id == nullptr) {
+					LOG(Level::WARN, "Skipping subscription's tag whose name is a null value");
+					continue;
+				}
+				result[std::string(id)].push_back(std_key);
 			}
 		}
 	}
@@ -183,7 +199,8 @@ bool request_successfull(json_object* payload)
 	if (json_object_object_get_ex(payload, "result", &result) == FALSE) {
 		return false;
 	} else {
-		return !strcmp("ok", json_object_get_string(result));
+		const auto result_str = json_object_get_string(result);
+		return result_str != nullptr && strcmp("ok", result_str) == 0;
 	}
 }
 
@@ -284,26 +301,32 @@ rsspp::Feed NewsBlurApi::fetch_feed(const std::string& id)
 
 			json_object* node{};
 
-			if (json_object_object_get_ex(
-					item_obj, "story_title", &node) == TRUE) {
-				item.title = json_object_get_string(node);
+			if (json_object_object_get_ex(item_obj, "story_title", &node) == TRUE) {
+				const auto title = json_object_get_string(node);
+				if (title != nullptr) {
+					item.title = title;
+				}
 			}
 
-			if (json_object_object_get_ex(
-					item_obj, "story_authors", &node) == TRUE) {
-				item.author = json_object_get_string(node);
+			if (json_object_object_get_ex(item_obj, "story_authors", &node) == TRUE) {
+				const auto author = json_object_get_string(node);
+				if (author != nullptr) {
+					item.author = author;
+				}
 			}
 
-			if (json_object_object_get_ex(item_obj,
-					"story_permalink",
-					&node) == TRUE) {
-				item.link = json_object_get_string(node);
+			if (json_object_object_get_ex(item_obj, "story_permalink", &node) == TRUE) {
+				const auto link = json_object_get_string(node);
+				if (link != nullptr) {
+					item.link = link;
+				}
 			}
 
-			if (json_object_object_get_ex(
-					item_obj, "story_content", &node) == TRUE) {
-				item.content_encoded =
-					json_object_get_string(node);
+			if (json_object_object_get_ex(item_obj, "story_content", &node) == TRUE) {
+				const auto content_encoded = json_object_get_string(node);
+				if (content_encoded != nullptr) {
+					item.content_encoded = content_encoded;
+				}
 			}
 
 			const char* article_id{};
@@ -325,11 +348,13 @@ rsspp::Feed NewsBlurApi::fetch_feed(const std::string& id)
 				}
 			}
 
-			if (json_object_object_get_ex(
-					item_obj, "story_date", &node) == TRUE) {
-				const char* pub_date =
-					json_object_get_string(node);
-				item.pubDate_ts = parse_date(pub_date);
+			if (json_object_object_get_ex(item_obj, "story_date", &node) == TRUE) {
+				const char* pub_date = json_object_get_string(node);
+				if (pub_date != nullptr) {
+					item.pubDate_ts = parse_date(pub_date);
+				} else {
+					item.pubDate_ts = ::time(nullptr);
+				}
 
 				item.pubDate = utils::mt_strf_localtime(
 						"%a, %d %b %Y %H:%M:%S %z",

--- a/src/ocnewsapi.cpp
+++ b/src/ocnewsapi.cpp
@@ -129,12 +129,10 @@ std::vector<TaggedFeedUrl> OcNewsApi::get_subscribed_urls()
 			current_feed.link = link;
 		}
 
-		while (known_feeds.find(current_feed.title) !=
-			known_feeds.end()) {
+		while (known_feeds.find(current_feed.title) != known_feeds.end()) {
 			current_feed.title += "*";
 		}
-		known_feeds[current_feed.title] =
-			std::make_pair(current_feed, feed_id);
+		known_feeds[current_feed.title] = std::make_pair(current_feed, feed_id);
 
 		json_object_object_get_ex(feed, "folderId", &node);
 		long folder_id = json_object_get_int(node);
@@ -285,10 +283,8 @@ rsspp::Feed OcNewsApi::fetch_feed(const std::string& feed_id)
 		{
 			json_object* type_obj;
 
-			json_object_object_get_ex(
-				item_j, "enclosureMime", &type_obj);
-			json_object_object_get_ex(
-				item_j, "enclosureLink", &node);
+			json_object_object_get_ex(item_j, "enclosureMime", &type_obj);
+			json_object_object_get_ex(item_j, "enclosureLink", &node);
 
 			const auto type_ptr = json_object_get_string(type_obj);
 			const auto url_ptr = json_object_get_string(node);

--- a/src/oldreaderapi.cpp
+++ b/src/oldreaderapi.cpp
@@ -183,8 +183,7 @@ std::vector<TaggedFeedUrl> OldReaderApi::get_subscribed_urls()
 			auto url = strprintf::fmt("%s%s?n=%u",
 					OLDREADER_FEED_PREFIX,
 					id,
-					cfg->get_configvalue_as_int(
-						"oldreader-min-items"));
+					cfg->get_configvalue_as_int("oldreader-min-items"));
 			urls.push_back(TaggedFeedUrl(url, tags));
 		}
 	}

--- a/src/oldreaderapi.cpp
+++ b/src/oldreaderapi.cpp
@@ -136,9 +136,20 @@ std::vector<TaggedFeedUrl> OldReaderApi::get_subscribed_urls()
 
 		json_object_object_get_ex(sub, "id", &node);
 		const char* id = json_object_get_string(node);
+		if (id == nullptr) {
+			LOG(Level::WARN, "Skipping a subscription without an id");
+			continue;
+		}
 
 		json_object_object_get_ex(sub, "title", &node);
-		const char* title = json_object_get_string(node);
+		const char* title_ptr = json_object_get_string(node);
+		std::string title;
+		if (title_ptr != nullptr) {
+			title = title_ptr;
+		} else {
+			LOG(Level::WARN, "Subscription has no title, so let's call it \"%i\"", i);
+			title = std::to_string(i);
+		}
 
 		// Ignore URLs where ID start with given prefix - those never
 		// load, always returning 404 and annoying people
@@ -161,8 +172,11 @@ std::vector<TaggedFeedUrl> OldReaderApi::get_subscribed_urls()
 				json_object* label_node{};
 				json_object_object_get_ex(
 					cat, "label", &label_node);
-				const char* label =
-					json_object_get_string(label_node);
+				const char* label = json_object_get_string(label_node);
+				if (label == nullptr) {
+					LOG(Level::WARN, "Skipping subscription's label whose name is a null value");
+					continue;
+				}
 				tags.push_back(std::string(label));
 			}
 


### PR DESCRIPTION
Fixes #2102, and prevents the same problem from happening to other APIs. Even if those other APIs never return `null`, it's better to be safe than sorry.

Since this is a fix for a segfault, I intend to merge this *before* the 2.28 release. Thus, reviews are especially welcome. @dennisschagt?