### PR TITLE
Use Asciidoctor's `kbd` macro to style keypresses in documentation

### DIFF
--- a/doc/chapter-cmdline.asciidoc
+++ b/doc/chapter-cmdline.asciidoc
@@ -1,29 +1,31 @@
+:experimental:
+
 Like other text-oriented software, Newsboat contains an internal commandline to
 modify configuration variables ad hoc and to run own commands. It provides a flexible
 access to the functionality of Newsboat which is especially useful for
 advanced users.
 
-To start the commandline, type ":". You will see a ":" prompt at the bottom of
+To start the commandline, type kbd:[:]. You will see a ":" prompt at the bottom of
 the screen, similar to tools like vi(m) or mutt. You can now enter commands.
-Pressing the "Enter" key executes the command (possibly giving feedback to the
+Pressing the kbd:[Enter] key executes the command (possibly giving feedback to the
 user) and closes the commandline. You can cancel entering commands by pressing
-the "Esc" key. The history of all the commands that you enter will be saved to
+the kbd:[Esc] key. The history of all the commands that you enter will be saved to
 the _history.cmdline_ file, stored next to the _cache.db_ file. The backlog is
 limited to 100 entries by default, but can be influenced by setting the
 <<history-limit,`history-limit`>> configuration variable. To disable history
 saving, set the `history-limit` to `0`.
 
 The commandline provides you with some help if you can't remember the full
-names of commandline commands. By pressing the "Tab" key, Newsboat will try to
+names of commandline commands. By pressing the kbd:[Tab] key, Newsboat will try to
 automatically complete your command. If there is more than one possible
-completion, you can subsequently press the "Tab" key to cycle through all
+completion, you can subsequently press the kbd:[Tab] key to cycle through all
 results. If no match is found, no suggestion will be inserted into the
 commandline. For the <<cmd-set,`set`>> command, the completion also works for configuration
 variable names.
 
-In addition, some common key combination such as "Ctrl-G" (to cancel input),
-"Ctrl-K" (to delete text from the cursor position to the end of line), "Ctrl-U" (to
-clear the whole line) and "Ctrl-W" (to delete the word before the current cursor
+In addition, some common key combination such as kbd:[Ctrl+G] (to cancel input),
+kbd:[Ctrl+K] (to delete text from the cursor position to the end of line), kbd:[Ctrl+U] (to
+clear the whole line) and kbd:[Ctrl+W] (to delete the word before the current cursor
 position) were added.
 
 Please be aware that the input history of both the command line and the search

--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -1,3 +1,5 @@
+:experimental:
+
 Several aspects of Newsboat can be configured via a _config_ file,
 which is stored next to the _urls_ file.
 A configuration line looks like this in general:
@@ -86,8 +88,8 @@ The syntax for a key binding looks like this:
 
 Lowercase keys, uppercase keys and special characters are written literally.
 
-Key combinations with `Ctrl` are written using the caret `^`.
-For instance `Ctrl-R` equals to `^R`.
+Key combinations with kbd:[Ctrl] are written using the caret `^`.
+For instance kbd:[Ctrl+R] equals to `^R`.
 Please be aware that all Ctrl-related key combinations need to be written in uppercase.
 
 The following identifiers for special keys are supported:

--- a/doc/chapter-firststeps.asciidoc
+++ b/doc/chapter-firststeps.asciidoc
@@ -1,3 +1,5 @@
+:experimental:
+
 After you've installed Newsboat, you can run it for the first time by typing
 `newsboat` on your command prompt. This will bring you the following message:
 
@@ -74,10 +76,10 @@ The main UI of Newsboat consists of three views
 
 _Feed List View -> Article List View -> Article View_
 
-You can drill down those views by pressing `Enter` and move to the previous one by pressing
-`q`. Pressing `q` on the _Feed List View_ — or pressing `Q` from anywhere — closes Newsboat.
+You can drill down those views by pressing kbd:[Enter] and move to the previous one by pressing
+kbd:[Q]. Pressing kbd:[Q] on the _Feed List View_ — or pressing kbd:[Shift+Q] from anywhere — closes Newsboat.
 
-You can also search articles' title or content by pressing `/` on the _Feed List View_ or the _Article List View_.
+You can also search articles' title or content by pressing kbd:[/] on the _Feed List View_ or the _Article List View_.
 On the _Feed List View_ all articles of all feeds are taken into account.
 On the _Article List View_ the articles of the current feed are taken into account.
 When opening an article from a search result dialog, the search phrase is highlighted.
@@ -96,11 +98,11 @@ When you start Newsboat, it presents you with a list of feeds that you added pre
 
 You can now:
 
-* Press `R` to download articles for all feeds.
-* Press `r` to download articles for the selected feed.
-* Press `/` to search all articles in all feeds.
-* Press `Enter` to go to the article list of a selected feed.
-* Press `q` to close Newsboat.
+* Press kbd:[Shift+R] to download articles for all feeds.
+* Press kbd:[R] to download articles for the selected feed.
+* Press kbd:[/] to search all articles in all feeds.
+* Press kbd:[Enter] to go to the article list of a selected feed.
+* Press kbd:[Q] to close Newsboat.
 
 ****
 *Local articles* Newsboat keeps the articles that it downloads.
@@ -131,9 +133,9 @@ A `N` on the left indicates that an article wasn't read yet.
 
 You can now:
 
-* Press `q` to go back to the _Feed List View_.
-* Press `/` to search all articles of this feed.
-* Press `Enter` to read a selected article.
+* Press kbd:[Q] to go back to the _Feed List View_.
+* Press kbd:[/] to search all articles of this feed.
+* Press kbd:[Enter] to read a selected article.
 
 *Article View*
 
@@ -143,15 +145,15 @@ Each link in the article has a number next to it.
 You can now:
 
 * Press any number to open an article link in the browser.
-  For numbers larger than 9 type `#`, then the number and press `Enter`.
-* Press `o` to open the article in the browser.
-* Press `q` to go back to the _Article List View_.
+  For numbers larger than 9 type kbd:[#], then the number and press kbd:[Enter].
+* Press kbd:[O] to open the article in the browser.
+* Press kbd:[Q] to go back to the _Article List View_.
 
 
 ****
 *Browser view* Sometimes the content of an article is empty or just
 an abstract or short description.
-You can always press `o` to view the complete article in a browser.
+You can always press kbd:[O] to view the complete article in a browser.
 The default browser is _lynx_.
 
 You can use your browser of choice by configuring <<browser,`browser`>>.

--- a/doc/chapter-password.asciidoc
+++ b/doc/chapter-password.asciidoc
@@ -1,3 +1,5 @@
+:experimental:
+
 There are a number of ways to specify a password, each represented by
 a separate setting. Newsboat looks for settings in certain order, and uses the
 first one that it finds. The exact order is described below.
@@ -28,8 +30,8 @@ GPG. They create the file like that:
 
     $ gpg --encrypt --default-recipient-self --output ~/.newsboat/password.gpg
 
-They enter their password, press Enter, and finish the command by pressing ^D
-(Control and d simultaneously). Then, they specify in their Newsboat config:
+They enter their password, press kbd:[Enter], and finish the command by pressing
+kbd:[Ctrl+D]. Then, they specify in their Newsboat config:
 
     REMOTEAPI-passwordeval "gpg --decrypt ~/.newsboat/password.gpg"
 
@@ -46,6 +48,6 @@ The user might use any other command here; for example, they could fetch the
 password from GNOME keyring, KeePass, or somewhere else entirely. The
 possibilities are truly endless.
 
-If no of the aforementioned settings were found, Newsboat will ask the user for
+If none of the aforementioned settings were found, Newsboat will ask the user for
 the password using an interactive prompt. If the password that the user enters
 is empty, Newsboat will give up and exit with an error.

--- a/doc/chapter-podboat.asciidoc
+++ b/doc/chapter-podboat.asciidoc
@@ -1,3 +1,5 @@
+:experimental:
+
 What the user can do is to add the podcast download URL to a download queue.
 Alternatively, Newsboat can be configured to automatically do that. This
 queue is stored in the _queue_ file next to the _cache.db_ file.
@@ -9,7 +11,7 @@ also shares the same configuration file.
 
 Podcasts that have been downloaded but haven't been played yet remain in the
 queue but are marked as downloaded. You can remove them by purging them from
-the queue with the "P" key. After you've played a file and close Podboat, it
+the queue with the kbd:[Shift+P] key. After you've played a file and close Podboat, it
 will be removed from the queue. The downloaded file remains on the
 filesystem unless "delete-played-files" is enabled.
 
@@ -17,4 +19,4 @@ A common "use case" is to configure Newsboat to automatically enqueue newly
 found podcast download URLs. Then, the user reloads the podcast RSS feeds in
 Newsboat, and after that, uses Podboat to view the current queue, and
 either selectively download certain files or automatically download them all
-together by pressing "a" within Podboat.
+together by pressing kbd:[A] within Podboat.

--- a/doc/chapter-tagging.asciidoc
+++ b/doc/chapter-tagging.asciidoc
@@ -1,3 +1,5 @@
+:experimental:
+
 Newsboat comes with the possibility to categorize or "tag", as we call it,
 RSS feeds. Every RSS feed can be assigned 0 or more tags. Within Newsboat, you
 can then select to only show RSS feeds that match a certain tag. That makes it
@@ -12,10 +14,10 @@ around the tag (see example below). An example _urls_ file may look like this:
 	https://rss.orf.at/news.xml news orf
 	https://www.heise.de/newsticker/heise.rdf news interesting
 
-When you now start Newsboat with this configuration, you can press "t" to select
+When you now start Newsboat with this configuration, you can press kbd:[T] to select
 a tag. When you select the tag "news", you will see all three RSS feeds. Pressing
-"t" again and e.g. selecting the "conspiracy" tag, you will only see the
-https://blog.fefe.de/rss.xml?html RSS feed. Pressing "^T" clears the current tag,
+kbd:[T] again and e.g. selecting the "conspiracy" tag, you will only see the
+https://blog.fefe.de/rss.xml?html RSS feed. Pressing kbd:[Ctrl+T] clears the current tag,
 and again shows all RSS feeds, regardless of their assigned tags.
 
 A special type of tag are tags that start with the tilde character (`~`). When such

--- a/doc/createAvailableOperationsListView.awk
+++ b/doc/createAvailableOperationsListView.awk
@@ -1,6 +1,30 @@
+function print_key(key) {
+    if (key == "n/a") {
+        return key
+    }
+
+    # TODO: Escape closing brackets `]` -> `\]`
+
+    if (substr(key, 1, 1) == "^") {
+        return "kbd:[Ctrl+" substr(key, 2) "]"
+    }
+
+    if (length(key) == 1) {
+        if (tolower(key) == key) {
+            return "kbd:[" toupper(key) "]"
+        } else {
+            return "kbd:[Shift+" key "]"
+        }
+    }
+
+    return "kbd:[" key "]"
+}
+
 BEGIN {
 	# Switch field separator from space to tabulator.
 	FS="\t"
+    print ":experimental:"
+    print ""
 }
 
 {
@@ -8,7 +32,7 @@ BEGIN {
 	print "[[" $1 "]]"
 	print "****"
 	print "*Operation:* <<" $1 "," $1 ">> +"
-	print "*Default key:*", $2, "+"
+	print "*Default key:*", print_key($2), "+"
 	print "****"
 	print "\n" $3, "+"
 	print "\n\n"

--- a/doc/createAvailableOperationsListView.awk
+++ b/doc/createAvailableOperationsListView.awk
@@ -1,25 +1,3 @@
-function print_key(key) {
-    if (key == "n/a") {
-        return key
-    }
-
-    # TODO: Escape closing brackets `]` -> `\]`
-
-    if (substr(key, 1, 1) == "^") {
-        return "kbd:[Ctrl+" substr(key, 2) "]"
-    }
-
-    if (length(key) == 1) {
-        if (tolower(key) == key) {
-            return "kbd:[" toupper(key) "]"
-        } else {
-            return "kbd:[Shift+" key "]"
-        }
-    }
-
-    return "kbd:[" key "]"
-}
-
 BEGIN {
 	# Switch field separator from space to tabulator.
 	FS="\t"
@@ -32,7 +10,7 @@ BEGIN {
 	print "[[" $1 "]]"
 	print "****"
 	print "*Operation:* <<" $1 "," $1 ">> +"
-	print "*Default key:*", print_key($2), "+"
+	print "*Default key:*", $2, "+"
 	print "****"
 	print "\n" $3, "+"
 	print "\n\n"

--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -1,73 +1,73 @@
-open||ENTER||Open the currently selected feed or article.
-quit||q||Quit the program or return to the previous dialog (depending on the context).
-hard-quit||Q||Quit the program without confirmation.
-reload||r||Reload the currently selected feed.
-reload-all||R||Reload all feeds.
-mark-feed-read||A||Mark all articles in the currently selected feed read.
-mark-all-feeds-read||C||Mark articles in all feeds read.
+open||kbd:[ENTER]||Open the currently selected feed or article.
+quit||kbd:[Q]||Quit the program or return to the previous dialog (depending on the context).
+hard-quit||kbd:[Shift+Q]||Quit the program without confirmation.
+reload||kbd:[R]||Reload the currently selected feed.
+reload-all||kbd:[Shift+R]||Reload all feeds.
+mark-feed-read||kbd:[Shift+A]||Mark all articles in the currently selected feed read.
+mark-all-feeds-read||kbd:[Shift+C]||Mark articles in all feeds read.
 mark-all-above-as-read||n/a||Mark all above as read.
-save||s||Export the currently selected article to a plain text file, word-wrapped according to the <<text-width,`text-width`>> setting.
+save||kbd:[S]||Export the currently selected article to a plain text file, word-wrapped according to the <<text-width,`text-width`>> setting.
 save-all||n/a||Export all articles from the currently selected feed to plain text files, word-wrapped according to the <<text-width,`text-width`>> setting.
-next-unread||n||Jump to the next unread article.
-prev-unread||p||Jump to the previous unread article.
-next||J||Jump to next list entry.
-prev||K||Jump to previous list entry.
-random-unread||^K||Jump to a random unread article.
-open-in-browser||o||Use browser to open the URL associated with the current article, feed, or entry in the URL view.
+next-unread||kbd:[N]||Jump to the next unread article.
+prev-unread||kbd:[P]||Jump to the previous unread article.
+next||kbd:[Shift+J]||Jump to next list entry.
+prev||kbd:[Shift+K]||Jump to previous list entry.
+random-unread||kbd:[Ctrl+K]||Jump to a random unread article.
+open-in-browser||kbd:[O]||Use browser to open the URL associated with the current article, feed, or entry in the URL view.
 open-in-browser-noninteractively||n/a||Use browser to open the URL associated with the current article, feed, or entry in the URL view. This operation works similar to <<open-in-browser,`open-in-browser`>>, but the output of the browser (stdout and stderr) is not shown, and the browser doesn't receive keyboard input. You would probably add `&` at the end of the <<browser,`browser`>> command to put it into background, too.
-open-in-browser-and-mark-read||O||Use browser to open the URL associated with the current article, or entry in the URL view. When used in the article list, it will also mark the article as read.
+open-in-browser-and-mark-read||kbd:[Shift+O]||Use browser to open the URL associated with the current article, or entry in the URL view. When used in the article list, it will also mark the article as read.
 open-all-unread-in-browser||n/a||Open all the unread URLs in the current feed.
 open-all-unread-in-browser-and-mark-read||n/a||Open all the unread URLs in the current feed and mark them as read.
-help||?||Run the help screen.
-toggle-source-view||^U||Toggle between the HTML view and the source view in the article view.
-toggle-article-read||N||Toggle the read flag for the currently selected article, and clear the delete flag if set.
-toggle-show-read-feeds||l||Toggle whether read feeds should be shown in the feed list.
-show-urls||u||Show all URLs in the article in a list (similar to urlview).
-clear-tag||^T||Clear current tag.
-set-tag||t||Select tag.
-open-search||/||Open the search dialog. When a search is done in the article list, then the search operation only applies to the articles of the current feed, otherwise to all articles.
-goto-url||#||Open the URL dialog and then open a specified URL in the browser.
-one||1||Open URL 1 in the browser.
-two||2||Open URL 2 in the browser.
-three||3||Open URL 3 in the browser.
-four||4||Open URL 4 in the browser.
-five||5||Open URL 5 in the browser.
-six||6||Open URL 6 in the browser.
-seven||7||Open URL 7 in the browser.
-eight||8||Open URL 8 in the browser.
-nine||9||Open URL 9 in the browser.
-zero||0||Open URL 10 in the browser.
-enqueue||e||Add the podcast download URL of the current article (if any is found) to the podcast download queue (see the respective section in the documentation for more information on podcast support).
-edit-urls||E||Edit the list of subscribed URLs. Newsboat will start the editor configured through the <<VISUAL,`VISUAL`>> environment variable (if unset, <<EDITOR,`EDITOR`>> is used; fallback: `vi`). When editing is finished, Newsboat will reload the URLs file.
-reload-urls||^R||Reload the URLs configuration file.
-redraw||^L||Redraw the screen.
-cmdline||:||Open the command line.
-set-filter||F||Set a filter.
-select-filter||f||Select a predefined filter.
-clear-filter||^F||Clear currently set filter.
-bookmark||^B||Bookmark currently selected article or URL.
-edit-flags||^E||Edit the flags of the currently selected article.
-next-unread-feed||^N||Go to the next feed with unread articles. This only works from the article list.
-prev-unread-feed||^P||Go to the previous feed with unread articles. This only works from the article list.
-next-feed||j||Go to the next feed. This only works from the article list.
-prev-feed||k||Go to the previous feed. This only works from the article list.
-delete-article||D||Delete the currently selected article.
-delete-all-articles||^D||Delete all articles in the articlelist. Note that the articlelist might contain a subset of feed's articles (because of filters or <<show-read-articles,`show-read-articles no`>>), or it might contain a mix of articles from different feeds (if you're viewing a query feed) — in either case, `delete-all-articles` affects just those articles, not all articles of the respective feed(s).
-purge-deleted||$||Purge all articles that are marked as deleted from the article list.
-view-dialogs||v||View list of open dialogs.
-close-dialog||^X||Close currently selected dialog.
-next-dialog||^V||Go to next dialog.
-prev-dialog||^G||Go to previous dialog.
-pipe-to||| ||Pipe article to command. The text will be word-wrapped according to the <<text-width,`text-width`>> setting.
-sort||g||Sort feeds/articles by interactively choosing the sort method.
-rev-sort||G||Sort feeds/articles by interactively choosing the sort method (reversed).
-up||UP||Go up one item in the list.
-down||DOWN||Go down one item in the list.
-pageup||PPAGE||Go up one page in the list.
-pagedown||NPAGE||Go down one page in the list.
-home||HOME||Go to the first item in the list.
-end||END||Go to the last item in the list.
-macro-prefix||,||Initiate macro execution. The next key press selects the actual macro and runs it.
-switch-focus||TAB||Switch focus between widgets. This is currently only applicable to the `filebrowser` and `dirbrowser` contexts.
+help||kbd:[?]||Run the help screen.
+toggle-source-view||kbd:[Ctrl+U]||Toggle between the HTML view and the source view in the article view.
+toggle-article-read||kbd:[Shift+N]||Toggle the read flag for the currently selected article, and clear the delete flag if set.
+toggle-show-read-feeds||kbd:[L]||Toggle whether read feeds should be shown in the feed list.
+show-urls||kbd:[U]||Show all URLs in the article in a list (similar to urlview).
+clear-tag||kbd:[Ctrl+T]||Clear current tag.
+set-tag||kbd:[T]||Select tag.
+open-search||kbd:[/]||Open the search dialog. When a search is done in the article list, then the search operation only applies to the articles of the current feed, otherwise to all articles.
+goto-url||kbd:[#]||Open the URL dialog and then open a specified URL in the browser.
+one||kbd:[1]||Open URL 1 in the browser.
+two||kbd:[2]||Open URL 2 in the browser.
+three||kbd:[3]||Open URL 3 in the browser.
+four||kbd:[4]||Open URL 4 in the browser.
+five||kbd:[5]||Open URL 5 in the browser.
+six||kbd:[6]||Open URL 6 in the browser.
+seven||kbd:[7]||Open URL 7 in the browser.
+eight||kbd:[8]||Open URL 8 in the browser.
+nine||kbd:[9]||Open URL 9 in the browser.
+zero||kbd:[0]||Open URL 10 in the browser.
+enqueue||kbd:[E]||Add the podcast download URL of the current article (if any is found) to the podcast download queue (see the respective section in the documentation for more information on podcast support).
+edit-urls||kbd:[Shift+E]||Edit the list of subscribed URLs. Newsboat will start the editor configured through the <<VISUAL,`VISUAL`>> environment variable (if unset, <<EDITOR,`EDITOR`>> is used; fallback: `vi`). When editing is finished, Newsboat will reload the URLs file.
+reload-urls||kbd:[Ctrl+R]||Reload the URLs configuration file.
+redraw||kbd:[Ctrl+L]||Redraw the screen.
+cmdline||kbd:[:]||Open the command line.
+set-filter||kbd:[Shift+F]||Set a filter.
+select-filter||kbd:[F]||Select a predefined filter.
+clear-filter||kbd:[Ctrl+F]||Clear currently set filter.
+bookmark||kbd:[Ctrl+B]||Bookmark currently selected article or URL.
+edit-flags||kbd:[Ctrl+E]||Edit the flags of the currently selected article.
+next-unread-feed||kbd:[Ctrl+N]||Go to the next feed with unread articles. This only works from the article list.
+prev-unread-feed||kbd:[Ctrl+P]||Go to the previous feed with unread articles. This only works from the article list.
+next-feed||kbd:[J]||Go to the next feed. This only works from the article list.
+prev-feed||kbd:[K]||Go to the previous feed. This only works from the article list.
+delete-article||kbd:[Shift+D]||Delete the currently selected article.
+delete-all-articles||kbd:[Ctrl+D]||Delete all articles in the articlelist. Note that the articlelist might contain a subset of feed's articles (because of filters or <<show-read-articles,`show-read-articles no`>>), or it might contain a mix of articles from different feeds (if you're viewing a query feed) — in either case, `delete-all-articles` affects just those articles, not all articles of the respective feed(s).
+purge-deleted||kbd:[$]||Purge all articles that are marked as deleted from the article list.
+view-dialogs||kbd:[V]||View list of open dialogs.
+close-dialog||kbd:[Ctrl+X]||Close currently selected dialog.
+next-dialog||kbd:[Ctrl+V]||Go to next dialog.
+prev-dialog||kbd:[Ctrl+G]||Go to previous dialog.
+pipe-to||kbd:[| ]||Pipe article to command. The text will be word-wrapped according to the <<text-width,`text-width`>> setting.
+sort||kbd:[G]||Sort feeds/articles by interactively choosing the sort method.
+rev-sort||kbd:[Shift+G]||Sort feeds/articles by interactively choosing the sort method (reversed).
+up||kbd:[UP]||Go up one item in the list.
+down||kbd:[DOWN]||Go down one item in the list.
+pageup||kbd:[PPAGE]||Go up one page in the list.
+pagedown||kbd:[NPAGE]||Go down one page in the list.
+home||kbd:[HOME]||Go to the first item in the list.
+end||kbd:[END]||Go to the last item in the list.
+macro-prefix||kbd:[,]||Initiate macro execution. The next key press selects the actual macro and runs it.
+switch-focus||kbd:[TAB]||Switch focus between widgets. This is currently only applicable to the `filebrowser` and `dirbrowser` contexts.
 goto-title||n/a||Go to item whose title contains the specified string (case-insensitive).
-prevsearchresults||z||Return to previous search results (if any). This only works from `searchresultslist`.
+prevsearchresults||kbd:[Z]||Return to previous search results (if any). This only works from `searchresultslist`.

--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -14,7 +14,7 @@ next||J||Jump to next list entry.
 prev||K||Jump to previous list entry.
 random-unread||^K||Jump to a random unread article.
 open-in-browser||o||Use browser to open the URL associated with the current article, feed, or entry in the URL view.
-open-in-browser-noninteractively||o||Use browser to open the URL associated with the current article, feed, or entry in the URL view. This operation works similar to <<open-in-browser,`open-in-browser`>>, but the output of the browser (stdout and stderr) is not shown, and the browser doesn't receive keyboard input. You would probably add `&` at the end of the <<browser,`browser`>> command to put it into background, too.
+open-in-browser-noninteractively||n/a||Use browser to open the URL associated with the current article, feed, or entry in the URL view. This operation works similar to <<open-in-browser,`open-in-browser`>>, but the output of the browser (stdout and stderr) is not shown, and the browser doesn't receive keyboard input. You would probably add `&` at the end of the <<browser,`browser`>> command to put it into background, too.
 open-in-browser-and-mark-read||O||Use browser to open the URL associated with the current article, or entry in the URL view. When used in the article list, it will also mark the article as read.
 open-all-unread-in-browser||n/a||Open all the unread URLs in the current feed.
 open-all-unread-in-browser-and-mark-read||n/a||Open all the unread URLs in the current feed and mark them as read.
@@ -69,5 +69,5 @@ home||HOME||Go to the first item in the list.
 end||END||Go to the last item in the list.
 macro-prefix||,||Initiate macro execution. The next key press selects the actual macro and runs it.
 switch-focus||TAB||Switch focus between widgets. This is currently only applicable to the `filebrowser` and `dirbrowser` contexts.
-goto-title||||Go to item whose title contains the specified string (case-insensitive).
+goto-title||n/a||Go to item whose title contains the specified string (case-insensitive).
 prevsearchresults||z||Return to previous search results (if any). This only works from `searchresultslist`.

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -5,7 +5,7 @@
 :sectlinks:
 :nofooter:
 :warning-caption: pass:[<span style='font-size: 3rem'>&#x26a0;</span>]
-:experimental: 
+:experimental:
 
 == Introduction
 

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -5,6 +5,7 @@
 :sectlinks:
 :nofooter:
 :warning-caption: pass:[<span style='font-size: 3rem'>&#x26a0;</span>]
+:experimental: 
 
 == Introduction
 
@@ -1619,21 +1620,21 @@ include::podboat-cmds-linked.asciidoc[]
 == Podboat Operations
 
 .Available Operations in Podboat
-[frame="all", grid="all", format="dsv", options="header", cols="20,20,60"]
+[frame="all", grid="all", format="psv", options="header", cols="20,20,60"]
 |=========================================================================
-Operation:Default key:Description
-[[pb-quit]]<<pb-quit,+quit+>>:q:Quit the program.
-[[pb-hard-quit]]<<pb-hard-quit,+hard-quit+>>:Q:Quit the program without confirmation.
-[[pb-help]]<<pb-help,+help+>>:?:Show the help screen.
-[[pb-download]]<<pb-download,+pb-download+>>:d:Download the currently selected URL.
-[[pb-cancel]]<<pb-cancel,+pb-cancel+>>:c:Cancel the currently selected download.
-[[pb-play]]<<pb-play,+pb-play+>>:p:Start player with currently selected download.
-[[pb-mark-as-finished]]<<pb-mark-as-finished,+pb-mark-as-finished+>>:m:Mark currently selected entry as finished.
-[[pb-delete]]<<pb-delete,+pb-delete+>>:D:Delete the currently selected URL from the queue.
-[[pb-purge]]<<pb-purge,+pb-purge+>>:P:Remove all finished and deleted downloads from the queue and load URLs that were newly added to the queue.
-[[pb-toggle-download-all]]<<pb-toggle-download-all,+pb-toggle-download-all+>>:a:Toggle the "automatic download" feature where all queued URLs are downloaded one after the other. The <<max-downloads,`max-downloads`>> configuration option controls how many downloads are done in parallel.
-[[pb-increase-max-dls]]<<pb-increase-max-dls,+pb-increase-max-dls+>>:+:Increase the <<max-download,`max-downloads`>> option by 1.
-[[pb-decrease-max-dls]]<<pb-decrease-max-dls,+pb-decrease-max-dls+>>:-:Decrease the <<max-download,`max-downloads`>> option by 1. If the option is already 1, no further decrease is possible.
+|Operation|Default key|Description
+|[[pb-quit]]<<pb-quit,+quit+>>|kbd:[Q]|Quit the program.
+|[[pb-hard-quit]]<<pb-hard-quit,+hard-quit+>>|kbd:[Shift+Q]|Quit the program without confirmation.
+|[[pb-help]]<<pb-help,+help+>>|kbd:[?]|Show the help screen.
+|[[pb-download]]<<pb-download,+pb-download+>>|kbd:[D]|Download the currently selected URL.
+|[[pb-cancel]]<<pb-cancel,+pb-cancel+>>|kbd:[C]|Cancel the currently selected download.
+|[[pb-play]]<<pb-play,+pb-play+>>|kbd:[P]|Start player with currently selected download.
+|[[pb-mark-as-finished]]<<pb-mark-as-finished,+pb-mark-as-finished+>>|kbd:[M]|Mark currently selected entry as finished.
+|[[pb-delete]]<<pb-delete,+pb-delete+>>|kbd:[Shift+D]|Delete the currently selected URL from the queue.
+|[[pb-purge]]<<pb-purge,+pb-purge+>>|kbd:[Shift+P]|Remove all finished and deleted downloads from the queue and load URLs that were newly added to the queue.
+|[[pb-toggle-download-all]]<<pb-toggle-download-all,+pb-toggle-download-all+>>|kbd:[A]|Toggle the "automatic download" feature where all queued URLs are downloaded one after the other. The <<max-downloads,`max-downloads`>> configuration option controls how many downloads are done in parallel.
+|[[pb-increase-max-dls]]<<pb-increase-max-dls,+pb-increase-max-dls+>>|kbd:[+]|Increase the <<max-download,`max-downloads`>> option by 1.
+|[[pb-decrease-max-dls]]<<pb-decrease-max-dls,+pb-decrease-max-dls+>>|kbd:[-]|Decrease the <<max-download,`max-downloads`>> option by 1. If the option is already 1, no further decrease is possible.
 |=========================================================================
 
 


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2028

I had to add the `experimental` attribute to use the `kbd` macro.
From [the Asciidoctor documentation](https://docs.asciidoctor.org/asciidoc/latest/macros/keyboard-macro/):
![image](https://user-images.githubusercontent.com/4629607/185236386-7ac91107-b59e-4b1a-86a9-cc0e66a4c91b.png)
