### PR TITLE
CI: Bump Rust to 1.65.0

### DIFF
--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.64.0 by default.
+# and Rust 1.65.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-8
-# - rust_version -- Rust version to install. Default: 1.64.0
+# - rust_version -- Rust version to install. Default: 1.65.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-8
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.64.0
+ARG rust_version=1.65.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -82,7 +82,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain 1.64.0 \
+        --default-toolchain 1.65.0 \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 9 and Rust 1.64.0 by default.
+# compilers. Contains GCC 9 and Rust 1.65.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.64.0
+# - rust_version -- Rust version to install. Default: 1.65.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.64.0
+ARG rust_version=1.65.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_22.04-build-tools.dockerfile
+++ b/docker/ubuntu_22.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 12 and Rust 1.64.0 by default.
+# compilers. Contains GCC 12 and Rust 1.65.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-12
-# - rust_version -- Rust version to install. Default: 1.64.0
+# - rust_version -- Rust version to install. Default: 1.65.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-12
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -92,7 +92,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.64.0
+ARG rust_version=1.65.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/rust/libnewsboat/build.rs
+++ b/rust/libnewsboat/build.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 fn main() {
     // Code lifted from https://stackoverflow.com/a/44407625/2350060
     let command_output = Command::new("git")
-        .args(&["describe", "--abbrev=4", "--dirty", "--always", "--tags"])
+        .args(["describe", "--abbrev=4", "--dirty", "--always", "--tags"])
         .output();
     match command_output {
         Ok(ref hash_output) if hash_output.status.success() => {

--- a/rust/libnewsboat/src/fslock.rs
+++ b/rust/libnewsboat/src/fslock.rs
@@ -50,7 +50,7 @@ impl FsLock {
         // first we open (and possibly create) the lock file
         let mut options = OpenOptions::new();
         options.create(true).read(true).write(true).mode(0o600);
-        let mut file = match options.open(&new_lock_path) {
+        let mut file = match options.open(new_lock_path) {
             Ok(file) => file,
             Err(reason) => {
                 return Err(fmt!(

--- a/rust/libnewsboat/src/matcher.rs
+++ b/rust/libnewsboat/src/matcher.rs
@@ -103,7 +103,7 @@ impl Operator {
 /// Return 0 if there is no numeric prefix. On underflow, return `std::i32::MIN`. On overflow,
 /// return `std::i32::MAX`.
 fn string_to_num(input: &str) -> i32 {
-    let search_start = if input.starts_with('-') { 1 } else { 0 };
+    let search_start = usize::from(input.starts_with('-'));
 
     let numerics_end = input[search_start..]
         .find(|c: char| !c.is_numeric())

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -540,7 +540,7 @@ pub fn make_title(rs_str: String) -> String {
         .trim_end_matches(".htm");
 
     // 'title with dashes'
-    let result = result.replace('-', " ").replace('_', " ");
+    let result = result.replace(['-', '_'], " ");
 
     //'Title with dashes'
     //let result = "";

--- a/rust/libnewsboat/tests/configpaths_helpers/mod.rs
+++ b/rust/libnewsboat/tests/configpaths_helpers/mod.rs
@@ -44,7 +44,7 @@ impl FileSentries {
 }
 
 fn mock_dotdir(dotdir_path: &path::Path, sentries: &FileSentries) {
-    assert!(fs::create_dir(&dotdir_path).is_ok());
+    assert!(fs::create_dir(dotdir_path).is_ok());
     assert!(create_file(&dotdir_path.join("config"), &sentries.config));
     assert!(create_file(&dotdir_path.join("urls"), &sentries.urls));
     assert!(create_file(&dotdir_path.join("cache.db"), &sentries.cache));
@@ -80,11 +80,11 @@ pub fn mock_newsboat_dotdir(tmp: &TempDir) -> FileSentries {
 pub fn mock_xdg_dirs(config_dir: &path::Path, data_dir: &path::Path) -> FileSentries {
     let sentries = FileSentries::new();
 
-    assert!(fs::create_dir_all(&config_dir).is_ok());
+    assert!(fs::create_dir_all(config_dir).is_ok());
     assert!(create_file(&config_dir.join("config"), &sentries.config));
     assert!(create_file(&config_dir.join("urls"), &sentries.urls));
 
-    assert!(fs::create_dir_all(&data_dir).is_ok());
+    assert!(fs::create_dir_all(data_dir).is_ok());
     assert!(create_file(&data_dir.join("cache.db"), &sentries.cache));
     assert!(create_file(&data_dir.join("queue"), &sentries.queue));
     assert!(create_file(
@@ -132,7 +132,7 @@ pub fn file_contents(path: &path::Path) -> String {
 }
 
 fn is_readable(filepath: &path::Path) -> bool {
-    fs::File::open(&filepath).is_ok()
+    fs::File::open(filepath).is_ok()
 }
 
 pub fn assert_xdg_not_migrated(config_dir: &path::Path, data_dir: &path::Path) {

--- a/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
+++ b/rust/libnewsboat/tests/getcwd_returns_an_error_if_current_directory_doesnt_exist.rs
@@ -6,7 +6,7 @@ use tempfile::TempDir;
 fn t_getcwd_returns_an_error_if_current_directory_doesnt_exist() {
     {
         let tmp = TempDir::new().unwrap();
-        let chdir_result = env::set_current_dir(&tmp.path());
+        let chdir_result = env::set_current_dir(tmp.path());
         assert!(chdir_result.is_ok());
     }
 

--- a/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
+++ b/rust/libnewsboat/tests/getcwd_value_depends_on_current_directory.rs
@@ -8,7 +8,7 @@ fn t_getcwd_value_depends_on_current_directory() {
 
     let tmp = TempDir::new().unwrap();
     assert_ne!(&initial_dir, tmp.path());
-    let chdir_result = env::set_current_dir(&tmp.path());
+    let chdir_result = env::set_current_dir(tmp.path());
     assert!(chdir_result.is_ok());
 
     let new_dir = utils::getcwd().unwrap();


### PR DESCRIPTION
Also fix all the Clippy warning that popped up in the new release.