### PR TITLE
Allow splitting a config command into multiple lines

### DIFF
--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -30,6 +30,22 @@ unbind-key       R
 bind-key         ^R    reload-all
 ----
 
+=== Splitting macros into multiple lines
+
+Macros defined in config files which are long can be split up into multiple
+lines using backslashes; these must be the last character on the line and will
+immediately concatenate it with the following line. It's important that _nothing_
+follows the \ on the same line, otherwise the \ character is treated "as is".
+
+Dummy example
+
+---
+macro p open; \
+reload; quit; \
+quit;         \
+quit -- "Opens, reloads then makes sure to quit newsboat"
+---
+
 === Using Double Quotes
 
 ****

--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -30,21 +30,21 @@ unbind-key       R
 bind-key         ^R    reload-all
 ----
 
-=== Splitting macros into multiple lines
+=== Splitting long lines into multiple ones
 
-Macros defined in config files which are long can be split up into multiple
-lines using backslashes; these must be the last character on the line and will
+Configuration items, such as macros defined in config files which are long can be split
+up into multiple ones using backslashes; these must be the last character on the line and will
 immediately concatenate it with the following line. It's important that _nothing_
 follows the \ on the same line, otherwise the \ character is treated "as is".
 
-Dummy example
+Dummy example:
 
----
+----
 macro p open; \
 reload; quit; \
 quit;         \
 quit -- "Opens, reloads then makes sure to quit newsboat"
----
+----
 
 === Using Double Quotes
 

--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -35,7 +35,7 @@ bind-key         ^R    reload-all
 Configuration items, such as macros defined in config files which are long can be split
 up into multiple ones using backslashes; these must be the last character on the line and will
 immediately concatenate it with the following line. It's important that _nothing_
