### PR TITLE
FIx some cppcheck warnings

### DIFF
--- a/include/regexowner.h
+++ b/include/regexowner.h
@@ -17,9 +17,9 @@ private:
 public:
 	~Regex();
 
-	static std::unique_ptr<Regex> compile(std::string reg_expression,
+	static std::unique_ptr<Regex> compile(const std::string& reg_expression,
 		int regcomp_flags, std::string& error);
-	std::vector<std::pair<int, int>> matches(std::string input, int max_matches,
+	std::vector<std::pair<int, int>> matches(const std::string& input, int max_matches,
 			int flags) const;
 
 private:

--- a/rss/xmlutilities.cpp
+++ b/rss/xmlutilities.cpp
@@ -10,7 +10,7 @@ std::string get_content(xmlNode* node)
 	if (node) {
 		xmlChar* content = xmlNodeGetContent(node);
 		if (content) {
-			retval = (const char*)content;
+			retval = reinterpret_cast<const char*>(content);
 			xmlFree(content);
 		}
 	}
@@ -29,7 +29,7 @@ std::string get_xml_content(xmlNode* node, xmlDocPtr doc)
 			ptr = ptr->next) {
 			if (xmlNodeDump(buf, doc, ptr, 0, 0) >= 0) {
 				result.append(
-					(const char*)xmlBufferContent(buf));
+					reinterpret_cast<const char*>(xmlBufferContent(buf)));
 				xmlBufferEmpty(buf);
 			} else {
 				result.append(get_content(ptr));
@@ -79,7 +79,7 @@ bool has_namespace(xmlNode* node, const char* ns_uri)
 		return true;
 	}
 	if (ns_uri && node->ns && node->ns->href &&
-		strcmp((const char*)node->ns->href, ns_uri) == 0) {
+		strcmp(reinterpret_cast<const char*>(node->ns->href), ns_uri) == 0) {
 		return true;
 	}
 	return false;
@@ -91,7 +91,7 @@ bool node_is(xmlNode* node, const char* name, const char* ns_uri)
 		return false;
 	}
 
-	if (strcmp((const char*)node->name, name) == 0) {
+	if (strcmp(reinterpret_cast<const char*>(node->name), name) == 0) {
 		return has_namespace(node, ns_uri);
 	}
 	return false;

--- a/src/matcherexception.cpp
+++ b/src/matcherexception.cpp
@@ -26,9 +26,9 @@ const char* MatcherException::what() const throw()
 
 MatcherException MatcherException::from_rust_error(MatcherErrorFfi error)
 {
-	const std::string info = RustString(error.info);
-	const std::string info2 = RustString(error.info2);
-	return MatcherException(error.type, info, info2);
+	const std::string info_ = RustString(error.info);
+	const std::string info2_ = RustString(error.info2);
+	return MatcherException(error.type, info_, info2_);
 }
 
 } // namespace newsboat

--- a/src/regexowner.cpp
+++ b/src/regexowner.cpp
@@ -14,7 +14,7 @@ Regex::~Regex()
 	regfree(&regex);
 }
 
-std::unique_ptr<Regex> Regex::compile(std::string reg_expression,
+std::unique_ptr<Regex> Regex::compile(const std::string& reg_expression,
 	int regcomp_flags, std::string& error)
 {
 	regex_t regex;
@@ -30,7 +30,7 @@ std::unique_ptr<Regex> Regex::compile(std::string reg_expression,
 	return std::unique_ptr<Regex>(new Regex(regex));
 }
 
-std::vector<std::pair<int, int>> Regex::matches(std::string input,
+std::vector<std::pair<int, int>> Regex::matches(const std::string& input,
 		int max_matches, int flags) const
 {
 	std::vector<regmatch_t> regMatches(max_matches);

--- a/src/regexowner.cpp
+++ b/src/regexowner.cpp
@@ -36,14 +36,14 @@ std::vector<std::pair<int, int>> Regex::matches(std::string input,
 	std::vector<regmatch_t> regMatches(max_matches);
 	if (regexec(&regex, input.c_str(), max_matches,
 			regMatches.data(), flags) == 0) {
-		std::vector<std::pair<int, int>>  matches;
+		std::vector<std::pair<int, int>> results;
 		for (const auto& regMatch : regMatches) {
 			if (regMatch.rm_so < 0 || regMatch.rm_eo < 0) {
 				break;
 			}
-			matches.push_back({regMatch.rm_so, regMatch.rm_eo});
+			results.push_back({regMatch.rm_so, regMatch.rm_eo});
 		}
-		return matches;
+		return results;
 	}
 	return {};
 }


### PR DESCRIPTION
Cppcheck 2.9 produced some new warnings, here are the fixes. None of them are useful by themselves, but fixing them means I get a clean(-ish) cppcheck report now, so it'd be easy to notice new warnings.

I don't think any of this is controversial, so I'll auto-merge. Comments are welcome regardless!