### PR TITLE
Let Operator derive Eq to resolve clippy warning

### DIFF
--- a/rust/libnewsboat/src/filterparser.rs
+++ b/rust/libnewsboat/src/filterparser.rs
@@ -16,7 +16,7 @@ use std::vec::Vec;
 use strprintf::fmt;
 
 /// Operators that can be used in comparisons.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Operator {
     Equals,
     NotEquals,


### PR DESCRIPTION
Relevant Clippy documentation:
https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

Probably resolves the build issues of the following open PRs:
- https://github.com/newsboat/newsboat/pull/2169
- https://github.com/newsboat/newsboat/pull/2168
- https://github.com/newsboat/newsboat/pull/2167