### PR TITLE
Add article-feed operation

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -71,3 +71,4 @@ macro-prefix||kbd:[,]||Initiate macro execution. The next key press selects the 
 switch-focus||kbd:[TAB]||Switch focus between widgets. This is currently only applicable to the `filebrowser` and `dirbrowser` contexts.
 goto-title||n/a||Go to item whose title contains the specified string (case-insensitive).
 prevsearchresults||kbd:[Z]||Return to previous search results (if any). This only works from `searchresultslist`.
+article-feed||n/a||Go to the feed of the currently selected article.

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -94,6 +94,7 @@ enum Operation {
 	OP_REVSORT,
 	OP_NB_MAX,
 	OP_PREVSEARCHRESULTS,
+	OP_ARTICLEFEED,
 
 	// podboat-specific operations:
 	OP_PB_MIN = 1000,

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -747,6 +747,20 @@ bool ItemListFormAction::process_operation(Operation op,
 			return false;
 		}
 		break;
+	case OP_ARTICLEFEED: {
+		auto feeds = v->get_ctrl()->get_feedcontainer()->get_all_feeds();
+		size_t pos;
+		auto article_feed = visible_items[itempos].first->get_feedptr();
+		for (pos = 0; pos < feeds.size(); pos++) {
+			if (feeds[pos] == article_feed) {
+				break;
+			}
+		}
+		if (pos != feeds.size()) {
+			v->push_itemlist(pos);
+		}
+	}
+	break;
 	default:
 		ListFormAction::process_operation(op, automatic, args);
 		break;

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -459,6 +459,20 @@ bool ItemViewFormAction::process_operation(Operation op,
 		}
 	}
 	break;
+	case OP_ARTICLEFEED: {
+		auto feeds = v->get_ctrl()->get_feedcontainer()->get_all_feeds();
+		size_t pos;
+		auto article_feed = item->get_feedptr();
+		for (pos = 0; pos < feeds.size(); pos++) {
+			if (feeds[pos] == article_feed) {
+				break;
+			}
+		}
+		if (pos != feeds.size()) {
+			v->push_itemlist(pos);
+		}
+	}
+	break;
 	default:
 		break;
 	}

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -406,6 +406,13 @@ static const std::vector<OpDesc> opdescs = {
 		translatable("Return to previous search results (if any)"),
 		KM_SEARCHRESULTSLIST
 	},
+	{
+		OP_ARTICLEFEED,
+		"article-feed",
+		"",
+		translatable("Go to the feed of the article"),
+		KM_ARTICLE | KM_ARTICLELIST | KM_SEARCHRESULTSLIST
+	},
 
 	{OP_OPEN_URL_1, "one", "1", translatable("Open URL 1"), KM_URLVIEW | KM_ARTICLE},
 	{OP_OPEN_URL_2, "two", "2", translatable("Open URL 2"), KM_URLVIEW | KM_ARTICLE},


### PR DESCRIPTION
This adds an operation to go to the currently selected article's feed. I find it useful in query feeds or searches.

First time contributing to newsboat, please let me know if I should make any modifications :)