### PR TITLE
ListWidget: Let update_scroll_offset force offset lower than max_offset

### DIFF
--- a/src/listwidget.cpp
+++ b/src/listwidget.cpp
@@ -191,16 +191,24 @@ void ListWidget::update_scroll_offset(std::uint32_t pos)
 			} else { // "pos" is towards the beginning of the list; don't scroll
 				set_scroll_offset(0);
 			}
+			return;
 		}
 
 		// Check if items at the top of the "context" are visible. If not,
 		// we'll have to scroll up.
 		if (pos < cur_scroll_offset + num_context_lines) {
 			if (pos >= num_context_lines) {
-				set_scroll_offset(pos - num_context_lines);
+				const std::uint32_t target_offset = pos - num_context_lines;
+				set_scroll_offset(std::min(target_offset, max_offset));
 			} else { // "pos" is towards the beginning of the list; don't scroll
 				set_scroll_offset(0);
 			}
+			return;
+		}
+
+		if (cur_scroll_offset > max_offset) {
+			set_scroll_offset(max_offset);
+			return;
 		}
 	} else { // Keep selected item in the middle
 		if (pos > h / 2) {
@@ -209,6 +217,7 @@ void ListWidget::update_scroll_offset(std::uint32_t pos)
 		} else { // "pos" is towards the beginning of the list; don't scroll
 			set_scroll_offset(0);
 		}
+		return;
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/2138

The position in the list was updated from the `FeedListFormAction::set_pos()` function, to keep the same item selected (if it existed after filtering).
It looks like the ListWidget's scroll_offset was not updated if the newly selected position was already in view.

Tested manually with different values for `scrolloff` (0, 1, 3).
I don't think an automatic test is possible, given that `max_offset` depends on the window height, which is dependent on the terminal in which the tests run.