### PR TITLE
Always convert downloaded text to utf-8, even if server says it is utf-8 already

### DIFF
--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -268,9 +268,7 @@ Feed Parser::parse_url(const std::string& url,
 
 	if (buf.length() > 0) {
 		LOG(Level::DEBUG, "Parser::parse_url: converting data from %s to utf-8", hdrs.charset);
-		const auto utf8_buf = (hdrs.charset == "utf-8"
-				? buf
-				: utils::convert_text(buf, "utf-8", hdrs.charset));
+		const auto utf8_buf = utils::convert_text(buf, "utf-8", hdrs.charset);
 
 		LOG(Level::DEBUG, "Parser::parse_url: handing over data to parse_buffer()");
 		return parse_buffer(utf8_buf, url);

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -916,10 +916,6 @@ pub fn translit(tocode: &str, fromcode: &str) -> String {
 
 /// Converts `text` from encoding `fromcode` to encoding `tocode`.
 pub fn convert_text(text: &[u8], tocode: &str, fromcode: &str) -> Vec<u8> {
-    if tocode.to_lowercase() == fromcode.to_lowercase() {
-        return text.to_owned();
-    }
-
     let mut result = vec![];
 
     let tocode_translit = translit(tocode, fromcode);
@@ -2082,61 +2078,11 @@ mod tests {
     }
 
     #[test]
-    fn t_convert_text_returns_input_string_if_fromcode_and_tocode_are_literally_the_same() {
-        let inputs: &[&[u8]] = &[
-            &[0x81, 0x13, 0xa0],       // \x81 is not valid UTF-8
-            &[0x01],                   // incomplete UTF-16
-            &[0x01, 0x1f, 0x80, 0x9b], // those bytes are not defined in ISO-8859-1
-            &[0x7f, 0x1e, 0x03],       // these bytes are not defined in KOI8-R
-        ];
-
-        let codes = &["utf-8", "utf-16", "iso-8859-1", "koi8-r"];
-
-        for code in codes {
-            for input in inputs {
-                assert_eq!(convert_text(input, code, code), *input);
-            }
-        }
-    }
-
-    #[test]
-    fn t_convert_text_returns_input_string_if_fromcode_is_an_uppercase_of_tocode() {
-        let inputs: &[&[u8]] = &[
-            &[0x81, 0x13, 0xa0],       // \x81 is not valid UTF-8
-            &[0x01],                   // incomplete UTF-16
-            &[0x01, 0x1f, 0x80, 0x9b], // those bytes are not defined in ISO-8859-1
-            &[0x7f, 0x1e, 0x03],       // these bytes are not defined in KOI8-R
-        ];
-
-        let codes = &["utf-8", "utf-16", "iso-8859-1", "koi8-r"];
-
-        for code in codes {
-            for input in inputs {
-                let fromcode = code.to_uppercase();
-                let tocode = code;
-                assert_eq!(convert_text(input, tocode, &fromcode), *input);
-            }
-        }
-    }
-
-    #[test]
-    fn t_convert_text_returns_input_string_if_tocode_is_an_uppercase_of_fromcode() {
-        let inputs: &[&[u8]] = &[
-            &[0x81, 0x13, 0xa0],       // \x81 is not valid UTF-8
-            &[0x01],                   // incomplete UTF-16
-            &[0x01, 0x1f, 0x80, 0x9b], // those bytes are not defined in ISO-8859-1
-            &[0x7f, 0x1e, 0x03],       // these bytes are not defined in KOI8-R
-        ];
-
-        let codes = &["utf-8", "utf-16", "iso-8859-1", "koi8-r"];
-
-        for code in codes {
-            for input in inputs {
-                let fromcode = code;
-                let tocode = code.to_uppercase();
-                assert_eq!(convert_text(input, &tocode, fromcode), *input);
-            }
-        }
+    fn t_convert_text_returns_input_string_if_fromcode_and_tocode_are_the_same() {
+        // \x81 is not valid UTF-8
+        let input = &[0x81, 0x13, 0x41];
+        let expected = &[0x3f, 0x13, 0x41];
+        assert_eq!(convert_text(input, "UTF-8", "UTF-8"), expected);
     }
 
     #[test]

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -381,12 +381,8 @@ std::string utils::retrieve_url(const std::string& url,
 	// See the clobbering note above.
 	curl_easy_setopt(easyhandle.ptr(), CURLOPT_ERRORBUFFER, NULL);
 
-	if (hdrs.charset == "utf-8") {
-		return buf;
-	} else {
-		LOG(Level::DEBUG, "Parser::parse_url: converting data from %s to utf-8", hdrs.charset);
-		return utils::convert_text(buf, "utf-8", hdrs.charset);
-	}
+	LOG(Level::DEBUG, "Parser::parse_url: converting data from %s to utf-8", hdrs.charset);
+	return utils::convert_text(buf, "utf-8", hdrs.charset);
 }
 
 std::string utils::run_program(const char* argv[], const std::string& input)

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1995,86 +1995,19 @@ void verify_convert_text(const std::vector<unsigned char>& input,
 	REQUIRE(utils::convert_text(input_str, tocode, fromcode) == expected_str);
 }
 
-TEST_CASE("convert_text() returns input string if fromcode and tocode are literally the same",
+TEST_CASE("convert_text() returns input string if fromcode and tocode are the same",
 	"[utils]")
 {
-	std::vector<std::vector<unsigned char>> inputs = {
-		{ 0x81, 0x13, 0xa0 },       // \x81 is not valid UTF-8
-		{ 0x01 },                   // incomplete UTF-16
-		{ 0x01, 0x1f, 0x80, 0x9b }, // those bytes are not defined in ISO-8859-1
-		{ 0x7f, 0x1e, 0x03 },       // these bytes are not defined in KOI8-R
+	std::vector<unsigned char> input = {
+		// \x81 is not valid UTF-8
+		0x81, 0x13, 0x41,
 	};
 
-	std::vector<std::string> codes = {
-		"utf-8",
-		"utf-16",
-		"iso-8859-1",
-		"koi8-r",
+	std::vector<unsigned char> expected = {
+		0x3f, 0x13, 0x41,
 	};
 
-	for (const auto& code : codes) {
-		for (const auto& input : inputs) {
-			verify_convert_text(input, code, code, input);
-		}
-	}
-}
-
-TEST_CASE("convert_text() returns input string if fromcode is uppercase of tocode",
-	"[utils]")
-{
-	std::vector<std::vector<unsigned char>> inputs = {
-		{ 0x81, 0x13, 0xa0 },       // \x81 is not valid UTF-8
-		{ 0x01 },                   // incomplete UTF-16
-		{ 0x01, 0x1f, 0x80, 0x9b }, // those bytes are not defined in ISO-8859-1
-		{ 0x7f, 0x1e, 0x03 },       // these bytes are not defined in KOI8-R
-	};
-
-	std::vector<std::string> codes = {
-		"utf-8",
-		"utf-16",
-		"iso-8859-1",
-		"koi8-r",
-	};
-
-	for (const auto& code : codes) {
-		for (const auto& input : inputs) {
-			const std::string tocode = code;
-
-			std::string fromcode = code;
-			std::transform(fromcode.begin(), fromcode.end(), fromcode.begin(), ::toupper);
-
-			verify_convert_text(input, fromcode, tocode, input);
-		}
-	}
-}
-
-TEST_CASE("convert_text() returns input string if tocode is uppercase of fromcode",
-	"[utils]")
-{
-	std::vector<std::vector<unsigned char>> inputs = {
-		{ 0x81, 0x13, 0xa0 },       // \x81 is not valid UTF-8
-		{ 0x01 },                   // incomplete UTF-16
-		{ 0x01, 0x1f, 0x80, 0x9b }, // those bytes are not defined in ISO-8859-1
-		{ 0x7f, 0x1e, 0x03 },       // these bytes are not defined in KOI8-R
-	};
-
-	std::vector<std::string> codes = {
-		"utf-8",
-		"utf-16",
-		"iso-8859-1",
-		"koi8-r",
-	};
-
-	for (const auto& code : codes) {
-		for (const auto& input : inputs) {
-			const std::string fromcode = code;
-
-			std::string tocode = code;
-			std::transform(tocode.begin(), tocode.end(), tocode.begin(), ::toupper);
-
-			verify_convert_text(input, tocode, fromcode, input);
-		}
-	}
+	verify_convert_text(input, "UTF-8", "UTF-8", expected);
 }
 
 TEST_CASE("convert_text() replaces incomplete multibyte sequences with a question mark: utf8 to utf16le",


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/1437

Verified using [response.txt](https://github.com/newsboat/newsboat/files/9944745/response.txt) and urls file:
```
filter:cat:http://localhost:8000
```
while running `cat response.txt | nc -l -p 8000`

When reloading, this will result in a title with a lot of question marks, but at least Newsboat does not crash anymore.
