### PR TITLE
Use Miniflux's /v1/me endpoint to validate user credentials

### DIFF
--- a/3rd-party/catch.hpp
+++ b/3rd-party/catch.hpp
@@ -1,6 +1,6 @@
 /*
- *  Catch v2.13.9
- *  Generated: 2022-04-12 22:37:23.260201
+ *  Catch v2.13.10
+ *  Generated: 2022-10-16 11:01:23.452308
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
  *  Copyright (c) 2022 Two Blue Cubes Ltd. All rights reserved.
@@ -15,7 +15,7 @@
 
 #define CATCH_VERSION_MAJOR 2
 #define CATCH_VERSION_MINOR 13
-#define CATCH_VERSION_PATCH 9
+#define CATCH_VERSION_PATCH 10
 
 #ifdef __clang__
 #    pragma clang system_header
@@ -7395,8 +7395,6 @@ namespace Catch {
             template <typename T, bool Destruct>
             struct ObjectStorage
             {
-                using TStorage = typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type;
-
                 ObjectStorage() : data() {}
 
                 ObjectStorage(const ObjectStorage& other)
@@ -7439,7 +7437,7 @@ namespace Catch {
                     return *static_cast<T*>(static_cast<void*>(&data));
                 }
 
-                TStorage data;
+                struct { alignas(T) unsigned char data[sizeof(T)]; }  data;
             };
         }
 
@@ -7949,7 +7947,7 @@ namespace Catch {
     #if defined(__i386__) || defined(__x86_64__)
         #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
     #elif defined(__aarch64__)
-        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+        #define CATCH_TRAP()  __asm__(".inst 0xd43e0000")
     #endif
 
 #elif defined(CATCH_PLATFORM_IPHONE)
@@ -13558,7 +13556,7 @@ namespace Catch {
 
             // Handle list request
             if( Option<std::size_t> listed = list( m_config ) )
-                return static_cast<int>( *listed );
+                return (std::min) (MaxExitCode, static_cast<int>(*listed));
 
             TestGroup tests { m_config };
             auto const totals = tests.execute();
@@ -15391,7 +15389,7 @@ namespace Catch {
     }
 
     Version const& libraryVersion() {
-        static Version version( 2, 13, 9, "", 0 );
+        static Version version( 2, 13, 10, "", 0 );
         return version;
     }
 
@@ -17526,12 +17524,20 @@ namespace Catch {
 
 #ifndef __OBJC__
 
+#ifndef CATCH_INTERNAL_CDECL
+#ifdef _MSC_VER
+#define CATCH_INTERNAL_CDECL __cdecl
+#else
+#define CATCH_INTERNAL_CDECL
+#endif
+#endif
+
 #if defined(CATCH_CONFIG_WCHAR) && defined(CATCH_PLATFORM_WINDOWS) && defined(_UNICODE) && !defined(DO_NOT_USE_WMAIN)
 // Standard C/C++ Win32 Unicode wmain entry point
-extern "C" int wmain (int argc, wchar_t * argv[], wchar_t * []) {
+extern "C" int CATCH_INTERNAL_CDECL wmain (int argc, wchar_t * argv[], wchar_t * []) {
 #else
 // Standard C/C++ main entry point
-int main (int argc, char * argv[]) {
+int CATCH_INTERNAL_CDECL main (int argc, char * argv[]) {
 #endif
 
     return Catch::Session().run( argc, argv );

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e580d70777c116df50c390d1211993f62d40302881e54d4b79727acb83d0199"
+checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
 dependencies = [
  "cc",
  "codespan-reporting",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f39818dcfc97d45b03953c1292efc4e80954e1583c4aa770bac1383e2310a4"
+checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -181,15 +181,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a46460b88d1cec95112c8c363f0e2c39afdb237f60583b0b36343bf627ea9c"
+checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747b608fecf06b0d72d440f27acc99288207324b793be2c17991839f3d4995ea"
+checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,9 +332,9 @@ checksum = "478ee9e62aaeaf5b140bd4138753d1f109765488581444218d3ddda43234f3e8"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libnewsboat"

--- a/include/utils.h
+++ b/include/utils.h
@@ -58,6 +58,9 @@ std::string utf8_to_locale(const std::string& text);
 /// nl_langinfo(CODESET)) to UTF-8.
 std::string locale_to_utf8(const std::string& text);
 
+std::string convert_text(const std::string& text, const std::string& tocode,
+	const std::string& fromcode);
+
 std::string get_command_output(const std::string& cmd);
 std::string http_method_str(const HTTPMethod method);
 std::string link_type_str(LinkType type);

--- a/rss/atomparser.cpp
+++ b/rss/atomparser.cpp
@@ -124,13 +124,12 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 							base, get_prop(node, "href"));
 				}
 			} else if (rel == "enclosure") {
-				const std::string type = get_prop(node, "type");
-				if (newsboat::utils::is_valid_podcast_type(
-						type)) {
-					it.enclosure_url =
-						get_prop(node, "href");
-					it.enclosure_type = std::move(type);
+				it.enclosures.push_back(
+				Enclosure {
+					get_prop(node, "href"),
+					get_prop(node, "type"),
 				}
+				);
 			}
 		} else if (node_is(node, "summary", ns)) {
 			const std::string mode = get_prop(node, "mode");

--- a/rss/item.h
+++ b/rss/item.h
@@ -7,6 +7,11 @@
 
 namespace rsspp {
 
+struct Enclosure {
+	std::string url;
+	std::string type;
+};
+
 class Item {
 public:
 	Item()
@@ -28,8 +33,7 @@ public:
 	std::string guid;
 	bool guid_isPermaLink;
 
-	std::string enclosure_url;
-	std::string enclosure_type;
+	std::vector<Enclosure> enclosures;
 
 	// extensions:
 	std::string content_encoded;

--- a/rss/medianamespace.cpp
+++ b/rss/medianamespace.cpp
@@ -23,11 +23,12 @@ void parse_media_node(xmlNode* node, Item& it)
 			parse_media_node(mnode, it);
 		}
 	} else if (node_is(node, "content", MEDIA_RSS_URI)) {
-		const std::string type = get_prop(node, "type");
-		if (utils::is_valid_podcast_type(type)) {
-			it.enclosure_url = get_prop(node, "url");
-			it.enclosure_type = std::move(type);
+		it.enclosures.push_back(
+		Enclosure {
+			get_prop(node, "url"),
+			get_prop(node, "type"),
 		}
+		);
 		for (xmlNode* mnode = node->children; mnode != nullptr; mnode = mnode->next) {
 			parse_media_node(mnode, it);
 		}

--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -5,6 +5,7 @@
 #include <curl/curl.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
+#include <vector>
 
 #include "config.h"
 #include "curlhandle.h"
@@ -53,15 +54,21 @@ Parser::~Parser()
 	}
 }
 
+namespace {
+
 struct HeaderValues {
 	time_t lastmodified;
 	std::string etag;
+	std::string charset;
 
 	HeaderValues()
 		: lastmodified(0)
+		, charset("utf-8")
 	{
 	}
 };
+
+}
 
 static size_t handle_headers(void* ptr, size_t size, size_t nmemb, void* data)
 {
@@ -94,6 +101,20 @@ static size_t handle_headers(void* ptr, size_t size, size_t nmemb, void* data)
 		values->etag = std::string(header + 5);
 		utils::trim(values->etag);
 		LOG(Level::DEBUG, "handle_headers: got etag %s", values->etag);
+	} else if (!strncasecmp("Content-Type:", header, 13)) {
+		std::string header_str = std::string(header, size * nmemb);
+		const std::string key = "charset=";
+		const auto charset_index = header_str.find(key);
+		if (charset_index != std::string::npos) {
+			auto charset = header_str.substr(charset_index + key.size());
+			utils::trim(charset);
+			if (charset.size() >= 2 && charset[0] == '"' && charset[charset.size() - 1] == '"') {
+				charset = charset.substr(1, charset.size() - 2);
+			}
+			if (charset.size() > 0) {
+				values->charset = charset;
+			}
+		}
 	}
 
 	delete[] header;
@@ -246,10 +267,13 @@ Feed Parser::parse_url(const std::string& url,
 		buf);
 
 	if (buf.length() > 0) {
-		LOG(Level::DEBUG,
-			"Parser::parse_url: handing over data to "
-			"parse_buffer()");
-		return parse_buffer(buf, url);
+		LOG(Level::DEBUG, "Parser::parse_url: converting data from %s to utf-8", hdrs.charset);
+		const auto utf8_buf = (hdrs.charset == "utf-8"
+				? buf
+				: utils::convert_text(buf, "utf-8", hdrs.charset));
+
+		LOG(Level::DEBUG, "Parser::parse_url: handing over data to parse_buffer()");
+		return parse_buffer(utf8_buf, url);
 	}
 
 	return Feed();

--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -115,11 +115,12 @@ Item Rss09xParser::parse_item(xmlNode* itemNode)
 		} else if (node_is(node, "creator", DC_URI)) {
 			author = get_content(node);
 		} else if (node_is(node, "enclosure", ns)) {
-			const std::string type = get_prop(node, "type");
-			if (utils::is_valid_podcast_type(type)) {
-				it.enclosure_url = get_prop(node, "url");
-				it.enclosure_type = std::move(type);
+			it.enclosures.push_back(
+			Enclosure {
+				get_prop(node, "url"),
+				get_prop(node, "type"),
 			}
+			);
 		} else if (is_media_node(node)) {
 			parse_media_node(node, it);
 		}

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -89,6 +89,7 @@ mod bridged {
         fn translit(tocode: &str, fromcode: &str) -> String;
         fn utf8_to_locale(text: &str) -> Vec<u8>;
         fn locale_to_utf8(text: &[u8]) -> String;
+        fn convert_text(text: &[u8], tocode: &str, fromcode: &str) -> Vec<u8>;
     }
 
     extern "C++" {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -54,6 +54,8 @@ void Cache::run_sql_nothrow(const std::string& query,
 	run_sql_impl(query, callback, callback_argument, false);
 }
 
+namespace {
+
 struct CbHandler {
 	CbHandler()
 		: c(-1)
@@ -76,6 +78,8 @@ struct HeaderValues {
 	time_t lastmodified;
 	std::string etag;
 };
+
+}
 
 static int count_callback(void* handler, int argc, char** argv,
 	char** /* azColName */)

