### PR TITLE
Fix incorrect command in Spanish localization

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -155,7 +155,7 @@ msgid ""
 "Newsboat is free software licensed under the MIT License. (Type `%s -vv' to "
 "see the full text.)"
 msgstr ""
-"Newsboat es un programa libre con licencia MIT. (Escribe `%s --vv' para ver "
+"Newsboat es un programa libre con licencia MIT. (Escribe `%s -vv' para ver "
 "el texto completo)."
 
 #: newsboat.cpp:178


### PR DESCRIPTION
I use Newsboat with the Spanish localization, and I noticed when I ran `newsboat -v` I got the message:
> (Escribe `newsboat --vv' para ver el texto completo)

When I ran `newsboat --vv` it didn't work, but I noticed if I changed the command to `newsboat -vv` it worked correctly, so it was just a problem in the Spanish localization. I've fixed this in this PR