### PR TITLE
Prevent ListWidget::set_scroll_offset to scroll too far

### DIFF
--- a/include/listwidget.h
+++ b/include/listwidget.h
@@ -29,10 +29,12 @@ public:
 
 	std::uint32_t get_width();
 	std::uint32_t get_height();
+
 private:
 	std::uint32_t get_scroll_offset();
 	void set_scroll_offset(std::uint32_t pos);
 
+	std::uint32_t max_offset();
 	void update_scroll_offset(std::uint32_t pos);
 
 	const std::string list_name;


### PR DESCRIPTION
This implements a suggestion I made in https://github.com/newsboat/newsboat/pull/2153#pullrequestreview-1071992907.