--- a/src/freshrssapi.cpp
+++ b/src/freshrssapi.cpp
@@ -520,10 +520,13 @@ rsspp::Feed FreshRssApi::fetch_feed(const std::string& id, CurlHandle& cached_ha
 			if (entry.contains("enclosure") && !entry["enclosure"].is_null()) {
 				for (const auto& a : entry["enclosure"]) {
 					if (a.contains("href") && a.contains("type")
-						&& !a["href"].is_null() && !a["type"].is_null()
-						&& newsboat::utils::is_valid_podcast_type(a["type"])) {
-						item.enclosure_type = a["type"];
-						item.enclosure_url = a["href"];
+						&& !a["href"].is_null() && !a["type"].is_null()) {
+						item.enclosures.push_back(
+						rsspp::Enclosure {
+							a["href"],
+							a["type"],
+						}
+						);
 						break;
 					}
 				}

--- a/src/minifluxapi.cpp
+++ b/src/minifluxapi.cpp
@@ -36,6 +36,16 @@ bool MinifluxApi::authenticate()
 	// error check handled in Controller
 	const Credentials creds = get_credentials("miniflux", "");
 	auth_info = strprintf::fmt("%s:%s", creds.user, creds.pass);
+
+	CurlHandle handle;
+	long response_code = 0;
+	run_op("/v1/me", json(), handle);
+	curl_easy_getinfo(handle.ptr(), CURLINFO_RESPONSE_CODE, &response_code);
+
+	if (response_code == 401) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/src/ocnewsapi.cpp
+++ b/src/ocnewsapi.cpp
@@ -289,12 +289,15 @@ rsspp::Feed OcNewsApi::fetch_feed(const std::string& feed_id)
 			const auto type_ptr = json_object_get_string(type_obj);
 			const auto url_ptr = json_object_get_string(node);
 
-			if (type_ptr != nullptr) {
+			if (type_ptr != nullptr && url_ptr != nullptr) {
 				const std::string type = type_ptr;
-				if (utils::is_valid_podcast_type(type) && url_ptr != nullptr) {
-					item.enclosure_url = url_ptr;
-					item.enclosure_type = type;
+				const std::string url = url_ptr;
+				item.enclosures.push_back(
+				rsspp::Enclosure {
+					url,
+					type,
 				}
+				);
 			}
 		}
 

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -574,14 +574,29 @@ std::string RssParser::get_guid(const rsspp::Item& item) const
 void RssParser::set_item_enclosure(std::shared_ptr<RssItem> x,
 	const rsspp::Item& item)
 {
-	x->set_enclosure_url(item.enclosure_url);
-	x->set_enclosure_type(item.enclosure_type);
+	std::string enclosure_url;
+	std::string enclosure_type;
+	bool found_valid_enclosure = false;
+
+	for (const auto& enclosure : item.enclosures) {
+		if (utils::is_valid_podcast_type(enclosure.type)) {
+			found_valid_enclosure = true;
+			enclosure_url = enclosure.url;
+			enclosure_type = enclosure.type;
+		} else if (!found_valid_enclosure) {
+			enclosure_url = enclosure.url;
+			enclosure_type = enclosure.type;
+		}
+	}
+
+	x->set_enclosure_url(enclosure_url);
+	x->set_enclosure_type(enclosure_type);
 	LOG(Level::DEBUG,
 		"RssParser::parse: found enclosure_url: %s",
-		item.enclosure_url);
+		enclosure_url);
 	LOG(Level::DEBUG,
 		"RssParser::parse: found enclosure_type: %s",
-		item.enclosure_type);
+		enclosure_type);
 }
 
 void RssParser::add_item_to_feed(std::shared_ptr<RssFeed> feed,

--- a/src/ttrssapi.cpp
+++ b/src/ttrssapi.cpp
@@ -431,11 +431,13 @@ rsspp::Feed TtRssApi::fetch_feed(const std::string& id, CurlHandle& cached_handl
 
 			if (!item_obj["attachments"].is_null()) {
 				for (const json& a : item_obj["attachments"]) {
-					if (!a["content_url"].is_null() && !a["content_type"].is_null()
-						&& newsboat::utils::is_valid_podcast_type(a["content_type"])) {
-						item.enclosure_type =
-							a["content_type"];
-						item.enclosure_url = a["content_url"];
+					if (!a["content_url"].is_null() && !a["content_type"].is_null()) {
+						item.enclosures.push_back(
+						rsspp::Enclosure {
+							a["content_url"],
+							a["content_type"],
+						}
+						);
 						break;
 					}
 				}

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.h"
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <ctype.h>
 #include <fstream>
@@ -1980,4 +1981,276 @@ TEST_CASE("translit() always returns the same value for the same inputs",
 			REQUIRE(utils::translit(tocode, fromcode) == results.at(std::make_pair(fromcode, tocode)));
 		}
 	}
+}
+
+void verify_convert_text(const std::vector<unsigned char>& input,
+	const std::string& tocode, const std::string& fromcode,
+	const std::vector<unsigned char>& expected_output)
+{
+	const std::string input_str = std::string(reinterpret_cast<const char*>(input.data()),
+			input.size());
+	const std::string expected_str = std::string(reinterpret_cast<const char*>
+			(expected_output.data()), expected_output.size());
+
+	REQUIRE(utils::convert_text(input_str, tocode, fromcode) == expected_str);
+}
+
+TEST_CASE("convert_text() returns input string if fromcode and tocode are literally the same",
+	"[utils]")
+{
+	std::vector<std::vector<unsigned char>> inputs = {
+		{ 0x81, 0x13, 0xa0 },       // \x81 is not valid UTF-8
+		{ 0x01 },                   // incomplete UTF-16
+		{ 0x01, 0x1f, 0x80, 0x9b }, // those bytes are not defined in ISO-8859-1
+		{ 0x7f, 0x1e, 0x03 },       // these bytes are not defined in KOI8-R
+	};
+
+	std::vector<std::string> codes = {
+		"utf-8",
+		"utf-16",
+		"iso-8859-1",
+		"koi8-r",
+	};
+
+	for (const auto& code : codes) {
+		for (const auto& input : inputs) {
+			verify_convert_text(input, code, code, input);
+		}
+	}
+}
+
+TEST_CASE("convert_text() returns input string if fromcode is uppercase of tocode",
+	"[utils]")
+{
+	std::vector<std::vector<unsigned char>> inputs = {
+		{ 0x81, 0x13, 0xa0 },       // \x81 is not valid UTF-8
+		{ 0x01 },                   // incomplete UTF-16
+		{ 0x01, 0x1f, 0x80, 0x9b }, // those bytes are not defined in ISO-8859-1
+		{ 0x7f, 0x1e, 0x03 },       // these bytes are not defined in KOI8-R
+	};
+
+	std::vector<std::string> codes = {
+		"utf-8",
+		"utf-16",
+		"iso-8859-1",
+		"koi8-r",
+	};
+
+	for (const auto& code : codes) {
+		for (const auto& input : inputs) {
+			const std::string tocode = code;
+
+			std::string fromcode = code;
+			std::transform(fromcode.begin(), fromcode.end(), fromcode.begin(), ::toupper);
+
+			verify_convert_text(input, fromcode, tocode, input);
+		}
+	}
+}
+
+TEST_CASE("convert_text() returns input string if tocode is uppercase of fromcode",
+	"[utils]")
+{
+	std::vector<std::vector<unsigned char>> inputs = {
+		{ 0x81, 0x13, 0xa0 },       // \x81 is not valid UTF-8
+		{ 0x01 },                   // incomplete UTF-16
+		{ 0x01, 0x1f, 0x80, 0x9b }, // those bytes are not defined in ISO-8859-1
+		{ 0x7f, 0x1e, 0x03 },       // these bytes are not defined in KOI8-R
+	};
+
+	std::vector<std::string> codes = {
+		"utf-8",
+		"utf-16",
+		"iso-8859-1",
+		"koi8-r",
+	};
+
+	for (const auto& code : codes) {
+		for (const auto& input : inputs) {
+			const std::string fromcode = code;
+
+			std::string tocode = code;
+			std::transform(tocode.begin(), tocode.end(), tocode.begin(), ::toupper);
+
+			verify_convert_text(input, tocode, fromcode, input);
+		}
+	}
+}
+
+TEST_CASE("convert_text() replaces incomplete multibyte sequences with a question mark: utf8 to utf16le",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "ой", "oops" in Russian, but the last byte is missing
+		0xd0, 0xbe, 0xd0,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3e, 0x04, 0x3f, 0x00,
+	};
+
+	verify_convert_text(input, "UTF-16LE", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() replaces incomplete multibyte sequences with a question mark: utf16le to utf8",
+	"[utils]")
+{
+	SECTION("input includes zero byte") {
+		std::vector<unsigned char> input = {
+			// "hi", but the last byte is missing
+			0x68, 0x00, 0x69,
+		};
+
+		std::vector<unsigned char> expected = {
+			0x68, 0x3f,
+		};
+
+		verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+	}
+
+	SECTION("input does not include zero byte") {
+		std::vector<unsigned char> input = {
+			// "эй", "hey" in Russian, but the last byte is missing
+			0x4d, 0x04, 0x39,
+		};
+
+		std::vector<unsigned char> expected = {
+			0xd1, 0x8d, 0x3f,
+		};
+
+		verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+	}
+}
+
+TEST_CASE("convert_text() replaces invalid multibyte sequences with a question mark: utf8 to utf16le",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "日本", "Japan", but the third byte of the first character (0xa5) is
+		// missing, making the whole first character an illegal sequence.
+		0xe6, 0x97, 0xe6, 0x9c, 0xac,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3f, 0x00, 0x3f, 0x00, 0x2c, 0x67,
+	};
+
+	verify_convert_text(input, "UTF-16LE", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() replaces invalid multibyte sequences with a question mark: utf16le to utf8",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// The first two bytes here are part of a surrogate pair, i.e. they
+		// imply that the next two bytes encode additional info. However, the
+		// next two bytes are an ordinary character. This breaks the decoding
+		// process, so some things get turned into a question mark while others
+		// are decoded incorrectly.
+		0x01, 0xd8, 0xd7, 0x03,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3f, 0xed, 0x9f, 0x98, 0x3f,
+	};
+
+	verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf8 to utf16le", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "Тестирую", "Testing" in Russian.
+		0xd0, 0xa2, 0xd0, 0xb5, 0xd1, 0x81, 0xd1, 0x82, 0xd0, 0xb8, 0xd1, 0x80, 0xd1, 0x83,
+		0xd1, 0x8e,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x22, 0x04, 0x35, 0x04, 0x41, 0x04, 0x42, 0x04, 0x38, 0x04, 0x40, 0x04, 0x43, 0x04,
+		0x4e, 0x04,
+	};
+
+	verify_convert_text(input, "UTF-16LE", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf8 to koi8r", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "Проверка", "Check" in Russian.
+		0xd0, 0x9f, 0xd1, 0x80, 0xd0, 0xbe, 0xd0, 0xb2, 0xd0, 0xb5, 0xd1, 0x80, 0xd0, 0xba,
+		0xd0, 0xb0,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xf0, 0xd2, 0xcf, 0xd7, 0xc5, 0xd2, 0xcb, 0xc1,
+	};
+
+	verify_convert_text(input, "KOI8-R", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf8 to ISO-8859-1", "[utils]")
+{
+	// Some symbols in the result will be transliterated.
+
+	std::vector<unsigned char> input = {
+		// "вау °±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃ": a mix of Cyrillic (unsupported by
+		// ISO-8859-1) and ISO-8859-1 characters.
+		0xd0, 0xb2, 0xd0, 0xb0, 0xd1, 0x83, 0x20, 0xc2, 0xb0, 0xc2, 0xb1, 0xc2, 0xb2, 0xc2,
+		0xb3, 0xc2, 0xb4, 0xc2, 0xb5, 0xc2, 0xb6, 0xc2, 0xb7, 0xc2, 0xb8, 0xc2, 0xb9, 0xc2,
+		0xba, 0xc2, 0xbb, 0xc2, 0xbc, 0xc2, 0xbd, 0xc2, 0xbe, 0xc2, 0xbf, 0xc3, 0x80, 0xc3,
+		0x81, 0xc3, 0x82, 0xc3, 0x83,
+	};
+
+	const std::string input_str = std::string(reinterpret_cast<const char*>(input.data()),
+			input.size());
+
+	const auto result = utils::convert_text(input_str, "ISO-8859-1", "UTF-8");
+
+	// We can't spell out an expected result because different platforms
+	// might follow different transliteration rules.
+	REQUIRE(result != "");
+	REQUIRE(result != input_str);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf16le to utf8", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "Успех", "Success" in Russian.
+		0xff, 0xfe, 0x23, 0x04, 0x41, 0x04, 0x3f, 0x04, 0x35, 0x04, 0x45, 0x04,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xef, 0xbb, 0xbf, 0xd0, 0xa3, 0xd1, 0x81, 0xd0, 0xbf, 0xd0, 0xb5, 0xd1, 0x85,
+	};
+
+	verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: koi8r to utf8", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "История", "History" in Russian.
+		0xe9, 0xd3, 0xd4, 0xcf, 0xd2, 0xc9, 0xd1,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xd0, 0x98, 0xd1, 0x81, 0xd1, 0x82, 0xd0, 0xbe, 0xd1, 0x80, 0xd0, 0xb8, 0xd1, 0x8f,
+	};
+
+	verify_convert_text(input, "UTF-8", "KOI8-R", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: ISO-8859-1 to utf8", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "ÄÅÆÇÈÉÊËÌÍÎÏ": some umlauts and Latin letters.
+		0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xc3, 0x84, 0xc3, 0x85, 0xc3, 0x86, 0xc3, 0x87, 0xc3, 0x88, 0xc3, 0x89, 0xc3, 0x8a,
+		0xc3, 0x8b, 0xc3, 0x8c, 0xc3, 0x8d, 0xc3, 0x8e, 0xc3, 0x8f,
+	};
+
+	verify_convert_text(input, "UTF-8", "ISO-8859-1", expected);
 }


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/2220

Uses the HTTP response code for a GET request on endpoint `/v1/me` (https://miniflux.app/docs/api.html#endpoint-me).