### PR TITLE
Convert feed data if charset specifies encoding different from utf-8

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -58,6 +58,9 @@ std::string utf8_to_locale(const std::string& text);
 /// nl_langinfo(CODESET)) to UTF-8.
 std::string locale_to_utf8(const std::string& text);
 
+std::string convert_text(const std::string& text, const std::string& tocode,
+	const std::string& fromcode);
+
 std::string get_command_output(const std::string& cmd);
 std::string http_method_str(const HTTPMethod method);
 std::string link_type_str(LinkType type);

--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -54,6 +54,8 @@ Parser::~Parser()
 	}
 }
 
+namespace {
+
 struct HeaderValues {
 	time_t lastmodified;
 	std::string etag;
@@ -65,6 +67,8 @@ struct HeaderValues {
 	{
 	}
 };
+
+}
 
 static size_t handle_headers(void* ptr, size_t size, size_t nmemb, void* data)
 {

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -89,6 +89,7 @@ mod bridged {
         fn translit(tocode: &str, fromcode: &str) -> String;
         fn utf8_to_locale(text: &str) -> Vec<u8>;
         fn locale_to_utf8(text: &[u8]) -> String;
+        fn convert_text(text: &[u8], tocode: &str, fromcode: &str) -> Vec<u8>;
     }
 
     extern "C++" {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -54,6 +54,8 @@ void Cache::run_sql_nothrow(const std::string& query,
 	run_sql_impl(query, callback, callback_argument, false);
 }
 
+namespace {
+
 struct CbHandler {
 	CbHandler()
 		: c(-1)
@@ -76,6 +78,8 @@ struct HeaderValues {
 	time_t lastmodified;
 	std::string etag;
 };
+
+}
 
 static int count_callback(void* handler, int argc, char** argv,
 	char** /* azColName */)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "curlhandle.h"
 #include "htmlrenderer.h"
+#include "libnewsboat-ffi/src/utils.rs.h"
 #include "logger.h"
 #include "strprintf.h"
 
@@ -184,6 +185,19 @@ std::string utils::locale_to_utf8(const std::string& text)
 			reinterpret_cast<const unsigned char*>(text.c_str()),
 			text.length());
 	return std::string(utils::bridged::locale_to_utf8(text_slice));
+}
+
+std::string utils::convert_text(const std::string& text, const std::string& tocode,
+	const std::string& fromcode)
+{
+	const auto text_slice =
+		rust::Slice<const unsigned char>(
+			reinterpret_cast<const unsigned char*>(text.c_str()),
+			text.length());
+
+	const auto result = utils::bridged::convert_text(text_slice, tocode, fromcode);
+
+	return std::string(reinterpret_cast<const char*>(result.data()), result.size());
 }
 
 std::string utils::get_command_output(const std::string& cmd)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -268,19 +268,23 @@ std::string utils::retrieve_url(const std::string& url,
 	return retrieve_url(url, handle, cfgcont, authinfo, body, method);
 }
 
-struct UtilsHeaderValues {
+namespace {
+
+struct HeaderValues {
 	std::string charset;
 
-	UtilsHeaderValues()
+	HeaderValues()
 		: charset("utf-8")
 	{
 	}
 };
 
+}
+
 static size_t handle_headers(void* ptr, size_t size, size_t nmemb, void* data)
 {
 	const auto header = std::string(reinterpret_cast<const char*>(ptr), size * nmemb);
-	UtilsHeaderValues* values = static_cast<UtilsHeaderValues*>(data);
+	HeaderValues* values = static_cast<HeaderValues*>(data);
 
 	if (header.find("Content-Type:") != std::string::npos) {
 		const std::string key = "charset=";
@@ -314,7 +318,7 @@ std::string utils::retrieve_url(const std::string& url,
 	curl_easy_setopt(easyhandle.ptr(), CURLOPT_WRITEFUNCTION, my_write_data);
 	curl_easy_setopt(easyhandle.ptr(), CURLOPT_WRITEDATA, &buf);
 
-	UtilsHeaderValues hdrs;
+	HeaderValues hdrs;
 	curl_easy_setopt(easyhandle.ptr(), CURLOPT_HEADERDATA, &hdrs);
 	curl_easy_setopt(easyhandle.ptr(), CURLOPT_HEADERFUNCTION, handle_headers);
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.h"
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <ctype.h>
 #include <fstream>
@@ -1980,4 +1981,276 @@ TEST_CASE("translit() always returns the same value for the same inputs",
 			REQUIRE(utils::translit(tocode, fromcode) == results.at(std::make_pair(fromcode, tocode)));
 		}
 	}
+}
+
+void verify_convert_text(const std::vector<unsigned char>& input,
+	const std::string& tocode, const std::string& fromcode,
+	const std::vector<unsigned char>& expected_output)
+{
+	const std::string input_str = std::string(reinterpret_cast<const char*>(input.data()),
+			input.size());
+	const std::string expected_str = std::string(reinterpret_cast<const char*>
+			(expected_output.data()), expected_output.size());
+
+	REQUIRE(utils::convert_text(input_str, tocode, fromcode) == expected_str);
+}
+
+TEST_CASE("convert_text() returns input string if fromcode and tocode are literally the same",
+	"[utils]")
+{
+	std::vector<std::vector<unsigned char>> inputs = {
+		{ 0x81, 0x13, 0xa0 },       // \x81 is not valid UTF-8
+		{ 0x01 },                   // incomplete UTF-16
+		{ 0x01, 0x1f, 0x80, 0x9b }, // those bytes are not defined in ISO-8859-1
+		{ 0x7f, 0x1e, 0x03 },       // these bytes are not defined in KOI8-R
+	};
+
+	std::vector<std::string> codes = {
+		"utf-8",
+		"utf-16",
+		"iso-8859-1",
+		"koi8-r",
+	};
+
+	for (const auto& code : codes) {
+		for (const auto& input : inputs) {
+			verify_convert_text(input, code, code, input);
+		}
+	}
+}
+
+TEST_CASE("convert_text() returns input string if fromcode is uppercase of tocode",
+	"[utils]")
+{
+	std::vector<std::vector<unsigned char>> inputs = {
+		{ 0x81, 0x13, 0xa0 },       // \x81 is not valid UTF-8
+		{ 0x01 },                   // incomplete UTF-16
+		{ 0x01, 0x1f, 0x80, 0x9b }, // those bytes are not defined in ISO-8859-1
+		{ 0x7f, 0x1e, 0x03 },       // these bytes are not defined in KOI8-R
+	};
+
+	std::vector<std::string> codes = {
+		"utf-8",
+		"utf-16",
+		"iso-8859-1",
+		"koi8-r",
+	};
+
+	for (const auto& code : codes) {
+		for (const auto& input : inputs) {
+			const std::string tocode = code;
+
+			std::string fromcode = code;
+			std::transform(fromcode.begin(), fromcode.end(), fromcode.begin(), ::toupper);
+
+			verify_convert_text(input, fromcode, tocode, input);
+		}
+	}
+}
+
+TEST_CASE("convert_text() returns input string if tocode is uppercase of fromcode",
+	"[utils]")
+{
+	std::vector<std::vector<unsigned char>> inputs = {
+		{ 0x81, 0x13, 0xa0 },       // \x81 is not valid UTF-8
+		{ 0x01 },                   // incomplete UTF-16
+		{ 0x01, 0x1f, 0x80, 0x9b }, // those bytes are not defined in ISO-8859-1
+		{ 0x7f, 0x1e, 0x03 },       // these bytes are not defined in KOI8-R
+	};
+
+	std::vector<std::string> codes = {
+		"utf-8",
+		"utf-16",
+		"iso-8859-1",
+		"koi8-r",
+	};
+
+	for (const auto& code : codes) {
+		for (const auto& input : inputs) {
+			const std::string fromcode = code;
+
+			std::string tocode = code;
+			std::transform(tocode.begin(), tocode.end(), tocode.begin(), ::toupper);
+
+			verify_convert_text(input, tocode, fromcode, input);
+		}
+	}
+}
+
+TEST_CASE("convert_text() replaces incomplete multibyte sequences with a question mark: utf8 to utf16le",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "ой", "oops" in Russian, but the last byte is missing
+		0xd0, 0xbe, 0xd0,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3e, 0x04, 0x3f, 0x00,
+	};
+
+	verify_convert_text(input, "UTF-16LE", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() replaces incomplete multibyte sequences with a question mark: utf16le to utf8",
+	"[utils]")
+{
+	SECTION("input includes zero byte") {
+		std::vector<unsigned char> input = {
+			// "hi", but the last byte is missing
+			0x68, 0x00, 0x69,
+		};
+
+		std::vector<unsigned char> expected = {
+			0x68, 0x3f,
+		};
+
+		verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+	}
+
+	SECTION("input does not include zero byte") {
+		std::vector<unsigned char> input = {
+			// "эй", "hey" in Russian, but the last byte is missing
+			0x4d, 0x04, 0x39,
+		};
+
+		std::vector<unsigned char> expected = {
+			0xd1, 0x8d, 0x3f,
+		};
+
+		verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+	}
+}
+
+TEST_CASE("convert_text() replaces invalid multibyte sequences with a question mark: utf8 to utf16le",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "日本", "Japan", but the third byte of the first character (0xa5) is
+		// missing, making the whole first character an illegal sequence.
+		0xe6, 0x97, 0xe6, 0x9c, 0xac,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3f, 0x00, 0x3f, 0x00, 0x2c, 0x67,
+	};
+
+	verify_convert_text(input, "UTF-16LE", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() replaces invalid multibyte sequences with a question mark: utf16le to utf8",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// The first two bytes here are part of a surrogate pair, i.e. they
+		// imply that the next two bytes encode additional info. However, the
+		// next two bytes are an ordinary character. This breaks the decoding
+		// process, so some things get turned into a question mark while others
+		// are decoded incorrectly.
+		0x01, 0xd8, 0xd7, 0x03,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3f, 0xed, 0x9f, 0x98, 0x3f,
+	};
+
+	verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf8 to utf16le", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "Тестирую", "Testing" in Russian.
+		0xd0, 0xa2, 0xd0, 0xb5, 0xd1, 0x81, 0xd1, 0x82, 0xd0, 0xb8, 0xd1, 0x80, 0xd1, 0x83,
+		0xd1, 0x8e,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x22, 0x04, 0x35, 0x04, 0x41, 0x04, 0x42, 0x04, 0x38, 0x04, 0x40, 0x04, 0x43, 0x04,
+		0x4e, 0x04,
+	};
+
+	verify_convert_text(input, "UTF-16LE", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf8 to koi8r", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "Проверка", "Check" in Russian.
+		0xd0, 0x9f, 0xd1, 0x80, 0xd0, 0xbe, 0xd0, 0xb2, 0xd0, 0xb5, 0xd1, 0x80, 0xd0, 0xba,
+		0xd0, 0xb0,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xf0, 0xd2, 0xcf, 0xd7, 0xc5, 0xd2, 0xcb, 0xc1,
+	};
+
+	verify_convert_text(input, "KOI8-R", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf8 to ISO-8859-1", "[utils]")
+{
+	// Some symbols in the result will be transliterated.
+
+	std::vector<unsigned char> input = {
+		// "вау °±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃ": a mix of Cyrillic (unsupported by
+		// ISO-8859-1) and ISO-8859-1 characters.
+		0xd0, 0xb2, 0xd0, 0xb0, 0xd1, 0x83, 0x20, 0xc2, 0xb0, 0xc2, 0xb1, 0xc2, 0xb2, 0xc2,
+		0xb3, 0xc2, 0xb4, 0xc2, 0xb5, 0xc2, 0xb6, 0xc2, 0xb7, 0xc2, 0xb8, 0xc2, 0xb9, 0xc2,
+		0xba, 0xc2, 0xbb, 0xc2, 0xbc, 0xc2, 0xbd, 0xc2, 0xbe, 0xc2, 0xbf, 0xc3, 0x80, 0xc3,
+		0x81, 0xc3, 0x82, 0xc3, 0x83,
+	};
+
+	const std::string input_str = std::string(reinterpret_cast<const char*>(input.data()),
+			input.size());
+
+	const auto result = utils::convert_text(input_str, "ISO-8859-1", "UTF-8");
+
+	// We can't spell out an expected result because different platforms
+	// might follow different transliteration rules.
+	REQUIRE(result != "");
+	REQUIRE(result != input_str);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf16le to utf8", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "Успех", "Success" in Russian.
+		0xff, 0xfe, 0x23, 0x04, 0x41, 0x04, 0x3f, 0x04, 0x35, 0x04, 0x45, 0x04,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xef, 0xbb, 0xbf, 0xd0, 0xa3, 0xd1, 0x81, 0xd0, 0xbf, 0xd0, 0xb5, 0xd1, 0x85,
+	};
+
+	verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: koi8r to utf8", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "История", "History" in Russian.
+		0xe9, 0xd3, 0xd4, 0xcf, 0xd2, 0xc9, 0xd1,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xd0, 0x98, 0xd1, 0x81, 0xd1, 0x82, 0xd0, 0xbe, 0xd1, 0x80, 0xd0, 0xb8, 0xd1, 0x8f,
+	};
+
+	verify_convert_text(input, "UTF-8", "KOI8-R", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: ISO-8859-1 to utf8", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "ÄÅÆÇÈÉÊËÌÍÎÏ": some umlauts and Latin letters.
+		0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xc3, 0x84, 0xc3, 0x85, 0xc3, 0x86, 0xc3, 0x87, 0xc3, 0x88, 0xc3, 0x89, 0xc3, 0x8a,
+		0xc3, 0x8b, 0xc3, 0x8c, 0xc3, 0x8d, 0xc3, 0x8e, 0xc3, 0x8f,
+	};
+
+	verify_convert_text(input, "UTF-8", "ISO-8859-1", expected);
 }


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1436

These changes might be useful for `utils::retrieve_url()` as well, but I rather find a way to merge/deduplicate the implementations of `utils::retrieve_url()` and `Parser::parse_url()` at some point (not in this PR).