### PR TITLE
use http1.1

### DIFF
--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -130,6 +130,7 @@ Feed Parser::parse_url(const std::string& url,
 		api->add_custom_headers(&custom_headers);
 	}
 	curl_easy_setopt(easyhandle.ptr(), CURLOPT_URL, url.c_str());
+	curl_easy_setopt(easyhandle.ptr(), CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 	curl_easy_setopt(easyhandle.ptr(), CURLOPT_SSL_VERIFYPEER, verify_ssl);
 	curl_easy_setopt(easyhandle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
 	curl_easy_setopt(easyhandle.ptr(), CURLOPT_WRITEDATA, &buf);


### PR DESCRIPTION
I attempted to add `https://perell.com/feed/` to my feedlist. Attempted to sync this feed produced

```
Error while retrieving https://perell.com/feed/: Stream error in the HTTP/2 framing layer
```

Since newsboat uses libcurl, I checked with curl (7.85.0) and sure enough:

```
1.292s ~/c/t/r/r/newsboat 11:51 $ curl https://perell.com/feed/
curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
```

Some poking around curl's issues suggests that this is likely due to an issue with the server not implementing http2 correctly. In any case, even if it isn't, fixing curl is clearly outside the scope of newsboat. It's possible that another option change could fix this, but I don't know what.

When we check curl's debug output, we see

```
* Connected to perell.com (199.16.172.213) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
```

In other words, the server claims to implement http2, but apparently does not (according to curl). I can open the url in a browser, and my browser reports that it's using h2, but that doesn't mean much; browsers probably do all kinds of sloppy protocol implementation handling.

Anyhow, I assume that since we don't currently specify a http version for libcurl, it just uses the highest version advertised. So it tries http2 and fails. AFAIK, curl doesn't have any kind of try-http2-and-if-that-fails-try-http1.1-etc option. newsboat could implement this kind of fallback logic itself, but this sounds like a lot of work. I'm not going to do it.

I could try to tell this Perell character to fix his web server, but I assume that this issue will occur elsewhere. Enough people seem to think RSS is obsolete that they may not be willing to devote a lot of effort to fixing an issue they don't really understand or may not control (in the case of hosted blogs).

So we need some way to force http1.1. This could be some kind of per-feed config, or just a blanket change for everything like I've done here. Which would probably be better but also more work and would require design decisions and I have no idea what a good design would be.

To the best of my knowledge, http2 is basically a browser-specific optimization. Like, it's better when you want to fetch 20 different documents from the same server (e.g. 19 css/js files and the html doc), but doesn't really make a difference for the fetch-one-rss-feed case. But I could be wrong about this.

Just as I was finishing this up, I identified another 11 urls in my feed that were experiencing this issue. So it's definitely not this one server. They mostly appear to originate from wordpress.com, although perell.com is coming from pressable. I believe in all cases the server identifies itself as nginx. In any case, it's sufficiently widespread that just telling people to fix their blogs seems like it won't work.