### PR TITLE
Accept enclosure with invalid type if no valid enclosure is found

### DIFF
--- a/rss/atomparser.cpp
+++ b/rss/atomparser.cpp
@@ -124,13 +124,12 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 							base, get_prop(node, "href"));
 				}
 			} else if (rel == "enclosure") {
-				const std::string type = get_prop(node, "type");
-				if (newsboat::utils::is_valid_podcast_type(
-						type)) {
-					it.enclosure_url =
-						get_prop(node, "href");
-					it.enclosure_type = std::move(type);
+				it.enclosures.push_back(
+				Enclosure {
+					get_prop(node, "href"),
+					get_prop(node, "type"),
 				}
+				);
 			}
 		} else if (node_is(node, "summary", ns)) {
 			const std::string mode = get_prop(node, "mode");

--- a/rss/item.h
+++ b/rss/item.h
@@ -7,6 +7,11 @@
 
 namespace rsspp {
 
+struct Enclosure {
+	std::string url;
+	std::string type;
+};
+
 class Item {
 public:
 	Item()
@@ -28,8 +33,7 @@ public:
 	std::string guid;
 	bool guid_isPermaLink;
 
-	std::string enclosure_url;
-	std::string enclosure_type;
+	std::vector<Enclosure> enclosures;
 
 	// extensions:
 	std::string content_encoded;

--- a/rss/medianamespace.cpp
+++ b/rss/medianamespace.cpp
@@ -23,11 +23,12 @@ void parse_media_node(xmlNode* node, Item& it)
 			parse_media_node(mnode, it);
 		}
 	} else if (node_is(node, "content", MEDIA_RSS_URI)) {
-		const std::string type = get_prop(node, "type");
-		if (utils::is_valid_podcast_type(type)) {
-			it.enclosure_url = get_prop(node, "url");
-			it.enclosure_type = std::move(type);
+		it.enclosures.push_back(
+		Enclosure {
+			get_prop(node, "url"),
+			get_prop(node, "type"),
 		}
+		);
 		for (xmlNode* mnode = node->children; mnode != nullptr; mnode = mnode->next) {
 			parse_media_node(mnode, it);
 		}

--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -115,11 +115,12 @@ Item Rss09xParser::parse_item(xmlNode* itemNode)
 		} else if (node_is(node, "creator", DC_URI)) {
 			author = get_content(node);
 		} else if (node_is(node, "enclosure", ns)) {
-			const std::string type = get_prop(node, "type");
-			if (utils::is_valid_podcast_type(type)) {
-				it.enclosure_url = get_prop(node, "url");
-				it.enclosure_type = std::move(type);
+			it.enclosures.push_back(
+			Enclosure {
+				get_prop(node, "url"),
+				get_prop(node, "type"),
 			}
+			);
 		} else if (is_media_node(node)) {
 			parse_media_node(node, it);
 		}

--- a/src/freshrssapi.cpp
+++ b/src/freshrssapi.cpp
@@ -520,10 +520,13 @@ rsspp::Feed FreshRssApi::fetch_feed(const std::string& id, CurlHandle& cached_ha
 			if (entry.contains("enclosure") && !entry["enclosure"].is_null()) {
 				for (const auto& a : entry["enclosure"]) {
 					if (a.contains("href") && a.contains("type")
-						&& !a["href"].is_null() && !a["type"].is_null()
-						&& newsboat::utils::is_valid_podcast_type(a["type"])) {
-						item.enclosure_type = a["type"];
-						item.enclosure_url = a["href"];
+						&& !a["href"].is_null() && !a["type"].is_null()) {
+						item.enclosures.push_back(
+						rsspp::Enclosure {
+							a["href"],
+							a["type"],
+						}
+						);
 						break;
 					}
 				}

--- a/src/ocnewsapi.cpp
+++ b/src/ocnewsapi.cpp
@@ -289,12 +289,15 @@ rsspp::Feed OcNewsApi::fetch_feed(const std::string& feed_id)
 			const auto type_ptr = json_object_get_string(type_obj);
 			const auto url_ptr = json_object_get_string(node);
 
-			if (type_ptr != nullptr) {
+			if (type_ptr != nullptr && url_ptr != nullptr) {
 				const std::string type = type_ptr;
-				if (utils::is_valid_podcast_type(type) && url_ptr != nullptr) {
-					item.enclosure_url = url_ptr;
-					item.enclosure_type = type;
+				const std::string url = url_ptr;
+				item.enclosures.push_back(
+				rsspp::Enclosure {
+					url,
+					type,
 				}
+				);
 			}
 		}
 

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -574,14 +574,29 @@ std::string RssParser::get_guid(const rsspp::Item& item) const
 void RssParser::set_item_enclosure(std::shared_ptr<RssItem> x,
 	const rsspp::Item& item)
 {
-	x->set_enclosure_url(item.enclosure_url);
-	x->set_enclosure_type(item.enclosure_type);
+	std::string enclosure_url;
+	std::string enclosure_type;
+	bool found_valid_enclosure = false;
+
+	for (const auto& enclosure : item.enclosures) {
+		if (utils::is_valid_podcast_type(enclosure.type)) {
+			found_valid_enclosure = true;
+			enclosure_url = enclosure.url;
+			enclosure_type = enclosure.type;
+		} else if (!found_valid_enclosure) {
+			enclosure_url = enclosure.url;
+			enclosure_type = enclosure.type;
+		}
+	}
+
+	x->set_enclosure_url(enclosure_url);
+	x->set_enclosure_type(enclosure_type);
 	LOG(Level::DEBUG,
 		"RssParser::parse: found enclosure_url: %s",
-		item.enclosure_url);
+		enclosure_url);
 	LOG(Level::DEBUG,
 		"RssParser::parse: found enclosure_type: %s",
-		item.enclosure_type);
+		enclosure_type);
 }
 
 void RssParser::add_item_to_feed(std::shared_ptr<RssFeed> feed,

--- a/src/ttrssapi.cpp
+++ b/src/ttrssapi.cpp
@@ -431,11 +431,13 @@ rsspp::Feed TtRssApi::fetch_feed(const std::string& id, CurlHandle& cached_handl
 
 			if (!item_obj["attachments"].is_null()) {
 				for (const json& a : item_obj["attachments"]) {
-					if (!a["content_url"].is_null() && !a["content_type"].is_null()
-						&& newsboat::utils::is_valid_podcast_type(a["content_type"])) {
-						item.enclosure_type =
-							a["content_type"];
-						item.enclosure_url = a["content_url"];
+					if (!a["content_url"].is_null() && !a["content_type"].is_null()) {
+						item.enclosures.push_back(
+						rsspp::Enclosure {
+							a["content_url"],
+							a["content_type"],
+						}
+						);
 						break;
 					}
 				}


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2050

This implements @Minoru's idea from https://github.com/newsboat/newsboat/issues/2050#issuecomment-1114181986:
> So Newsboat is technically correct, but I still think it could do better :) Current algorithm is to pick the last enclosure of the supported type. I guess it could be changed to pick the last enclosure (regardless of the type) if the existing algorithm hasn't picked anything.