### PR TITLE
Use feed level author if entry does not have one

### DIFF
--- a/rss/atomparser.cpp
+++ b/rss/atomparser.cpp
@@ -36,6 +36,7 @@ void AtomParser::parse_feed(Feed& f, xmlNode* rootNode)
 
 	f.language = get_prop(rootNode, "lang");
 	globalbase = get_prop(rootNode, "base", XML_URI);
+	std::string author;
 
 	for (xmlNode* node = rootNode->children; node != nullptr;
 		node = node->next) {
@@ -55,8 +56,18 @@ void AtomParser::parse_feed(Feed& f, xmlNode* rootNode)
 			}
 		} else if (node_is(node, "updated", ns)) {
 			f.pubDate = w3cdtf_to_rfc822(get_content(node));
+		} else if (node_is(node, "author", ns)) {
+			parse_and_update_author(node, author);
 		} else if (node_is(node, "entry", ns)) {
 			f.items.push_back(parse_entry(node));
+		}
+	}
+
+	if (!author.empty()) {
+		for (auto& it : f.items) {
+			if (it.author.empty()) {
+				it.author = author;
+			}
 		}
 	}
 }
@@ -76,16 +87,7 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 	for (xmlNode* node = entryNode->children; node != nullptr;
 		node = node->next) {
 		if (node_is(node, "author", ns)) {
-			for (xmlNode* authornode = node->children;
-				authornode != nullptr;
-				authornode = authornode->next) {
-				if (node_is(authornode, "name", ns)) {
-					if (!it.author.empty()) {
-						it.author += ", ";
-					}
-					it.author += get_content(authornode);
-				} // TODO: is there more?
-			}
+			parse_and_update_author(node, it.author);
 		} else if (node_is(node, "title", ns)) {
 			it.title = get_content(node);
 			it.title_type = get_prop(node, "type");
@@ -164,6 +166,19 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 	}
 
 	return it;
+}
+
+void AtomParser::parse_and_update_author(xmlNode* authorNode, std::string& author)
+{
+	for (xmlNode* child = authorNode->children; child != nullptr;
+		child = child->next) {
+		if (node_is(child, "name", ns)) {
+			if (!author.empty()) {
+				author += ", ";
+			}
+			author += get_content(child);
+		}
+	}
 }
 
 std::string AtomParser::content_type_to_mime(const std::string& type)