-follows the \ on the same line, otherwise the \ character is treated "as is".
+follows the `{backslash}` on the same line, otherwise the `{backslash}` character is treated "as is".
 
 Dummy example:
 

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -102,13 +102,8 @@ bool ConfigParser::parse_file(const std::string& tmp_filename)
 	for (const auto& line : lines.value()) {
 		linecounter++;
 		const auto ln_del = line.rfind('\\');
-		const auto trailing_ws = [](bool& acc, char ch) {
-			return acc && std::iswspace(ch);
-		};
-		if (ln_del != std::string::npos &&
-				std::accumulate(line.begin()+ln_del+1, line.end(), true, trailing_ws)) {
+		if (ln_del != std::string::npos && ln_del == line.size()-1) {
 			multi_line_buffer.append(line.substr(0, ln_del));
-			multi_line_buffer.push_back(' ');
 		} else {
 			const std::string location = strprintf::fmt(_("%s line %u"), filename, linecounter);
 			if (!multi_line_buffer.empty()) {

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -3,9 +3,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
-#include <cwctype>
 #include <fstream>
-#include <numeric>
 #include <pwd.h>
 #include <sys/types.h>
 
@@ -101,9 +99,8 @@ bool ConfigParser::parse_file(const std::string& tmp_filename)
 	std::string multi_line_buffer{};
 	for (const auto& line : lines.value()) {
 		linecounter++;
-		const auto ln_del = line.rfind('\\');
-		if (ln_del != std::string::npos && ln_del == line.size()-1) {
-			multi_line_buffer.append(line.substr(0, ln_del));
+		if (!line.empty() && line.back() == '\\') {
+			multi_line_buffer.append(line.substr(0, line.size()-1));
 		} else {
 			const std::string location = strprintf::fmt(_("%s line %u"), filename, linecounter);
 			if (!multi_line_buffer.empty()) {

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -248,27 +248,25 @@ TEST_CASE("\"unbind-key -a\" removes all key bindings", "[ConfigParser]")
 	}
 }
 
-TEST_CASE("Include config file with multi line macros", "[ConfigParser]")
+TEST_CASE("Concatenates lines that end with a backslash", "[ConfigParser]")
 {
 	ConfigParser cfgparser;
-	SECTION("Successfully includes & parse file with multi-line macros") {
-		KeyMap k(KM_NEWSBOAT);
-		cfgparser.register_handler("macro", k);
-		REQUIRE_NOTHROW(cfgparser.parse_file("data/config-multi-line"));
-		auto p_macro = k.get_macro("p");
-		REQUIRE(!p_macro.empty());
-		REQUIRE(p_macro[0].op == newsboat::OP_OPEN);
-		REQUIRE(p_macro[1].op == newsboat::OP_RELOAD);
-		REQUIRE(p_macro[2].op == newsboat::OP_QUIT);
-		REQUIRE(p_macro[3].op == newsboat::OP_QUIT);
+	KeyMap k(KM_NEWSBOAT);
+	cfgparser.register_handler("macro", k);
+	REQUIRE_NOTHROW(cfgparser.parse_file("data/config-multi-line"));
+	auto p_macro = k.get_macro("p");
+	REQUIRE(!p_macro.empty());
+	REQUIRE(p_macro[0].op == newsboat::OP_OPEN);
+	REQUIRE(p_macro[1].op == newsboat::OP_RELOAD);
+	REQUIRE(p_macro[2].op == newsboat::OP_QUIT);
+	REQUIRE(p_macro[3].op == newsboat::OP_QUIT);
 
-		auto stupid = k.get_macro("j");
-		REQUIRE(!stupid.empty());
-		REQUIRE(stupid[0].op == newsboat::OP_QUIT);
-		REQUIRE(stupid[1].op == newsboat::OP_QUIT);
-		REQUIRE(stupid[2].op == newsboat::OP_QUIT);
-		REQUIRE(stupid[3].op == newsboat::OP_QUIT);
-	}
+	auto contrived = k.get_macro("j");
+	REQUIRE(!contrived.empty());
+	REQUIRE(contrived[0].op == newsboat::OP_QUIT);
+	REQUIRE(contrived[1].op == newsboat::OP_QUIT);
+	REQUIRE(contrived[2].op == newsboat::OP_QUIT);
+	REQUIRE(contrived[3].op == newsboat::OP_QUIT);
 }
 
 TEST_CASE("`include` directive includes other config files", "[ConfigParser]")

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -248,6 +248,29 @@ TEST_CASE("\"unbind-key -a\" removes all key bindings", "[ConfigParser]")
 	}
 }
 
+TEST_CASE("Include config file with multi line macros", "[ConfigParser]")
+{
+	ConfigParser cfgparser;
+	SECTION("Successfully includes & parse file with multi-line macros") {
+		KeyMap k(KM_NEWSBOAT);
+		cfgparser.register_handler("macro", k);
+		REQUIRE_NOTHROW(cfgparser.parse_file("data/config-multi-line"));
+		auto p_macro = k.get_macro("p");
+		REQUIRE(!p_macro.empty());
+		REQUIRE(p_macro[0].op == newsboat::OP_OPEN);
+		REQUIRE(p_macro[1].op == newsboat::OP_RELOAD);
+		REQUIRE(p_macro[2].op == newsboat::OP_QUIT);
+		REQUIRE(p_macro[3].op == newsboat::OP_QUIT);
+
+		auto stupid = k.get_macro("j");
+		REQUIRE(!stupid.empty());
+		REQUIRE(stupid[0].op == newsboat::OP_QUIT);
+		REQUIRE(stupid[1].op == newsboat::OP_QUIT);
+		REQUIRE(stupid[2].op == newsboat::OP_QUIT);
+		REQUIRE(stupid[3].op == newsboat::OP_QUIT);
+	}
+}
+
 TEST_CASE("`include` directive includes other config files", "[ConfigParser]")
 {
 	// TODO: error messages should be more descriptive than "file couldn't be opened"

--- a/test/data/config-multi-line
+++ b/test/data/config-multi-line
@@ -10,11 +10,3 @@ it;\
 q\
 uit;\
 quit -- "Dummy macro"
-
-
-macro f open;  \
-reload;        \
-quit;          \
-quit  -- "Spaces before \ are ok. Not after, if concatenation is what the user is after. Otherwise treated as-is"
-
-macro a open; quit; reload -- "some macro description"

--- a/test/data/config-multi-line
+++ b/test/data/config-multi-line
@@ -1,0 +1,20 @@
+macro p open;\
+reload;\
+quit;\
+quit -- "opens, reloads, quits, then quits newsboat"
+
+macro j qui\
+t;\
+qu\
+it;\
+q\
+uit;\
+quit -- "Dummy macro"
+
+
+macro f open;  \
+reload;        \
+quit;          \
+quit  -- "Spaces before \ are ok. Not after, if concatenation is what the user is after. Otherwise treated as-is"
+
+macro a open; quit; reload -- "some macro description"


### PR DESCRIPTION
Concatenates lines separated by a '\\' in config file.

Ignores whitespaces after '\\', if non white space characters are found (or no '\' is found) it joins the line as the last line of the multi-line and hands off parsing logic as usual to ConfigParser::parse_line.