--- a/rss/atomparser.cpp
+++ b/rss/atomparser.cpp
@@ -48,7 +48,7 @@ void AtomParser::parse_feed(Feed& f, xmlNode* rootNode)
 		} else if (node_is(node, "subtitle", ns)) {
 			f.description = get_content(node);
 		} else if (node_is(node, "link", ns)) {
-			std::string rel = get_prop(node, "rel");
+			const std::string rel = get_prop(node, "rel");
 			if (rel == "alternate") {
 				f.link = newsboat::utils::absolute_url(
 						globalbase, get_prop(node, "href"));
@@ -93,8 +93,8 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 				it.title_type = "text";
 			}
 		} else if (node_is(node, "content", ns)) {
-			std::string mode = get_prop(node, "mode");
-			std::string type = get_prop(node, "type");
+			const std::string mode = get_prop(node, "mode");
+			const std::string type = get_prop(node, "type");
 			if (mode == "xml" || mode == "") {
 				if (type == "html" || type == "text" || type == "text/plain") {
 					it.description = get_content(node);
@@ -117,7 +117,7 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 		} else if (node_is(node, "updated", ns)) {
 			updated = w3cdtf_to_rfc822(get_content(node));
 		} else if (node_is(node, "link", ns)) {
-			std::string rel = get_prop(node, "rel");
+			const std::string rel = get_prop(node, "rel");
 			if (rel == "" || rel == "alternate") {
 				if (it.link.empty() || !newsboat::utils::is_http_url(it.link)) {
 					it.link = newsboat::utils::absolute_url(

--- a/rss/atomparser.h
+++ b/rss/atomparser.h
@@ -21,6 +21,7 @@ struct AtomParser : public RssParser {
 
 private:
 	Item parse_entry(xmlNode* itemNode);
+	void parse_and_update_author(xmlNode* authorNode, std::string& author);
 	static std::string content_type_to_mime(const std::string& type);
 	const char* ns;
 };

--- a/test/data/atom10_2.xml
+++ b/test/data/atom10_2.xml
@@ -14,6 +14,10 @@
     <link href="http://example.com/1.html"/>
     <id>tag:example.com,2008-12-30:/1</id>
     <content type="html">regular html content</content>
+    <author>
+      <name>A Person</name>
+      <uri>http://example.com/</uri>
+    </author>
   </entry>
 
   <entry>

--- a/test/data/atom10_feed_authors.xml
+++ b/test/data/atom10_feed_authors.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+  <title>Author Test Feed</title>
+  <link rel="alternate" href="http://example.com/"/>
+  <updated>2022-11-28T14:01:25+01:00</updated>
+  <author>
+    <name>First Feed Author</name>
+  </author>
+  <id>urn:uuid:b5997c2b-110f-47e2-9007-5327f8d948da</id>
+
+  <entry>
+    <title>Entry Without Author</title>
+    <link href="http://example.com/1.html"/>
+    <id>http://example.com/1.html</id>
+    <content type="text">Feed authors should be used.</content>
+  </entry>
+
+  <entry>
+    <title>Entry With Single Author</title>
+    <link href="http://example.com/2.html"/>
+    <id>http://example.com/2.html</id>
+    <content type="text">Entry author should be used.</content>
+    <author>
+      <name>Entry Author</name>
+      <uri>http://example.com/</uri>
+    </author>
+  </entry>
+
+  <author>
+    <name>Second Feed Author</name>
+	<uri>http://example.com/actually-illegal-since-feed-author-must-appear-before-entry</uri>
+  </author>
+
+  <entry>
+    <title>Entry With Multiple Authors</title>
+    <author>
+      <name>Entry Author 1</name>
+      <uri>http://example.com/</uri>
+    </author>
+    <link href="http://example.com/3.html"/>
+    <id>http://example.com/3.html</id>
+    <content type="text">Both entry authors should be used.</content>
+    <author>
+      <name>Entry Author 2</name>
+      <uri>http://example.com/</uri>
+    </author>
+  </entry>
+
+  <entry>
+    <title>Entry With Empty Author Names</title>
+    <author>
+      <name></name>
+      <uri>http://example.com/</uri>
+    </author>
+    <link href="http://example.com/4.html"/>
+    <id>http://example.com/4.html</id>
+    <content type="text">Both feed authors should be used.</content>
+    <author>
+      <uri>http://example.com/</uri>
+    </author>
+  </entry>
+
+</feed>

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -236,27 +236,32 @@ TEST_CASE("Extracts data from media:... tags in atom feed", "[rsspp::Parser]")
 	REQUIRE(f.items[0].title == "using regular content");
 	REQUIRE(f.items[0].description == "regular html content");
 	REQUIRE(f.items[0].description_mime_type == "text/html");
+	REQUIRE(f.items[0].author == "A Person");
 
 	REQUIRE(f.items[1].title == "using media:description");
 	REQUIRE(f.items[1].description == "media plaintext content");
 	REQUIRE(f.items[1].description_mime_type == "text/plain");
+	REQUIRE(f.items[1].author == "John Doe");
 
 	REQUIRE(f.items[2].title == "using multiple media tags");
 	REQUIRE(f.items[2].description == "media html content");
 	REQUIRE(f.items[2].description_mime_type == "text/html");
 	REQUIRE(f.items[2].link == "http://example.com/player.html");
+	REQUIRE(f.items[2].author == "John Doe");
 
 	REQUIRE(f.items[3].title ==
 		"using multiple media tags nested in group/content");
 	REQUIRE(f.items[3].description == "nested media html content");
 	REQUIRE(f.items[3].description_mime_type == "text/html");
 	REQUIRE(f.items[3].link == "http://example.com/player.html");
+	REQUIRE(f.items[3].author == "John Doe");
 
 	SECTION("media:{title,description,player} does not overwrite regular title, description, and link if they exist") {
 		REQUIRE(f.items[4].title == "regular title");
 		REQUIRE(f.items[4].description == "regular content");
 		REQUIRE(f.items[4].description_mime_type == "text/html");
 		REQUIRE(f.items[4].link == "http://example.com/regular-link");
+		REQUIRE(f.items[4].author == "John Doe");
 	}
 }
 
@@ -297,4 +302,36 @@ TEST_CASE("Multiple links in item", "[rsspp::Parser]")
 
 	REQUIRE(f.items[0].title == "Multiple links");
 	REQUIRE(f.items[0].link == "http://www.test.org/tests");
+}
+
+TEST_CASE("Feed authors in atom feed", "[rsspp::Parser]")
+{
+	rsspp::Parser p;
+	rsspp::Feed f;
+
+	REQUIRE_NOTHROW(f = p.parse_file("data/atom10_feed_authors.xml"));
+
+	REQUIRE(f.rss_version == rsspp::Feed::ATOM_1_0);
+
+	REQUIRE(f.title == "Author Test Feed");
+	REQUIRE(f.title_type == "text");
+	REQUIRE(f.pubDate == "Mon, 28 Nov 2022 13:01:25 +0000");
+	REQUIRE(f.link == "http://example.com/");
+
+	REQUIRE(f.items.size() == 4u);
+	REQUIRE(f.items[0].title == "Entry Without Author");
+	REQUIRE(f.items[0].description == "Feed authors should be used.");
+	REQUIRE(f.items[0].author == "First Feed Author, Second Feed Author");
+
+	REQUIRE(f.items[1].title == "Entry With Single Author");
+	REQUIRE(f.items[1].description == "Entry author should be used.");
+	REQUIRE(f.items[1].author == "Entry Author");
+
+	REQUIRE(f.items[2].title == "Entry With Multiple Authors");
+	REQUIRE(f.items[2].description == "Both entry authors should be used.");
+	REQUIRE(f.items[2].author == "Entry Author 1, Entry Author 2");
+
+	REQUIRE(f.items[3].title == "Entry With Empty Author Names");
+	REQUIRE(f.items[3].description == "Both feed authors should be used.");
+	REQUIRE(f.items[3].author == "First Feed Author, Second Feed Author");
 }


### PR DESCRIPTION
This merge request only addresses the feed level author, but not the source element. As requested, I will create a separate MR for it. Hence, this one here just partially fixes #2256.

Three things to note upfront:

1. I'm not entirely sold on the method name `parse_and_update_author`. Maybe sb. comes up with something better.
2. Not sure if I should have created a new Atom feed for the test case or whether it's alright to reuse the already existing one.
3. Lastly, I don't consider myself an experienced C++ programmer, so please have a thorough look.