### PR TITLE
Utf8 string

### DIFF
--- a/config.h
+++ b/config.h
@@ -6,7 +6,7 @@
 
 #define PROGRAM_URL			"https://newsboat.org/"
 
-#define NEWSBEUTER_PATH_SEP			'/'
+#define NEWSBOAT_PATH_SEP			"/"
 #define NEWSBEUTER_CONFIG_SUBDIR	".newsbeuter"
 #define NEWSBEUTER_SUBDIR_XDG		"newsbeuter"
 #define NEWSBOAT_CONFIG_SUBDIR	".newsboat"

--- a/include/colormanager.h
+++ b/include/colormanager.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "configactionhandler.h"
+#include "utf8string.h"
 
 namespace podboat {
 class PbView;
@@ -18,9 +19,9 @@ namespace newsboat {
 class ConfigParser;
 
 struct TextStyle {
-	std::string fg_color;
-	std::string bg_color;
-	std::vector<std::string> attributes;
+	Utf8String fg_color;
+	Utf8String bg_color;
+	std::vector<Utf8String> attributes;
 };
 
 class ColorManager : public ConfigActionHandler {
@@ -28,18 +29,18 @@ public:
 	ColorManager();
 	~ColorManager() override;
 	void register_commands(ConfigParser& cfgparser);
-	void handle_action(const std::string& action,
-		const std::vector<std::string>& params) override;
-	void dump_config(std::vector<std::string>& config_output) const override;
-	void apply_colors(std::function<void(const std::string&, const std::string&)>
+	void handle_action(const Utf8String& action,
+		const std::vector<Utf8String>& params) override;
+	void dump_config(std::vector<Utf8String>& config_output) const override;
+	void apply_colors(std::function<void(const Utf8String&, const Utf8String&)>
 		stfl_value_setter) const;
 
 private:
-	void emit_fallback_from_to(const std::string& from_element, const std::string& to_element,
-		const std::function<void(const std::string&, const std::string&)>& stfl_value_setter)
+	void emit_fallback_from_to(const Utf8String& from_element, const Utf8String& to_element,
+		const std::function<void(const Utf8String&, const Utf8String&)>& stfl_value_setter)
 	const;
 
-	std::map<std::string, TextStyle> element_styles;
+	std::map<Utf8String, TextStyle> element_styles;
 };
 
 } // namespace newsboat

--- a/include/configactionhandler.h
+++ b/include/configactionhandler.h
@@ -1,25 +1,26 @@
 #ifndef NEWSBOAT_CONFIGACTIONHANDLER_H_
 #define NEWSBOAT_CONFIGACTIONHANDLER_H_
 
-#include <string>
 #include <vector>
+
+#include "utf8string.h"
 
 namespace newsboat {
 
 class ConfigActionHandler {
 public:
 	// Derived classes can override this function to handle the `params` string without the default tokenization
-	virtual void handle_action(const std::string& action,
-		const std::string& params);
+	virtual void handle_action(const Utf8String& action,
+		const Utf8String& params);
 
-	virtual void dump_config(std::vector<std::string>& config_output) const = 0;
+	virtual void dump_config(std::vector<Utf8String>& config_output) const = 0;
 	ConfigActionHandler() {}
 	virtual ~ConfigActionHandler() {}
 
 private:
 	// Derived classes should override either of the handle_action() overloads
-	virtual void handle_action(const std::string& action,
-		const std::vector<std::string>& params);
+	virtual void handle_action(const Utf8String& action,
+		const std::vector<Utf8String>& params);
 };
 
 } // namespace newsboat

--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -3,10 +3,10 @@
 
 #include <map>
 #include <mutex>
-#include <string>
 #include <vector>
 
 #include "configactionhandler.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -61,24 +61,24 @@ public:
 	ConfigContainer();
 	~ConfigContainer() override;
 	void register_commands(ConfigParser& cfgparser);
-	void handle_action(const std::string& action,
-		const std::vector<std::string>& params) override;
-	void dump_config(std::vector<std::string>& config_output) const override;
+	void handle_action(const Utf8String& action,
+		const std::vector<Utf8String>& params) override;
+	void dump_config(std::vector<Utf8String>& config_output) const override;
 
-	bool get_configvalue_as_bool(const std::string& key) const;
-	int get_configvalue_as_int(const std::string& key) const;
-	std::string get_configvalue(const std::string& key) const;
-	void set_configvalue(const std::string& key, const std::string& value);
-	void reset_to_default(const std::string& key);
-	void toggle(const std::string& key);
-	std::vector<std::string> get_suggestions(const std::string& fragment) const;
+	bool get_configvalue_as_bool(const Utf8String& key) const;
+	int get_configvalue_as_int(const Utf8String& key) const;
+	Utf8String get_configvalue(const Utf8String& key) const;
+	void set_configvalue(const Utf8String& key, const Utf8String& value);
+	void reset_to_default(const Utf8String& key);
+	void toggle(const Utf8String& key);
+	std::vector<Utf8String> get_suggestions(const Utf8String& fragment) const;
 	FeedSortStrategy get_feed_sort_strategy() const;
 	ArticleSortStrategy get_article_sort_strategy() const;
 
-	static const std::string PARTIAL_FILE_SUFFIX;
+	static const Utf8String PARTIAL_FILE_SUFFIX;
 
 private:
-	std::map<std::string, ConfigData> config_data;
+	std::map<Utf8String, ConfigData> config_data;
 	mutable std::recursive_mutex config_data_mtx;
 };
 

--- a/include/configdata.h
+++ b/include/configdata.h
@@ -1,10 +1,11 @@
 #ifndef NEWSBOAT_CONFIGDATA_H_
 #define NEWSBOAT_CONFIGDATA_H_
 
-#include <string>
 #include <unordered_set>
 
 #include "3rd-party/expected.hpp"
+
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -17,15 +18,15 @@ public:
 	/// Construct a value of type `t` and equal to `v`. If `multi_option` is
 	/// true and config file contains this option multiple times, the values
 	/// will be combined instead of rewritten.
-	ConfigData(const std::string& v = "",
+	ConfigData(const Utf8String& v = "",
 		ConfigDataType t = ConfigDataType::INVALID, bool multi_option = false);
 
 	/// Construct a value that can take any of given `values`, and currently
 	/// equal to `v` (which *must* be one of `values`).
-	ConfigData(const std::string& v, const std::unordered_set<std::string>& values);
+	ConfigData(const Utf8String& v, const std::unordered_set<Utf8String>& values);
 
 	/// Current value of the setting.
-	std::string value() const
+	Utf8String value() const
 	{
 		return value_;
 	}
@@ -33,10 +34,10 @@ public:
 	/// Change the setting's value to `new_value`.
 	///
 	/// On error, returns internationalized error message.
-	nonstd::expected<void, std::string> set_value(std::string new_value);
+	nonstd::expected<void, Utf8String> set_value(Utf8String new_value);
 
 	/// Default value of the setting.
-	std::string default_value() const
+	Utf8String default_value() const
 	{
 		return default_value_;
 	}
@@ -54,7 +55,7 @@ public:
 	}
 
 	/// Possible values of this setting if `type` is `ENUM`.
-	const std::unordered_set<std::string>& enum_values() const
+	const std::unordered_set<Utf8String>& enum_values() const
 	{
 		return enum_values_;
 	}
@@ -67,10 +68,10 @@ public:
 	}
 
 private:
-	std::string value_;
-	std::string default_value_;
+	Utf8String value_;
+	Utf8String default_value_;
 	ConfigDataType type_;
-	std::unordered_set<std::string> enum_values_;
+	std::unordered_set<Utf8String> enum_values_;
 	bool multi_option_;
 };
 

--- a/include/configexception.h
+++ b/include/configexception.h
@@ -2,13 +2,14 @@
 #define NEWSBOAT_CONFIGEXCEPTION_H_
 
 #include <stdexcept>
-#include <string>
+
+#include "utf8string.h"
 
 namespace newsboat {
 
 class ConfigException : public std::exception {
 public:
-	explicit ConfigException(const std::string& errmsg)
+	explicit ConfigException(const Utf8String& errmsg)
 		: msg(errmsg)
 	{
 	}
@@ -19,7 +20,7 @@ public:
 	}
 
 private:
-	std::string msg;
+	Utf8String msg;
 };
 
 } // namespace newsboat

--- a/include/confighandlerexception.h
+++ b/include/confighandlerexception.h
@@ -2,7 +2,8 @@
 #define NEWSBOAT_CONFIGHANDLEREXCEPTION_H_
 
 #include <stdexcept>
-#include <string>
+
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -10,7 +11,7 @@ enum class ActionHandlerStatus;
 
 class ConfigHandlerException : public std::exception {
 public:
-	explicit ConfigHandlerException(const std::string& emsg)
+	explicit ConfigHandlerException(const Utf8String& emsg)
 		: msg(emsg)
 	{
 	}
@@ -26,8 +27,8 @@ public:
 	}
 
 private:
-	const char* get_errmsg(ActionHandlerStatus e);
-	std::string msg;
+	Utf8String get_errmsg(ActionHandlerStatus e);
+	Utf8String msg;
 };
 
 } // namespace newsboat

--- a/include/configparser.h
+++ b/include/configparser.h
@@ -5,6 +5,7 @@
 #include <map>
 
 #include "configactionhandler.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -20,11 +21,11 @@ class ConfigParser : public ConfigActionHandler {
 public:
 	ConfigParser();
 	~ConfigParser() override;
-	void register_handler(const std::string& cmd,
+	void register_handler(const Utf8String& cmd,
 		ConfigActionHandler& handler);
-	void handle_action(const std::string& action,
-		const std::vector<std::string>& params) override;
-	void dump_config(std::vector<std::string>&) const override
+	void handle_action(const Utf8String& action,
+		const std::vector<Utf8String>& params) override;
+	void dump_config(std::vector<Utf8String>&) const override
 	{
 		/* nothing because ConfigParser itself only handles include */
 	}
@@ -37,17 +38,17 @@ public:
 	///
 	/// If the file contains any errors, throws `ConfigException` with
 	/// a message explaining the problem.
-	bool parse_file(const std::string& filename);
+	bool parse_file(const Utf8String& filename);
 
-	void parse_line(const std::string& line, const std::string& location);
-	static std::string evaluate_backticks(std::string token);
+	void parse_line(const Utf8String& line, const Utf8String& location);
+	static Utf8String evaluate_backticks(Utf8String token);
 
 private:
-	static std::string evaluate_cmd(const std::string& cmd);
-	std::vector<std::vector<std::string>> parsed_content;
-	std::map<std::string, std::reference_wrapper<ConfigActionHandler>>
+	static Utf8String evaluate_cmd(const Utf8String& cmd);
+	std::vector<std::vector<Utf8String>> parsed_content;
+	std::map<Utf8String, std::reference_wrapper<ConfigActionHandler>>
 		action_handlers;
-	std::vector<std::string> included_files;
+	std::vector<Utf8String> included_files;
 };
 
 } // namespace newsboat

--- a/include/dbexception.h
+++ b/include/dbexception.h
@@ -5,12 +5,16 @@
 #include <stdexcept>
 #include <string>
 
+#include "utf8string.h"
+
 namespace newsboat {
 
 class DbException : public std::exception {
 public:
 	explicit DbException(sqlite3* h)
-		: msg(sqlite3_errmsg(h))
+	// SQLite guarantees that the result of `sqlite3_errmsg` is UTF-8:
+	// https://sqlite.org/c3ref/errcode.html
+		: msg(Utf8String::from_utf8(sqlite3_errmsg(h)))
 	{
 	}
 	~DbException() throw() override {}
@@ -20,7 +24,7 @@ public:
 	}
 
 private:
-	std::string msg;
+	Utf8String msg;
 };
 
 } // namespace newsboat

--- a/include/dialogsformaction.h
+++ b/include/dialogsformaction.h
@@ -3,27 +3,28 @@
 
 #include "formaction.h"
 #include "listwidget.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
 class DialogsFormAction : public FormAction {
 public:
-	DialogsFormAction(View*, std::string formstr, ConfigContainer* cfg);
+	DialogsFormAction(View*, Utf8String formstr, ConfigContainer* cfg);
 	~DialogsFormAction() override;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
-	std::string id() const override
+	Utf8String id() const override
 	{
 		return "dialogs";
 	}
-	std::string title() override;
-	void handle_cmdline(const std::string& cmd) override;
+	Utf8String title() override;
+	void handle_cmdline(const Utf8String& cmd) override;
 
 private:
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+		std::vector<Utf8String>* args = nullptr) override;
 	void update_heading();
 
 	ListWidget dialogs_list;

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -39,8 +39,6 @@ private:
 
 	std::string get_formatted_dirname(std::string dirname, mode_t mode);
 
-	std::string cwd;
-
 	ListWidget files_list;
 };
 

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -9,35 +9,36 @@
 #include "formaction.h"
 #include "listformatter.h"
 #include "listwidget.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
 class DirBrowserFormAction : public FormAction {
 public:
-	DirBrowserFormAction(View*, std::string formstr, ConfigContainer* cfg);
+	DirBrowserFormAction(View*, Utf8String formstr, ConfigContainer* cfg);
 	~DirBrowserFormAction() override;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
 
-	std::string id() const override
+	Utf8String id() const override
 	{
 		return "dirbrowser";
 	}
-	std::string title() override;
+	Utf8String title() override;
 
 private:
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
-	void update_title(const std::string& working_directory);
+		std::vector<Utf8String>* args = nullptr) override;
+	void update_title(const Utf8String& working_directory);
 
 	void add_directory(ListFormatter& listfmt,
 		std::vector<file_system::FileSystemEntry>& id_at_position,
-		std::string dirname);
+		Utf8String dirname);
 	std::vector<file_system::FileSystemEntry> id_at_position;
 
-	std::string get_formatted_dirname(std::string dirname, mode_t mode);
+	Utf8String get_formatted_dirname(Utf8String dirname, mode_t mode);
 
 	ListWidget files_list;
 };

--- a/include/download.h
+++ b/include/download.h
@@ -2,7 +2,10 @@
 #define PODBOAT_DOWNLOAD_H_
 
 #include <functional>
-#include <string>
+
+#include "utf8string.h"
+
+using newsboat::Utf8String;
 
 namespace podboat {
 
@@ -24,22 +27,22 @@ public:
 	explicit Download(std::function<void()> cb_require_view_update);
 	~Download();
 	double percents_finished() const;
-	const std::string status_text() const;
+	const Utf8String status_text() const;
 	DlStatus status() const
 	{
 		return download_status;
 	}
-	const std::string& status_msg() const
+	const Utf8String& status_msg() const
 	{
 		return msg;
 	}
-	const std::string filename() const;
-	const std::string basename() const;
-	const std::string url() const;
-	void set_filename(const std::string& str);
-	void set_url(const std::string& url);
+	const Utf8String filename() const;
+	const Utf8String basename() const;
+	const Utf8String url() const;
+	void set_filename(const Utf8String& str);
+	void set_url(const Utf8String& url);
 	void set_progress(double downloaded, double total);
-	void set_status(DlStatus dls, const std::string& msg_ = {});
+	void set_status(DlStatus dls, const Utf8String& msg_ = {});
 	void set_kbps(double kbps);
 	double kbps() const;
 	void set_offset(unsigned long offset);
@@ -54,10 +57,10 @@ public:
 	}
 
 private:
-	std::string fn;
-	std::string url_;
+	Utf8String fn;
+	Utf8String url_;
 	DlStatus download_status;
-	std::string msg;
+	Utf8String msg;
 	double cursize;
 	double totalsize;
 	double curkbps;

--- a/include/emptyformaction.h
+++ b/include/emptyformaction.h
@@ -2,16 +2,17 @@
 #define NEWSBOAT_EMPTYFORMACTION_H_
 
 #include "formaction.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
 class EmptyFormAction : public FormAction {
 public:
-	EmptyFormAction(View* v, const std::string& formstr, ConfigContainer* cfg);
+	EmptyFormAction(View* v, const Utf8String& formstr, ConfigContainer* cfg);
 	virtual ~EmptyFormAction() = default;
 
-	std::string id() const override;
-	std::string title() override;
+	Utf8String id() const override;
+	Utf8String title() override;
 
 	void init() override;
 	void prepare() override;
@@ -21,7 +22,7 @@ public:
 protected:
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+		std::vector<Utf8String>* args = nullptr) override;
 };
 
 } // namespace newsboat

--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -9,15 +9,16 @@
 #include "matcher.h"
 #include "regexmanager.h"
 #include "view.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
-typedef std::pair<std::shared_ptr<RssFeed>, unsigned int> FeedPtrPosPair;
+using FeedPtrPosPair = std::pair<std::shared_ptr<RssFeed>, unsigned int>;
 
 class FeedListFormAction : public ListFormAction {
 public:
 	FeedListFormAction(View*,
-		std::string formstr,
+		Utf8String formstr,
 		Cache* cc,
 		FilterContainer& f,
 		ConfigContainer* cfg,
@@ -30,11 +31,11 @@ public:
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
 	std::shared_ptr<RssFeed> get_feed();
 
-	std::string id() const override
+	Utf8String id() const override
 	{
 		return "feedlist";
 	}
-	std::string title() override;
+	Utf8String title() override;
 
 	bool jump_to_next_unread_feed(unsigned int& feedpos);
 	bool jump_to_previous_unread_feed(unsigned int& feedpos);
@@ -42,7 +43,7 @@ public:
 	bool jump_to_previous_feed(unsigned int& feedpos);
 	bool jump_to_random_unread_feed(unsigned int& feedpos);
 
-	void handle_cmdline(const std::string& cmd) override;
+	void handle_cmdline(const Utf8String& cmd) override;
 
 	void finished_qna(Operation op) override;
 
@@ -59,11 +60,11 @@ private:
 	int get_pos(unsigned int realidx);
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+		std::vector<Utf8String>* args = nullptr) override;
 
 	bool open_position_in_browser(unsigned int pos, bool interactive) const;
 
-	void goto_feed(const std::string& str);
+	void goto_feed(const Utf8String& str);
 
 	void save_filterpos();
 
@@ -71,24 +72,24 @@ private:
 	void op_start_search();
 
 	void handle_cmdline_num(unsigned int idx);
-	void handle_tag(const std::string& params);
-	void handle_goto(const std::string& param);
+	void handle_tag(const Utf8String& params);
+	void handle_goto(const Utf8String& param);
 	void set_pos();
 
-	std::string get_title(std::shared_ptr<RssFeed> feed);
+	Utf8String get_title(std::shared_ptr<RssFeed> feed);
 
-	std::string format_line(const std::string& feedlist_format,
+	Utf8String format_line(const Utf8String& feedlist_format,
 		std::shared_ptr<RssFeed> feed,
 		unsigned int pos,
 		unsigned int width);
 
 	bool zero_feedpos;
 	std::vector<FeedPtrPosPair> visible_feeds;
-	std::string tag;
+	Utf8String tag;
 
 	Matcher matcher;
 	bool filter_active;
-	void apply_filter(const std::string& filter_query);
+	void apply_filter(const Utf8String& filter_query);
 
 	History filterhistory;
 

--- a/include/file_system.h
+++ b/include/file_system.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <sys/stat.h>
 
+#include "utf8string.h"
+
 #include "3rd-party/optional.hpp"
 
 namespace newsboat {
@@ -35,19 +37,19 @@ nonstd::optional<char> mode_suffix(mode_t mode);
 /// An entry in a listing, e.g. a file, a directory or suchlike.
 struct FileSystemEntry {
 	FileType filetype;
-	std::string name;
+	Utf8String name;
 };
 
 /// The name of the user with a given UID, padded on the right to the width of
 /// 8 characters. If the name is unknown, returns 8 question marks.
-std::string get_user_padded(uid_t uid);
+Utf8String get_user_padded(uid_t uid);
 
 /// The name of the group with a given GID, padded on the right to the width of
 /// 8 characters. If the name is unknown, returns 8 question marks.
-std::string get_group_padded(gid_t gid);
+Utf8String get_group_padded(gid_t gid);
 
 /// Convert permissions into an rwxrwxrwx-style string.
-std::string permissions_string(mode_t mode);
+Utf8String permissions_string(mode_t mode);
 
 } // namespace file_system
 

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -9,43 +9,44 @@
 #include "formaction.h"
 #include "listformatter.h"
 #include "listwidget.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
 class FileBrowserFormAction : public FormAction {
 public:
-	FileBrowserFormAction(View*, std::string formstr, ConfigContainer* cfg);
+	FileBrowserFormAction(View*, Utf8String formstr, ConfigContainer* cfg);
 	~FileBrowserFormAction() override;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
 
-	void set_default_filename(const std::string& fn)
+	void set_default_filename(const Utf8String& fn)
 	{
 		default_filename = fn;
 	}
 
-	std::string id() const override
+	Utf8String id() const override
 	{
 		return "filebrowser";
 	}
-	std::string title() override;
+	Utf8String title() override;
 
 private:
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
-	void update_title(const std::string& working_directory);
+		std::vector<Utf8String>* args = nullptr) override;
+	void update_title(const Utf8String& working_directory);
 
 	void add_file(ListFormatter& listfmt,
 		std::vector<file_system::FileSystemEntry>& id_at_position,
-		std::string filename);
-	std::string get_filename_suggestion(const std::string& s);
+		Utf8String filename);
+	Utf8String get_filename_suggestion(const Utf8String& s);
 	std::vector<file_system::FileSystemEntry> id_at_position;
 
-	std::string get_formatted_filename(std::string filename, mode_t mode);
+	Utf8String get_formatted_filename(Utf8String filename, mode_t mode);
 
-	std::string default_filename;
+	Utf8String default_filename;
 
 	ListWidget files_list;
 };

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -45,8 +45,6 @@ private:
 
 	std::string get_formatted_filename(std::string filename, mode_t mode);
 
-	bool quit;
-	std::string cwd;
 	std::string default_filename;
 
 	ListWidget files_list;

--- a/include/filtercontainer.h
+++ b/include/filtercontainer.h
@@ -24,7 +24,7 @@ public:
 	void handle_action(const std::string& action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;
-	std::vector<FilterNameExprPair>& get_filters()
+	const std::vector<FilterNameExprPair>& get_filters() const
 	{
 		return filters;
 	}

--- a/include/filtercontainer.h
+++ b/include/filtercontainer.h
@@ -2,6 +2,7 @@
 #define NEWSBOAT_FILTERCONTAINER_H_
 
 #include "configactionhandler.h"
+#include "utf8string.h"
 
 #include "3rd-party/optional.hpp"
 
@@ -11,19 +12,19 @@ namespace newsboat {
 /// `define-filter` configuration option
 struct FilterNameExprPair {
 	/// Name of the filter
-	std::string name;
+	Utf8String name;
 
 	/// Filter expression for this named filter
-	std::string expr;
+	Utf8String expr;
 };
 
 class FilterContainer : public ConfigActionHandler {
 public:
 	FilterContainer() = default;
 	~FilterContainer() override;
-	void handle_action(const std::string& action,
-		const std::vector<std::string>& params) override;
-	void dump_config(std::vector<std::string>& config_output) const override;
+	void handle_action(const Utf8String& action,
+		const std::vector<Utf8String>& params) override;
+	void dump_config(std::vector<Utf8String>& config_output) const override;
 	const std::vector<FilterNameExprPair>& get_filters() const
 	{
 		return filters;
@@ -33,7 +34,7 @@ public:
 		return filters.size();
 	}
 
-	nonstd::optional<std::string> get_filter(const std::string& name);
+	nonstd::optional<Utf8String> get_filter(const Utf8String& name);
 
 private:
 	std::vector<FilterNameExprPair> filters;

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -2,13 +2,13 @@
 #define NEWSBOAT_FORMACTION_H_
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "history.h"
 #include "keymap.h"
 #include "listwidget.h"
 #include "stflpp.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -16,7 +16,7 @@ class ConfigContainer;
 class RssFeed;
 class View;
 
-typedef std::pair<std::string, std::string> QnaPair;
+using QnaPair = std::pair<Utf8String, Utf8String>;
 
 enum class CommandType {
 	QUIT,
@@ -28,17 +28,17 @@ enum class CommandType {
 	DUMPCONFIG,
 	EXEC,
 	UNKNOWN,	/// Unknown/non-existing command. Tokenized input is stored in Command.args
-	INVALID, 	/// differs from UNKNOWN in that no input was parsed
+	INVALID,	/// differs from UNKNOWN in that no input was parsed
 };
 
 struct Command {
 	CommandType type;
-	std::vector<std::string> args;
+	std::vector<Utf8String> args;
 };
 
 class FormAction {
 public:
-	FormAction(View*, std::string formstr, ConfigContainer* cfg);
+	FormAction(View*, Utf8String formstr, ConfigContainer* cfg);
 	virtual ~FormAction();
 	virtual void prepare() = 0;
 	virtual void init() = 0;
@@ -49,24 +49,24 @@ public:
 
 	virtual const std::vector<KeyMapHintEntry>& get_keymap_hint() const = 0;
 
-	virtual std::string id() const = 0;
+	virtual Utf8String id() const = 0;
 
-	std::string get_value(const std::string& name);
-	void set_value(const std::string& name, const std::string& value);
+	Utf8String get_value(const Utf8String& name);
+	void set_value(const Utf8String& name, const Utf8String& value);
 
 	void draw_form();
-	std::string draw_form_wait_for_event(unsigned int timeout);
+	Utf8String draw_form_wait_for_event(unsigned int timeout);
 	void recalculate_widget_dimensions();
 
-	virtual void handle_cmdline(const std::string& cmd);
+	virtual void handle_cmdline(const Utf8String& cmd);
 
 	bool process_op(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr);
+		std::vector<Utf8String>* args = nullptr);
 
 	virtual void finished_qna(Operation op);
 
-	void start_cmdline(std::string default_value = "");
+	void start_cmdline(Utf8String default_value = "");
 
 	void start_qna(const std::vector<QnaPair>& prompts,
 		Operation finish_op,
@@ -81,34 +81,34 @@ public:
 		return parent_formaction;
 	}
 
-	virtual std::string title() = 0;
+	virtual Utf8String title() = 0;
 
-	virtual std::vector<std::string> get_suggestions(
-		const std::string& fragment);
+	virtual std::vector<Utf8String> get_suggestions(
+		const Utf8String& fragment);
 
-	static void load_histories(const std::string& searchfile,
-		const std::string& cmdlinefile);
-	static void save_histories(const std::string& searchfile,
-		const std::string& cmdlinefile,
+	static void load_histories(const Utf8String& searchfile,
+		const Utf8String& cmdlinefile);
+	static void save_histories(const Utf8String& searchfile,
+		const Utf8String& cmdlinefile,
 		unsigned int limit);
 
-	std::string bookmark(const std::string& url,
-		const std::string& title,
-		const std::string& description,
-		const std::string& feed_title);
+	Utf8String bookmark(const Utf8String& url,
+		const Utf8String& title,
+		const Utf8String& description,
+		const Utf8String& feed_title);
 
 protected:
 	virtual bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) = 0;
+		std::vector<Utf8String>* args = nullptr) = 0;
 	virtual void set_keymap_hints();
 
-	void start_bookmark_qna(const std::string& default_title,
-		const std::string& default_url,
-		const std::string& default_feed_title);
+	void start_bookmark_qna(const Utf8String& default_title,
+		const Utf8String& default_url,
+		const Utf8String& default_feed_title);
 
-	static Command parse_command(const std::string& input,
-		std::string delimiters = " \r\n\t");
+	static Command parse_command(const Utf8String& input,
+		Utf8String delimiters = " \r\n\t");
 
 	void handle_parsed_command(const Command& command);
 
@@ -119,21 +119,21 @@ protected:
 	Stfl::Form f;
 	bool do_redraw;
 
-	std::vector<std::string> qna_responses;
+	std::vector<Utf8String> qna_responses;
 
 	static History searchhistory;
 	static History cmdlinehistory;
 
-	std::vector<std::string> valid_cmds;
+	std::vector<Utf8String> valid_cmds;
 
 private:
 	void start_next_question();
-	bool handle_single_argument_set(std::string argument);
-	void handle_set(const std::vector<std::string>& args);
+	bool handle_single_argument_set(Utf8String argument);
+	void handle_set(const std::vector<Utf8String>& args);
 	void handle_quit();
-	void handle_source(const std::vector<std::string>& args);
-	void handle_dumpconfig(const std::vector<std::string>& args);
-	void handle_exec(const std::vector<std::string>& args);
+	void handle_source(const std::vector<Utf8String>& args);
+	void handle_dumpconfig(const std::vector<Utf8String>& args);
+	void handle_exec(const std::vector<Utf8String>& args);
 
 	std::vector<QnaPair> qna_prompts;
 	Operation finish_operation;

--- a/include/helpformaction.h
+++ b/include/helpformaction.h
@@ -3,34 +3,35 @@
 
 #include "formaction.h"
 #include "textviewwidget.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
 class HelpFormAction : public FormAction {
 public:
-	HelpFormAction(View*, std::string formstr, ConfigContainer* cfg,
-		const std::string& ctx);
+	HelpFormAction(View*, Utf8String formstr, ConfigContainer* cfg,
+		const Utf8String& ctx);
 	~HelpFormAction() override;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
-	std::string id() const override
+	Utf8String id() const override
 	{
 		return "help";
 	}
-	std::string title() override;
+	Utf8String title() override;
 
 	void finished_qna(Operation op) override;
 
 private:
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
-	std::string make_colorstring(const std::vector<std::string>& colors);
+		std::vector<Utf8String>* args = nullptr) override;
+	Utf8String make_colorstring(const std::vector<Utf8String>& colors);
 	bool quit;
 	bool apply_search;
-	std::string searchphrase;
-	const std::string context;
+	Utf8String searchphrase;
+	const Utf8String context;
 	TextviewWidget textview;
 };
 

--- a/include/history.h
+++ b/include/history.h
@@ -3,7 +3,7 @@
 
 #include "libnewsboat-ffi/src/history.rs.h"
 
-#include <string>
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -11,11 +11,11 @@ class History {
 public:
 	History();
 	~History() = default;
-	void add_line(const std::string& line);
-	std::string previous_line();
-	std::string next_line();
-	void load_from_file(const std::string& file);
-	void save_to_file(const std::string& file, unsigned int limit);
+	void add_line(const Utf8String& line);
+	Utf8String previous_line();
+	Utf8String next_line();
+	void load_from_file(const Utf8String& file);
+	void save_to_file(const Utf8String& file, unsigned int limit);
 
 private:
 	rust::Box<history::bridged::History> rs_object;

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -12,6 +12,7 @@
 #include "listformatter.h"
 #include "regexmanager.h"
 #include "view.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -24,7 +25,7 @@ enum class InvalidationMode { NONE, PARTIAL, COMPLETE };
 class ItemListFormAction : public ListFormAction {
 public:
 	ItemListFormAction(View*,
-		std::string formstr,
+		Utf8String formstr,
 		Cache* cc,
 		FilterContainer& f,
 		ConfigContainer* cfg,
@@ -35,11 +36,11 @@ public:
 
 	void set_feed(std::shared_ptr<RssFeed> fd);
 
-	std::string id() const override
+	Utf8String id() const override
 	{
 		return "articlelist";
 	}
-	std::string title() override;
+	Utf8String title() override;
 
 	std::shared_ptr<RssFeed> get_feed()
 	{
@@ -49,7 +50,7 @@ public:
 	{
 		pos = p;
 	}
-	std::string get_guid();
+	Utf8String get_guid();
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
 
 	bool jump_to_next_unread_item(bool start_with_first);
@@ -58,7 +59,7 @@ public:
 	bool jump_to_previous_item(bool start_with_last);
 	bool jump_to_random_unread_item();
 
-	void handle_cmdline(const std::string& cmd) override;
+	void handle_cmdline(const Utf8String& cmd) override;
 
 	void finished_qna(Operation op) override;
 
@@ -72,7 +73,7 @@ public:
 protected:
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+		std::vector<Utf8String>* args = nullptr) override;
 
 	void invalidate(const unsigned int invalidated_pos)
 	{
@@ -84,10 +85,10 @@ protected:
 		invalidated_itempos.push_back(invalidated_pos);
 	}
 
-	virtual FmtStrFormatter setup_head_formatter(const std::string& s,
+	virtual FmtStrFormatter setup_head_formatter(const Utf8String& s,
 		unsigned int unread,
 		unsigned int total,
-		const std::string& url);
+		const Utf8String& url);
 
 	std::vector<ItemPtrPosPair> visible_items;
 	int old_itempos;
@@ -95,7 +96,7 @@ protected:
 
 	Matcher matcher;
 	bool filter_active;
-	void apply_filter(const std::string& filter_query);
+	void apply_filter(const Utf8String& filter_query);
 
 private:
 	void register_format_styles();
@@ -106,17 +107,17 @@ private:
 	bool open_position_in_browser(unsigned int pos,
 		bool interactive) const;
 
-	virtual void set_head(const std::string& s,
+	virtual void set_head(const Utf8String& s,
 		unsigned int unread,
 		unsigned int total,
-		const std::string& url);
+		const Utf8String& url);
 
 	int get_pos(unsigned int idx);
 
-	void save_article(const std::string& filename,
+	void save_article(const Utf8String& filename,
 		std::shared_ptr<RssItem> item);
 
-	void handle_save(const std::vector<std::string>& cmd_args);
+	void handle_save(const std::vector<Utf8String>& cmd_args);
 
 	void save_filterpos();
 
@@ -126,16 +127,16 @@ private:
 
 	void handle_cmdline_num(unsigned int idx);
 
-	std::string gen_flags(std::shared_ptr<RssItem> item);
+	Utf8String gen_flags(std::shared_ptr<RssItem> item);
 
 	void prepare_set_filterpos();
 
-	std::string item2formatted_line(const ItemPtrPosPair& item,
+	Utf8String item2formatted_line(const ItemPtrPosPair& item,
 		const unsigned int width,
-		const std::string& itemlist_format,
-		const std::string& datetime_format);
+		const Utf8String& itemlist_format,
+		const Utf8String& datetime_format);
 
-	void goto_item(const std::string& title);
+	void goto_item(const Utf8String& title);
 
 	void handle_op_saveall();
 

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -6,6 +6,7 @@
 #include "regexmanager.h"
 #include "textformatter.h"
 #include "textviewwidget.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -17,14 +18,14 @@ class ItemViewFormAction : public FormAction {
 public:
 	ItemViewFormAction(View*,
 		std::shared_ptr<ItemListFormAction> il,
-		std::string formstr,
+		Utf8String formstr,
 		Cache* cc,
 		ConfigContainer* cfg,
 		RegexManager& r);
 	~ItemViewFormAction() override;
 	void prepare() override;
 	void init() override;
-	void set_guid(const std::string& guid_)
+	void set_guid(const Utf8String& guid_)
 	{
 		guid = guid_;
 	}
@@ -32,23 +33,23 @@ public:
 	{
 		feed = fd;
 	}
-	void set_highlightphrase(const std::string& text);
+	void set_highlightphrase(const Utf8String& text);
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
-	void handle_cmdline(const std::string& cmd) override;
+	void handle_cmdline(const Utf8String& cmd) override;
 
-	std::string id() const override
+	Utf8String id() const override
 	{
 		return "article";
 	}
-	std::string title() override;
+	Utf8String title() override;
 
 	void finished_qna(Operation op) override;
 
 	void render_html(
-		const std::string& source,
-		std::vector<std::pair<LineType, std::string>>& lines,
+		const Utf8String& source,
+		std::vector<std::pair<LineType, Utf8String>>& lines,
 		std::vector<LinkPair>& thelinks,
-		const std::string& url);
+		const Utf8String& url);
 
 	void update_percent();
 
@@ -57,25 +58,25 @@ private:
 
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+		std::vector<Utf8String>* args = nullptr) override;
 
-	bool open_link_in_browser(const std::string& link, const std::string& type,
+	bool open_link_in_browser(const Utf8String& link, const Utf8String& type,
 		bool interactive) const;
 
 	void update_head(const std::shared_ptr<RssItem>& item);
-	void set_head(const std::string& s,
-		const std::string& feedtitle,
+	void set_head(const Utf8String& s,
+		const Utf8String& feedtitle,
 		unsigned int unread,
 		unsigned int total);
-	void highlight_text(const std::string& searchphrase);
+	void highlight_text(const Utf8String& searchphrase);
 
-	void render_source(std::vector<std::pair<LineType, std::string>>& lines,
-		std::string source);
+	void render_source(std::vector<std::pair<LineType, Utf8String>>& lines,
+		Utf8String source);
 
 	void do_search();
-	void handle_save(const std::string& filename_param);
+	void handle_save(const Utf8String& filename_param);
 
-	std::string guid;
+	Utf8String guid;
 	std::shared_ptr<RssFeed> feed;
 	std::shared_ptr<RssItem> item;
 	bool show_source;

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -210,8 +210,6 @@ public:
 	std::vector<KeyMapDesc> get_keymap_descriptions(std::string context);
 	const std::map<std::string, MacroBinding>& get_macro_descriptions();
 
-	ParsedOperations parse_operation_sequence(const std::string& line,
-		const std::string& command_name, bool allow_description = true);
 	std::vector<MacroCmd> get_startup_operation_sequence();
 
 	std::string prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints,
@@ -222,6 +220,9 @@ private:
 	unsigned short get_flag_from_context(const std::string& context);
 	std::map<std::string, Operation> get_internal_operations() const;
 	std::string getopname(Operation op) const;
+	ParsedOperations parse_operation_sequence(const std::string& line,
+		const std::string& command_name, bool allow_description = true);
+
 	std::map<std::string, std::map<std::string, Operation>> keymap_;
 	std::map<std::string, MacroBinding> macros_;
 	std::vector<MacroCmd> startup_operations_sequence;

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -2,11 +2,11 @@
 #define NEWSBOAT_KEYMAP_H_
 
 #include <map>
-#include <string>
 #include <utility>
 #include <vector>
 
 #include "configactionhandler.h"
+#include "utf8string.h"
 
 // in configuration: bind-key <key> <operation>
 
@@ -162,31 +162,31 @@ enum Operation {
 };
 
 struct KeyMapDesc {
-	std::string key;
-	std::string cmd;
-	std::string desc;
-	std::string ctx;
+	Utf8String key;
+	Utf8String cmd;
+	Utf8String desc;
+	Utf8String ctx;
 	unsigned short flags;
 };
 
 struct MacroCmd {
 	Operation op;
-	std::vector<std::string> args;
+	std::vector<Utf8String> args;
 };
 
 struct MacroBinding {
 	std::vector<MacroCmd> cmds;
-	std::string description;
+	Utf8String description;
 };
 
 struct ParsedOperations {
 	std::vector<MacroCmd> operations;
-	std::string description;
+	Utf8String description;
 };
 
 struct KeyMapHintEntry {
 	Operation op;
-	std::string text;
+	Utf8String text;
 };
 
 class KeyMap : public ConfigActionHandler {
@@ -194,37 +194,37 @@ public:
 	explicit KeyMap(unsigned int flags);
 	~KeyMap() override;
 	void set_key(Operation op,
-		const std::string& key,
-		const std::string& context);
-	void unset_key(const std::string& key, const std::string& context);
-	void unset_all_keys(const std::string& context);
-	Operation get_opcode(const std::string& opstr);
-	Operation get_operation(const std::string& keycode,
-		const std::string& context);
-	std::vector<MacroCmd> get_macro(const std::string& key);
-	char get_key(const std::string& keycode);
-	std::vector<std::string> get_keys(Operation op, const std::string& context);
-	void handle_action(const std::string& action,
-		const std::string& params) override;
-	void dump_config(std::vector<std::string>& config_output) const override;
-	std::vector<KeyMapDesc> get_keymap_descriptions(std::string context);
-	const std::map<std::string, MacroBinding>& get_macro_descriptions();
+		const Utf8String& key,
+		const Utf8String& context);
+	void unset_key(const Utf8String& key, const Utf8String& context);
+	void unset_all_keys(const Utf8String& context);
+	Operation get_opcode(const Utf8String& opstr);
+	Operation get_operation(const Utf8String& keycode,
+		const Utf8String& context);
+	std::vector<MacroCmd> get_macro(const Utf8String& key);
+	char get_key(const Utf8String& keycode);
+	std::vector<Utf8String> get_keys(Operation op, const Utf8String& context);
+	void handle_action(const Utf8String& action,
+		const Utf8String& params) override;
+	void dump_config(std::vector<Utf8String>& config_output) const override;
+	std::vector<KeyMapDesc> get_keymap_descriptions(Utf8String context);
+	const std::map<Utf8String, MacroBinding>& get_macro_descriptions();
 
 	std::vector<MacroCmd> get_startup_operation_sequence();
 
-	std::string prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints,
-		const std::string& context);
+	Utf8String prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints,
+		const Utf8String& context);
 
 private:
-	bool is_valid_context(const std::string& context);
-	unsigned short get_flag_from_context(const std::string& context);
-	std::map<std::string, Operation> get_internal_operations() const;
-	std::string getopname(Operation op) const;
-	ParsedOperations parse_operation_sequence(const std::string& line,
-		const std::string& command_name, bool allow_description = true);
+	bool is_valid_context(const Utf8String& context);
+	unsigned short get_flag_from_context(const Utf8String& context);
+	std::map<Utf8String, Operation> get_internal_operations() const;
+	Utf8String getopname(Operation op) const;
+	ParsedOperations parse_operation_sequence(const Utf8String& line,
+		const Utf8String& command_name, bool allow_description = true);
 
-	std::map<std::string, std::map<std::string, Operation>> keymap_;
-	std::map<std::string, MacroBinding> macros_;
+	std::map<Utf8String, std::map<Utf8String, Operation>> keymap_;
+	std::map<Utf8String, MacroBinding> macros_;
 	std::vector<MacroCmd> startup_operations_sequence;
 };
 

--- a/include/listformaction.h
+++ b/include/listformaction.h
@@ -7,18 +7,19 @@
 
 #include "formaction.h"
 #include "listwidget.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
 class ListFormAction : public FormAction {
 public:
-	ListFormAction(View*, std::string formstr, std::string list_name,
+	ListFormAction(View*, Utf8String formstr, Utf8String list_name,
 		ConfigContainer* cfg);
 
 protected:
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+		std::vector<Utf8String>* args = nullptr) override;
 	nonstd::optional<std::uint8_t> open_unread_items_in_browser(
 		std::shared_ptr<RssFeed> feed,
 		bool markread);

--- a/include/newsblurapi.h
+++ b/include/newsblurapi.h
@@ -7,8 +7,6 @@
 #include "rss/feed.h"
 #include "utils.h"
 
-#define ID_SEPARATOR "/////"
-
 using HTTPMethod = newsboat::utils::HTTPMethod;
 
 namespace newsboat {

--- a/include/newsblururlreader.h
+++ b/include/newsblururlreader.h
@@ -10,8 +10,6 @@ namespace newsboat {
 
 class RemoteApi;
 
-typedef std::map<std::string, rsspp::Feed> FeedMap;
-
 class NewsBlurUrlReader : public UrlReader {
 public:
 	NewsBlurUrlReader(const std::string& url_file, RemoteApi* a);

--- a/include/newsblururlreader.h
+++ b/include/newsblururlreader.h
@@ -4,8 +4,6 @@
 #include "rss/feed.h"
 #include "urlreader.h"
 
-#define ID_SEPARATOR "/////"
-
 namespace newsboat {
 
 class RemoteApi;

--- a/include/nullconfigactionhandler.h
+++ b/include/nullconfigactionhandler.h
@@ -2,6 +2,7 @@
 #define NEWSBOAT_NULLCONFIGACTIONHANDLER_H_
 
 #include "configactionhandler.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -9,11 +10,11 @@ class NullConfigActionHandler : public ConfigActionHandler {
 public:
 	NullConfigActionHandler() {}
 	~NullConfigActionHandler() override {}
-	void handle_action(const std::string&,
-		const std::vector<std::string>&) override
+	void handle_action(const Utf8String&,
+		const std::vector<Utf8String>&) override
 	{
 	}
-	void dump_config(std::vector<std::string>&) const override {}
+	void dump_config(std::vector<Utf8String>&) const override {}
 };
 
 } // namespace newsboat

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <regex.h>
 #include <regex>
-#include <string>
 #include <sys/types.h>
 #include <utility>
 #include <vector>
@@ -13,37 +12,38 @@
 #include "configactionhandler.h"
 #include "matcher.h"
 #include "regexowner.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
 class RegexManager : public ConfigActionHandler {
 public:
 	RegexManager();
-	void handle_action(const std::string& action,
-		const std::vector<std::string>& params) override;
-	void dump_config(std::vector<std::string>& config_output) const override;
-	void quote_and_highlight(std::string& str, const std::string& location);
-	void remove_last_regex(const std::string& location);
+	void handle_action(const Utf8String& action,
+		const std::vector<Utf8String>& params) override;
+	void dump_config(std::vector<Utf8String>& config_output) const override;
+	void quote_and_highlight(Utf8String& str, const Utf8String& location);
+	void remove_last_regex(const Utf8String& location);
 	int article_matches(Matchable* item);
 	int feed_matches(Matchable* feed);
-	std::map<size_t, std::string> extract_style_tags(std::string& str);
-	void insert_style_tags(std::string& str, std::map<size_t, std::string>& tags);
-	void merge_style_tag(std::map<size_t, std::string>& tags,
-		const std::string& tag,
+	std::map<size_t, Utf8String> extract_style_tags(Utf8String& str);
+	void insert_style_tags(Utf8String& str, std::map<size_t, Utf8String>& tags);
+	void merge_style_tag(std::map<size_t, Utf8String>& tags,
+		const Utf8String& tag,
 		size_t start, size_t end);
-	std::string get_attrs_stfl_string(const std::string& location, bool hasFocus);
+	Utf8String get_attrs_stfl_string(const Utf8String& location, bool hasFocus);
 
 private:
-	typedef std::vector<std::pair<std::shared_ptr<Regex>, std::string>>
+	typedef std::vector<std::pair<std::shared_ptr<Regex>, Utf8String>>
 		RegexStyleVector;
-	std::map<std::string, RegexStyleVector> locations;
-	std::vector<std::string> cheat_store_for_dump_config;
+	std::map<Utf8String, RegexStyleVector> locations;
+	std::vector<Utf8String> cheat_store_for_dump_config;
 	std::vector<std::pair<std::shared_ptr<Matcher>, int>> matchers_article;
 	std::vector<std::pair<std::shared_ptr<Matcher>, int>> matchers_feed;
 
-	void handle_highlight_action(const std::vector<std::string>& params);
-	void handle_highlight_item_action(const std::string& action,
-		const std::vector<std::string>& params);
+	void handle_highlight_action(const std::vector<Utf8String>& params);
+	void handle_highlight_item_action(const Utf8String& action,
+		const std::vector<Utf8String>& params);
 };
 
 } // namespace newsboat

--- a/include/rssignores.h
+++ b/include/rssignores.h
@@ -1,34 +1,34 @@
 #ifndef NEWSBOAT_RSSIGNORES_H_
 #define NEWSBOAT_RSSIGNORES_H_
 
-#include <string>
 #include <vector>
 
 #include "configactionhandler.h"
 #include "matcher.h"
 #include "rssitem.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
-typedef std::pair<std::string, std::shared_ptr<Matcher>> FeedUrlExprPair;
+typedef std::pair<Utf8String, std::shared_ptr<Matcher>> FeedUrlExprPair;
 
 class RssIgnores : public ConfigActionHandler {
 public:
 	RssIgnores() {}
 	~RssIgnores() override {}
-	void handle_action(const std::string& action,
-		const std::vector<std::string>& params) override;
-	void dump_config(std::vector<std::string>& config_output) const override;
+	void handle_action(const Utf8String& action,
+		const std::vector<Utf8String>& params) override;
+	void dump_config(std::vector<Utf8String>& config_output) const override;
 	bool matches(RssItem* item);
-	bool matches_lastmodified(const std::string& url);
-	bool matches_resetunread(const std::string& url);
+	bool matches_lastmodified(const Utf8String& url);
+	bool matches_resetunread(const Utf8String& url);
 
 private:
 	std::vector<FeedUrlExprPair> ignores;
-	std::vector<std::string> ignores_lastmodified;
-	std::vector<std::string> resetflag;
+	std::vector<Utf8String> ignores_lastmodified;
+	std::vector<Utf8String> resetflag;
 
-	static const std::string REGEX_PREFIX;
+	static const Utf8String REGEX_PREFIX;
 };
 
 } // namespace newsboat

--- a/include/searchresultslistformaction.h
+++ b/include/searchresultslistformaction.h
@@ -10,57 +10,58 @@
 #include "view.h"
 #include "keymap.h"
 #include "fmtstrformatter.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
 struct SearchResult {
 	std::shared_ptr<RssFeed> search_result_feed;
-	std::string search_phrase;
+	Utf8String search_phrase;
 };
 
 class SearchResultsListFormAction : public ItemListFormAction {
 public:
 	SearchResultsListFormAction(View* vv,
-		std::string formstr,
+		Utf8String formstr,
 		Cache* cc,
 		FilterContainer& f,
 		ConfigContainer* cfg,
 		RegexManager& r);
 
-	std::string id() const override
+	Utf8String id() const override
 	{
 		return "searchresultslist";
 	}
 
-	void set_searchphrase(const std::string& s)
+	void set_searchphrase(const Utf8String& s)
 	{
 		search_phrase = s;
 	}
 
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
 
-	void add_to_history(const std::shared_ptr<RssFeed>& feed, const std::string& str);
+	void add_to_history(const std::shared_ptr<RssFeed>& feed, const Utf8String& str);
 
-	void set_head(const std::string& s,
+	void set_head(const Utf8String& s,
 		unsigned int unread,
 		unsigned int total,
-		const std::string& url) override;
+		const Utf8String& url) override;
 
-	std::string title() override;
+	Utf8String title() override;
 
 protected:
-	FmtStrFormatter setup_head_formatter(const std::string& s,
+	FmtStrFormatter setup_head_formatter(const Utf8String& s,
 		unsigned int unread,
 		unsigned int total,
-		const std::string& url) override;
+		const Utf8String& url) override;
 
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+		std::vector<Utf8String>* args = nullptr) override;
 
 private:
 	std::stack<SearchResult> search_results;
-	std::string search_phrase;
+	Utf8String search_phrase;
 };
 
 } // namespace newsboat

--- a/include/selectformaction.h
+++ b/include/selectformaction.h
@@ -4,6 +4,7 @@
 #include "filtercontainer.h"
 #include "formaction.h"
 #include "listwidget.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -11,20 +12,20 @@ class SelectFormAction : public FormAction {
 public:
 	enum class SelectionType { TAG, FILTER };
 
-	SelectFormAction(View*, std::string formstr, ConfigContainer* cfg);
+	SelectFormAction(View*, Utf8String formstr, ConfigContainer* cfg);
 	~SelectFormAction() override;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
-	void set_selected_value(const std::string& new_value)
+	void set_selected_value(const Utf8String& new_value)
 	{
 		value = new_value;
 	}
-	std::string get_selected_value()
+	Utf8String get_selected_value()
 	{
 		return value;
 	}
-	void set_tags(const std::vector<std::string>& t)
+	void set_tags(const std::vector<Utf8String>& t)
 	{
 		tags = t;
 	}
@@ -36,27 +37,30 @@ public:
 	{
 		type = t;
 	}
-	void handle_cmdline(const std::string& cmd) override;
-	std::string id() const override
+	void handle_cmdline(const Utf8String& cmd) override;
+	Utf8String id() const override
 	{
-		return (type == SelectionType::TAG) ? "tagselection"
-			: "filterselection";
+		if (type == SelectionType::TAG) {
+			return "tagselection";
+		} else {
+			return "filterselection";
+		}
 	}
-	std::string title() override;
+	Utf8String title() override;
 
 private:
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+		std::vector<Utf8String>* args = nullptr) override;
 	bool quit;
 	bool is_first_draw;
 	SelectionType type;
-	std::string value;
-	std::vector<std::string> tags;
+	Utf8String value;
+	std::vector<Utf8String> tags;
 	std::vector<FilterNameExprPair> filters;
 
-	std::string format_line(const std::string& selecttag_format,
-		const std::string& tag,
+	Utf8String format_line(const Utf8String& selecttag_format,
+		const Utf8String& tag,
 		unsigned int pos,
 		unsigned int width);
 	void update_heading();

--- a/include/stflpp.h
+++ b/include/stflpp.h
@@ -5,7 +5,7 @@ extern "C" {
 #include <stfl.h>
 }
 
-#include <string>
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -13,7 +13,7 @@ namespace Stfl {
 
 class Form {
 public:
-	explicit Form(const std::string& text);
+	explicit Form(const Utf8String& text);
 	~Form();
 
 	// Make sure this class cannot accidentally get copied.
@@ -27,18 +27,18 @@ public:
 
 	const char* run(int timeout);
 
-	std::string get(const std::string& name);
-	void set(const std::string& name, const std::string& value);
+	Utf8String get(const Utf8String& name);
+	void set(const Utf8String& name, const Utf8String& value);
 
-	std::string get_focus();
-	void set_focus(const std::string& name);
+	Utf8String get_focus();
+	void set_focus(const Utf8String& name);
 
-	std::string dump(const std::string& name,
-		const std::string& prefix,
+	Utf8String dump(const Utf8String& name,
+		const Utf8String& prefix,
 		int focus);
-	void modify(const std::string& name,
-		const std::string& mode,
-		const std::string& text);
+	void modify(const Utf8String& name,
+		const Utf8String& mode,
+		const Utf8String& text);
 
 private:
 	stfl_form* f;
@@ -46,7 +46,7 @@ private:
 };
 
 void reset();
-std::string quote(const std::string& text);
+Utf8String quote(const Utf8String& text);
 
 } // namespace Stfl
 

--- a/include/stflpp.h
+++ b/include/stflpp.h
@@ -9,45 +9,46 @@ extern "C" {
 
 namespace newsboat {
 
-class Stfl {
+namespace Stfl {
+
+class Form {
 public:
-	class Form {
-	public:
-		explicit Form(const std::string& text);
-		~Form();
+	explicit Form(const std::string& text);
+	~Form();
 
-		// Make sure this class cannot accidentally get copied.
-		// Copying this class would be bad because the `f` and `ipool` member
-		// variables are managed manually.
-		Form(const Form&) = delete;
-		Form& operator=(const Form&) = delete;
-		// The move operations are not needed at the moment but can be added when necessary.
-		Form(Form&&) = delete;
-		Form& operator=(Form&&) = delete;
+	// Make sure this class cannot accidentally get copied.
+	// Copying this class would be bad because the `f` and `ipool` member
+	// variables are managed manually.
+	Form(const Form&) = delete;
+	Form& operator=(const Form&) = delete;
+	// The move operations are not needed at the moment but can be added when necessary.
+	Form(Form&&) = delete;
+	Form& operator=(Form&&) = delete;
 
-		const char* run(int timeout);
+	const char* run(int timeout);
 
-		std::string get(const std::string& name);
-		void set(const std::string& name, const std::string& value);
+	std::string get(const std::string& name);
+	void set(const std::string& name, const std::string& value);
 
-		std::string get_focus();
-		void set_focus(const std::string& name);
+	std::string get_focus();
+	void set_focus(const std::string& name);
 
-		std::string dump(const std::string& name,
-			const std::string& prefix,
-			int focus);
-		void modify(const std::string& name,
-			const std::string& mode,
-			const std::string& text);
+	std::string dump(const std::string& name,
+		const std::string& prefix,
+		int focus);
+	void modify(const std::string& name,
+		const std::string& mode,
+		const std::string& text);
 
-	private:
-		stfl_form* f;
-		stfl_ipool* ipool;
-	};
-
-	static void reset();
-	static std::string quote(const std::string& text);
+private:
+	stfl_form* f;
+	stfl_ipool* ipool;
 };
+
+void reset();
+std::string quote(const std::string& text);
+
+} // namespace Stfl
 
 } // namespace newsboat
 

--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -6,6 +6,8 @@
 #include <tuple>
 #include <vector>
 
+#include "utf8string.h"
+
 namespace newsboat {
 
 namespace strprintf {
@@ -93,6 +95,14 @@ std::string fmt(const std::string& format,
 	Args... args)
 {
 	return fmt(format, argument->c_str(), args...);
+}
+
+template<typename... Args>
+std::string fmt(const std::string& format,
+	const Utf8String& argument,
+	Args... args)
+{
+	return fmt(format, argument.to_utf8(), args...);
 }
 
 namespace detail {

--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -102,7 +102,7 @@ std::string fmt(const std::string& format,
 	const Utf8String& argument,
 	Args... args)
 {
-	return fmt(format, argument.to_utf8(), args...);
+	return fmt(format, argument.utf8(), args...);
 }
 
 namespace detail {

--- a/include/urlviewformaction.h
+++ b/include/urlviewformaction.h
@@ -4,6 +4,7 @@
 #include "formaction.h"
 #include "htmlrenderer.h"
 #include "listwidget.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -11,7 +12,7 @@ class UrlViewFormAction : public FormAction {
 public:
 	UrlViewFormAction(View*,
 		std::shared_ptr<RssFeed>& feed,
-		std::string formstr,
+		Utf8String formstr,
 		ConfigContainer* cfg);
 	~UrlViewFormAction() override;
 	void prepare() override;
@@ -21,17 +22,17 @@ public:
 	{
 		links = l;
 	}
-	std::string id() const override
+	Utf8String id() const override
 	{
 		return "urlview";
 	}
-	std::string title() override;
-	void handle_cmdline(const std::string& cmd) override;
+	Utf8String title() override;
+	void handle_cmdline(const Utf8String& cmd) override;
 
 private:
 	bool process_operation(Operation op,
 		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+		std::vector<Utf8String>* args = nullptr) override;
 	void open_current_position_in_browser(bool interactive);
 	void update_heading();
 

--- a/include/utf8string.h
+++ b/include/utf8string.h
@@ -53,7 +53,7 @@ public:
 	static Utf8String from_locale_charset(std::string input);
 
 	/// Return inner UTF-8 string.
-	const std::string& to_utf8() const
+	const std::string& utf8() const
 	{
 		return inner;
 	}
@@ -174,7 +174,7 @@ namespace std {
 template<> struct hash<::newsboat::Utf8String> {
 	std::size_t operator()(const ::newsboat::Utf8String& s) const noexcept
 	{
-		return std::hash<std::string> {}(s.to_utf8());
+		return std::hash<std::string> {}(s.utf8());
 	}
 };
 } // namespace std

--- a/include/utf8string.h
+++ b/include/utf8string.h
@@ -1,0 +1,73 @@
+#ifndef NEWSBOAT_UTF8STRING_H_
+#define NEWSBOAT_UTF8STRING_H_
+
+#include <string>
+
+namespace newsboat {
+
+/// A string that's guaranteed to contain valid UTF-8.
+class Utf8String {
+public:
+	/// Construct an object from a string literal, which is assumed to be in
+	/// UTF-8 since Newsboat's source code is in UTF-8.
+	///
+	/// \note This actually allows construction from a char array, which is not
+	/// intentional — it's just that C++ won't let us disallow that. Hopefully
+	/// that will never happen.
+	// Lifted from https://stackoverflow.com/a/13724458/2350060
+	template<size_t N> Utf8String(const char (&input)[N])
+	// -1 to exclude the terminating NUL
+		: Utf8String(std::string(input, N-1))
+	{
+	}
+
+	/// Construct an object from a UTF-8 `std::string`.
+	///
+	/// \note This doesn't check if the string is actually in UTF-8.
+	static Utf8String from_utf8(std::string input);
+
+	/// Construct an object from a string in the locale charset.
+	///
+	/// Invalid characters will be replaced by a question mark.
+	static Utf8String from_locale_charset(std::string input);
+
+	/// Return inner UTF-8 string.
+	const std::string& to_utf8() const
+	{
+		return inner;
+	}
+
+	/// Return the string re-coded to the locale charset.
+	///
+	/// Invalid characters will be replaces by a question mark.
+	std::string to_locale_charset() const;
+
+	Utf8String(const Utf8String&) = default;
+	Utf8String(Utf8String&&) = default;
+	Utf8String& operator=(const Utf8String&) = default;
+	Utf8String& operator=(Utf8String&&) = default;
+
+	friend bool operator==(const Utf8String& lhs, const Utf8String& rhs);
+	friend bool operator!=(const Utf8String& lhs, const Utf8String& rhs);
+
+private:
+	explicit Utf8String(std::string input);
+
+	// UTF-8 encoded string
+	std::string inner;
+};
+
+inline bool operator==(const Utf8String& lhs, const Utf8String& rhs)
+{
+	return lhs.inner == rhs.inner;
+}
+
+inline bool operator!=(const Utf8String& lhs, const Utf8String& rhs)
+{
+	return lhs.inner != rhs.inner;
+}
+
+} // namespace newsboat
+
+#endif /* NEWSBOAT_UTF8STRING_H_ */
+

--- a/include/utf8string.h
+++ b/include/utf8string.h
@@ -53,15 +53,20 @@ public:
 	static Utf8String from_locale_charset(std::string input);
 
 	/// Return inner UTF-8 string.
-	const std::string& utf8() const
+	[[nodiscard]] const std::string& utf8() const
 	{
 		return inner;
+	}
+
+	[[nodiscard]] const char *c_str() const
+	{
+		return inner.c_str();
 	}
 
 	/// Return the string re-coded to the locale charset.
 	///
 	/// Invalid characters will be replaces by a question mark.
-	std::string to_locale_charset() const;
+	[[nodiscard]] std::string to_locale_charset() const;
 
 	Utf8String(const Utf8String&) = default;
 	Utf8String(Utf8String&&) = default;
@@ -87,17 +92,17 @@ public:
 		return append(other);
 	}
 
-	size_type length() const noexcept
+	[[nodiscard]] size_type length() const noexcept
 	{
 		return inner.length();
 	}
 
-	size_type size() const noexcept
+	[[nodiscard]] size_type size() const noexcept
 	{
 		return inner.size();
 	}
 
-	bool empty() const noexcept
+	[[nodiscard]] bool empty() const noexcept
 	{
 		return inner.empty();
 	}
@@ -107,12 +112,12 @@ public:
 		inner.clear();
 	}
 
-	size_type rfind(const Utf8String& str, size_type pos = npos) const noexcept
+	[[nodiscard]] size_type rfind(const Utf8String& str, size_type pos = npos) const noexcept
 	{
 		return inner.rfind(str.inner, pos);
 	}
 
-	size_type find(const Utf8String& str, size_type pos = 0) const noexcept
+	[[nodiscard]] size_type find(const Utf8String& str, size_type pos = 0) const noexcept
 	{
 		return inner.find(str.inner, pos);
 	}

--- a/include/utf8string.h
+++ b/include/utf8string.h
@@ -32,6 +32,7 @@ public:
 	/// This performs no validations because Rust strings are known to be
 	/// represented in UTF-8.
 	Utf8String(const rust::String&);
+	Utf8String(const rust::Str&);
 
 	/// Convert the object to a Rust String.
 	///

--- a/include/utf8string.h
+++ b/include/utf8string.h
@@ -17,6 +17,15 @@ class Utf8String {
 public:
 	Utf8String() = default;
 
+	// XXX: Hack for the duration of converting.
+	// These should reduce some of the churn, when working
+	// between converted and old interfaces.
+	Utf8String(std::string input);
+	operator std::string() const
+	{
+		return inner;
+	}
+
 	/// Construct an object from a String received from Rust.
 	///
 	/// This performs no validations because Rust strings are known to be
@@ -132,7 +141,8 @@ public:
 	friend Utf8String operator+(const Utf8String& lhs, const Utf8String& rhs);
 
 private:
-	explicit Utf8String(std::string input);
+	// TODO: add back once the implicit conversion hack is served its purpose
+	// explicit Utf8String(std::string input);
 
 	// UTF-8 encoded string
 	std::string inner;

--- a/include/utf8string.h
+++ b/include/utf8string.h
@@ -142,6 +142,12 @@ public:
 
 	friend Utf8String operator+(const Utf8String& lhs, const Utf8String& rhs);
 
+	/// Convenience method to operate directly on the std::string.
+	Utf8String map(std::function<std::string(std::string)>&& f) const
+	{
+		return Utf8String::from_utf8(f(inner));
+	}
+
 private:
 	// TODO: add back once the implicit conversion hack is served its purpose
 	// explicit Utf8String(std::string input);

--- a/include/utf8string.h
+++ b/include/utf8string.h
@@ -70,7 +70,7 @@ public:
 		return inner;
 	}
 
-	[[nodiscard]] const char *c_str() const
+	[[nodiscard]] const char* c_str() const
 	{
 		return inner.c_str();
 	}

--- a/include/utf8string.h
+++ b/include/utf8string.h
@@ -7,6 +7,7 @@
 namespace rust {
 inline namespace cxxbridge1 {
 class String;
+class Str;
 }
 }
 
@@ -36,6 +37,7 @@ public:
 	///
 	/// This constructs a new Rust String from the UTF-8 data.
 	operator rust::String() const;
+	operator rust::Str() const;
 
 
 	/// Construct an object from a string literal, which is assumed to be in

--- a/include/utils.h
+++ b/include/utils.h
@@ -176,6 +176,13 @@ std::string program_version();
 
 /// Threadsafe combination of strftime() and localtime()
 std::string mt_strf_localtime(const std::string& format, time_t t);
+
+// Returns `true` if `input` starts with `prefix`.
+bool starts_with(const std::string& prefix, const std::string& input);
+
+// Returns `true` if `input` ends with `suffix`.
+bool ends_with(const std::string& suffix, const std::string& input);
+
 }
 
 } // namespace newsboat

--- a/include/utils.h
+++ b/include/utils.h
@@ -15,6 +15,7 @@
 
 #include "configcontainer.h"
 #include "logger.h"
+#include "utf8string.h"
 
 #include "libnewsboat-ffi/src/utils.rs.h"
 
@@ -112,6 +113,8 @@ std::vector<std::pair<unsigned int, unsigned int>> partition_indexes(
 
 std::string join(const std::vector<std::string>& strings,
 	const std::string& separator);
+Utf8String join(const std::vector<Utf8String>& strings,
+	const Utf8String& separator);
 
 std::string censor_url(const std::string& url);
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -47,6 +47,15 @@ std::vector<std::string> tokenize_quoted(const std::string& str,
 nonstd::optional<std::string> extract_token_quoted(std::string& str,
 	std::string delimiters = " \r\n\t");
 
+Utf8String strip_comments(const Utf8String& line);
+std::vector<Utf8String> tokenize(const Utf8String& str,
+	Utf8String delimiters = " \r\n\t");
+std::vector<Utf8String> tokenize_spaced(const Utf8String& str,
+	Utf8String delimiters = " \r\n\t");
+std::vector<Utf8String> tokenize_nl(const Utf8String& str,
+	Utf8String delimiters = "\r\n");
+std::vector<Utf8String> tokenize_quoted(const Utf8String& str,
+	Utf8String delimiters = " \r\n\t");
 nonstd::optional<Utf8String> extract_token_quoted(Utf8String& str,
 	Utf8String delimiters = " \r\n\t");
 
@@ -127,6 +136,10 @@ void trim_end(std::string& str);
 
 void trim(std::string& str);
 
+void trim_end(Utf8String& str);
+
+void trim(Utf8String& str);
+
 std::string quote(const std::string& str);
 
 std::string quote_if_necessary(const std::string& str);
@@ -166,6 +179,7 @@ nonstd::expected<std::vector<std::string>, ReadTextFileError> read_text_file(
 	const std::string& filename);
 
 void remove_soft_hyphens(std::string& text);
+void remove_soft_hyphens(Utf8String& text);
 
 bool is_valid_podcast_type(const std::string& mimetype);
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -47,6 +47,9 @@ std::vector<std::string> tokenize_quoted(const std::string& str,
 nonstd::optional<std::string> extract_token_quoted(std::string& str,
 	std::string delimiters = " \r\n\t");
 
+nonstd::optional<Utf8String> extract_token_quoted(Utf8String& str,
+	Utf8String delimiters = " \r\n\t");
+
 std::string consolidate_whitespace(const std::string& str);
 
 std::string translit(const std::string& tocode,

--- a/include/view.h
+++ b/include/view.h
@@ -10,6 +10,7 @@
 
 #include "htmlrenderer.h"
 #include "statusline.h"
+#include "utf8string.h"
 
 namespace newsboat {
 
@@ -166,7 +167,7 @@ protected:
 	void show_error(const std::string& msg) override;
 	StatusLine status_line;
 
-	std::vector<std::string> tags;
+	std::vector<Utf8String> tags;
 
 	RegexManager& rxman;
 
@@ -178,7 +179,7 @@ protected:
 	Cache* rsscache;
 	FilterContainer& filters;
 	const ColorManager& colorman;
-	std::vector<std::string> suggestions;
+	std::vector<Utf8String> suggestions;
 };
 
 } // namespace newsboat

--- a/mk/libboat.deps
+++ b/mk/libboat.deps
@@ -14,4 +14,5 @@ src/ruststring.cpp
 src/scopemeasure.cpp
 src/stflpp.cpp
 src/strprintf.cpp
+src/utf8string.cpp
 src/utils.cpp

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -31,8 +31,8 @@ void ColorManager::register_commands(ConfigParser& cfgparser)
 	cfgparser.register_handler("color", *this);
 }
 
-void ColorManager::handle_action(const std::string& action,
-	const std::vector<std::string>& params)
+void ColorManager::handle_action(const Utf8String& action,
+	const std::vector<Utf8String>& params)
 {
 	LOG(Level::DEBUG,
 		"ColorManager::handle_action(%s,...) was called",
@@ -46,9 +46,9 @@ void ColorManager::handle_action(const std::string& action,
 		 * the command syntax is:
 		 * color <element> <fgcolor> <bgcolor> [<attribute> ...]
 		 */
-		const std::string element = params[0];
-		const std::string fgcolor = params[1];
-		const std::string bgcolor = params[2];
+		const auto element = params[0];
+		const auto fgcolor = params[1];
+		const auto bgcolor = params[2];
 
 		if (!utils::is_valid_color(fgcolor)) {
 			throw ConfigHandlerException(strprintf::fmt(
@@ -59,7 +59,7 @@ void ColorManager::handle_action(const std::string& action,
 					_("`%s' is not a valid color"), bgcolor));
 		}
 
-		const std::vector<std::string> attribs(
+		const std::vector<Utf8String> attribs(
 			std::next(params.cbegin(), 3),
 			params.cend());
 		for (const auto& attr : attribs) {
@@ -72,7 +72,7 @@ void ColorManager::handle_action(const std::string& action,
 
 		/* we only allow certain elements to be configured, also to
 		 * indicate the user possible mis-spellings */
-		const std::vector<std::string> supported_elements({
+		const std::vector<Utf8String> supported_elements({
 			"listnormal",
 			"listfocus",
 			"listnormal_unread",
@@ -102,12 +102,12 @@ void ColorManager::handle_action(const std::string& action,
 	}
 }
 
-void ColorManager::dump_config(std::vector<std::string>& config_output) const
+void ColorManager::dump_config(std::vector<Utf8String>& config_output) const
 {
 	for (const auto& element_style : element_styles) {
-		const std::string& element = element_style.first;
+		const auto& element = element_style.first;
 		const TextStyle& style = element_style.second;
-		std::string configline = strprintf::fmt("color %s %s %s",
+		auto configline = strprintf::fmt("color %s %s %s",
 				element,
 				style.fg_color,
 				style.bg_color);
@@ -119,9 +119,9 @@ void ColorManager::dump_config(std::vector<std::string>& config_output) const
 	}
 }
 
-std::string format_style(const TextStyle& style)
+Utf8String format_style(const TextStyle& style)
 {
-	std::string result;
+	Utf8String result;
 
 	if (style.fg_color != "default") {
 		result.append("fg=");
@@ -145,9 +145,9 @@ std::string format_style(const TextStyle& style)
 	return result;
 }
 
-void ColorManager::emit_fallback_from_to(const std::string& from_element,
-	const std::string& to_element,
-	const std::function<void(const std::string&, const std::string&)>& stfl_value_setter) const
+void ColorManager::emit_fallback_from_to(const Utf8String& from_element,
+	const Utf8String& to_element,
+	const std::function<void(const Utf8String&, const Utf8String&)>& stfl_value_setter) const
 {
 	const auto from_style = element_styles.find(from_element);
 	const auto to_style = element_styles.find(to_element);
@@ -160,11 +160,11 @@ void ColorManager::emit_fallback_from_to(const std::string& from_element,
 }
 
 void ColorManager::apply_colors(
-	std::function<void(const std::string&, const std::string&)> stfl_value_setter)
+	std::function<void(const Utf8String&, const Utf8String&)> stfl_value_setter)
 const
 {
 	for (const auto& element_style : element_styles) {
-		const std::string& element = element_style.first;
+		const auto& element = element_style.first;
 		const TextStyle& style = element_style.second;
 		const auto colorattr = format_style(style);
 
@@ -176,8 +176,8 @@ const
 		stfl_value_setter(element, colorattr);
 
 		if (element == "article") {
-			std::string bold = colorattr;
-			std::string underline = colorattr;
+			auto bold = colorattr;
+			auto underline = colorattr;
 			if (!bold.empty()) {
 				bold.append(",");
 			}

--- a/src/configactionhandler.cpp
+++ b/src/configactionhandler.cpp
@@ -4,15 +4,19 @@
 
 namespace newsboat {
 
-void ConfigActionHandler::handle_action(const std::string& action,
-	const std::string& params)
+void ConfigActionHandler::handle_action(const Utf8String& action,
+	const Utf8String& params)
 {
-	const std::vector<std::string> tokens = utils::tokenize_quoted(params);
+	const auto raw_tokens = utils::tokenize_quoted(params);
+	std::vector<Utf8String> tokens;
+	for (const auto& raw : raw_tokens) {
+		tokens.push_back(raw);
+	}
 	handle_action(action, tokens);
 }
 
-void ConfigActionHandler::handle_action(const std::string&,
-	const std::vector<std::string>&)
+void ConfigActionHandler::handle_action(const Utf8String&,
+	const std::vector<Utf8String>&)
 {
 }
 

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -107,7 +107,7 @@ ConfigContainer::ConfigContainer()
 	{
 		"http-auth-method",
 		ConfigData("any",
-		std::unordered_set<std::string>({"any",
+		std::unordered_set<Utf8String>({"any",
 			"basic",
 			"digest",
 			"digest_ie",
@@ -117,7 +117,7 @@ ConfigContainer::ConfigContainer()
 	{
 		"ignore-mode",
 		ConfigData("download",
-			std::unordered_set<std::string>(
+			std::unordered_set<Utf8String>(
 		{"download", "display"}))},
 	{"inoreader-app-id", ConfigData("", ConfigDataType::STR)},
 	{"inoreader-app-key", ConfigData("", ConfigDataType::STR)},
@@ -157,7 +157,7 @@ ConfigContainer::ConfigContainer()
 	{"notify-beep", ConfigData("no", ConfigDataType::BOOL)},
 	{
 		"notify-format",
-		ConfigData(_("Newsboat: finished reload, %f unread "
+		ConfigData(_s("Newsboat: finished reload, %f unread "
 				"feeds (%n unread articles total)"),
 			ConfigDataType::STR)},
 	{"notify-program", ConfigData("", ConfigDataType::PATH)},
@@ -197,7 +197,7 @@ ConfigContainer::ConfigContainer()
 	{
 		"proxy-auth-method",
 		ConfigData("any",
-		std::unordered_set<std::string>({"any",
+		std::unordered_set<Utf8String>({"any",
 			"basic",
 			"digest",
 			"digest_ie",
@@ -207,7 +207,7 @@ ConfigContainer::ConfigContainer()
 	{
 		"proxy-type",
 		ConfigData("http",
-		std::unordered_set<std::string>({"http",
+		std::unordered_set<Utf8String>({"http",
 			"socks4",
 			"socks4a",
 			"socks5",
@@ -249,7 +249,7 @@ ConfigContainer::ConfigContainer()
 	{
 		"ttrss-mode",
 		ConfigData("multi",
-			std::unordered_set<std::string>(
+			std::unordered_set<Utf8String>(
 		{"single", "multi"}))},
 	{"ttrss-password", ConfigData("", ConfigDataType::STR)},
 	{"ttrss-passwordfile", ConfigData("", ConfigDataType::PATH)},
@@ -273,7 +273,7 @@ ConfigContainer::ConfigContainer()
 	{
 		"urls-source",
 		ConfigData("local",
-		std::unordered_set<std::string>({"local",
+		std::unordered_set<Utf8String>({"local",
 			"opml",
 			"oldreader",
 			"ttrss",
@@ -289,45 +289,45 @@ ConfigContainer::ConfigContainer()
 	/* title formats: */
 	{
 		"articlelist-title-format",
-		ConfigData(_("%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter '%F'&? - %U"),
+		ConfigData(_s("%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter '%F'&? - %U"),
 			ConfigDataType::STR)},
 	{
 		"dialogs-title-format",
-		ConfigData(_("%N %V - Dialogs"), ConfigDataType::STR)},
+		ConfigData(_s("%N %V - Dialogs"), ConfigDataType::STR)},
 	{
 		"feedlist-title-format",
-		ConfigData(_("%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter '%F'&?%?T? - tag '%T'&?"),
+		ConfigData(_s("%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter '%F'&?%?T? - tag '%T'&?"),
 			ConfigDataType::STR)},
 	{
 		"filebrowser-title-format",
-		ConfigData(_("%N %V - %?O?Open File&Save File? - %f"),
+		ConfigData(_s("%N %V - %?O?Open File&Save File? - %f"),
 			ConfigDataType::STR)},
 	{
 		"dirbrowser-title-format",
-		ConfigData(_("%N %V - %?O?Open Directory&Save File? - %f"),
+		ConfigData(_s("%N %V - %?O?Open Directory&Save File? - %f"),
 			ConfigDataType::STR)},
 	{
 		"help-title-format",
-		ConfigData(_("%N %V - Help"), ConfigDataType::STR)},
+		ConfigData(_s("%N %V - Help"), ConfigDataType::STR)},
 	{
 		"itemview-title-format",
-		ConfigData(_("%N %V - Article '%T' (%u unread, %t total)"),
+		ConfigData(_s("%N %V - Article '%T' (%u unread, %t total)"),
 			ConfigDataType::STR)},
 	{
 		"searchresult-title-format",
-		ConfigData(_("%N %V - Search results for '%s' (%u unread, %t total)%?F? matching filter '%F'&?"),
+		ConfigData(_s("%N %V - Search results for '%s' (%u unread, %t total)%?F? matching filter '%F'&?"),
 			ConfigDataType::STR)},
 	{
 		"selectfilter-title-format",
-		ConfigData(_("%N %V - Select Filter"),
+		ConfigData(_s("%N %V - Select Filter"),
 			ConfigDataType::STR)},
 	{
 		"selecttag-title-format",
-		ConfigData(_("%N %V - Select Tag"),
+		ConfigData(_s("%N %V - Select Tag"),
 			ConfigDataType::STR)},
 	{
 		"urlview-title-format",
-		ConfigData(_("%N %V - URLs"), ConfigDataType::STR)},
+		ConfigData(_s("%N %V - URLs"), ConfigDataType::STR)},
 	{
 		"wrap-scroll",
 		ConfigData("no", ConfigDataType::BOOL)},

--- a/src/configdata.cpp
+++ b/src/configdata.cpp
@@ -7,22 +7,22 @@
 #include "config.h"
 #include "strprintf.h"
 
-bool is_bool(const std::string& s)
+bool is_bool(const newsboat::Utf8String& s)
 {
-	const auto bool_values = std::vector<std::string>(
+	const auto bool_values = std::vector<newsboat::Utf8String>(
 	{"yes", "no", "true", "false"});
 	return (std::find(bool_values.begin(), bool_values.end(), s) !=
 			bool_values.end());
 }
 
-bool is_int(const std::string& s)
+bool is_int(const newsboat::Utf8String& s)
 {
-	return std::all_of(s.begin(), s.end(), ::isdigit);
+	return std::all_of(s.utf8().begin(), s.utf8().end(), ::isdigit);
 }
 
 namespace newsboat {
 
-ConfigData::ConfigData(const std::string& v, ConfigDataType t,
+ConfigData::ConfigData(const Utf8String& v, ConfigDataType t,
 	bool multi_option)
 	: value_(v)
 	, default_value_(v)
@@ -31,8 +31,8 @@ ConfigData::ConfigData(const std::string& v, ConfigDataType t,
 {
 }
 
-ConfigData::ConfigData(const std::string& v,
-	const std::unordered_set<std::string>& values)
+ConfigData::ConfigData(const Utf8String& v,
+	const std::unordered_set<Utf8String>& values)
 	: value_(v)
 	, default_value_(v)
 	, type_(ConfigDataType::ENUM)
@@ -41,8 +41,8 @@ ConfigData::ConfigData(const std::string& v,
 {
 }
 
-nonstd::expected<void, std::string> ConfigData::set_value(
-	std::string new_value)
+nonstd::expected<void, Utf8String> ConfigData::set_value(
+	Utf8String new_value)
 {
 	switch (type_) {
 	case ConfigDataType::BOOL:

--- a/src/confighandlerexception.cpp
+++ b/src/confighandlerexception.cpp
@@ -12,19 +12,19 @@ ConfigHandlerException::ConfigHandlerException(ActionHandlerStatus e)
 	msg = get_errmsg(e);
 }
 
-const char* ConfigHandlerException::get_errmsg(ActionHandlerStatus status)
+Utf8String ConfigHandlerException::get_errmsg(ActionHandlerStatus status)
 {
 	switch (status) {
 	case ActionHandlerStatus::INVALID_PARAMS:
-		return _("invalid parameters.");
+		return _s("invalid parameters.");
 	case ActionHandlerStatus::TOO_FEW_PARAMS:
-		return _("too few parameters.");
+		return _s("too few parameters.");
 	case ActionHandlerStatus::TOO_MANY_PARAMS:
-		return _("too many parameters.");
+		return _s("too many parameters.");
 	case ActionHandlerStatus::INVALID_COMMAND:
-		return _("unknown command (bug).");
+		return _s("unknown command (bug).");
 	case ActionHandlerStatus::FILENOTFOUND:
-		return _("file couldn't be opened.");
+		return _s("file couldn't be opened.");
 	}
 
 	assert(0 && "unreachable, because the switch() above handles everything");

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -65,9 +65,9 @@ bool ConfigParser::parse_file(const std::string& tmp_filename)
 
 	// It would be nice if this function was only give absolute paths, but the
 	// tests are easier as relative paths
-	const std::string filename = (tmp_filename.front() == NEWSBEUTER_PATH_SEP) ?
+	const std::string filename = utils::starts_with(NEWSBOAT_PATH_SEP, tmp_filename) ?
 		tmp_filename :
-		utils::getcwd() + NEWSBEUTER_PATH_SEP + tmp_filename;
+		utils::getcwd() + NEWSBOAT_PATH_SEP + tmp_filename;
 
 	if (std::find(included_files.begin(), included_files.end(),
 			filename) != included_files.end()) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1008,7 +1008,7 @@ void Controller::load_configfile(const std::string& filename)
 
 void Controller::dump_config(const std::string& filename) const
 {
-	std::vector<std::string> configlines;
+	std::vector<Utf8String> configlines;
 	cfg.dump_config(configlines);
 	if (v) {
 		v->get_keymap()->dump_config(configlines);
@@ -1020,7 +1020,7 @@ void Controller::dump_config(const std::string& filename) const
 	std::fstream f(filename, std::fstream::out);
 	if (f.is_open()) {
 		for (const auto& line : configlines) {
-			f << line << std::endl;
+			f << line.to_locale_charset() << std::endl;
 		}
 	}
 }

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -13,7 +13,7 @@
 namespace newsboat {
 
 DialogsFormAction::DialogsFormAction(View* vv,
-	std::string formstr,
+	Utf8String formstr,
 	ConfigContainer* cfg)
 	: FormAction(vv, formstr, cfg)
 	, dialogs_list("dialogs", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
@@ -64,11 +64,11 @@ void DialogsFormAction::update_heading()
 {
 
 	const unsigned int width = dialogs_list.get_width();
-	const std::string title_format = cfg->get_configvalue("dialogs-title-format");
+	const auto title_format = cfg->get_configvalue("dialogs-title-format");
 	FmtStrFormatter fmt;
 	fmt.register_fmt('N', PROGRAM_NAME);
 	fmt.register_fmt('V', utils::program_version());
-	set_value("head", fmt.do_format(title_format, width));
+	set_value("head", fmt.do_format(title_format.utf8(), width));
 }
 
 const std::vector<KeyMapHintEntry>& DialogsFormAction::get_keymap_hint() const
@@ -82,7 +82,7 @@ const std::vector<KeyMapHintEntry>& DialogsFormAction::get_keymap_hint() const
 
 bool DialogsFormAction::process_operation(Operation op,
 	bool /* automatic */,
-	std::vector<std::string>* /* args */)
+	std::vector<Utf8String>* /* args */)
 {
 	switch (op) {
 	case OP_OPEN: {
@@ -119,12 +119,12 @@ bool DialogsFormAction::process_operation(Operation op,
 	return true;
 }
 
-std::string DialogsFormAction::title()
+Utf8String DialogsFormAction::title()
 {
 	return ""; // will never be displayed
 }
 
-void DialogsFormAction::handle_cmdline(const std::string& cmd)
+void DialogsFormAction::handle_cmdline(const Utf8String& cmd)
 {
 	unsigned int idx = 0;
 	if (1 == sscanf(cmd.c_str(), "%u", &idx)) {

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -73,9 +73,9 @@ void DialogsFormAction::update_heading()
 
 const std::vector<KeyMapHintEntry>& DialogsFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Close")},
-		{OP_OPEN, _("Goto Dialog")},
-		{OP_CLOSEDIALOG, _("Close Dialog")}
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Close")},
+		{OP_OPEN, _s("Goto Dialog")},
+		{OP_CLOSEDIALOG, _s("Close Dialog")}
 	};
 	return hints;
 }

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -71,8 +71,8 @@ bool DirBrowserFormAction::process_operation(Operation op,
 					std::string fn = utils::getcwd();
 					update_title(fn);
 
-					if (fn.back() != NEWSBEUTER_PATH_SEP) {
-						fn.push_back(NEWSBEUTER_PATH_SEP);
+					if (utils::ends_with(NEWSBOAT_PATH_SEP, fn)) {
+						fn.append(NEWSBOAT_PATH_SEP);
 					}
 
 					set_value("filenametext", fn);
@@ -81,8 +81,8 @@ bool DirBrowserFormAction::process_operation(Operation op,
 				break;
 				case file_system::FileType::RegularFile: {
 					std::string fn = utils::getcwd();
-					if (fn.back() != NEWSBEUTER_PATH_SEP) {
-						fn.push_back(NEWSBEUTER_PATH_SEP);
+					if (utils::ends_with(NEWSBOAT_PATH_SEP, fn)) {
+						fn.append(NEWSBOAT_PATH_SEP);
 					}
 					fn.append(selection.name);
 					set_value("filenametext", fn);

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -281,8 +281,8 @@ void DirBrowserFormAction::init()
 
 const std::vector<KeyMapHintEntry>& DirBrowserFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Cancel")},
-		{OP_OPEN, _("Save")}
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Cancel")},
+		{OP_OPEN, _s("Save")}
 	};
 
 	return hints;

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -31,7 +31,7 @@ const std::string Download::filename() const
 
 const std::string Download::basename() const
 {
-	std::string::size_type start = fn.rfind(NEWSBEUTER_PATH_SEP);
+	std::string::size_type start = fn.rfind(NEWSBOAT_PATH_SEP);
 
 	if (start != std::string::npos) {
 		return fn.substr(start+1);

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -24,27 +24,29 @@ Download::Download(std::function<void()> cb_require_view_update_)
 
 Download::~Download() {}
 
-const std::string Download::filename() const
+const Utf8String Download::filename() const
 {
 	return fn;
 }
 
-const std::string Download::basename() const
+const Utf8String Download::basename() const
 {
-	std::string::size_type start = fn.rfind(NEWSBOAT_PATH_SEP);
+	auto start = fn.rfind(NEWSBOAT_PATH_SEP);
 
 	if (start != std::string::npos) {
-		return fn.substr(start+1);
+		return fn.map([&](std::string s) {
+			return s.substr(start+1);
+		});
 	}
 	return fn;
 }
 
-const std::string Download::url() const
+const Utf8String Download::url() const
 {
 	return url_;
 }
 
-void Download::set_filename(const std::string& str)
+void Download::set_filename(const Utf8String& str)
 {
 	fn = str;
 }
@@ -58,7 +60,7 @@ double Download::percents_finished() const
 	}
 }
 
-const std::string Download::status_text() const
+const Utf8String Download::status_text() const
 {
 	switch (download_status) {
 	case DlStatus::QUEUED:
@@ -86,7 +88,7 @@ const std::string Download::status_text() const
 	}
 }
 
-void Download::set_url(const std::string& u)
+void Download::set_url(const Utf8String& u)
 {
 	url_ = u;
 }
@@ -100,7 +102,7 @@ void Download::set_progress(double downloaded, double total)
 	totalsize = total;
 }
 
-void Download::set_status(DlStatus dls, const std::string& msg_)
+void Download::set_status(DlStatus dls, const Utf8String& msg_)
 {
 	if (download_status != dls) {
 		cb_require_view_update();

--- a/src/emptyformaction.cpp
+++ b/src/emptyformaction.cpp
@@ -2,18 +2,18 @@
 
 namespace newsboat {
 
-EmptyFormAction::EmptyFormAction(View* v, const std::string& formstr,
+EmptyFormAction::EmptyFormAction(View* v, const Utf8String& formstr,
 	ConfigContainer* cfg)
 	: FormAction(v, formstr, cfg)
 {
 }
 
-std::string EmptyFormAction::id() const
+Utf8String EmptyFormAction::id() const
 {
 	return "empty";
 }
 
-std::string EmptyFormAction::title()
+Utf8String EmptyFormAction::title()
 {
 	return "Empty FormAction";
 }
@@ -34,7 +34,7 @@ const std::vector<KeyMapHintEntry>& EmptyFormAction::get_keymap_hint() const
 
 bool EmptyFormAction::process_operation(Operation /*op*/,
 	bool /*automatic*/,
-	std::vector<std::string>* /*args*/)
+	std::vector<Utf8String>* /*args*/)
 {
 	return false;
 }

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -636,15 +636,15 @@ void FeedListFormAction::set_feedlist(
 
 const std::vector<KeyMapHintEntry>& FeedListFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
-		{OP_OPEN, _("Open")},
-		{OP_NEXTUNREAD, _("Next Unread")},
-		{OP_RELOAD, _("Reload")},
-		{OP_RELOADALL, _("Reload All")},
-		{OP_MARKFEEDREAD, _("Mark Read")},
-		{OP_MARKALLFEEDSREAD, _("Mark All Read")},
-		{OP_SEARCH, _("Search")},
-		{OP_HELP, _("Help")}
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Quit")},
+		{OP_OPEN, _s("Open")},
+		{OP_NEXTUNREAD, _s("Next Unread")},
+		{OP_RELOAD, _s("Reload")},
+		{OP_RELOADALL, _s("Reload All")},
+		{OP_MARKFEEDREAD, _s("Mark Read")},
+		{OP_MARKALLFEEDSREAD, _s("Mark All Read")},
+		{OP_SEARCH, _s("Search")},
+		{OP_HELP, _s("Help")}
 	};
 	return hints;
 }

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -25,7 +25,7 @@
 namespace newsboat {
 
 FeedListFormAction::FeedListFormAction(View* vv,
-	std::string formstr,
+	Utf8String formstr,
 	Cache* cc,
 	FilterContainer& f,
 	ConfigContainer* cfg,
@@ -86,7 +86,7 @@ void FeedListFormAction::prepare()
 
 bool FeedListFormAction::process_operation(Operation op,
 	bool automatic,
-	std::vector<std::string>* args)
+	std::vector<Utf8String>* args)
 {
 	unsigned int pos = 0;
 	if (visible_feeds.size() >= 1) {
@@ -459,7 +459,7 @@ REDO:
 			finished_qna(OP_INT_START_SEARCH);
 		} else {
 			std::vector<QnaPair> qna;
-			qna.push_back(QnaPair(_("Search for: "), ""));
+			qna.push_back(QnaPair(_s("Search for: "), ""));
 			this->start_qna(
 				qna, OP_INT_START_SEARCH, &searchhistory);
 		}
@@ -472,7 +472,7 @@ REDO:
 			}
 		} else {
 			std::vector<QnaPair> qna;
-			qna.push_back(QnaPair(_("Title: "), ""));
+			qna.push_back(QnaPair(_s("Title: "), ""));
 			this->start_qna(qna, OP_INT_GOTO_TITLE);
 		}
 		break;
@@ -488,7 +488,7 @@ REDO:
 			finished_qna(OP_INT_END_SETFILTER);
 		} else {
 			std::vector<QnaPair> qna;
-			qna.push_back(QnaPair(_("Filter: "), ""));
+			qna.push_back(QnaPair(_s("Filter: "), ""));
 			this->start_qna(
 				qna, OP_INT_END_SETFILTER, &filterhistory);
 		}
@@ -553,8 +553,8 @@ bool FeedListFormAction::open_position_in_browser(unsigned int pos,
 		feed->link(),
 		interactive ? "true" : "false");
 
-	std::string url;
-	std::string type;
+	Utf8String url;
+	Utf8String type;
 	if (!feed->link().empty()) {
 		url = feed->link();
 		type = "feed";
@@ -573,7 +573,7 @@ bool FeedListFormAction::open_position_in_browser(unsigned int pos,
 	}
 
 	if (!url.empty()) {
-		const std::string feedurl = feed->rssurl();
+		const auto feedurl = feed->rssurl();
 		const auto exit_code = v->open_in_browser(url, feedurl, type, interactive);
 		if (!exit_code.has_value()) {
 			v->get_statusline().show_error(_("Failed to spawn browser"));
@@ -616,7 +616,7 @@ void FeedListFormAction::set_feedlist(
 
 	const unsigned int width = list.get_width();
 
-	std::string feedlist_format = cfg->get_configvalue("feedlist-format");
+	auto feedlist_format = cfg->get_configvalue("feedlist-format");
 
 	ListFormatter listfmt(&rxman, "feedlist");
 
@@ -684,7 +684,7 @@ bool FeedListFormAction::jump_to_previous_unread_feed(unsigned int& feedpos)
 	return false;
 }
 
-void FeedListFormAction::goto_feed(const std::string& str)
+void FeedListFormAction::goto_feed(const Utf8String& str)
 {
 	if (visible_feeds.empty()) {
 		return;
@@ -814,7 +814,7 @@ int FeedListFormAction::get_pos(unsigned int realidx)
 	return -1;
 }
 
-void FeedListFormAction::handle_cmdline(const std::string& cmd)
+void FeedListFormAction::handle_cmdline(const Utf8String& cmd)
 {
 	unsigned int idx = 0;
 	/*
@@ -828,7 +828,7 @@ void FeedListFormAction::handle_cmdline(const std::string& cmd)
 		handle_cmdline_num(idx);
 	} else {
 		// hand over all other commands to formaction
-		constexpr auto delimiters = " \t";
+		const Utf8String delimiters = " \t";
 		const auto command = FormAction::parse_command(cmd, delimiters);
 		switch (command.type) {
 		case CommandType::TAG:
@@ -847,7 +847,7 @@ void FeedListFormAction::handle_cmdline(const std::string& cmd)
 	}
 }
 
-void FeedListFormAction::handle_tag(const std::string& tag_param)
+void FeedListFormAction::handle_tag(const Utf8String& tag_param)
 {
 	if (tag_param != "") {
 		tag = tag_param;
@@ -856,7 +856,7 @@ void FeedListFormAction::handle_tag(const std::string& tag_param)
 	}
 }
 
-void FeedListFormAction::handle_goto(const std::string& param)
+void FeedListFormAction::handle_goto(const Utf8String& param)
 {
 	if (param != "") {
 		goto_feed(param);
@@ -926,8 +926,8 @@ void FeedListFormAction::save_filterpos()
 
 void FeedListFormAction::register_format_styles()
 {
-	const std::string attrstr = rxman.get_attrs_stfl_string("feedlist", true);
-	const std::string textview = strprintf::fmt(
+	const auto attrstr = rxman.get_attrs_stfl_string("feedlist", true);
+	const auto textview = strprintf::fmt(
 			"{!list[feeds] .expand:vh style_normal[listnormal]: "
 			"style_focus[listfocus]:fg=yellow,bg=blue,attr=bold "
 			"pos[feeds_pos]:0 offset[feeds_offset]:0 %s richtext:1}",
@@ -937,7 +937,7 @@ void FeedListFormAction::register_format_styles()
 
 void FeedListFormAction::update_form_title(unsigned int width)
 {
-	std::string title_format =
+	auto title_format =
 		cfg->get_configvalue("feedlist-title-format");
 
 	FmtStrFormatter fmt;
@@ -973,7 +973,7 @@ unsigned int FeedListFormAction::count_unread_articles()
 
 void FeedListFormAction::op_end_setfilter()
 {
-	std::string filtertext = qna_responses[0];
+	auto filtertext = qna_responses[0];
 	apply_filter(filtertext);
 }
 
@@ -1048,9 +1048,9 @@ void FeedListFormAction::set_pos()
 	}
 }
 
-std::string FeedListFormAction::get_title(std::shared_ptr<RssFeed> feed)
+Utf8String FeedListFormAction::get_title(std::shared_ptr<RssFeed> feed)
 {
-	std::string title = feed->title();
+	auto title = feed->title();
 	utils::remove_soft_hyphens(title);
 	if (title.length() == 0) {
 		title = utils::censor_url(feed->rssurl());
@@ -1061,7 +1061,7 @@ std::string FeedListFormAction::get_title(std::shared_ptr<RssFeed> feed)
 	return title;
 }
 
-std::string FeedListFormAction::format_line(const std::string& feedlist_format,
+Utf8String FeedListFormAction::format_line(const Utf8String& feedlist_format,
 	std::shared_ptr<RssFeed> feed,
 	unsigned int pos,
 	unsigned int width)
@@ -1099,14 +1099,14 @@ std::string FeedListFormAction::format_line(const std::string& feedlist_format,
 	return formattedLine;
 }
 
-std::string FeedListFormAction::title()
+Utf8String FeedListFormAction::title()
 {
 	return strprintf::fmt(_("Feed List - %u unread, %u total"),
 			count_unread_feeds(),
 			static_cast<unsigned int>(visible_feeds.size()));
 }
 
-void FeedListFormAction::apply_filter(const std::string& filtertext)
+void FeedListFormAction::apply_filter(const Utf8String& filtertext)
 {
 	if (filtertext.empty()) {
 		return;

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -306,8 +306,8 @@ void FileBrowserFormAction::init()
 
 const std::vector<KeyMapHintEntry>& FileBrowserFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Cancel")},
-		{OP_OPEN, _("Save")}
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Cancel")},
+		{OP_OPEN, _s("Save")}
 	};
 	return hints;
 }

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -73,14 +73,14 @@ bool FileBrowserFormAction::process_operation(Operation op,
 					std::string fn = utils::getcwd();
 					update_title(fn);
 
-					if (fn.back() != NEWSBEUTER_PATH_SEP) {
-						fn.push_back(NEWSBEUTER_PATH_SEP);
+					if (utils::ends_with(NEWSBOAT_PATH_SEP, fn)) {
+						fn.append(NEWSBOAT_PATH_SEP);
 					}
 
 					const std::string fnstr =
 						f.get("filenametext");
 					const std::string::size_type base =
-						fnstr.find_last_of(NEWSBEUTER_PATH_SEP);
+						fnstr.find_last_of(NEWSBOAT_PATH_SEP);
 					if (base == std::string::npos) {
 						fn.append(fnstr);
 					} else {
@@ -94,8 +94,8 @@ bool FileBrowserFormAction::process_operation(Operation op,
 				break;
 				case file_system::FileType::RegularFile: {
 					std::string fn = utils::getcwd();
-					if (fn.back() != NEWSBEUTER_PATH_SEP) {
-						fn.push_back(NEWSBEUTER_PATH_SEP);
+					if (utils::ends_with(NEWSBOAT_PATH_SEP, fn)) {
+						fn.append(NEWSBOAT_PATH_SEP);
 					}
 					fn.append(selection.name);
 					set_value("filenametext", fn);

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -28,7 +28,6 @@ FileBrowserFormAction::FileBrowserFormAction(View* vv,
 	std::string formstr,
 	ConfigContainer* cfg)
 	: FormAction(vv, formstr, cfg)
-	, quit(false)
 	, files_list("files", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
 {
 	// In filebrowser, keyboard focus is at the input field, so user will be

--- a/src/filtercontainer.cpp
+++ b/src/filtercontainer.cpp
@@ -13,8 +13,8 @@ namespace newsboat {
 
 FilterContainer::~FilterContainer() {}
 
-void FilterContainer::handle_action(const std::string& action,
-	const std::vector<std::string>& params)
+void FilterContainer::handle_action(const Utf8String& action,
+	const std::vector<Utf8String>& params)
 {
 	/*
 	 * FilterContainer does nothing but to save (filter name, filter
@@ -45,7 +45,7 @@ void FilterContainer::handle_action(const std::string& action,
 	}
 }
 
-void FilterContainer::dump_config(std::vector<std::string>& config_output) const
+void FilterContainer::dump_config(std::vector<Utf8String>& config_output) const
 {
 	for (const auto& filter : filters) {
 		config_output.push_back(strprintf::fmt("define-filter %s %s",
@@ -54,7 +54,7 @@ void FilterContainer::dump_config(std::vector<std::string>& config_output) const
 	}
 }
 
-nonstd::optional<std::string> FilterContainer::get_filter(const std::string& name)
+nonstd::optional<Utf8String> FilterContainer::get_filter(const Utf8String& name)
 {
 	const auto filter = std::find_if(filters.begin(),
 	filters.end(), [&](const FilterNameExprPair& pair) {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -200,19 +200,17 @@ std::vector<std::string> FormAction::get_suggestions(
 		if (tokens.size() >= 1) {
 			if (tokens[0] == "set") {
 				if (tokens.size() < 3) {
-					std::vector<std::string>
-					variable_suggestions;
 					std::string variable_fragment;
 					if (tokens.size() > 1) {
 						variable_fragment = tokens[1];
 					}
-					variable_suggestions =
+					auto variable_suggestions =
 						cfg->get_suggestions(
 							variable_fragment);
 					for (const auto& suggestion :
 						variable_suggestions) {
 						std::string line = fragment +
-							suggestion.substr(
+							suggestion.utf8().substr(
 								variable_fragment
 								.length(),
 								suggestion.length() -

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -15,9 +15,9 @@
 namespace newsboat {
 
 HelpFormAction::HelpFormAction(View* vv,
-	std::string formstr,
+	Utf8String formstr,
 	ConfigContainer* cfg,
-	const std::string& ctx)
+	const Utf8String& ctx)
 	: FormAction(vv, formstr, cfg)
 	, quit(false)
 	, apply_search(false)
@@ -30,7 +30,7 @@ HelpFormAction::~HelpFormAction() {}
 
 bool HelpFormAction::process_operation(Operation op,
 	bool /* automatic */,
-	std::vector<std::string>* /* args */)
+	std::vector<Utf8String>* /* args */)
 {
 	bool hardquit = false;
 	switch (op) {
@@ -60,7 +60,7 @@ bool HelpFormAction::process_operation(Operation op,
 		break;
 	case OP_SEARCH: {
 		std::vector<QnaPair> qna;
-		qna.push_back(QnaPair(_("Search for: "), ""));
+		qna.push_back(QnaPair(_s("Search for: "), ""));
 		this->start_qna(qna, OP_INT_START_SEARCH, &searchhistory);
 	}
 	break;
@@ -96,9 +96,9 @@ void HelpFormAction::prepare()
 
 		const auto descs = v->get_keymap()->get_keymap_descriptions(context);
 
-		std::string highlighted_searchphrase =
+		auto highlighted_searchphrase =
 			strprintf::fmt("<hl>%s</>", searchphrase);
-		std::vector<std::string> colors = utils::tokenize(
+		auto colors = utils::tokenize(
 				cfg->get_configvalue("search-highlight-colors"), " ");
 		set_value("highlight", make_colorstring(colors));
 		ListFormatter listfmt;
@@ -166,7 +166,7 @@ void HelpFormAction::prepare()
 					continue;
 				}
 				if (should_be_visible(desc)) {
-					std::string line = strprintf::fmt("%-39s %s", desc.cmd, desc.desc);
+					auto line = strprintf::fmt("%-39s %s", desc.cmd, desc.desc);
 					line = utils::quote_for_stfl(line);
 					line = apply_highlights(line);
 					listfmt.add_line(line);
@@ -181,11 +181,11 @@ void HelpFormAction::prepare()
 			listfmt.add_line("");
 
 			for (const auto& macro : macros) {
-				const std::string key = macro.first;
-				const std::string description = macro.second.description;
+				const auto key = macro.first;
+				const auto description = macro.second.description;
 
 				// "macro-prefix" is not translated because it refers to an operation name
-				std::string line = strprintf::fmt("<macro-prefix>%s  %s", key, description);
+				auto line = strprintf::fmt("<macro-prefix>%s  %s", key, description);
 				line = utils::quote_for_stfl(line);
 				line = apply_highlights(line);
 				listfmt.add_line(line);
@@ -228,15 +228,15 @@ void HelpFormAction::finished_qna(Operation op)
 	}
 }
 
-std::string HelpFormAction::title()
+Utf8String HelpFormAction::title()
 {
-	return _("Help");
+	return _s("Help");
 }
 
-std::string HelpFormAction::make_colorstring(
-	const std::vector<std::string>& colors)
+Utf8String HelpFormAction::make_colorstring(
+	const std::vector<Utf8String>& colors)
 {
-	std::string result;
+	Utf8String result;
 	if (colors.size() > 0) {
 		if (colors[0] != "default") {
 			result.append("fg=");

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -206,9 +206,9 @@ void HelpFormAction::init()
 
 const std::vector<KeyMapHintEntry>& HelpFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
-		{OP_SEARCH, _("Search")},
-		{OP_CLEARFILTER, _("Clear")}
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Quit")},
+		{OP_SEARCH, _s("Search")},
+		{OP_CLEARFILTER, _s("Clear")}
 	};
 	return hints;
 }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -7,27 +7,27 @@ History::History()
 {
 }
 
-void History::add_line(const std::string& line)
+void History::add_line(const Utf8String& line)
 {
 	history::bridged::add_line(*rs_object, line);
 }
 
-std::string History::previous_line()
+Utf8String History::previous_line()
 {
-	return std::string(history::bridged::previous_line(*rs_object));
+	return Utf8String(history::bridged::previous_line(*rs_object));
 }
 
-std::string History::next_line()
+Utf8String History::next_line()
 {
-	return std::string(history::bridged::next_line(*rs_object));
+	return Utf8String(history::bridged::next_line(*rs_object));
 }
 
-void History::load_from_file(const std::string& file)
+void History::load_from_file(const Utf8String& file)
 {
 	history::bridged::load_from_file(*rs_object, file);
 }
 
-void History::save_to_file(const std::string& file, unsigned int limit)
+void History::save_to_file(const Utf8String& file, unsigned int limit)
 {
 	history::bridged::save_to_file(*rs_object, file, limit);
 }

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -26,7 +26,7 @@
 namespace newsboat {
 
 ItemListFormAction::ItemListFormAction(View* vv,
-	std::string formstr,
+	Utf8String formstr,
 	Cache* cc,
 	FilterContainer& f,
 	ConfigContainer* cfg,
@@ -51,7 +51,7 @@ ItemListFormAction::~ItemListFormAction() {}
 
 bool ItemListFormAction::process_operation(Operation op,
 	bool automatic,
-	std::vector<std::string>* args)
+	std::vector<Utf8String>* args)
 {
 	bool quit = false;
 	bool hardquit = false;
@@ -275,7 +275,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_SHOWURLS:
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				std::string urlviewer = cfg->get_configvalue(
+				auto urlviewer = cfg->get_configvalue(
 						"external-url-viewer");
 				if (urlviewer == "") {
 					std::vector<LinkPair> links;
@@ -356,7 +356,7 @@ bool ItemListFormAction::process_operation(Operation op,
 					}
 				} else {
 					std::vector<QnaPair> qna;
-					qna.push_back(QnaPair(_("Flags: "),
+					qna.push_back(QnaPair(_s("Flags: "),
 							visible_items[itempos]
 							.first->flags()));
 					this->start_qna(
@@ -487,7 +487,7 @@ bool ItemListFormAction::process_operation(Operation op,
 
 				std::vector<std::string> guids;
 				for (const auto& item : visible_items) {
-					const std::string guid = item.first->guid();
+					const auto guid = item.first->guid();
 					guids.push_back(guid);
 				}
 				rsscache->mark_items_read_by_guid(guids);
@@ -509,7 +509,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				if (cfg->get_configvalue_as_bool("markfeedread-jumps-to-next-unread")) {
 					process_operation(OP_NEXTUNREAD);
 				} else { // reposition to first/last item
-					std::string sortorder =
+					auto sortorder =
 						cfg->get_configvalue("article-sort-order");
 
 					if (sortorder == "date-desc") {
@@ -578,7 +578,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				}
 			} else {
 				qna.push_back(QnaPair(
-						_("Pipe article to command: "), ""));
+						_s("Pipe article to command: "), ""));
 				this->start_qna(
 					qna, OP_PIPE_TO, &cmdlinehistory);
 			}
@@ -595,7 +595,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				finished_qna(OP_INT_START_SEARCH);
 			}
 		} else {
-			qna.push_back(QnaPair(_("Search for: "), ""));
+			qna.push_back(QnaPair(_s("Search for: "), ""));
 			this->start_qna(
 				qna, OP_INT_START_SEARCH, &searchhistory);
 		}
@@ -609,7 +609,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			}
 		} else {
 			std::vector<QnaPair> qna;
-			qna.push_back(QnaPair(_("Title: "), ""));
+			qna.push_back(QnaPair(_s("Title: "), ""));
 			this->start_qna(qna, OP_INT_GOTO_TITLE);
 		}
 		break;
@@ -620,7 +620,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		if (filter_container.size() > 0) {
 			std::string newfilter;
 			if (automatic && args->size() > 0) {
-				const std::string filter_name = (*args)[0];
+				const auto filter_name = (*args)[0];
 				const auto filter = filter_container.get_filter(filter_name);
 
 				if (filter.has_value()) {
@@ -630,7 +630,7 @@ bool ItemListFormAction::process_operation(Operation op,
 							filter_name));
 				}
 			} else {
-				const std::string filter_text = v->select_filter(filter_container.get_filters());
+				const auto filter_text = v->select_filter(filter_container.get_filters());
 				apply_filter(filter_text);
 			}
 		} else {
@@ -647,7 +647,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			}
 		} else {
 			std::vector<QnaPair> qna;
-			qna.push_back(QnaPair(_("Filter: "), ""));
+			qna.push_back(QnaPair(_s("Filter: "), ""));
 			this->start_qna(
 				qna, OP_INT_END_SETFILTER, &filterhistory);
 		}
@@ -826,7 +826,7 @@ void ItemListFormAction::finished_qna(Operation op)
 	case OP_PIPE_TO: {
 		if (!visible_items.empty()) {
 			unsigned int itempos = list.get_position();
-			std::string cmd = qna_responses[0];
+			auto cmd = qna_responses[0];
 			std::ostringstream ostr;
 			v->get_ctrl()->write_item(
 				visible_items[itempos].first, ostr);
@@ -851,7 +851,7 @@ void ItemListFormAction::finished_qna(Operation op)
 
 void ItemListFormAction::qna_end_setfilter()
 {
-	std::string filtertext = qna_responses[0];
+	auto filtertext = qna_responses[0];
 	apply_filter(filtertext);
 }
 
@@ -1059,10 +1059,10 @@ void ItemListFormAction::prepare()
 	prepare_set_filterpos();
 }
 
-std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
+Utf8String ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	const unsigned int width,
-	const std::string& itemlist_format,
-	const std::string& datetime_format)
+	const Utf8String& itemlist_format,
+	const Utf8String& datetime_format)
 {
 	FmtStrFormatter fmt;
 	fmt.register_fmt('i', strprintf::fmt("%u", item.second + 1));
@@ -1078,7 +1078,7 @@ std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	using days = duration<int, std::ratio<86400>>;
 	const auto article_age = duration_cast<days>(
 			system_clock::now() - article_time_point).count();
-	const std::string new_datetime_format = utils::replace_all(
+	const auto new_datetime_format = utils::replace_all(
 			datetime_format, "%L", strprintf::fmt(
 				ngettext("1 day ago", "%u days ago", article_age), article_age));
 	fmt.register_fmt('D', utils::mt_strf_localtime(new_datetime_format,
@@ -1116,7 +1116,7 @@ std::string ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	return formattedLine;
 }
 
-void ItemListFormAction::goto_item(const std::string& title)
+void ItemListFormAction::goto_item(const Utf8String& title)
 {
 	if (visible_items.empty()) {
 		return;
@@ -1159,10 +1159,10 @@ void ItemListFormAction::init()
 	invalidate_list();
 }
 
-FmtStrFormatter ItemListFormAction::setup_head_formatter(const std::string& s,
+FmtStrFormatter ItemListFormAction::setup_head_formatter(const Utf8String& s,
 	unsigned int unread,
 	unsigned int total,
-	const std::string& url)
+	const Utf8String& url)
 {
 	FmtStrFormatter fmt;
 
@@ -1183,17 +1183,15 @@ FmtStrFormatter ItemListFormAction::setup_head_formatter(const std::string& s,
 	return fmt;
 }
 
-void ItemListFormAction::set_head(const std::string& s,
+void ItemListFormAction::set_head(const Utf8String& s,
 	unsigned int unread,
 	unsigned int total,
-	const std::string& url)
+	const Utf8String& url)
 {
-	std::string title;
-
 	FmtStrFormatter fmt = setup_head_formatter(s, unread, total, url);
 
 	const unsigned int width = utils::to_u(f.get("title:w"));
-	title = fmt.do_format(
+	auto title = fmt.do_format(
 			cfg->get_configvalue("articlelist-title-format"),
 			width);
 	set_value("head", title);
@@ -1306,7 +1304,7 @@ bool ItemListFormAction::jump_to_next_item(bool start_with_first)
 	return false;
 }
 
-std::string ItemListFormAction::get_guid()
+Utf8String ItemListFormAction::get_guid()
 {
 	const unsigned int itempos = list.get_position();
 	return visible_items[itempos].first->guid();
@@ -1341,7 +1339,7 @@ void ItemListFormAction::handle_cmdline_num(unsigned int idx)
 	}
 }
 
-void ItemListFormAction::handle_cmdline(const std::string& cmd)
+void ItemListFormAction::handle_cmdline(const Utf8String& cmd)
 {
 	unsigned int idx = 0;
 	if (1 == sscanf(cmd.c_str(), "%u", &idx)) {
@@ -1387,7 +1385,7 @@ void ItemListFormAction::restore_selected_position()
 
 }
 
-void ItemListFormAction::save_article(const std::string& filename,
+void ItemListFormAction::save_article(const Utf8String& filename,
 	std::shared_ptr<RssItem> item)
 {
 	if (filename == "") {
@@ -1405,7 +1403,7 @@ void ItemListFormAction::save_article(const std::string& filename,
 	}
 }
 
-void ItemListFormAction::handle_save(const std::vector<std::string>& cmd_args)
+void ItemListFormAction::handle_save(const std::vector<Utf8String>& cmd_args)
 {
 	if (cmd_args.size() < 1) {
 		v->get_statusline().show_error(_("Error: no filename provided"));
@@ -1415,7 +1413,7 @@ void ItemListFormAction::handle_save(const std::vector<std::string>& cmd_args)
 		v->get_statusline().show_error(_("Error: no item selected!"));
 		return;
 	}
-	const std::string filename = utils::resolve_tilde(cmd_args.front());
+	const auto filename = utils::resolve_tilde(cmd_args.front());
 	const unsigned int itempos = list.get_position();
 	LOG(Level::INFO,
 		"ItemListFormAction::handle_cmdline: saving item at pos `%u' to `%s'",
@@ -1435,8 +1433,8 @@ void ItemListFormAction::save_filterpos()
 
 void ItemListFormAction::register_format_styles()
 {
-	const std::string attrstr = rxman.get_attrs_stfl_string("articlelist", true);
-	const std::string textview = strprintf::fmt(
+	const auto attrstr = rxman.get_attrs_stfl_string("articlelist", true);
+	const auto textview = strprintf::fmt(
 			"{list[items] .expand:vh style_normal[listnormal]: "
 			"style_focus[listfocus]:fg=yellow,bg=blue,attr=bold "
 			"pos[items_pos]:0 offset[items_offset]:0 %s richtext:1}",
@@ -1444,9 +1442,9 @@ void ItemListFormAction::register_format_styles()
 	list.stfl_replace_list(0, textview);
 }
 
-std::string ItemListFormAction::gen_flags(std::shared_ptr<RssItem> item)
+Utf8String ItemListFormAction::gen_flags(std::shared_ptr<RssItem> item)
 {
-	std::string flags;
+	Utf8String flags;
 	if (item->deleted()) {
 		flags.append("D");
 	} else if (item->unread()) {
@@ -1490,7 +1488,7 @@ void ItemListFormAction::set_feed(std::shared_ptr<RssFeed> fd)
 	do_update_visible_items();
 }
 
-std::string ItemListFormAction::title()
+Utf8String ItemListFormAction::title()
 {
 	if (feed->is_query_feed()) {
 		return strprintf::fmt(_("Query Feed - %s"),
@@ -1513,7 +1511,7 @@ void ItemListFormAction::handle_op_saveall()
 		return;
 	}
 
-	std::string directory = v->run_dirbrowser();
+	auto directory = v->run_dirbrowser();
 
 	if (directory.empty()) {
 		return;
@@ -1523,13 +1521,12 @@ void ItemListFormAction::handle_op_saveall()
 		directory.append(NEWSBOAT_PATH_SEP);
 	}
 
-	std::vector<std::string> filenames;
+	std::vector<Utf8String> filenames;
 	for (const auto& item : visible_items) {
-		filenames.emplace_back( utils::utf8_to_locale(v->get_filename_suggestion(
-					item.first->title())));
+		filenames.emplace_back(v->get_filename_suggestion(item.first->title()));
 	}
 
-	const auto unique_filenames = std::set<std::string>(
+	const auto unique_filenames = std::set<Utf8String>(
 			std::begin(filenames),
 			std::end(filenames));
 
@@ -1537,7 +1534,7 @@ void ItemListFormAction::handle_op_saveall()
 	for (const auto& filename : unique_filenames) {
 		const auto filepath = directory + filename;
 		struct stat sbuf;
-		if (::stat(filepath.c_str(), &sbuf) != -1) {
+		if (::stat(filepath.to_locale_charset().c_str(), &sbuf) != -1) {
 			nfiles_exist++;
 		}
 	}
@@ -1560,7 +1557,7 @@ void ItemListFormAction::handle_op_saveall()
 		auto item = visible_items[item_idx].first;
 
 		struct stat sbuf;
-		if (::stat(filepath.c_str(), &sbuf) != -1) {
+		if (::stat(filepath.to_locale_charset().c_str(), &sbuf) != -1) {
 			if (overwrite_all) {
 				save_article(filepath, item);
 				continue;
@@ -1602,7 +1599,7 @@ void ItemListFormAction::handle_op_saveall()
 	}
 }
 
-void ItemListFormAction::apply_filter(const std::string& filtertext)
+void ItemListFormAction::apply_filter(const Utf8String& filtertext)
 {
 	if (filtertext.empty()) {
 		return;

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -875,8 +875,8 @@ void ItemListFormAction::qna_end_editflags()
 
 void ItemListFormAction::qna_start_search()
 {
-	const std::string searchphrase = qna_responses[0];
-	if (searchphrase.length() == 0) {
+	const auto searchphrase = qna_responses[0];
+	if (searchphrase.empty()) {
 		return;
 	}
 
@@ -886,8 +886,7 @@ void ItemListFormAction::qna_start_search()
 		const auto message_lifetime = v->get_statusline().show_message_until_finished(
 				_("Searching..."));
 		const auto utf8searchphrase = utils::locale_to_utf8(searchphrase);
-		items = v->get_ctrl()->search_for_items(
-				utf8searchphrase, feed);
+		items = v->get_ctrl()->search_for_items(utf8searchphrase, feed);
 	} catch (const DbException& e) {
 		v->get_statusline().show_error(
 			strprintf::fmt(_("Error while searching for `%s': %s"),

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1314,14 +1314,14 @@ std::string ItemListFormAction::get_guid()
 
 const std::vector<KeyMapHintEntry>& ItemListFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
-		{OP_OPEN, _("Open")},
-		{OP_SAVE, _("Save")},
-		{OP_RELOAD, _("Reload")},
-		{OP_NEXTUNREAD, _("Next Unread")},
-		{OP_MARKFEEDREAD, _("Mark All Read")},
-		{OP_SEARCH, _("Search")},
-		{OP_HELP, _("Help")}
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Quit")},
+		{OP_OPEN, _s("Open")},
+		{OP_SAVE, _s("Save")},
+		{OP_RELOAD, _s("Reload")},
+		{OP_NEXTUNREAD, _s("Next Unread")},
+		{OP_MARKFEEDREAD, _s("Mark All Read")},
+		{OP_SEARCH, _s("Search")},
+		{OP_HELP, _s("Help")}
 	};
 	return hints;
 }

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1520,8 +1520,8 @@ void ItemListFormAction::handle_op_saveall()
 		return;
 	}
 
-	if (directory.back() != NEWSBEUTER_PATH_SEP) {
-		directory.push_back(NEWSBEUTER_PATH_SEP);
+	if (utils::ends_with(NEWSBOAT_PATH_SEP, directory)) {
+		directory.append(NEWSBOAT_PATH_SEP);
 	}
 
 	std::vector<std::string> filenames;

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -26,7 +26,7 @@ namespace newsboat {
 
 ItemViewFormAction::ItemViewFormAction(View* vv,
 	std::shared_ptr<ItemListFormAction> il,
-	std::string formstr,
+	Utf8String formstr,
 	Cache* cc,
 	ConfigContainer* cfg,
 	RegexManager& r)
@@ -71,7 +71,7 @@ void ItemViewFormAction::init()
 
 void ItemViewFormAction::update_head(const std::shared_ptr<RssItem>& item)
 {
-	const std::string feedtitle = item_renderer::get_feedtitle(item);
+	const auto feedtitle = item_renderer::get_feedtitle(item);
 
 	unsigned int unread_item_count = feed->unread_item_count();
 	// we need to subtract because the current item isn't yet marked
@@ -158,7 +158,7 @@ void ItemViewFormAction::prepare()
 
 bool ItemViewFormAction::process_operation(Operation op,
 	bool automatic,
-	std::vector<std::string>* args)
+	std::vector<Utf8String>* args)
 {
 	bool hardquit = false;
 	bool quit = false;
@@ -273,7 +273,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 				finished_qna(OP_INT_START_SEARCH);
 			}
 		} else {
-			qna.push_back(QnaPair(_("Search for: "), ""));
+			qna.push_back(QnaPair(_s("Search for: "), ""));
 			this->start_qna(
 				qna, OP_INT_START_SEARCH, &searchhistory);
 		}
@@ -289,7 +289,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 			}
 		} else {
 			qna.push_back(
-				QnaPair(_("Pipe article to command: "), ""));
+				QnaPair(_s("Pipe article to command: "), ""));
 			this->start_qna(qna, OP_PIPE_TO, &cmdlinehistory);
 		}
 	}
@@ -303,12 +303,12 @@ bool ItemViewFormAction::process_operation(Operation op,
 			}
 		} else {
 			std::vector<QnaPair> qna;
-			qna.push_back(QnaPair(_("Flags: "), item->flags()));
+			qna.push_back(QnaPair(_s("Flags: "), item->flags()));
 			this->start_qna(qna, OP_INT_EDITFLAGS_END);
 		}
 		break;
 	case OP_SHOWURLS: {
-		std::string urlviewer =
+		auto urlviewer =
 			cfg->get_configvalue("external-url-viewer");
 		LOG(Level::DEBUG, "ItemViewFormAction::process_operation: showing URLs");
 		if (urlviewer == "") {
@@ -455,7 +455,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 				finished_qna(OP_INT_GOTO_URL);
 			}
 		} else {
-			qna.push_back(QnaPair(_("Goto URL #"), ""));
+			qna.push_back(QnaPair(_s("Goto URL #"), ""));
 			this->start_qna(qna, OP_INT_GOTO_URL);
 		}
 	}
@@ -498,10 +498,10 @@ bool ItemViewFormAction::process_operation(Operation op,
 	return true;
 }
 
-bool ItemViewFormAction::open_link_in_browser(const std::string& link,
-	const std::string& type, bool interactive) const
+bool ItemViewFormAction::open_link_in_browser(const Utf8String& link,
+	const Utf8String& type, bool interactive) const
 {
-	const std::string feedurl = item->feedurl();
+	const auto feedurl = item->feedurl();
 	const auto exit_code = v->open_in_browser(link, feedurl, type, interactive);
 	if (!exit_code.has_value()) {
 		v->get_statusline().show_error(_("Failed to spawn browser"));
@@ -526,8 +526,8 @@ const std::vector<KeyMapHintEntry>& ItemViewFormAction::get_keymap_hint() const
 	return hints;
 }
 
-void ItemViewFormAction::set_head(const std::string& s,
-	const std::string& feedtitle,
+void ItemViewFormAction::set_head(const Utf8String& s,
+	const Utf8String& feedtitle,
 	unsigned int unread,
 	unsigned int total)
 {
@@ -553,7 +553,7 @@ void ItemViewFormAction::set_head(const std::string& s,
 			cfg->get_configvalue("itemview-title-format"), width));
 }
 
-void ItemViewFormAction::handle_cmdline(const std::string& cmd)
+void ItemViewFormAction::handle_cmdline(const Utf8String& cmd)
 {
 	const auto command = FormAction::parse_command(cmd);
 	switch (command.type) {
@@ -567,9 +567,9 @@ void ItemViewFormAction::handle_cmdline(const std::string& cmd)
 	}
 }
 
-void ItemViewFormAction::handle_save(const std::string& filename_param)
+void ItemViewFormAction::handle_save(const Utf8String& filename_param)
 {
-	std::string filename = utils::resolve_tilde(filename_param);
+	auto filename = utils::resolve_tilde(filename_param);
 	if (filename == "") {
 		v->get_statusline().show_error(_("Aborted saving."));
 	} else {
@@ -603,7 +603,7 @@ void ItemViewFormAction::finished_qna(Operation op)
 		do_search();
 		break;
 	case OP_PIPE_TO: {
-		std::string cmd = qna_responses[0];
+		auto cmd = qna_responses[0];
 		std::ostringstream ostr;
 		v->get_ctrl()->write_item(feed->get_item_by_guid(guid), ostr);
 		v->push_empty_formaction();
@@ -635,11 +635,11 @@ void ItemViewFormAction::finished_qna(Operation op)
 
 void ItemViewFormAction::register_format_styles()
 {
-	std::string attrstr = rxman.get_attrs_stfl_string("article", false);
+	auto attrstr = rxman.get_attrs_stfl_string("article", false);
 	attrstr.append(
 		"@style_b_normal[color_bold]:attr=bold "
 		"@style_u_normal[color_underline]:attr=underline ");
-	std::string stfl_textview = strprintf::fmt(
+	auto stfl_textview = strprintf::fmt(
 			"{textview[article] style_normal[article]: "
 			"style_end[end-of-text-marker]:fg=blue,attr=bold %s .expand:vh "
 			"offset[article_offset]:0 richtext:1}",
@@ -667,23 +667,23 @@ void ItemViewFormAction::update_percent()
 			percent);
 
 		if (offset == 0 || percent == 0) {
-			set_value("percent", _("Top"));
+			set_value("percent", _s("Top"));
 		} else if (offset == (num_lines - 1)) {
-			set_value("percent", _("Bottom"));
+			set_value("percent", _s("Bottom"));
 		} else {
 			set_value("percent", strprintf::fmt("%3u %% ", percent));
 		}
 	}
 }
 
-std::string ItemViewFormAction::title()
+Utf8String ItemViewFormAction::title()
 {
 	auto title = item->title();
 	utils::remove_soft_hyphens(title);
 	return strprintf::fmt(_("Article - %s"), utils::utf8_to_locale(title));
 }
 
-void ItemViewFormAction::set_highlightphrase(const std::string& text)
+void ItemViewFormAction::set_highlightphrase(const Utf8String& text)
 {
 	highlight_text(text);
 }
@@ -704,7 +704,7 @@ void ItemViewFormAction::do_search()
 	highlight_text(searchphrase);
 }
 
-void ItemViewFormAction::highlight_text(const std::string& searchphrase)
+void ItemViewFormAction::highlight_text(const Utf8String& searchphrase)
 {
 	std::vector<Utf8String> params;
 	params.push_back("article");

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -18,6 +18,7 @@
 #include "scopemeasure.h"
 #include "strprintf.h"
 #include "textformatter.h"
+#include "utf8string.h"
 #include "utils.h"
 #include "view.h"
 
@@ -515,12 +516,12 @@ bool ItemViewFormAction::open_link_in_browser(const std::string& link,
 
 const std::vector<KeyMapHintEntry>& ItemViewFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
-		{OP_SAVE, _("Save")},
-		{OP_NEXTUNREAD, _("Next Unread")},
-		{OP_OPENINBROWSER, _("Open in Browser")},
-		{OP_ENQUEUE, _("Enqueue")},
-		{OP_HELP, _("Help")}
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Quit")},
+		{OP_SAVE, _s("Save")},
+		{OP_NEXTUNREAD, _s("Next Unread")},
+		{OP_OPENINBROWSER, _s("Open in Browser")},
+		{OP_ENQUEUE, _s("Enqueue")},
+		{OP_HELP, _s("Help")}
 	};
 	return hints;
 }
@@ -705,11 +706,11 @@ void ItemViewFormAction::do_search()
 
 void ItemViewFormAction::highlight_text(const std::string& searchphrase)
 {
-	std::vector<std::string> params;
+	std::vector<Utf8String> params;
 	params.push_back("article");
 	params.push_back(searchphrase);
 
-	std::vector<std::string> colors = utils::tokenize(
+	auto colors = utils::tokenize(
 			cfg->get_configvalue("search-highlight-colors"), " ");
 	std::copy(colors.begin(), colors.end(), std::back_inserter(params));
 

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -689,8 +689,8 @@ void ItemViewFormAction::set_highlightphrase(const std::string& text)
 
 void ItemViewFormAction::do_search()
 {
-	std::string searchphrase = qna_responses[0];
-	if (searchphrase.length() == 0) {
+	const auto searchphrase = qna_responses[0];
+	if (searchphrase.empty()) {
 		return;
 	}
 

--- a/src/listformaction.cpp
+++ b/src/listformaction.cpp
@@ -7,8 +7,8 @@
 namespace newsboat {
 
 ListFormAction::ListFormAction(View* v,
-	std::string formstr,
-	std::string list_name,
+	Utf8String formstr,
+	Utf8String list_name,
 	ConfigContainer* cfg)
 	: FormAction(v, formstr, cfg)
 	, list(list_name, FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
@@ -17,7 +17,7 @@ ListFormAction::ListFormAction(View* v,
 
 bool ListFormAction::process_operation(Operation op,
 	bool,
-	std::vector<std::string>*)
+	std::vector<Utf8String>*)
 {
 	switch (op) {
 	case OP_CMD_START_1:

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -5,6 +5,7 @@
 
 #include "stflpp.h"
 #include "strprintf.h"
+#include "utf8string.h"
 #include "utils.h"
 
 namespace newsboat {
@@ -44,7 +45,9 @@ std::string ListFormatter::format_list() const
 	std::string format_cache = "{list";
 	for (auto str : lines) {
 		if (rxman) {
-			rxman->quote_and_highlight(str, location);
+			auto s = Utf8String::from_utf8(str);
+			rxman->quote_and_highlight(s, location);
+			str = s.utf8();
 		}
 		format_cache.append(strprintf::fmt(
 				"{listitem text:%s}", Stfl::quote(str)));

--- a/src/newsblurapi.cpp
+++ b/src/newsblurapi.cpp
@@ -24,6 +24,8 @@
 
 #define NEWSBLUR_ITEMS_PER_PAGE 6
 
+static const char* ID_SEPARATOR = "/////";
+
 using HTTPMethod = newsboat::utils::HTTPMethod;
 
 namespace newsboat {

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -55,7 +55,7 @@ bool PbController::setup_dirs_xdg(const char* env_home)
 		xdg_config_dir = env_xdg_config;
 	} else {
 		xdg_config_dir = env_home;
-		xdg_config_dir.push_back(NEWSBEUTER_PATH_SEP);
+		xdg_config_dir.append(NEWSBOAT_PATH_SEP);
 		xdg_config_dir.append(".config");
 	}
 
@@ -64,16 +64,16 @@ bool PbController::setup_dirs_xdg(const char* env_home)
 		xdg_data_dir = env_xdg_data;
 	} else {
 		xdg_data_dir = env_home;
-		xdg_data_dir.push_back(NEWSBEUTER_PATH_SEP);
+		xdg_data_dir.append(NEWSBOAT_PATH_SEP);
 		xdg_data_dir.append(".local");
-		xdg_data_dir.push_back(NEWSBEUTER_PATH_SEP);
+		xdg_data_dir.append(NEWSBOAT_PATH_SEP);
 		xdg_data_dir.append("share");
 	}
 
-	xdg_config_dir.push_back(NEWSBEUTER_PATH_SEP);
+	xdg_config_dir.append(NEWSBOAT_PATH_SEP);
 	xdg_config_dir.append(NEWSBOAT_SUBDIR_XDG);
 
-	xdg_data_dir.push_back(NEWSBEUTER_PATH_SEP);
+	xdg_data_dir.append(NEWSBOAT_PATH_SEP);
 	xdg_data_dir.append(NEWSBOAT_SUBDIR_XDG);
 
 	bool config_dir_exists =
@@ -108,14 +108,12 @@ bool PbController::setup_dirs_xdg(const char* env_home)
 	}
 
 	/* in config */
-	config_file =
-		config_dir + NEWSBEUTER_PATH_SEP + config_file;
+	config_file = config_dir + NEWSBOAT_PATH_SEP + config_file;
 
 	/* in data */
 	const std::string LOCK_SUFFIX(".lock");
-	lock_file = xdg_data_dir + NEWSBEUTER_PATH_SEP + LOCK_SUFFIX;
-	queue_file =
-		xdg_data_dir + NEWSBEUTER_PATH_SEP + queue_file;
+	lock_file = xdg_data_dir + NEWSBOAT_PATH_SEP + LOCK_SUFFIX;
+	queue_file = xdg_data_dir + NEWSBOAT_PATH_SEP + queue_file;
 
 	return true;
 }
@@ -151,7 +149,7 @@ PbController::PbController()
 		return;
 	}
 
-	config_dir.push_back(NEWSBEUTER_PATH_SEP);
+	config_dir.append(NEWSBOAT_PATH_SEP);
 	config_dir.append(NEWSBOAT_CONFIG_SUBDIR);
 
 	// create configuration directory if it doesn't exist
@@ -167,9 +165,9 @@ PbController::PbController()
 		::exit(EXIT_FAILURE);
 	}
 
-	config_file = config_dir + NEWSBEUTER_PATH_SEP + config_file;
-	queue_file = config_dir + NEWSBEUTER_PATH_SEP + queue_file;
-	lock_file = config_dir + NEWSBEUTER_PATH_SEP + lock_file;
+	config_file = config_dir + NEWSBOAT_PATH_SEP + config_file;
+	queue_file = config_dir + NEWSBOAT_PATH_SEP + queue_file;
+	lock_file = config_dir + NEWSBOAT_PATH_SEP + lock_file;
 }
 
 void PbController::initialize(int argc, char* argv[])

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -17,6 +17,7 @@
 #include "logger.h"
 #include "pbcontroller.h"
 #include "strprintf.h"
+#include "utf8string.h"
 #include "utils.h"
 
 using namespace newsboat;
@@ -123,7 +124,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			continue;
 		}
 
-		Operation op = keys->get_operation(event, "podboat");
+		Operation op = keys->get_operation(Utf8String::from_utf8(event), "podboat");
 
 		if (dllist_form.get("msg").length() > 0) {
 			dllist_form.set("msg", "");
@@ -327,7 +328,7 @@ void PbView::run_help()
 			continue;
 		}
 
-		Operation op = keys->get_operation(event, "help");
+		Operation op = keys->get_operation(Utf8String::from_utf8(event), "help");
 
 		switch (op) {
 		case OP_SK_UP:
@@ -360,22 +361,22 @@ void PbView::run_help()
 
 void PbView::set_help_keymap_hint()
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")}};
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Quit")}};
 	const auto keymap_hint = keys->prepare_keymap_hint(hints, "podboat");
 	help_form.set("help", keymap_hint);
 }
 
 void PbView::set_dllist_keymap_hint()
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
-		{OP_PB_DOWNLOAD, _("Download")},
-		{OP_PB_CANCEL, _("Cancel")},
-		{OP_PB_DELETE, _("Delete")},
-		{OP_PB_PURGE, _("Purge Finished")},
-		{OP_PB_TOGGLE_DLALL, _("Toggle Automatic Download")},
-		{OP_PB_PLAY, _("Play")},
-		{OP_PB_MARK_FINISHED, _("Mark as Finished")},
-		{OP_HELP, _("Help")}
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Quit")},
+		{OP_PB_DOWNLOAD, _s("Download")},
+		{OP_PB_CANCEL, _s("Cancel")},
+		{OP_PB_DELETE, _s("Delete")},
+		{OP_PB_PURGE, _s("Purge Finished")},
+		{OP_PB_TOGGLE_DLALL, _s("Toggle Automatic Download")},
+		{OP_PB_PLAY, _s("Play")},
+		{OP_PB_MARK_FINISHED, _s("Mark as Finished")},
+		{OP_HELP, _s("Help")}
 	};
 
 	const auto keymap_hint = keys->prepare_keymap_hint(hints, "podboat");

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -161,7 +161,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		case OP_HARDQUIT:
 		case OP_QUIT:
 			if (ctrl->downloads_in_progress() > 0) {
-				dllist_form.set("msg", _("Error: can't quit: download(s) in progress."));
+				dllist_form.set("msg", _s("Error: can't quit: download(s) in progress."));
 				update_view = true;
 			} else {
 				quit = true;
@@ -197,7 +197,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 						DlStatus::PLAYED);
 				} else {
 					dllist_form.set("msg",
-						_("Error: download needs to be "
+						_s("Error: download needs to be "
 							"finished before the file "
 							"can be played."));
 				}
@@ -247,7 +247,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		case OP_PB_PURGE:
 			if (ctrl->downloads_in_progress() > 0) {
 				dllist_form.set("msg",
-					_("Error: unable to perform operation: "
+					_s("Error: unable to perform operation: "
 						"download(s) in progress."));
 			} else {
 				ctrl->purge_queue();
@@ -297,7 +297,7 @@ void PbView::run_help()
 {
 	set_help_keymap_hint();
 
-	help_form.set("head", _("Help"));
+	help_form.set("head", _s("Help"));
 
 	const auto descs = keys->get_keymap_descriptions("podboat");
 

--- a/src/poddlthread.cpp
+++ b/src/poddlthread.cpp
@@ -124,7 +124,7 @@ void PodDlThread::run()
 			if (rename(filename.c_str(), dl->filename().c_str()) == 0) {
 				dl->set_status(DlStatus::READY);
 			} else {
-				dl->set_status(DlStatus::RENAME_FAILED, strerror(errno));
+				dl->set_status(DlStatus::RENAME_FAILED, Utf8String::from_utf8(strerror(errno)));
 			}
 		} else if (dl->status() != DlStatus::CANCELLED) {
 			// attempt complete re-download
@@ -132,12 +132,12 @@ void PodDlThread::run()
 				::unlink(filename.c_str());
 				this->run();
 			} else {
-				dl->set_status(DlStatus::FAILED, curl_easy_strerror(success));
+				dl->set_status(DlStatus::FAILED, Utf8String::from_utf8(curl_easy_strerror(success)));
 				::unlink(filename.c_str());
 			}
 		}
 	} else {
-		dl->set_status(DlStatus::FAILED, strerror(errno));
+		dl->set_status(DlStatus::FAILED, Utf8String::from_utf8(strerror(errno)));
 	}
 }
 

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -259,8 +259,8 @@ std::string QueueLoader::get_filename(const std::string& str) const
 {
 	std::string fn = cfg.get_configvalue("download-path");
 
-	if (fn[fn.length() - 1] != NEWSBEUTER_PATH_SEP) {
-		fn.push_back(NEWSBEUTER_PATH_SEP);
+	if (!utils::ends_with(NEWSBOAT_PATH_SEP, fn)) {
+		fn.append(NEWSBOAT_PATH_SEP);
 	}
 	char buf[1024];
 	snprintf(buf, sizeof(buf), "%s", str.c_str());

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -118,7 +118,7 @@ void QueueLoader::update_from_queue_file(CategorizedDownloads& downloads) const
 		LOG(Level::DEBUG,
 			"QueueLoader::reload: loaded `%s' from queue file",
 			line);
-		const std::vector<std::string> fields = utils::tokenize_quoted(line);
+		const auto fields = utils::tokenize_quoted(line);
 		bool url_found = false;
 
 		if (fields.empty()) {
@@ -211,7 +211,7 @@ void QueueLoader::write_queue_file(const CategorizedDownloads& downloads) const
 	}
 
 	for (const auto& dl : downloads.to_keep) {
-		f << dl.url() << " " << utils::quote(dl.filename());
+		f << dl.url().to_locale_charset() << " " << utils::quote(dl.filename());
 		switch (dl.status()) {
 		case DlStatus::READY:
 			f << " downloaded";
@@ -243,7 +243,7 @@ void QueueLoader::delete_played_files(const CategorizedDownloads& downloads)
 const
 {
 	for (const auto& dl : downloads.to_delete) {
-		const std::string filename = dl.filename();
+		const auto filename = dl.filename();
 		LOG(Level::INFO, "Deleting file %s", filename);
 		if (std::remove(filename.c_str()) != 0) {
 			if (errno != ENOENT) {
@@ -257,7 +257,7 @@ const
 
 std::string QueueLoader::get_filename(const std::string& str) const
 {
-	std::string fn = cfg.get_configvalue("download-path");
+	auto fn = cfg.get_configvalue("download-path");
 
 	if (!utils::ends_with(NEWSBOAT_PATH_SEP, fn)) {
 		fn.append(NEWSBOAT_PATH_SEP);

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -71,8 +71,8 @@ std::string QueueManager::generate_enqueue_filename(
 	const time_t pubDate = item->pubDate_timestamp();
 
 	std::string dlformat = cfg->get_configvalue("download-path");
-	if (dlformat[dlformat.length() - 1] != NEWSBEUTER_PATH_SEP) {
-		dlformat.push_back(NEWSBEUTER_PATH_SEP);
+	if (!utils::ends_with(NEWSBOAT_PATH_SEP, dlformat)) {
+		dlformat.append(NEWSBOAT_PATH_SEP);
 	}
 
 	const std::string filemask = cfg->get_configvalue("download-filename-format");

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -22,15 +22,15 @@ RegexManager::RegexManager()
 	locations["feedlist"];
 }
 
-void RegexManager::dump_config(std::vector<std::string>& config_output) const
+void RegexManager::dump_config(std::vector<Utf8String>& config_output) const
 {
 	for (const auto& foo : cheat_store_for_dump_config) {
 		config_output.push_back(foo);
 	}
 }
 
-void RegexManager::handle_action(const std::string& action,
-	const std::vector<std::string>& params)
+void RegexManager::handle_action(const Utf8String& action,
+	const std::vector<Utf8String>& params)
 {
 	if (action == "highlight") {
 		handle_highlight_action(params);
@@ -40,7 +40,7 @@ void RegexManager::handle_action(const std::string& action,
 		throw ConfigHandlerException(
 			ActionHandlerStatus::INVALID_COMMAND);
 	}
-	std::string line = action;
+	auto line = action;
 	for (const auto& param : params) {
 		line.append(" ");
 		line.append(utils::quote(param));
@@ -68,7 +68,7 @@ int RegexManager::feed_matches(Matchable* feed)
 	return -1;
 }
 
-void RegexManager::remove_last_regex(const std::string& location)
+void RegexManager::remove_last_regex(const Utf8String& location)
 {
 	auto& regexes = locations[location];
 	if (regexes.empty()) {
@@ -78,51 +78,54 @@ void RegexManager::remove_last_regex(const std::string& location)
 	regexes.pop_back();
 }
 
-std::map<size_t, std::string> RegexManager::extract_style_tags(std::string& str)
+std::map<size_t, Utf8String> RegexManager::extract_style_tags(Utf8String& str)
 {
-	std::map<size_t, std::string> tags;
+	std::map<size_t, Utf8String> tags;
 
-	size_t pos = 0;
-	while (pos < str.size()) {
-		auto tag_start = str.find_first_of("<>", pos);
-		if (tag_start == std::string::npos) {
-			break;
+	str = str.map([&tags](std::string str) {
+		size_t pos = 0;
+		while (pos < str.size()) {
+			auto tag_start = str.find_first_of("<>", pos);
+			if (tag_start == std::string::npos) {
+				break;
+			}
+			if (str[tag_start] == '>') {
+				// Keep unmatched '>' (stfl way of encoding a literal '>')
+				pos = tag_start + 1;
+				continue;
+			}
+			auto tag_end = str.find_first_of("<>", tag_start + 1);
+			if (tag_end == std::string::npos) {
+				break;
+			}
+			if (str[tag_end] == '<') {
+				// First '<' bracket is unmatched, ignoring it
+				pos = tag_start + 1;
+				continue;
+			}
+			if (tag_end - tag_start == 1) {
+				// Convert "<>" into "<" (stfl way of encoding a literal '<')
+				str.erase(tag_end, 1);
+				pos = tag_start + 1;
+				continue;
+			}
+			tags[tag_start] = Utf8String::from_utf8(str.substr(tag_start, tag_end - tag_start + 1));
+			str.erase(tag_start, tag_end - tag_start + 1);
+			pos = tag_start;
 		}
-		if (str[tag_start] == '>') {
-			// Keep unmatched '>' (stfl way of encoding a literal '>')
-			pos = tag_start + 1;
-			continue;
-		}
-		auto tag_end = str.find_first_of("<>", tag_start + 1);
-		if (tag_end == std::string::npos) {
-			break;
-		}
-		if (str[tag_end] == '<') {
-			// First '<' bracket is unmatched, ignoring it
-			pos = tag_start + 1;
-			continue;
-		}
-		if (tag_end - tag_start == 1) {
-			// Convert "<>" into "<" (stfl way of encoding a literal '<')
-			str.erase(tag_end, 1);
-			pos = tag_start + 1;
-			continue;
-		}
-		tags[tag_start] = str.substr(tag_start, tag_end - tag_start + 1);
-		str.erase(tag_start, tag_end - tag_start + 1);
-		pos = tag_start;
-	}
+		return str;
+	});
 	return tags;
 }
 
-void RegexManager::insert_style_tags(std::string& str,
-	std::map<size_t, std::string>& tags)
+void RegexManager::insert_style_tags(Utf8String& str,
+	std::map<size_t, Utf8String>& tags)
 {
 	// Expand "<" into "<>" (reverse of what happened in extract_style_tags()
 	size_t pos = 0;
 	while (pos < str.size()) {
-		auto bracket = str.find_first_of("<", pos);
-		if (bracket == std::string::npos) {
+		auto bracket = str.find("<", pos);
+		if (bracket == Utf8String::npos) {
 			break;
 		}
 		pos = bracket + 1;
@@ -136,12 +139,15 @@ void RegexManager::insert_style_tags(std::string& str,
 			// Ignore tags outside of string
 			continue;
 		}
-		str.insert(it->first, it->second);
+		str = str.map([&](std::string s) {
+			s.insert(it->first, it->second.utf8());
+			return s;
+		});
 	}
 }
 
-void RegexManager::merge_style_tag(std::map<size_t, std::string>& tags,
-	const std::string& tag, size_t start, size_t end)
+void RegexManager::merge_style_tag(std::map<size_t, Utf8String>& tags,
+	const Utf8String& tag, size_t start, size_t end)
 {
 	if (end <= start) {
 		return;
@@ -149,7 +155,7 @@ void RegexManager::merge_style_tag(std::map<size_t, std::string>& tags,
 
 	// Find the latest tag occurring before `end`.
 	// It is important that looping executes in ascending order of location.
-	std::string latest_tag = "</>";
+	Utf8String latest_tag = "</>";
 	for (const auto& location_tag : tags) {
 		size_t location = location_tag.first;
 		if (location > end) {
@@ -170,8 +176,8 @@ void RegexManager::merge_style_tag(std::map<size_t, std::string>& tags,
 	}
 }
 
-void RegexManager::quote_and_highlight(std::string& str,
-	const std::string& location)
+void RegexManager::quote_and_highlight(Utf8String& str,
+	const Utf8String& location)
 {
 	auto& regexes = locations[location];
 
@@ -185,14 +191,14 @@ void RegexManager::quote_and_highlight(std::string& str,
 		unsigned int offset = 0;
 		int eflags = 0;
 		while (offset < str.length()) {
-			const auto matches = regex->matches(str.substr(offset), 1, eflags);
+			const auto matches = regex->matches(str.utf8().substr(offset), 1, eflags);
 			eflags |= REG_NOTBOL; // Don't match beginning-of-line operator (^) in following checks
 			if (matches.empty()) {
 				break;
 			}
 			const auto& match = matches[0];
 			if (match.first != match.second) {
-				const std::string marker = strprintf::fmt("<%u>", i);
+				const auto marker = strprintf::fmt("<%u>", i);
 				const int match_start = offset + match.first;
 				const int match_end = offset + match.second;
 				merge_style_tag(tag_locations, marker, match_start, match_end);
@@ -206,14 +212,14 @@ void RegexManager::quote_and_highlight(std::string& str,
 	insert_style_tags(str, tag_locations);
 }
 
-void RegexManager::handle_highlight_action(const std::vector<std::string>&
+void RegexManager::handle_highlight_action(const std::vector<Utf8String>&
 	params)
 {
 	if (params.size() < 3) {
 		throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 	}
 
-	std::string location = params[0];
+	const auto& location = params[0];
 	if (location != "all" && location != "article" &&
 		location != "articlelist" && location != "feedlist") {
 		throw ConfigHandlerException(strprintf::fmt(
@@ -228,7 +234,7 @@ void RegexManager::handle_highlight_action(const std::vector<std::string>&
 				params[1],
 				errorMessage));
 	}
-	std::string colorstr;
+	Utf8String colorstr;
 	if (params[2] != "default") {
 		colorstr.append("fg=");
 		if (!utils::is_valid_color(params[2])) {
@@ -295,18 +301,17 @@ void RegexManager::handle_highlight_action(const std::vector<std::string>&
 	}
 }
 
-void RegexManager::handle_highlight_item_action(const std::string& action,
-	const std::vector<std::string>& params)
+void RegexManager::handle_highlight_item_action(const Utf8String& action,
+	const std::vector<Utf8String>& params)
 {
 	if (params.size() < 3) {
 		throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 	}
 
-	std::string expr = params[0];
-	std::string fgcolor = params[1];
-	std::string bgcolor = params[2];
+	auto fgcolor = params[1];
+	auto bgcolor = params[2];
 
-	std::string colorstr;
+	Utf8String colorstr;
 	if (fgcolor != "default") {
 		colorstr.append("fg=");
 		if (!utils::is_valid_color(fgcolor)) {
@@ -370,13 +375,13 @@ void RegexManager::handle_highlight_item_action(const std::string& action,
 	}
 }
 
-std::string RegexManager::get_attrs_stfl_string(const std::string& location,
+Utf8String RegexManager::get_attrs_stfl_string(const Utf8String& location,
 	bool hasFocus)
 {
 	const auto& attributes = locations[location];
-	std::string attrstr;
+	Utf8String attrstr;
 	for (unsigned int i = 0; i < attributes.size(); ++i) {
-		const std::string& attribute = attributes[i].second;
+		const auto& attribute = attributes[i].second;
 		attrstr.append(strprintf::fmt("@style_%u_normal:%s ", i, attribute));
 		if (hasFocus) {
 			attrstr.append(strprintf::fmt("@style_%u_focus:%s ", i, attribute));

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -28,17 +28,17 @@
 
 namespace newsboat {
 
-const std::string RssIgnores::REGEX_PREFIX = "regex:";
+const Utf8String RssIgnores::REGEX_PREFIX = "regex:";
 
-void RssIgnores::handle_action(const std::string& action,
-	const std::vector<std::string>& params)
+void RssIgnores::handle_action(const Utf8String& action,
+	const std::vector<Utf8String>& params)
 {
 	if (action == "ignore-article") {
 		if (params.size() < 2) {
 			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 		}
-		std::string ignore_rssurl = params[0];
-		std::string ignore_expr = params[1];
+		auto ignore_rssurl = params[0].utf8();
+		const auto& ignore_expr = params[1];
 		auto m = std::make_shared<Matcher>();
 		if (!m->parse(ignore_expr)) {
 			throw ConfigHandlerException(strprintf::fmt(
@@ -50,7 +50,7 @@ void RssIgnores::handle_action(const std::string& action,
 		const int prefix_len = REGEX_PREFIX.length();
 		if (!ignore_rssurl.compare(0, prefix_len, REGEX_PREFIX)) {
 			std::string errorMessage;
-			const std::string pattern = ignore_rssurl.substr(prefix_len,
+			const auto pattern = ignore_rssurl.substr(prefix_len,
 					ignore_rssurl.length() - prefix_len);
 			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
 			if (regex == nullptr) {
@@ -82,10 +82,10 @@ void RssIgnores::handle_action(const std::string& action,
 	}
 }
 
-void RssIgnores::dump_config(std::vector<std::string>& config_output) const
+void RssIgnores::dump_config(std::vector<Utf8String>& config_output) const
 {
 	for (const auto& ign : ignores) {
-		std::string configline = "ignore-article ";
+		Utf8String configline = "ignore-article ";
 		if (ign.first == "*") {
 			configline.append("*");
 		} else {
@@ -115,8 +115,10 @@ bool RssIgnores::matches(RssItem* item)
 			ign.first,
 			item->feedurl());
 
-		if (!ign.first.compare(0, prefix_len, REGEX_PREFIX)) {
-			const std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
+		if (utils::starts_with(REGEX_PREFIX, ign.first)) {
+			const auto pattern = ign.first.map([&](std::string s) {
+				return s.substr(prefix_len, ign.first.length() - prefix_len);
+			});
 			std::string errorMessage;
 			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
 			const auto matches = regex->matches(item->feedurl(), 1, 0);
@@ -134,21 +136,21 @@ bool RssIgnores::matches(RssItem* item)
 	return false;
 }
 
-bool RssIgnores::matches_lastmodified(const std::string& url)
+bool RssIgnores::matches_lastmodified(const Utf8String& url)
 {
 	return std::find_if(ignores_lastmodified.begin(),
 			ignores_lastmodified.end(),
-	[&](const std::string& u) {
+	[&](const Utf8String& u) {
 		return u == url;
 	}) !=
 	ignores_lastmodified.end();
 }
 
-bool RssIgnores::matches_resetunread(const std::string& url)
+bool RssIgnores::matches_resetunread(const Utf8String& url)
 {
 	return std::find_if(resetflag.begin(),
 			resetflag.end(),
-	[&](const std::string& u) {
+	[&](const Utf8String& u) {
 		return u == url;
 	}) !=
 	resetflag.end();

--- a/src/searchresultslistformaction.cpp
+++ b/src/searchresultslistformaction.cpp
@@ -3,7 +3,7 @@
 
 namespace newsboat {
 SearchResultsListFormAction::SearchResultsListFormAction(View* vv,
-	std::string formstr,
+	Utf8String formstr,
 	Cache* cc,
 	FilterContainer& f,
 	ConfigContainer* cfg,
@@ -23,7 +23,7 @@ const std::vector<KeyMapHintEntry>& SearchResultsListFormAction::get_keymap_hint
 };
 
 void SearchResultsListFormAction::add_to_history(const std::shared_ptr<RssFeed>& feed,
-	const std::string& str)
+	const Utf8String& str)
 {
 	if (search_phrase != str) {
 		this->set_feed(feed);
@@ -35,7 +35,7 @@ void SearchResultsListFormAction::add_to_history(const std::shared_ptr<RssFeed>&
 bool SearchResultsListFormAction::process_operation(
 	Operation op,
 	bool automatic,
-	std::vector<std::string>* args)
+	std::vector<Utf8String>* args)
 {
 	const unsigned int itempos = list.get_position();
 
@@ -69,31 +69,30 @@ bool SearchResultsListFormAction::process_operation(
 	return true;
 }
 
-void SearchResultsListFormAction::set_head(const std::string& s,
+void SearchResultsListFormAction::set_head(const Utf8String& s,
 	unsigned int unread,
 	unsigned int total,
-	const std::string& url)
+	const Utf8String& url)
 {
-	std::string title;
 	FmtStrFormatter fmt = setup_head_formatter(s, unread, total, url);
 
 	const unsigned int width = utils::to_u(f.get("title:w"));
-	title = fmt.do_format(
+	auto title = fmt.do_format(
 			cfg->get_configvalue("searchresult-title-format"),
 			width);
 	set_value("head", title);
 }
 
-std::string SearchResultsListFormAction::title()
+Utf8String SearchResultsListFormAction::title()
 {
 	return strprintf::fmt(_("Search Result - '%s'"), search_phrase);
 }
 
 FmtStrFormatter SearchResultsListFormAction::setup_head_formatter(
-	const std::string& s,
+	const Utf8String& s,
 	unsigned int unread,
 	unsigned int total,
-	const std::string& url)
+	const Utf8String& url)
 {
 	FmtStrFormatter fmt = ItemListFormAction::setup_head_formatter(s, unread, total, url);
 

--- a/src/searchresultslistformaction.cpp
+++ b/src/searchresultslistformaction.cpp
@@ -13,11 +13,11 @@ SearchResultsListFormAction::SearchResultsListFormAction(View* vv,
 const std::vector<KeyMapHintEntry>& SearchResultsListFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints = {
-		{OP_QUIT, _("Quit")},
-		{OP_OPEN, _("Open")},
-		{OP_PREVSEARCHRESULTS, _("Prev search results")},
-		{OP_SEARCH, _("Search")},
-		{OP_HELP, _("Help")}
+		{OP_QUIT, _s("Quit")},
+		{OP_OPEN, _s("Open")},
+		{OP_PREVSEARCHRESULTS, _s("Prev search results")},
+		{OP_SEARCH, _s("Search")},
+		{OP_HELP, _s("Help")}
 	};
 	return hints;
 };

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -248,11 +248,11 @@ void SelectFormAction::update_heading()
 
 const std::vector<KeyMapHintEntry>& SelectFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints_tag = {{OP_QUIT, _("Cancel")},
-		{OP_OPEN, _("Select Tag")}
+	static const std::vector<KeyMapHintEntry> hints_tag = {{OP_QUIT, _s("Cancel")},
+		{OP_OPEN, _s("Select Tag")}
 	};
-	static const std::vector<KeyMapHintEntry> hints_filter = {{OP_QUIT, _("Cancel")},
-		{OP_OPEN, _("Select Filter")}
+	static const std::vector<KeyMapHintEntry> hints_filter = {{OP_QUIT, _s("Cancel")},
+		{OP_OPEN, _s("Select Filter")}
 	};
 	switch (type) {
 	case SelectionType::TAG:

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -23,7 +23,7 @@ namespace newsboat {
  */
 
 SelectFormAction::SelectFormAction(View* vv,
-	std::string formstr,
+	Utf8String formstr,
 	ConfigContainer* cfg)
 	: FormAction(vv, formstr, cfg)
 	, quit(false)
@@ -36,7 +36,7 @@ SelectFormAction::SelectFormAction(View* vv,
 
 SelectFormAction::~SelectFormAction() {}
 
-void SelectFormAction::handle_cmdline(const std::string& cmd)
+void SelectFormAction::handle_cmdline(const Utf8String& cmd)
 {
 	unsigned int idx = 0;
 	if (1 == sscanf(cmd.c_str(), "%u", &idx)) {
@@ -53,7 +53,7 @@ void SelectFormAction::handle_cmdline(const std::string& cmd)
 
 bool SelectFormAction::process_operation(Operation op,
 	bool /* automatic */,
-	std::vector<std::string>* /* args */)
+	std::vector<Utf8String>* /* args */)
 {
 	bool hardquit = false;
 	switch (op) {
@@ -161,7 +161,7 @@ void SelectFormAction::prepare()
 			break;
 		case SelectionType::FILTER:
 			for (const auto& filter : filters) {
-				std::string tagstr = strprintf::fmt(
+				auto tagstr = strprintf::fmt(
 						"%4u  %s", i + 1, filter.name);
 				listfmt.add_line(utils::quote_for_stfl(tagstr));
 				i++;
@@ -195,8 +195,8 @@ void SelectFormAction::init()
 	set_keymap_hints();
 }
 
-std::string SelectFormAction::format_line(const std::string& selecttag_format,
-	const std::string& tag,
+Utf8String SelectFormAction::format_line(const Utf8String& selecttag_format,
+	const Utf8String& tag,
 	unsigned int pos,
 	unsigned int width)
 {
@@ -223,7 +223,7 @@ std::string SelectFormAction::format_line(const std::string& selecttag_format,
 
 void SelectFormAction::update_heading()
 {
-	std::string title;
+	Utf8String title;
 	const unsigned int width = tags_list.get_width();
 
 	FmtStrFormatter fmt;
@@ -268,13 +268,13 @@ const std::vector<KeyMapHintEntry>& SelectFormAction::get_keymap_hint() const
 	return no_hints;
 }
 
-std::string SelectFormAction::title()
+Utf8String SelectFormAction::title()
 {
 	switch (type) {
 	case SelectionType::TAG:
-		return _("Select Tag");
+		return _s("Select Tag");
 	case SelectionType::FILTER:
-		return _("Select Filter");
+		return _s("Select Filter");
 	default:
 		return "";
 	}

--- a/src/stflpp.cpp
+++ b/src/stflpp.cpp
@@ -12,13 +12,13 @@ namespace newsboat {
 
 /*
  * This is a wrapper around the low-level C functions of STFL.
- * In order to make working with std::string easier, this wrapper
+ * In order to make working with Utf8String easier, this wrapper
  * was created. This is also useful for logging all stfl-related
  * operations if necessary, and for working around bugs in STFL,
  * especially related to stuff like multithreading fuckups.
  */
 
-Stfl::Form::Form(const std::string& text)
+Stfl::Form::Form(const Utf8String& text)
 	: f(0)
 {
 	ipool = stfl_ipool_create(
@@ -47,19 +47,19 @@ const char* Stfl::Form::run(int timeout)
 	return stfl_ipool_fromwc(ipool, stfl_run(f, timeout));
 }
 
-std::string Stfl::Form::get(const std::string& name)
+Utf8String Stfl::Form::get(const Utf8String& name)
 {
 	const char* text = stfl_ipool_fromwc(
 			ipool, stfl_get(f, stfl_ipool_towc(ipool, name.c_str())));
-	std::string retval;
+	Utf8String retval;
 	if (text) {
-		retval = text;
+		retval = Utf8String::from_utf8(text);
 	}
 	stfl_ipool_flush(ipool);
 	return retval;
 }
 
-void Stfl::Form::set(const std::string& name, const std::string& value)
+void Stfl::Form::set(const Utf8String& name, const Utf8String& value)
 {
 	stfl_set(f,
 		stfl_ipool_towc(ipool, name.c_str()),
@@ -67,26 +67,26 @@ void Stfl::Form::set(const std::string& name, const std::string& value)
 	stfl_ipool_flush(ipool);
 }
 
-std::string Stfl::Form::get_focus()
+Utf8String Stfl::Form::get_focus()
 {
 	const char* focus = stfl_ipool_fromwc(ipool, stfl_get_focus(f));
-	std::string retval;
+	Utf8String retval;
 	if (focus) {
-		retval = focus;
+		retval = Utf8String::from_utf8(focus);
 	}
 	stfl_ipool_flush(ipool);
 	return retval;
 }
 
-void Stfl::Form::set_focus(const std::string& name)
+void Stfl::Form::set_focus(const Utf8String& name)
 {
 	stfl_set_focus(f, stfl_ipool_towc(ipool, name.c_str()));
 	LOG(Level::DEBUG, "Stfl::Form::set_focus: %s", name);
 }
 
-void Stfl::Form::modify(const std::string& name,
-	const std::string& mode,
-	const std::string& text)
+void Stfl::Form::modify(const Utf8String& name,
+	const Utf8String& mode,
+	const Utf8String& text)
 {
 	const wchar_t* wname, *wmode, *wtext;
 	wname = stfl_ipool_towc(ipool, name.c_str());
@@ -103,7 +103,7 @@ void Stfl::reset()
 
 static std::mutex quote_mtx;
 
-std::string Stfl::quote(const std::string& text)
+Utf8String Stfl::quote(const Utf8String& text)
 {
 	std::lock_guard<std::mutex> lock(quote_mtx);
 	stfl_ipool* ipool = stfl_ipool_create(
@@ -111,10 +111,10 @@ std::string Stfl::quote(const std::string& text)
 	std::string retval = stfl_ipool_fromwc(
 			ipool, stfl_quote(stfl_ipool_towc(ipool, text.c_str())));
 	stfl_ipool_destroy(ipool);
-	return retval;
+	return Utf8String::from_utf8(retval);
 }
 
-std::string Stfl::Form::dump(const std::string& name, const std::string& prefix,
+Utf8String Stfl::Form::dump(const Utf8String& name, const Utf8String& prefix,
 	int focus)
 {
 	const char* text = stfl_ipool_fromwc(ipool,
@@ -122,9 +122,9 @@ std::string Stfl::Form::dump(const std::string& name, const std::string& prefix,
 				stfl_ipool_towc(ipool, name.c_str()),
 				stfl_ipool_towc(ipool, prefix.c_str()),
 				focus));
-	std::string retval;
+	Utf8String retval;
 	if (text) {
-		retval = text;
+		retval = Utf8String::from_utf8(text);
 	}
 	stfl_ipool_flush(ipool);
 	return retval;

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -9,6 +9,7 @@
 #include "regexmanager.h"
 #include "stflpp.h"
 #include "strprintf.h"
+#include "utf8string.h"
 #include "utils.h"
 
 namespace newsboat {
@@ -160,7 +161,9 @@ std::vector<std::string> format_text_plain_helper(
 			static_cast<unsigned int>(type));
 
 		if (rxman && type != LineType::hr) {
-			rxman->quote_and_highlight(text, location);
+			auto s = Utf8String::from_utf8(text);
+			rxman->quote_and_highlight(s, location);
+			text = s.utf8();
 		}
 
 		switch (type) {

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -162,10 +162,10 @@ void UrlViewFormAction::update_heading()
 
 const std::vector<KeyMapHintEntry>& UrlViewFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
-		{OP_OPEN, _("Open in Browser")},
-		{OP_BOOKMARK, _("Save Bookmark")},
-		{OP_HELP, _("Help")}
+	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _s("Quit")},
+		{OP_OPEN, _s("Open in Browser")},
+		{OP_BOOKMARK, _s("Save Bookmark")},
+		{OP_HELP, _s("Help")}
 	};
 	return hints;
 }

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -21,7 +21,7 @@ namespace newsboat {
 
 UrlViewFormAction::UrlViewFormAction(View* vv,
 	std::shared_ptr<RssFeed>& feed,
-	std::string formstr,
+	Utf8String formstr,
 	ConfigContainer* cfg)
 	: FormAction(vv, formstr, cfg)
 	, quit(false)
@@ -34,7 +34,7 @@ UrlViewFormAction::~UrlViewFormAction() {}
 
 bool UrlViewFormAction::process_operation(Operation op,
 	bool /* automatic */,
-	std::vector<std::string>* /* args */)
+	std::vector<Utf8String>* /* args */)
 {
 	bool hardquit = false;
 	switch (op) {
@@ -78,7 +78,7 @@ bool UrlViewFormAction::process_operation(Operation op,
 		unsigned int idx = op - OP_OPEN_URL_1;
 
 		if (idx < links.size()) {
-			const std::string feedurl = (feed != nullptr ?  feed->rssurl() : "");
+			const auto feedurl = (feed != nullptr ?  feed->rssurl() : "");
 			const bool interactive = true;
 			v->open_in_browser(links[idx].first, feedurl, utils::link_type_str(links[idx].second),
 				interactive);
@@ -114,7 +114,7 @@ void UrlViewFormAction::open_current_position_in_browser(bool interactive)
 {
 	if (!links.empty()) {
 		const unsigned int pos = urls_list.get_position();
-		const std::string feedurl = (feed != nullptr ?  feed->rssurl() : "");
+		const auto feedurl = (feed != nullptr ?  feed->rssurl() : "");
 		v->open_in_browser(links[pos].first, feedurl, utils::link_type_str(links[pos].second),
 			interactive);
 	} else {
@@ -170,7 +170,7 @@ const std::vector<KeyMapHintEntry>& UrlViewFormAction::get_keymap_hint() const
 	return hints;
 }
 
-void UrlViewFormAction::handle_cmdline(const std::string& cmd)
+void UrlViewFormAction::handle_cmdline(const Utf8String& cmd)
 {
 	unsigned int idx = 0;
 	if (1 == sscanf(cmd.c_str(), "%u", &idx)) {
@@ -184,9 +184,9 @@ void UrlViewFormAction::handle_cmdline(const std::string& cmd)
 	}
 }
 
-std::string UrlViewFormAction::title()
+Utf8String UrlViewFormAction::title()
 {
-	return _("URLs");
+	return _s("URLs");
 }
 
 } // namespace newsboat

--- a/src/utf8string.cpp
+++ b/src/utf8string.cpp
@@ -1,0 +1,27 @@
+#include "utf8string.h"
+
+#include "utils.h"
+
+namespace newsboat {
+
+Utf8String::Utf8String(std::string input)
+{
+	inner = std::move(input);
+}
+
+Utf8String Utf8String::from_utf8(std::string input)
+{
+	return Utf8String(std::move(input));
+}
+
+Utf8String Utf8String::from_locale_charset(std::string input)
+{
+	return Utf8String(utils::locale_to_utf8(input));
+}
+
+std::string Utf8String::to_locale_charset() const
+{
+	return utils::utf8_to_locale(inner);
+}
+
+} // namespace newsboat

--- a/src/utf8string.cpp
+++ b/src/utf8string.cpp
@@ -19,6 +19,11 @@ Utf8String::operator rust::String() const
 	return rust::String(inner);
 }
 
+Utf8String::operator rust::Str() const
+{
+	return rust::Str(inner);
+}
+
 Utf8String::Utf8String(std::string input)
 {
 	inner = std::move(input);

--- a/src/utf8string.cpp
+++ b/src/utf8string.cpp
@@ -1,8 +1,23 @@
 #include "utf8string.h"
 
+#include <stfl.h>
+#include <wctype.h>
+
+#include "rust/cxx.h"
+
 #include "utils.h"
 
 namespace newsboat {
+
+Utf8String::Utf8String(const rust::String& input)
+{
+	inner = std::string(input);
+}
+
+Utf8String::operator rust::String() const
+{
+	return rust::String(inner);
+}
 
 Utf8String::Utf8String(std::string input)
 {

--- a/src/utf8string.cpp
+++ b/src/utf8string.cpp
@@ -14,6 +14,11 @@ Utf8String::Utf8String(const rust::String& input)
 	inner = std::string(input);
 }
 
+Utf8String::Utf8String(const rust::Str& input)
+{
+	inner = std::string(input);
+}
+
 Utf8String::operator rust::String() const
 {
 	return rust::String(inner);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -50,15 +50,15 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 using HTTPMethod = newsboat::utils::HTTPMethod;
 
 namespace {
-	std::vector<newsboat::Utf8String> string_to_utf8_vector(std::vector<std::string> input)
-	{
-		std::vector<newsboat::Utf8String> output;
-		output.reserve(input.size());
-		for (auto s : input) {
-			output.push_back(newsboat::Utf8String::from_utf8(s));
-		}
-		return output;
+std::vector<newsboat::Utf8String> string_to_utf8_vector(std::vector<std::string> input)
+{
+	std::vector<newsboat::Utf8String> output;
+	output.reserve(input.size());
+	for (auto s : input) {
+		output.push_back(newsboat::Utf8String::from_utf8(s));
 	}
+	return output;
+}
 }
 
 namespace newsboat {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -49,11 +49,28 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 
 using HTTPMethod = newsboat::utils::HTTPMethod;
 
+namespace {
+	std::vector<newsboat::Utf8String> string_to_utf8_vector(std::vector<std::string> input)
+	{
+		std::vector<newsboat::Utf8String> output;
+		output.reserve(input.size());
+		for (auto s : input) {
+			output.push_back(newsboat::Utf8String::from_utf8(s));
+		}
+		return output;
+	}
+}
+
 namespace newsboat {
 
 std::string utils::strip_comments(const std::string& line)
 {
 	return std::string(utils::bridged::strip_comments(line));
+}
+
+Utf8String utils::strip_comments(const Utf8String& line)
+{
+	return Utf8String(utils::bridged::strip_comments(line));
 }
 
 std::vector<std::string> utils::tokenize_quoted(const std::string& str,
@@ -64,6 +81,18 @@ std::vector<std::string> utils::tokenize_quoted(const std::string& str,
 	std::vector<std::string> result;
 	for (const auto& token : tokens) {
 		result.push_back(std::string(token));
+	}
+	return result;
+}
+
+std::vector<Utf8String> utils::tokenize_quoted(const Utf8String& str,
+	Utf8String delimiters)
+{
+	const auto tokens = utils::bridged::tokenize_quoted(str, delimiters);
+
+	std::vector<Utf8String> result;
+	for (const auto& token : tokens) {
+		result.push_back(token);
 	}
 	return result;
 }
@@ -112,6 +141,12 @@ std::vector<std::string> utils::tokenize(const std::string& str,
 	return tokens;
 }
 
+std::vector<Utf8String> utils::tokenize(const Utf8String& str,
+	Utf8String delimiters)
+{
+	return string_to_utf8_vector(tokenize(str.utf8(), delimiters.utf8()));
+}
+
 std::vector<std::string> utils::tokenize_spaced(const std::string& str,
 	std::string delimiters)
 {
@@ -133,6 +168,12 @@ std::vector<std::string> utils::tokenize_spaced(const std::string& str,
 	}
 
 	return tokens;
+}
+
+std::vector<Utf8String> utils::tokenize_spaced(const Utf8String& str,
+	Utf8String delimiters)
+{
+	return string_to_utf8_vector(tokenize_spaced(str.utf8(), delimiters.utf8()));
 }
 
 std::string utils::consolidate_whitespace(const std::string& str)
@@ -179,6 +220,12 @@ std::vector<std::string> utils::tokenize_nl(const std::string& str,
 	}
 
 	return tokens;
+}
+
+std::vector<Utf8String> utils::tokenize_nl(const Utf8String& str,
+	Utf8String delimiters)
+{
+	return string_to_utf8_vector(tokenize_nl(str.utf8(), delimiters.utf8()));
 }
 
 std::string utils::translit(const std::string& tocode, const std::string& fromcode)
@@ -608,6 +655,16 @@ void utils::trim_end(std::string& str)
 	str = std::string(utils::bridged::trim_end(str));
 }
 
+void utils::trim(Utf8String& str)
+{
+	str = Utf8String(utils::bridged::trim(str));
+}
+
+void utils::trim_end(Utf8String& str)
+{
+	str = Utf8String(utils::bridged::trim_end(str));
+}
+
 std::string utils::quote(const std::string& str)
 {
 	return std::string(utils::bridged::quote(str));
@@ -840,6 +897,13 @@ void utils::remove_soft_hyphens(std::string& text)
 	rust::String tmp(text);
 	utils::bridged::remove_soft_hyphens(tmp);
 	text = std::string(tmp);
+}
+
+void utils::remove_soft_hyphens(Utf8String& text)
+{
+	rust::String tmp(text.utf8());
+	utils::bridged::remove_soft_hyphens(tmp);
+	text = Utf8String(tmp);
 }
 
 bool utils::is_valid_podcast_type(const std::string& mimetype)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -915,4 +915,18 @@ std::string utils::mt_strf_localtime(const std::string& format, time_t t)
 	return std::string(buffer, written);
 }
 
+bool utils::starts_with(const std::string& prefix, const std::string& input)
+{
+	return input.substr(0, prefix.size()) == prefix;
+}
+
+bool utils::ends_with(const std::string& suffix, const std::string& input)
+{
+	if (input.size() < suffix.size()) {
+		return false;
+	} else {
+		return input.substr(input.size() - suffix.size(), suffix.size()) == suffix;
+	}
+}
+
 } // namespace newsboat

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -556,6 +556,25 @@ std::string utils::join(const std::vector<std::string>& strings,
 	return result;
 }
 
+Utf8String utils::join(const std::vector<Utf8String>& strings,
+	const Utf8String& separator)
+{
+	Utf8String result;
+
+	bool first = true;
+	for (const auto& str : strings) {
+		if (first) {
+			first = false;
+		} else {
+			result.append(separator);
+		}
+		result.append(str);
+	}
+
+	return result;
+}
+
+
 std::string utils::censor_url(const std::string& url)
 {
 	return std::string(utils::bridged::censor_url(url));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -81,6 +81,19 @@ nonstd::optional<std::string> utils::extract_token_quoted(std::string& str,
 	return {};
 }
 
+nonstd::optional<Utf8String> utils::extract_token_quoted(Utf8String& str,
+	Utf8String delimiters)
+{
+	rust::String remaining = str;
+	rust::String token;
+	if (utils::bridged::extract_token_quoted(remaining, delimiters, token)) {
+		str = Utf8String(remaining);
+		return Utf8String(token);
+	}
+	str = Utf8String(remaining);
+	return {};
+}
+
 std::vector<std::string> utils::tokenize(const std::string& str,
 	std::string delimiters)
 {

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -142,11 +142,7 @@ bool View::run_commands(const std::vector<MacroCmd>& commands)
 		std::shared_ptr<FormAction> fa = get_current_formaction();
 		fa->prepare();
 		fa->draw_form();
-		std::vector<std::string> args;
-		for (const auto& arg : command.args) {
-			args.push_back(arg.utf8());
-		}
-		if (!fa->process_op(command.op, true, &args)) {
+		if (!fa->process_op(command.op, true, &command.args)) {
 			// Operation failed, abort
 			return false;
 		}
@@ -450,7 +446,10 @@ void View::set_feedlist(std::vector<std::shared_ptr<RssFeed>> feeds)
 
 void View::set_tags(const std::vector<std::string>& t)
 {
-	tags = t;
+	tags.clear();
+	for (const auto& s : t) {
+		tags.push_back(Utf8String::from_utf8(s));
+	}
 }
 
 void View::push_searchresult(std::shared_ptr<RssFeed> feed,
@@ -1267,14 +1266,14 @@ void View::handle_resize()
 
 void View::handle_cmdline_completion(std::shared_ptr<FormAction> fa)
 {
-	std::string fragment = fa->get_value("qna_value");
+	auto fragment = fa->get_value("qna_value");
 	if (fragment != last_fragment || fragment == "") {
 		last_fragment = fragment;
 		suggestions = fa->get_suggestions(fragment);
 		tab_count = 0;
 	}
 	tab_count++;
-	std::string suggestion;
+	Utf8String suggestion;
 	switch (suggestions.size()) {
 	case 0:
 		LOG(Level::DEBUG,

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -142,7 +142,11 @@ bool View::run_commands(const std::vector<MacroCmd>& commands)
 		std::shared_ptr<FormAction> fa = get_current_formaction();
 		fa->prepare();
 		fa->draw_form();
-		if (!fa->process_op(command.op, true, &command.args)) {
+		std::vector<std::string> args;
+		for (const auto& arg : command.args) {
+			args.push_back(arg.utf8());
+		}
+		if (!fa->process_op(command.op, true, &args)) {
 			// Operation failed, abort
 			return false;
 		}

--- a/test/colormanager.cpp
+++ b/test/colormanager.cpp
@@ -8,18 +8,19 @@
 
 #include "confighandlerexception.h"
 #include "configparser.h"
+#include "utf8string.h"
 
 using namespace newsboat;
 
 class StylesCollector {
-	std::map<std::string, std::string> styles;
+	std::map<Utf8String, Utf8String> styles;
 
 public:
 	StylesCollector() = default;
 
-	std::function<void(const std::string&, const std::string&)> setter()
+	std::function<void(const Utf8String&, const Utf8String&)> setter()
 	{
-		return [this](const std::string& element, const std::string& style) {
+		return [this](const Utf8String& element, const Utf8String& style) {
 			if (this->styles.find(element) != this->styles.cend()) {
 				throw std::invalid_argument(std::string("Multiple styles for element ") + element);
 			}
@@ -33,7 +34,7 @@ public:
 		return styles.size();
 	}
 
-	std::string style(const std::string& element) const
+	Utf8String style(const Utf8String& element) const
 	{
 		const auto style = styles.find(element);
 		if (style != styles.cend()) {
@@ -135,7 +136,7 @@ TEST_CASE(
 {
 	ColorManager c;
 
-	const std::vector<std::string> non_colors{
+	const std::vector<Utf8String> non_colors{
 		{"awesome", "but", "nonexistent", "colors"}};
 	for (const auto& color : non_colors) {
 		CHECK_THROWS_AS(c.handle_action("color",
@@ -151,7 +152,7 @@ TEST_CASE(
 {
 	ColorManager c;
 
-	const std::vector<std::string> non_colors{
+	const std::vector<Utf8String> non_colors{
 		{"awesome", "but", "nonexistent", "colors"}};
 	for (const auto& color : non_colors) {
 		CHECK_THROWS_AS(c.handle_action("color",
@@ -167,7 +168,7 @@ TEST_CASE(
 {
 	ColorManager c;
 
-	const std::vector<std::string> non_attributes{
+	const std::vector<Utf8String> non_attributes{
 		{"awesome", "but", "nonexistent", "attributes"}};
 	for (const auto& attr : non_attributes) {
 		CHECK_THROWS_AS(c.handle_action("color",
@@ -183,7 +184,7 @@ TEST_CASE(
 {
 	ColorManager c;
 
-	const std::vector<std::string> non_elements{
+	const std::vector<Utf8String> non_elements{
 		{"awesome", "but", "nonexistent", "elements"}};
 	for (const auto& element : non_elements) {
 		CHECK_THROWS_AS(
@@ -199,7 +200,7 @@ TEST_CASE(
 {
 	ColorManager c;
 
-	const std::vector<std::string> other_commands{
+	const std::vector<Utf8String> other_commands{
 		{"browser", "include", "auto-reload", "ocnews-flag-star"}};
 	for (const auto& command : other_commands) {
 		CHECK_THROWS_AS(
@@ -212,8 +213,8 @@ TEST_CASE("dump_config() returns everything we put into ColorManager",
 {
 	ColorManager c;
 
-	std::unordered_set<std::string> expected;
-	std::vector<std::string> config;
+	std::unordered_set<Utf8String> expected;
+	std::vector<Utf8String> config;
 
 	// Checks that `expected` contains the same lines as `config` contains,
 	// and nothing more.
@@ -281,11 +282,11 @@ TEST_CASE("If no colors were specified for the "
 	"then use colors from the `info` element (if any)",
 	"[ColorManager]")
 {
-	const std::vector<std::string> elements {
+	const std::vector<Utf8String> elements {
 		"title", "hint-key", "hint-keys-delimiter", "hint-separator", "hint-description"};
 
 	for (const auto& element : elements) {
-		DYNAMIC_SECTION("element: " << element) {
+		DYNAMIC_SECTION("element: " << element.utf8()) {
 			ColorManager c;
 			StylesCollector collector;
 

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -6,6 +6,7 @@
 #include "confighandlerexception.h"
 #include "configparser.h"
 #include "keymap.h"
+#include "utf8string.h"
 
 using namespace newsboat;
 
@@ -118,19 +119,19 @@ TEST_CASE("reset_to_default changes setting to its default value",
 {
 	ConfigContainer cfg;
 
-	const std::string default_value = "any";
-	const std::vector<std::string> tests{"any",
+	const Utf8String default_value = "any";
+	const std::vector<Utf8String> tests{"any",
 		"basic",
 		"digest",
 		"digest_ie",
 		"gssnegotiate",
 		"ntlm",
 		"anysafe"};
-	const std::string key("http-auth-method");
+	const Utf8String key = "http-auth-method";
 
 	REQUIRE(cfg.get_configvalue(key) == default_value);
 
-	for (const std::string& test_value : tests) {
+	for (const auto& test_value : tests) {
 		cfg.set_configvalue(key, test_value);
 		REQUIRE(cfg.get_configvalue(key) == test_value);
 		REQUIRE_NOTHROW(cfg.reset_to_default(key));
@@ -183,8 +184,8 @@ TEST_CASE("get_configvalue_as_int() returns zero if setting doesn't exist",
 TEST_CASE("get_configvalue_as_int() returns zero if value can't be parsed as int",
 	"[ConfigContainer]")
 {
-	const auto key = std::string("auto-reload");
-	const auto value = std::string("true");
+	const auto key = Utf8String("auto-reload");
+	const auto value = Utf8String("true");
 
 	ConfigContainer cfg;
 	cfg.set_configvalue(key, value);
@@ -198,7 +199,7 @@ TEST_CASE("toggle() inverts the value of a boolean setting",
 {
 	ConfigContainer cfg;
 
-	const std::string key("always-display-description");
+	const Utf8String key("always-display-description");
 	SECTION("\"true\" becomes \"false\"") {
 		cfg.set_configvalue(key, "true");
 		REQUIRE_NOTHROW(cfg.toggle(key));
@@ -217,7 +218,7 @@ TEST_CASE("toggle() does nothing if setting is non-boolean",
 {
 	ConfigContainer cfg;
 
-	const std::vector<std::string> tests{"articlelist-title-format",
+	const std::vector<Utf8String> tests{"articlelist-title-format",
 		"cache-file",
 		"http-auth-method",
 		"inoreader-passwordeval",
@@ -226,8 +227,8 @@ TEST_CASE("toggle() does nothing if setting is non-boolean",
 		"oldreader-min-items",
 		"save-path"};
 
-	for (const std::string& key : tests) {
-		const std::string expected = cfg.get_configvalue(key);
+	for (const auto& key : tests) {
+		const auto expected = cfg.get_configvalue(key);
 		REQUIRE_NOTHROW(cfg.toggle(key));
 		REQUIRE(cfg.get_configvalue(key) == expected);
 	}
@@ -241,8 +242,8 @@ TEST_CASE(
 	ConfigContainer cfg;
 
 	auto all_values_found =
-		[](std::unordered_set<std::string>& expected,
-	const std::vector<std::string>& result) {
+		[](std::unordered_set<Utf8String>& expected,
+	const std::vector<Utf8String>& result) {
 		for (const auto& line : result) {
 			auto it = expected.find(line);
 			if (it != expected.end()) {
@@ -253,10 +254,10 @@ TEST_CASE(
 		return expected.empty();
 	};
 
-	std::vector<std::string> result;
+	std::vector<Utf8String> result;
 
 	SECTION("By default, simply enumerates all settings") {
-		std::unordered_set<std::string> expected{
+		std::unordered_set<Utf8String> expected{
 			"always-display-description false",
 			"download-timeout 30",
 			"ignore-mode \"download\"",
@@ -278,7 +279,7 @@ TEST_CASE(
 		cfg.set_configvalue("download-timeout", "100");
 		cfg.set_configvalue("http-auth-method", "digest");
 
-		std::unordered_set<std::string> expected{
+		std::unordered_set<Utf8String> expected{
 			"download-timeout 100 # default: 30",
 			"http-auth-method \"digest\" # default: any",
 		};
@@ -299,8 +300,8 @@ TEST_CASE(
 {
 	ConfigContainer cfg;
 
-	const std::string key1("d");
-	const std::unordered_set<std::string> expected1{
+	const Utf8String key1("d");
+	const std::unordered_set<Utf8String> expected1{
 		"datetime-format",
 		"delete-played-files",
 		"delete-read-articles-on-quit",
@@ -313,13 +314,13 @@ TEST_CASE(
 		"download-retries",
 		"download-timeout",
 	};
-	std::vector<std::string> results = cfg.get_suggestions(key1);
-	const std::unordered_set<std::string> results_set1(
+	std::vector<Utf8String> results = cfg.get_suggestions(key1);
+	const std::unordered_set<Utf8String> results_set1(
 		results.begin(), results.end());
 	REQUIRE(results_set1 == expected1);
 
-	const std::string key2("feed");
-	const std::unordered_set<std::string> expected2{
+	const Utf8String key2("feed");
+	const std::unordered_set<Utf8String> expected2{
 		"feed-sort-order",
 		"feedhq-flag-share",
 		"feedhq-flag-star",
@@ -334,7 +335,7 @@ TEST_CASE(
 		"feedlist-title-format",
 	};
 	results = cfg.get_suggestions(key2);
-	const std::unordered_set<std::string> results_set2(
+	const std::unordered_set<Utf8String> results_set2(
 		results.begin(), results.end());
 	REQUIRE(results_set2 == expected2);
 }
@@ -344,15 +345,15 @@ TEST_CASE("get_suggestions() returns results in alphabetical order",
 {
 	ConfigContainer cfg;
 
-	const std::vector<std::string> keys{"dow", "rel", "us", "d"};
+	const std::vector<Utf8String> keys{"dow", "rel", "us", "d"};
 	for (const auto& key : keys) {
-		const std::vector<std::string> results =
+		const std::vector<Utf8String> results =
 			cfg.get_suggestions(key);
 		for (auto one = results.begin(), two = one + 1;
 			two != results.end();
 			one = two, ++two) {
-			INFO("Previous: " << *one);
-			INFO("Current:  " << *two);
+			INFO("Previous: " << one->utf8());
+			INFO("Current:  " << two->utf8());
 			REQUIRE(*one <= *two);
 		}
 	}

--- a/test/configpaths.cpp
+++ b/test/configpaths.cpp
@@ -190,13 +190,13 @@ TEST_CASE("ConfigPaths::create_dirs() returns true if both config and data dirs 
 		ConfigPaths paths;
 		REQUIRE(paths.initialized());
 
-		REQUIRE(test_helpers::starts_with(tmp.get_path(), paths.url_file()));
-		REQUIRE(test_helpers::starts_with(tmp.get_path(), paths.config_file()));
-		REQUIRE(test_helpers::starts_with(tmp.get_path(), paths.cache_file()));
-		REQUIRE(test_helpers::starts_with(tmp.get_path(), paths.lock_file()));
-		REQUIRE(test_helpers::starts_with(tmp.get_path(), paths.queue_file()));
-		REQUIRE(test_helpers::starts_with(tmp.get_path(), paths.search_file()));
-		REQUIRE(test_helpers::starts_with(tmp.get_path(), paths.cmdline_file()));
+		REQUIRE(utils::starts_with(tmp.get_path(), paths.url_file()));
+		REQUIRE(utils::starts_with(tmp.get_path(), paths.config_file()));
+		REQUIRE(utils::starts_with(tmp.get_path(), paths.cache_file()));
+		REQUIRE(utils::starts_with(tmp.get_path(), paths.lock_file()));
+		REQUIRE(utils::starts_with(tmp.get_path(), paths.queue_file()));
+		REQUIRE(utils::starts_with(tmp.get_path(), paths.search_file()));
+		REQUIRE(utils::starts_with(tmp.get_path(), paths.cmdline_file()));
 
 		REQUIRE(paths.create_dirs());
 

--- a/test/filtercontainer.cpp
+++ b/test/filtercontainer.cpp
@@ -71,7 +71,7 @@ TEST_CASE("FilterContainer::handle_action throws ConfigHandlerException on unkno
 		ConfigHandlerException);
 }
 
-TEST_CASE("FilterContainer::get_filters() gives direct access to stored filters",
+TEST_CASE("FilterContainer::get_filters() gives access to stored filters",
 	"[FilterContainer]")
 {
 	FilterContainer filters;
@@ -90,9 +90,6 @@ TEST_CASE("FilterContainer::get_filters() gives direct access to stored filters"
 	REQUIRE(filters.get_filters()[0].expr == filter1);
 	REQUIRE(filters.get_filters()[1].name == name2);
 	REQUIRE(filters.get_filters()[1].expr == filter2);
-
-	filters.get_filters().clear();
-	REQUIRE(filters.size() == 0);
 }
 
 TEST_CASE("FilterContainer::dump_config() writes out all configured settings to the provided vector",

--- a/test/filtercontainer.cpp
+++ b/test/filtercontainer.cpp
@@ -2,6 +2,7 @@
 
 #include "3rd-party/catch.hpp"
 #include "confighandlerexception.h"
+#include "utf8string.h"
 
 using namespace newsboat;
 
@@ -10,7 +11,7 @@ TEST_CASE("FilterContainer::handle_action handles `define-filter`",
 {
 	FilterContainer filters;
 
-	const auto action = "define-filter";
+	const Utf8String action = "define-filter";
 
 	SECTION("Throws ConfigHandlerException if less than 2 parameters") {
 		REQUIRE_THROWS_AS(filters.handle_action(action, {}), ConfigHandlerException);
@@ -37,8 +38,8 @@ TEST_CASE("FilterContainer allows two filters to have the same name",
 {
 	FilterContainer filters;
 
-	const auto action = "define-filter";
-	const auto filter_name = "arbitrary name";
+	const Utf8String action = "define-filter";
+	const Utf8String filter_name = "arbitrary name";
 
 	REQUIRE_NOTHROW(filters.handle_action(action, {filter_name, "title = \"Updates\""}));
 	REQUIRE_NOTHROW(filters.handle_action(action, {filter_name, "author != \"Jon Doe\""}));
@@ -51,8 +52,8 @@ TEST_CASE("FilterContainer allows the same filter to have two different names",
 {
 	FilterContainer filters;
 
-	const auto action = "define-filter";
-	const auto filter = "title = \"Whatever, really\"";
+	const Utf8String action = "define-filter";
+	const Utf8String filter = "title = \"Whatever, really\"";
 
 	REQUIRE_NOTHROW(filters.handle_action(action, {"first filter", filter}));
 	REQUIRE_NOTHROW(filters.handle_action(action, {"second filter", filter}));
@@ -76,11 +77,11 @@ TEST_CASE("FilterContainer::get_filters() gives access to stored filters",
 {
 	FilterContainer filters;
 
-	const auto action = "define-filter";
-	const auto name1 = "filter1";
-	const auto filter1 =  "title == \"Best\"";
-	const auto name2 = "other";
-	const auto filter2 =  "author # \"Ted\"";
+	const Utf8String action = "define-filter";
+	const Utf8String name1 = "filter1";
+	const Utf8String filter1 =  "title == \"Best\"";
+	const Utf8String name2 = "other";
+	const Utf8String filter2 =  "author # \"Ted\"";
 
 	filters.handle_action(action, {name1, filter1});
 	filters.handle_action(action, {name2, filter2});
@@ -97,15 +98,15 @@ TEST_CASE("FilterContainer::dump_config() writes out all configured settings to 
 {
 	FilterContainer filters;
 
-	const auto action = "define-filter";
+	const Utf8String action = "define-filter";
 
 	filters.handle_action(action, {"first", "title = \"x\""});
 	filters.handle_action(action, {"second", "author = \"Me\""});
 	filters.handle_action(action, {"third", "content =~ \"Linux\""});
 
-	std::vector<std::string> config;
+	std::vector<Utf8String> config;
 
-	const auto comment =
+	const Utf8String comment =
 		"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
 	config.push_back(comment);
 
@@ -123,7 +124,7 @@ TEST_CASE("FilterContainer::get_filter() returns non-value when filter does not 
 {
 	FilterContainer filters;
 
-	const auto filter1_expression = R"(title = "title 1")";
+	const Utf8String filter1_expression = R"(title = "title 1")";
 
 	REQUIRE_FALSE(filters.get_filter("non-existing").has_value());
 	REQUIRE_FALSE(filters.get_filter("filter1").has_value());
@@ -140,12 +141,12 @@ TEST_CASE("FilterContainer::get_filter() returns first filter with given name",
 {
 	FilterContainer filters;
 
-	const auto action = "define-filter";
-	const auto filter_name = "arbitrary name";
+	const Utf8String action = "define-filter";
+	const Utf8String filter_name = "arbitrary name";
 
-	const auto filter1 = R"(title = "title 1")";
-	const auto filter2 = R"(title = "title 2")";
-	const auto filter3 = R"(title = "title 3")";
+	const Utf8String filter1 = R"(title = "title 1")";
+	const Utf8String filter2 = R"(title = "title 2")";
+	const Utf8String filter3 = R"(title = "title 3")";
 
 	REQUIRE_NOTHROW(filters.handle_action(action, {"other filter", filter1}));
 	REQUIRE_NOTHROW(filters.handle_action(action, {filter_name, filter2}));

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -14,6 +14,7 @@
 #include "rssfeed.h"
 #include "test_helpers/misc.h"
 #include "test_helpers/tempfile.h"
+#include "utf8string.h"
 
 using namespace newsboat;
 
@@ -25,10 +26,10 @@ TEST_CASE("OP_OPEN displays article using an external pager",
 	newsboat::View v(&c);
 	test_helpers::TempFile pagerfile;
 
-	const std::string test_url = "http://test_url";
-	std::string test_title = "Article Title";
-	std::string test_author = "Article Author";
-	std::string test_description = "Article Description";
+	const Utf8String test_url = "http://test_url";
+	Utf8String test_title = "Article Title";
+	Utf8String test_author = "Article Author";
+	Utf8String test_description = "Article Description";
 	time_t test_pubDate = 42;
 	char test_pubDate_str[128];
 	strftime(test_pubDate_str,
@@ -111,7 +112,7 @@ TEST_CASE(
 	newsboat::View v(&c);
 	test_helpers::TempFile browserfile;
 
-	const std::string test_url = "http://test_url";
+	const Utf8String test_url = "http://test_url";
 	std::string line;
 
 	ConfigContainer cfg;
@@ -149,7 +150,7 @@ TEST_CASE(
 	Controller c(paths);
 	newsboat::View v(&c);
 
-	const std::string test_url = "http://test_url";
+	const Utf8String test_url = "http://test_url";
 
 	ConfigContainer cfg;
 	cfg.set_configvalue("browser", "false %u");
@@ -181,7 +182,7 @@ TEST_CASE("OP_OPENINBROWSER passes the url to the browser",
 	Controller c(paths);
 	newsboat::View v(&c);
 	test_helpers::TempFile browserfile;
-	const std::string test_url = "http://test_url";
+	const Utf8String test_url = "http://test_url";
 	std::string line;
 
 	ConfigContainer cfg;
@@ -215,7 +216,7 @@ TEST_CASE("OP_OPENINBROWSER_NONINTERACTIVE passes the url to the browser",
 	Controller c(paths);
 	newsboat::View v(&c);
 	test_helpers::TempFile browserfile;
-	const std::string test_url = "http://test_url";
+	const Utf8String test_url = "http://test_url";
 	std::string line;
 
 	ConfigContainer cfg;
@@ -249,8 +250,8 @@ TEST_CASE("OP_OPENALLUNREADINBROWSER passes the url list to the browser",
 	Controller c(paths);
 	newsboat::View v(&c);
 	test_helpers::TempFile browserfile;
-	std::unordered_set<std::string> url_set;
-	const std::string test_url = "http://test_url";
+	std::unordered_set<Utf8String> url_set;
+	const Utf8String test_url = "http://test_url";
 	std::string line;
 	int itemCount = 6;
 
@@ -333,8 +334,8 @@ TEST_CASE(
 	Controller c(paths);
 	newsboat::View v(&c);
 	test_helpers::TempFile browserfile;
-	std::unordered_set<std::string> url_set;
-	const std::string test_url = "http://test_url";
+	std::unordered_set<Utf8String> url_set;
+	const Utf8String test_url = "http://test_url";
 	std::string line;
 	const unsigned int itemCount = 6;
 
@@ -421,10 +422,10 @@ TEST_CASE("OP_SHOWURLS shows the article's properties", "[ItemListFormAction]")
 	RegexManager rxman;
 	test_helpers::TempFile urlFile;
 
-	const std::string test_url = "http://test_url";
-	std::string test_title = "Article Title";
-	std::string test_author = "Article Author";
-	std::string test_description = "Article Description";
+	const Utf8String test_url = "http://test_url";
+	Utf8String test_title = "Article Title";
+	Utf8String test_author = "Article Author";
+	Utf8String test_description = "Article Description";
 	time_t test_pubDate = 42;
 	char test_pubDate_str[128];
 	strftime(test_pubDate_str,
@@ -484,13 +485,13 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 	RegexManager rxman;
 	test_helpers::TempFile bookmarkFile;
 	std::string line;
-	std::vector<std::string> bookmark_args;
+	std::vector<Utf8String> bookmark_args;
 
-	const std::string test_url = "http://test_url";
-	std::string test_title = "Article Title";
-	std::string feed_title = "Feed Title";
-	std::string separator = " ";
-	std::string extra_arg = "extra arg";
+	const Utf8String test_url = "http://test_url";
+	Utf8String test_title = "Article Title";
+	Utf8String feed_title = "Feed Title";
+	Utf8String separator = " ";
+	Utf8String extra_arg = "extra arg";
 
 	v.set_config_container(&cfg);
 	c.set_view(&v);
@@ -532,7 +533,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	FilterContainer filters;
 	RegexManager rxman;
 
-	std::vector<std::string> op_args;
+	std::vector<Utf8String> op_args;
 
 	v.set_config_container(&cfg);
 	c.set_view(&v);
@@ -546,7 +547,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	itemlist.set_feed(feed);
 
 	SECTION("Single flag") {
-		std::string flags = "G";
+		Utf8String flags = "G";
 		op_args.push_back(flags);
 
 		REQUIRE_NOTHROW(
@@ -555,8 +556,8 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	}
 
 	SECTION("Unordered flags") {
-		std::string flags = "abdefc";
-		std::string ordered_flags = "abcdef";
+		Utf8String flags = "abdefc";
+		Utf8String ordered_flags = "abcdef";
 		op_args.push_back(flags);
 
 		REQUIRE_NOTHROW(
@@ -565,7 +566,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	}
 
 	SECTION("Duplicate flag in argument") {
-		std::string flags = "Abd";
+		Utf8String flags = "Abd";
 		op_args.push_back(flags + "ddd");
 
 		REQUIRE_NOTHROW(
@@ -574,7 +575,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	}
 
 	SECTION("Unauthorized values in arguments") {
-		std::string flags = "Abd";
+		Utf8String flags = "Abd";
 		SECTION("Numbers") {
 			op_args.push_back(flags + "1236");
 
@@ -600,7 +601,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	}
 
 	SECTION("All possible flags at once") {
-		std::string flags =
+		Utf8String flags =
 			"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 		op_args.push_back(flags);
 
@@ -622,13 +623,13 @@ TEST_CASE("OP_SAVE writes an article's attributes to the specified file",
 	FilterContainer filters;
 	RegexManager rxman;
 
-	std::vector<std::string> op_args;
+	std::vector<Utf8String> op_args;
 	op_args.push_back(saveFile.get_path());
 
-	const std::string test_url = "http://test_url";
-	std::string test_title = "Article Title";
-	std::string test_author = "Article Author";
-	std::string test_description = "Article Description";
+	const Utf8String test_url = "http://test_url";
+	Utf8String test_title = "Article Title";
+	Utf8String test_author = "Article Author";
+	Utf8String test_description = "Article Description";
 	time_t test_pubDate = 42;
 	char test_pubDate_str[128];
 	strftime(test_pubDate_str,
@@ -727,9 +728,9 @@ TEST_CASE("Navigate back and forth using OP_NEXT and OP_PREV",
 	Cache rsscache(":memory:", &cfg);
 	std::string line;
 
-	std::string first_article_title = "First_Article";
-	std::string second_article_title = "Second_Article";
-	std::string prefix_title = "Title: ";
+	Utf8String first_article_title = "First_Article";
+	Utf8String second_article_title = "Second_Article";
+	Utf8String prefix_title = "Title: ";
 
 	KeyMap k(KM_NEWSBOAT);
 	v.set_keymap(&k);
@@ -812,13 +813,13 @@ TEST_CASE("OP_PIPE_TO pipes an article's content to an external command",
 	FilterContainer filters;
 	RegexManager rxman;
 
-	std::vector<std::string> op_args;
+	std::vector<Utf8String> op_args;
 	op_args.push_back("tee > " + articleFile.get_path());
 
-	const std::string test_url = "http://test_url";
-	std::string test_title = "Article Title";
-	std::string test_author = "Article Author";
-	std::string test_description = "Article Description";
+	const Utf8String test_url = "http://test_url";
+	Utf8String test_title = "Article Title";
+	Utf8String test_author = "Article Author";
+	Utf8String test_description = "Article Description";
 	time_t test_pubDate = 42;
 	char test_pubDate_str[128];
 	strftime(test_pubDate_str,

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -9,6 +9,7 @@
 
 #include "configcontainer.h"
 #include "download.h"
+#include "utils.h"
 
 using namespace newsboat;
 using namespace podboat;
@@ -339,8 +340,8 @@ TEST_CASE("Generates filename if it's absent from the queue file",
 		"here%27s_one_with_a_quote.mp4");
 	// These two downloads should have filenames based on current time, so we
 	// only check their prefixes.
-	REQUIRE(test_helpers::starts_with(download_path, downloads[3].filename()));
-	REQUIRE(test_helpers::starts_with(download_path, downloads[4].filename()));
+	REQUIRE(utils::starts_with(download_path, downloads[3].filename()));
+	REQUIRE(utils::starts_with(download_path, downloads[4].filename()));
 }
 
 TEST_CASE("reload() removes files corresponding to \"DELETED\" downloads "

--- a/test/queuemanager.cpp
+++ b/test/queuemanager.cpp
@@ -48,8 +48,8 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 
 				const auto lines = test_helpers::file_contents(queue_file.get_path());
 				REQUIRE(lines.size() == 2);
-				REQUIRE(test_helpers::starts_with(enclosure_url, lines[0]));
-				REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
+				REQUIRE(utils::starts_with(enclosure_url, lines[0]));
+				REQUIRE(utils::ends_with(R"(/podcast.mp3")", lines[0]));
 
 				REQUIRE(lines[1] == "");
 			}
@@ -73,8 +73,8 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 
 				const auto lines = test_helpers::file_contents(queue_file.get_path());
 				REQUIRE(lines.size() == 2);
-				REQUIRE(test_helpers::starts_with(enclosure_url, lines[0]));
-				REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
+				REQUIRE(utils::starts_with(enclosure_url, lines[0]));
+				REQUIRE(utils::ends_with(R"(/podcast.mp3")", lines[0]));
 
 				REQUIRE(lines[1] == "");
 			}
@@ -163,8 +163,8 @@ SCENARIO("enqueue_url() errors if the filename is already used", "[QueueManager]
 
 				const auto lines = test_helpers::file_contents(queue_file.get_path());
 				REQUIRE(lines.size() == 2);
-				REQUIRE(test_helpers::starts_with(enclosure_url1, lines[0]));
-				REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
+				REQUIRE(utils::starts_with(enclosure_url1, lines[0]));
+				REQUIRE(utils::ends_with(R"(/podcast.mp3")", lines[0]));
 
 				REQUIRE(lines[1] == "");
 			}
@@ -188,8 +188,8 @@ SCENARIO("enqueue_url() errors if the filename is already used", "[QueueManager]
 
 					const auto lines = test_helpers::file_contents(queue_file.get_path());
 					REQUIRE(lines.size() == 2);
-					REQUIRE(test_helpers::starts_with(enclosure_url1, lines[0]));
-					REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
+					REQUIRE(utils::starts_with(enclosure_url1, lines[0]));
+					REQUIRE(utils::ends_with(R"(/podcast.mp3")", lines[0]));
 
 					REQUIRE(lines[1] == "");
 				}
@@ -517,8 +517,8 @@ SCENARIO("autoenqueue() errors if the filename is already used", "[QueueManager]
 
 				const auto lines = test_helpers::file_contents(queue_file.get_path());
 				REQUIRE(lines.size() == 2);
-				REQUIRE(test_helpers::starts_with(enclosure_url1, lines[0]));
-				REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
+				REQUIRE(utils::starts_with(enclosure_url1, lines[0]));
+				REQUIRE(utils::ends_with(R"(/podcast.mp3")", lines[0]));
 
 				REQUIRE(lines[1] == "");
 			}

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -5,6 +5,7 @@
 #include "cache.h"
 #include "confighandlerexception.h"
 #include "rssitem.h"
+#include "utf8string.h"
 
 using namespace newsboat;
 
@@ -49,7 +50,7 @@ TEST_CASE("RssIgnores::handle_action() handles `ignore-article`",
 {
 	RssIgnores ignores;
 
-	const std::string action = "ignore-article";
+	const Utf8String action = "ignore-article";
 
 	SECTION("Throws ConfigHandlerException if less than 2 parameters") {
 		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
@@ -78,7 +79,7 @@ TEST_CASE("RssIgnores::handle_action() handles `always-download`",
 {
 	RssIgnores ignores;
 
-	const std::string action = "always-download";
+	const Utf8String action = "always-download";
 
 	SECTION("Throws ConfigHandlerException if given zero parameters") {
 		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
@@ -96,7 +97,7 @@ TEST_CASE("RssIgnores::handle_action() handles `reset-unread-on-update`",
 {
 	RssIgnores ignores;
 
-	const std::string action = "reset-unread-on-update";
+	const Utf8String action = "reset-unread-on-update";
 
 	SECTION("Throws ConfigHandlerException if given zero parameters") {
 		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
@@ -130,14 +131,14 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 	RssIgnores ignores;
 
 	SECTION("`ignore-article`") {
-		const std::string action = "ignore-article";
+		const Utf8String action = "ignore-article";
 
 		ignores.handle_action(action, {"https://example.com/feed.xml", "author =~ \"Joe\""});
 		ignores.handle_action(action, {"*", "title # \"interesting\""});
 		ignores.handle_action(action, {"https://blog.example.com/joe/posts.xml", "guid # 123"});
 
-		std::vector<std::string> config;
-		const auto comment =
+		std::vector<Utf8String> config;
+		const Utf8String comment =
 			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
 		config.push_back(comment);
 
@@ -153,13 +154,13 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 	}
 
 	SECTION("`always-download`") {
-		const std::string action = "always-download";
+		const Utf8String action = "always-download";
 
 		ignores.handle_action(action, {"url1"});
 		ignores.handle_action(action, {"url2", "url3", "url4"});
 
-		std::vector<std::string> config;
-		const auto comment =
+		std::vector<Utf8String> config;
+		const Utf8String comment =
 			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
 		config.push_back(comment);
 
@@ -174,13 +175,13 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 	}
 
 	SECTION("`reset-unread-on-update`") {
-		const std::string action = "reset-unread-on-update";
+		const Utf8String action = "reset-unread-on-update";
 
 		ignores.handle_action(action, {"url1"});
 		ignores.handle_action(action, {"url2", "url3", "url4"});
 
-		std::vector<std::string> config;
-		const auto comment =
+		std::vector<Utf8String> config;
+		const Utf8String comment =
 			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
 		config.push_back(comment);
 
@@ -202,8 +203,8 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 		ignores.handle_action("reset-unread-on-update", {"url2", "url3"});
 		ignores.handle_action("always-download", {"url2", "url3", "url4"});
 
-		std::vector<std::string> config;
-		const auto comment =
+		std::vector<Utf8String> config;
+		const Utf8String comment =
 			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
 		config.push_back(comment);
 
@@ -234,7 +235,7 @@ TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
 	Cache rsscache(":memory:", &cfg);
 	RssItem item(&rsscache);
 
-	const auto feedurl = "https://example.com/feed.xml";
+	const Utf8String feedurl = "https://example.com/feed.xml";
 
 	item.set_title("Updates");
 	item.set_author("John Doe");

--- a/test/strprintf.cpp
+++ b/test/strprintf.cpp
@@ -226,6 +226,12 @@ TEST_CASE("strprintf::fmt() formats std::string*", "[strprintf]")
 	REQUIRE(strprintf::fmt("%-15s", input) == "Hello, world!  ");
 }
 
+TEST_CASE("strprintf::fmt() formats Utf8String", "[strprintf]")
+{
+	const auto input = Utf8String::from_utf8("Здравствуй, мир!");
+	REQUIRE(strprintf::fmt("%s", input) == "Здравствуй, мир!");
+}
+
 TEST_CASE("strprintf::fmt() works fine with 2MB format string", "[strprintf]")
 {
 	const auto spacer = std::string(1024 * 1024, ' ');

--- a/test/test_helpers/misc.cpp
+++ b/test/test_helpers/misc.cpp
@@ -67,34 +67,7 @@ std::vector<std::string> test_helpers::file_contents(const std::string& filepath
 	return lines;
 }
 
-bool test_helpers::starts_with(const std::string& prefix,
-	const std::string& input)
-{
-	return input.substr(0, prefix.size()) == prefix;
-}
-
-bool test_helpers::ends_with(const std::string& suffix,
-	const std::string& input)
-{
-	if (input.size() < suffix.size()) {
-		return false;
-	} else {
-		return input.substr(input.size() - suffix.size(), suffix.size()) == suffix;
-	}
-}
-
 bool test_helpers::file_exists(const std::string& filepath)
 {
 	return access(filepath.c_str(), F_OK) == 0;
-}
-
-TEST_CASE("ends_with", "[test_helpers]")
-{
-	REQUIRE_FALSE(test_helpers::ends_with("bye", "hello"));
-	REQUIRE_FALSE(test_helpers::ends_with("bye", "hi"));
-
-	REQUIRE(test_helpers::ends_with("ype", "type"));
-	REQUIRE(test_helpers::ends_with("pe", "type"));
-	REQUIRE(test_helpers::ends_with("e", "type"));
-	REQUIRE(test_helpers::ends_with("", "type"));
 }

--- a/test/test_helpers/misc.h
+++ b/test/test_helpers/misc.h
@@ -29,14 +29,6 @@ void copy_file(const std::string& source, const std::string& destination);
  */
 std::vector<std::string> file_contents(const std::string& filepath);
 
-/* \brief Returns `true` if `input` starts with `prefix`.
- */
-bool starts_with(const std::string& prefix, const std::string& input);
-
-/* \brief Returns `true` if `input` ends with `suffix`.
- */
-bool ends_with(const std::string& suffix, const std::string& input);
-
 /* \brief Returns `true` if the file at `filepath` exists.
  */
 bool file_exists(const std::string& filepath);

--- a/test/utf8string.cpp
+++ b/test/utf8string.cpp
@@ -1,0 +1,252 @@
+#include "utf8string.h"
+
+#include <locale.h>
+#include <string>
+
+#include "3rd-party/catch.hpp"
+#include "3rd-party/optional.hpp"
+#include "test_helpers/envvar.h"
+
+using namespace newsboat;
+
+TEST_CASE("Utf8String can be constructed from valid UTF-8", "[Utf8String]")
+{
+	const auto str1 = Utf8String::from_utf8("");
+	REQUIRE(str1.to_utf8() == "");
+
+	// Russian "Привет", "hello"
+	const auto str2 =
+		Utf8String::from_utf8("\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82");
+	REQUIRE(str2.to_utf8() == "Привет");
+}
+
+TEST_CASE("Utf8String can be implicitly constructed from a string literal", "[Utf8String]")
+{
+	const auto check = [](Utf8String actual, std::string expected) {
+		REQUIRE(actual.to_utf8() == expected);
+	};
+
+	check("", "");
+	// Russian "Привет", "hello"
+	check("\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82", "Привет");
+}
+
+SCENARIO("Utf8String can be constructed from strings in locale locale charset",
+	"[Utf8String]")
+{
+	test_helpers::LcCtypeEnvVar lc_ctype;
+	const auto try_set_locale = [&lc_ctype](std::string new_locale) -> bool {
+		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr)
+		{
+			WARN("Couldn't set locale " + new_locale + "; test skipped.");
+			return false;
+		}
+		lc_ctype.set(new_locale);
+		return true;
+	};
+
+	GIVEN("UTF-8 locale") {
+		if (!try_set_locale("en_US.UTF-8")) {
+			return;
+		}
+
+		WHEN("Utf8String is constructed from an empty string") {
+			const auto str = Utf8String::from_locale_charset("");
+
+			THEN("the result is empty") {
+				REQUIRE(str.to_utf8() == "");
+			}
+
+			THEN("the result in locale encoding is empty") {
+				REQUIRE(str.to_locale_charset() == "");
+			}
+		}
+
+		WHEN("Utf8String is constructed from a string \"проверка\"") {
+			// Russian "проверка", "check"
+			const std::string
+			input("\xd0\xbf\xd1\x80\xd0\xbe\xd0\xb2\xd0\xb5\xd1\x80\xd0\xba\xd0\xb0");
+			const auto str = Utf8String::from_locale_charset(input);
+
+			THEN("the result is that string in UTF-8") {
+				REQUIRE(str.to_utf8() == "проверка");
+			}
+
+			THEN("the result in locale encoding is the same as input") {
+				REQUIRE(str.to_locale_charset() == input);
+			}
+		}
+	}
+
+	GIVEN("KOI8-R locale") {
+		if (!try_set_locale("ru_RU.KOI8-R")) {
+			return;
+		}
+
+		WHEN("Utf8String is constructed from an empty string") {
+			const auto str = Utf8String::from_locale_charset("");
+
+			THEN("the result is empty") {
+				REQUIRE(str.to_utf8() == "");
+			}
+
+			THEN("the result in locale encoding is empty") {
+				REQUIRE(str.to_locale_charset() == "");
+			}
+		}
+
+		WHEN("Utf8String is constructed from a string \"строка\"") {
+			// Russian "строка", "string"
+			const std::string input("\xd3\xd4\xd2\xcf\xcb\xc1");
+			const auto str = Utf8String::from_locale_charset(input);
+
+			THEN("the result is that string in UTF-8") {
+				REQUIRE(str.to_utf8() == "строка");
+			}
+
+			THEN("the result in locale encoding is the same as input") {
+				REQUIRE(str.to_locale_charset() == input);
+			}
+		}
+	}
+
+	GIVEN("CP1251 locale") {
+		if (!try_set_locale("ru_RU.CP1251")) {
+			return;
+		}
+
+		WHEN("Utf8String is constructed from an empty string") {
+			const auto str = Utf8String::from_locale_charset("");
+
+			THEN("the result is empty") {
+				REQUIRE(str.to_utf8() == "");
+			}
+
+			THEN("the result in locale encoding is empty") {
+				REQUIRE(str.to_locale_charset() == "");
+			}
+		}
+
+		WHEN("Utf8String is constructed from string \"окна\"") {
+			// Russian "окна", "windows"
+			const std::string input("\xee\xea\xed\xe0");
+			const auto str = Utf8String::from_locale_charset(input);
+
+			THEN("the result is that string in UTF-8") {
+				REQUIRE(str.to_utf8() == "окна");
+			}
+
+			THEN("the result in locale encoding is the same as input") {
+				REQUIRE(str.to_locale_charset() == input);
+			}
+		}
+	}
+}
+
+TEST_CASE("Utf8String::from_locale_charset() replaces invalid codepoints of locale charset with question marks",
+	"[Utf8String]")
+{
+	test_helpers::LcCtypeEnvVar lc_ctype;
+	const auto try_set_locale = [&lc_ctype](std::string new_locale) -> bool {
+		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr)
+		{
+			WARN("Couldn't set locale " + new_locale + "; test skipped.");
+			return false;
+		}
+		lc_ctype.set(new_locale);
+		return true;
+	};
+
+	SECTION("UTF-8 locale") {
+		if (!try_set_locale("en_US.UTF-8")) {
+			return;
+		}
+
+		// Russian "мотоцикл", "motorbike", with a few bytes missing in the middle
+		const std::string input("\xd0\xbc\xd0\xbe\xd1\x82\xbe\xd1\xd0\xb8\xd0\xba\xd0\xbb");
+		const auto str = Utf8String::from_locale_charset(input);
+
+		REQUIRE(str.to_utf8() == "мот??икл");
+	}
+
+	// There is no tests for KOI8-R and CP1251 because there is no invalid codepoints there.
+}
+
+TEST_CASE("Utf8String::to_locale_charset() replaces invalid characters with question marks",
+	"[Utf8String]")
+{
+	test_helpers::LcCtypeEnvVar lc_ctype;
+	const auto try_set_locale = [&lc_ctype](std::string new_locale) -> bool {
+		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr)
+		{
+			WARN("Couldn't set locale " + new_locale + "; test skipped.");
+			return false;
+		}
+		lc_ctype.set(new_locale);
+		return true;
+	};
+
+	GIVEN("UTF-8 locale") {
+		if (!try_set_locale("en_US.UTF-8")) {
+			return;
+		}
+
+		WHEN("Utf8String is constructed from a string \"повтор\"") {
+			// Russian "повтор", "repetition"
+			const std::string input("\xd0\xbf\xd0\xbe\xd0\xb2\xd1\x82\xd0\xbe\xd1\x80");
+			const auto str = Utf8String::from_utf8(input);
+
+			THEN("the result represents the string faithfully") {
+				REQUIRE(str.to_utf8() == input);
+			}
+
+			THEN("the result in locale encoding is the same as input") {
+				REQUIRE(str.to_locale_charset() == input);
+			}
+		}
+	}
+
+	GIVEN("KOI8-R locale") {
+		if (!try_set_locale("ru_RU.KOI8-R")) {
+			return;
+		}
+
+		WHEN("Utf8String is constructed from a string \"привіт\"") {
+			// Ukrainian "привіт", "hello" -- KOI8-R can't represent "і'
+			const std::string input("\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd1\x96\xd1\x82");
+			const auto str = Utf8String::from_utf8(input);
+
+			THEN("the result represents the string faithfully") {
+				REQUIRE(str.to_utf8() == input);
+			}
+
+			THEN("the result in locale encoding has a question mark where \"і\" should be") {
+				REQUIRE(str.to_locale_charset() == "\xd0\xd2\xc9\xd7\x3f\xd4");
+			}
+		}
+	}
+
+	GIVEN("CP1251 locale") {
+		if (!try_set_locale("ru_RU.CP1251")) {
+			return;
+		}
+
+		WHEN("Utf8String is constructed from string \"Приветствуем, 日本!\"") {
+			// "Приветствуем, 日本!", "Greetings, Japan!" (a mix of Russian and
+			// Japanese). CP1251 can't represent Japanese characters, but can
+			// represent Russian and the exclamation mark
+			const std::string
+			input("\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82\xd1\x81\xd1\x82\xd0\xb2\xd1\x83\xd0\xb5\xd0\xbc\x2c\x20\xe6\x97\xa5\xe6\x9c\xac\x21");
+			const auto str = Utf8String::from_utf8(input);
+
+			THEN("the result represents the string faithfully") {
+				REQUIRE(str.to_utf8() == input);
+			}
+
+			THEN("the result in locale encoding has question marks instead of Japanese characters") {
+				REQUIRE(str.to_locale_charset() ==
+					"\xcf\xf0\xe8\xe2\xe5\xf2\xf1\xf2\xe2\xf3\xe5\xec\x2c\x20\x3f\x3f\x21");
+			}
+		}
+	}
+}

--- a/test/utf8string.cpp
+++ b/test/utf8string.cpp
@@ -15,7 +15,7 @@ struct StringMaker<Utf8String> {
 	static std::string convert(const Utf8String& value)
 	{
 		std::string result("Utf8String( \"");
-		result.append(value.to_utf8());
+		result.append(value.utf8());
 		result.append("\" )");
 		return result;
 	}
@@ -25,18 +25,18 @@ struct StringMaker<Utf8String> {
 TEST_CASE("Utf8String can be constructed from valid UTF-8", "[Utf8String]")
 {
 	const auto str1 = Utf8String::from_utf8("");
-	REQUIRE(str1.to_utf8() == "");
+	REQUIRE(str1.utf8() == "");
 
 	// Russian "Привет", "hello"
 	const auto str2 =
 		Utf8String::from_utf8("\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82");
-	REQUIRE(str2.to_utf8() == "Привет");
+	REQUIRE(str2.utf8() == "Привет");
 }
 
 TEST_CASE("Utf8String can be implicitly constructed from a string literal", "[Utf8String]")
 {
 	const auto check = [](Utf8String actual, std::string expected) {
-		REQUIRE(actual.to_utf8() == expected);
+		REQUIRE(actual.utf8() == expected);
 	};
 
 	check("", "");
@@ -67,7 +67,7 @@ SCENARIO("Utf8String can be constructed from strings in locale locale charset",
 			const auto str = Utf8String::from_locale_charset("");
 
 			THEN("the result is empty") {
-				REQUIRE(str.to_utf8() == "");
+				REQUIRE(str.utf8() == "");
 			}
 
 			THEN("the result in locale encoding is empty") {
@@ -82,7 +82,7 @@ SCENARIO("Utf8String can be constructed from strings in locale locale charset",
 			const auto str = Utf8String::from_locale_charset(input);
 
 			THEN("the result is that string in UTF-8") {
-				REQUIRE(str.to_utf8() == "проверка");
+				REQUIRE(str.utf8() == "проверка");
 			}
 
 			THEN("the result in locale encoding is the same as input") {
@@ -100,7 +100,7 @@ SCENARIO("Utf8String can be constructed from strings in locale locale charset",
 			const auto str = Utf8String::from_locale_charset("");
 
 			THEN("the result is empty") {
-				REQUIRE(str.to_utf8() == "");
+				REQUIRE(str.utf8() == "");
 			}
 
 			THEN("the result in locale encoding is empty") {
@@ -114,7 +114,7 @@ SCENARIO("Utf8String can be constructed from strings in locale locale charset",
 			const auto str = Utf8String::from_locale_charset(input);
 
 			THEN("the result is that string in UTF-8") {
-				REQUIRE(str.to_utf8() == "строка");
+				REQUIRE(str.utf8() == "строка");
 			}
 
 			THEN("the result in locale encoding is the same as input") {
@@ -132,7 +132,7 @@ SCENARIO("Utf8String can be constructed from strings in locale locale charset",
 			const auto str = Utf8String::from_locale_charset("");
 
 			THEN("the result is empty") {
-				REQUIRE(str.to_utf8() == "");
+				REQUIRE(str.utf8() == "");
 			}
 
 			THEN("the result in locale encoding is empty") {
@@ -146,7 +146,7 @@ SCENARIO("Utf8String can be constructed from strings in locale locale charset",
 			const auto str = Utf8String::from_locale_charset(input);
 
 			THEN("the result is that string in UTF-8") {
-				REQUIRE(str.to_utf8() == "окна");
+				REQUIRE(str.utf8() == "окна");
 			}
 
 			THEN("the result in locale encoding is the same as input") {
@@ -179,7 +179,7 @@ TEST_CASE("Utf8String::from_locale_charset() replaces invalid codepoints of loca
 		const std::string input("\xd0\xbc\xd0\xbe\xd1\x82\xbe\xd1\xd0\xb8\xd0\xba\xd0\xbb");
 		const auto str = Utf8String::from_locale_charset(input);
 
-		REQUIRE(str.to_utf8() == "мот??икл");
+		REQUIRE(str.utf8() == "мот??икл");
 	}
 
 	// There is no tests for KOI8-R and CP1251 because there is no invalid codepoints there.
@@ -210,7 +210,7 @@ TEST_CASE("Utf8String::to_locale_charset() replaces invalid characters with ques
 			const auto str = Utf8String::from_utf8(input);
 
 			THEN("the result represents the string faithfully") {
-				REQUIRE(str.to_utf8() == input);
+				REQUIRE(str.utf8() == input);
 			}
 
 			THEN("the result in locale encoding is the same as input") {
@@ -230,7 +230,7 @@ TEST_CASE("Utf8String::to_locale_charset() replaces invalid characters with ques
 			const auto str = Utf8String::from_utf8(input);
 
 			THEN("the result represents the string faithfully") {
-				REQUIRE(str.to_utf8() == input);
+				REQUIRE(str.utf8() == input);
 			}
 
 			THEN("the result in locale encoding has a question mark where \"і\" should be") {
@@ -253,7 +253,7 @@ TEST_CASE("Utf8String::to_locale_charset() replaces invalid characters with ques
 			const auto str = Utf8String::from_utf8(input);
 
 			THEN("the result represents the string faithfully") {
-				REQUIRE(str.to_utf8() == input);
+				REQUIRE(str.utf8() == input);
 			}
 
 			THEN("the result in locale encoding has question marks instead of Japanese characters") {

--- a/test/utf8string.cpp
+++ b/test/utf8string.cpp
@@ -9,6 +9,19 @@
 
 using namespace newsboat;
 
+namespace Catch {
+template<>
+struct StringMaker<Utf8String> {
+	static std::string convert(const Utf8String& value)
+	{
+		std::string result("Utf8String( \"");
+		result.append(value.to_utf8());
+		result.append("\" )");
+		return result;
+	}
+};
+}
+
 TEST_CASE("Utf8String can be constructed from valid UTF-8", "[Utf8String]")
 {
 	const auto str1 = Utf8String::from_utf8("");

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -22,28 +22,28 @@ using namespace newsboat;
 
 TEST_CASE("tokenize() extracts tokens separated by given delimiters", "[utils]")
 {
-	std::vector<std::string> tokens;
+	std::vector<Utf8String> tokens;
 
 	SECTION("Default delimiters") {
-		tokens = utils::tokenize("as df qqq");
+		tokens = utils::tokenize(Utf8String("as df qqq"));
 		REQUIRE(tokens.size() == 3);
 		REQUIRE(tokens[0] == "as");
 		REQUIRE(tokens[1] == "df");
 		REQUIRE(tokens[2] == "qqq");
 
-		tokens = utils::tokenize(" aa ");
+		tokens = utils::tokenize(Utf8String(" aa "));
 		REQUIRE(tokens.size() == 1);
 		REQUIRE(tokens[0] == "aa");
 
-		tokens = utils::tokenize("	");
+		tokens = utils::tokenize(Utf8String("	"));
 		REQUIRE(tokens.size() == 0);
 
-		tokens = utils::tokenize("");
+		tokens = utils::tokenize(Utf8String(""));
 		REQUIRE(tokens.size() == 0);
 	}
 
 	SECTION("Splitting by tabulation characters") {
-		tokens = utils::tokenize("hello world\thow are you?", "\t");
+		tokens = utils::tokenize(Utf8String("hello world\thow are you?"), "\t");
 		REQUIRE(tokens.size() == 2);
 		REQUIRE(tokens[0] == "hello world");
 		REQUIRE(tokens[1] == "how are you?");
@@ -55,14 +55,14 @@ TEST_CASE(
 	"interspersed with runs of non-delimiter chars",
 	"[utils]")
 {
-	std::vector<std::string> tokens;
+	std::vector<Utf8String> tokens;
 
 	SECTION("Default delimiters include space and tab") {
-		tokens = utils::tokenize_spaced("a b");
+		tokens = utils::tokenize_spaced(Utf8String("a b"));
 		REQUIRE(tokens.size() == 3);
 		REQUIRE(tokens[1] == " ");
 
-		tokens = utils::tokenize_spaced(" a\t b ");
+		tokens = utils::tokenize_spaced(Utf8String(" a\t b "));
 		REQUIRE(tokens.size() == 5);
 		REQUIRE(tokens[0] == " ");
 		REQUIRE(tokens[1] == "a");
@@ -72,7 +72,7 @@ TEST_CASE(
 	}
 
 	SECTION("Comma-separated values containing spaces and tabs") {
-		tokens = utils::tokenize_spaced("123,John Doe,\t\t$8", ",");
+		tokens = utils::tokenize_spaced(Utf8String("123,John Doe,\t\t$8"), ",");
 		REQUIRE(tokens.size() == 5);
 		REQUIRE(tokens[0] == "123");
 		REQUIRE(tokens[1] == ",");
@@ -87,24 +87,24 @@ TEST_CASE(
 	"inside double quotes as single token",
 	"[utils]")
 {
-	std::vector<std::string> tokens;
+	std::vector<Utf8String> tokens;
 
 	SECTION("Default delimiters include spaces, newlines and tabs") {
 		tokens = utils::tokenize_quoted(
-				"asdf \"foobar bla\" \"foo\\r\\n\\tbar\"");
+				Utf8String("asdf \"foobar bla\" \"foo\\r\\n\\tbar\""));
 		REQUIRE(tokens.size() == 3);
 		REQUIRE(tokens[0] == "asdf");
 		REQUIRE(tokens[1] == "foobar bla");
 		REQUIRE(tokens[2] == "foo\r\n\tbar");
 
-		tokens = utils::tokenize_quoted("  \"foo \\\\xxx\"\t\r \" \"");
+		tokens = utils::tokenize_quoted(Utf8String("  \"foo \\\\xxx\"\t\r \" \""));
 		REQUIRE(tokens.size() == 2);
 		REQUIRE(tokens[0] == "foo \\xxx");
 		REQUIRE(tokens[1] == " ");
 	}
 
 	SECTION("Closing double quote marks the end of a token") {
-		tokens = utils::tokenize_quoted(R"(set browser "mpv %u";)");
+		tokens = utils::tokenize_quoted(Utf8String(R"(set browser "mpv %u";)"));
 
 		REQUIRE(tokens.size() == 4);
 		REQUIRE(tokens[0] == "set");
@@ -117,19 +117,19 @@ TEST_CASE(
 TEST_CASE("tokenize_quoted() implicitly closes quotes at the end of the string",
 	"[utils]")
 {
-	std::vector<std::string> tokens;
+	std::vector<Utf8String> tokens;
 
-	tokens = utils::tokenize_quoted("\"\\\\");
+	tokens = utils::tokenize_quoted(Utf8String("\"\\\\"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == "\\");
 
-	tokens = utils::tokenize_quoted("\"\\\\\" and \"some other stuff");
+	tokens = utils::tokenize_quoted(Utf8String("\"\\\\\" and \"some other stuff"));
 	REQUIRE(tokens.size() == 3);
 	REQUIRE(tokens[0] == "\\");
 	REQUIRE(tokens[1] == "and");
 	REQUIRE(tokens[2] == "some other stuff");
 
-	tokens = utils::tokenize_quoted(R"("abc\)");
+	tokens = utils::tokenize_quoted(Utf8String(R"("abc\)"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == "abc");
 }
@@ -139,52 +139,52 @@ TEST_CASE(
 	"single backslash in output",
 	"[utils]")
 {
-	std::vector<std::string> tokens;
+	std::vector<Utf8String> tokens;
 
-	tokens = utils::tokenize_quoted(R"_("")_");
+	tokens = utils::tokenize_quoted(Utf8String(R"_("")_"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == "");
 
-	tokens = utils::tokenize_quoted(R"_("\\")_");
+	tokens = utils::tokenize_quoted(Utf8String(R"_("\\")_"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == R"_(\)_");
 
-	tokens = utils::tokenize_quoted(R"_("#\\")_");
+	tokens = utils::tokenize_quoted(Utf8String(R"_("#\\")_"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == R"_(#\)_");
 
-	tokens = utils::tokenize_quoted(R"_("'#\\'")_");
+	tokens = utils::tokenize_quoted(Utf8String(R"_("'#\\'")_"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == R"_('#\')_");
 
-	tokens = utils::tokenize_quoted(R"_("'#\\ \\'")_");
+	tokens = utils::tokenize_quoted(Utf8String(R"_("'#\\ \\'")_"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == R"_('#\ \')_");
 
-	tokens = utils::tokenize_quoted("\"\\\\\\\\");
+	tokens = utils::tokenize_quoted(Utf8String("\"\\\\\\\\"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == "\\\\");
 
-	tokens = utils::tokenize_quoted("\"\\\\\\\\\\\\");
+	tokens = utils::tokenize_quoted(Utf8String("\"\\\\\\\\\\\\"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == "\\\\\\");
 
-	tokens = utils::tokenize_quoted("\"\\\\\\\\\"");
+	tokens = utils::tokenize_quoted(Utf8String("\"\\\\\\\\\""));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == "\\\\");
 
-	tokens = utils::tokenize_quoted("\"\\\\\\\\\\\\\"");
+	tokens = utils::tokenize_quoted(Utf8String("\"\\\\\\\\\\\\\""));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == "\\\\\\");
 
 	// https://github.com/newsboat/newsboat/issues/642
-	tokens = utils::tokenize_quoted(R"("\\bgit\\b")");
+	tokens = utils::tokenize_quoted(Utf8String(R"("\\bgit\\b")"));
 	REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == R"(\bgit\b)");
 
 	// https://github.com/newsboat/newsboat/issues/536
 	tokens = utils::tokenize_quoted(
-			R"(browser "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --app %u")");
+			Utf8String(R"(browser "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --app %u")"));
 	REQUIRE(tokens.size() == 2);
 	REQUIRE(tokens[0] == "browser");
 	REQUIRE(tokens[1] ==
@@ -193,9 +193,9 @@ TEST_CASE(
 
 TEST_CASE("tokenize_quoted() doesn't un-escape escaped backticks", "[utils]")
 {
-	std::vector<std::string> tokens;
+	std::vector<Utf8String> tokens;
 
-	tokens = utils::tokenize_quoted("asdf \"\\`foobar `bla`\\`\"");
+	tokens = utils::tokenize_quoted(Utf8String("asdf \"\\`foobar `bla`\\`\""));
 
 	REQUIRE(tokens.size() == 2);
 	REQUIRE(tokens[0] == "asdf");
@@ -206,34 +206,34 @@ TEST_CASE("tokenize_quoted stops tokenizing once it found a # character "
 	"(outside of double quotes)",
 	"[utils]")
 {
-	std::vector<std::string> tokens;
+	std::vector<Utf8String> tokens;
 
 	SECTION("A string consisting of just a comment") {
-		tokens = utils::tokenize_quoted("# just a comment");
+		tokens = utils::tokenize_quoted(Utf8String("# just a comment"));
 		REQUIRE(tokens.empty());
 	}
 
 	SECTION("A string with one quoted substring") {
-		tokens = utils::tokenize_quoted(R"#("a test substring" # !!!)#");
+		tokens = utils::tokenize_quoted(Utf8String(R"#("a test substring" # !!!)#"));
 		REQUIRE(tokens.size() == 1);
 		REQUIRE(tokens[0] == "a test substring");
 	}
 
 	SECTION("A string with two quoted substrings") {
-		tokens = utils::tokenize_quoted(R"#("first sub" "snd" # comment)#");
+		tokens = utils::tokenize_quoted(Utf8String(R"#("first sub" "snd" # comment)#"));
 		REQUIRE(tokens.size() == 2);
 		REQUIRE(tokens[0] == "first sub");
 		REQUIRE(tokens[1] == "snd");
 	}
 
 	SECTION("A comment containing # character") {
-		tokens = utils::tokenize_quoted(R"#(one # a comment with # char)#");
+		tokens = utils::tokenize_quoted(Utf8String(R"#(one # a comment with # char)#"));
 		REQUIRE(tokens.size() == 1);
 		REQUIRE(tokens[0] == "one");
 	}
 
 	SECTION("A # character inside quoted substring is ignored") {
-		tokens = utils::tokenize_quoted(R"#(this "will # be" ignored)#");
+		tokens = utils::tokenize_quoted(Utf8String(R"#(this "will # be" ignored)#"));
 		REQUIRE(tokens.size() == 3);
 		REQUIRE(tokens[0] == "this");
 		REQUIRE(tokens[1] == "will # be");
@@ -245,7 +245,7 @@ TEST_CASE("tokenize_quoted does not consider escaped pound sign (\\#) "
 	"a beginning of a comment",
 	"[utils]")
 {
-	const auto tokens = utils::tokenize_quoted(R"#(one \# two three # ???)#");
+	const auto tokens = utils::tokenize_quoted(Utf8String(R"#(one \# two three # ???)#"));
 	REQUIRE(tokens.size() == 4);
 	REQUIRE(tokens[0] == "one");
 	REQUIRE(tokens[1] == "\\#");
@@ -357,10 +357,10 @@ TEST_CASE("extract_token_quoted() works with Unicode strings too", "[utils]")
 
 TEST_CASE("tokenize_nl() split a string into delimiters and fields", "[utils]")
 {
-	std::vector<std::string> tokens;
+	std::vector<Utf8String> tokens;
 
 	SECTION("a few words separated by newlines") {
-		tokens = utils::tokenize_nl("first\nsecond\nthird");
+		tokens = utils::tokenize_nl(Utf8String("first\nsecond\nthird"));
 
 		REQUIRE(tokens.size() == 5);
 		REQUIRE(tokens[0] == "first");
@@ -369,14 +369,14 @@ TEST_CASE("tokenize_nl() split a string into delimiters and fields", "[utils]")
 	}
 
 	SECTION("several preceding delimiters") {
-		tokens = utils::tokenize_nl("\n\n\nonly");
+		tokens = utils::tokenize_nl(Utf8String("\n\n\nonly"));
 
 		REQUIRE(tokens.size() == 4);
 		REQUIRE(tokens[3] == "only");
 	}
 
 	SECTION("redundant internal delimiters") {
-		tokens = utils::tokenize_nl("first\nsecond\n\nthird");
+		tokens = utils::tokenize_nl(Utf8String("first\nsecond\n\nthird"));
 
 		REQUIRE(tokens.size() == 6);
 		REQUIRE(tokens[0] == "first");
@@ -385,7 +385,7 @@ TEST_CASE("tokenize_nl() split a string into delimiters and fields", "[utils]")
 	}
 
 	SECTION("custom delimiter") {
-		tokens = utils::tokenize_nl("first\nsecond\nthird", "i");
+		tokens = utils::tokenize_nl(Utf8String("first\nsecond\nthird"), "i");
 
 		REQUIRE(tokens.size() == 5);
 		REQUIRE(tokens[0] == "f");
@@ -395,14 +395,14 @@ TEST_CASE("tokenize_nl() split a string into delimiters and fields", "[utils]")
 
 	SECTION("no non-delimiter text") {
 		SECTION("single newline") {
-			tokens = utils::tokenize_nl("\n");
+			tokens = utils::tokenize_nl(Utf8String("\n"));
 
 			REQUIRE(tokens.size() == 1);
 			REQUIRE(tokens[0] == "\n");
 		}
 
 		SECTION("multiple newlines") {
-			tokens = utils::tokenize_nl("\n\n\n");
+			tokens = utils::tokenize_nl(Utf8String("\n\n\n"));
 
 			REQUIRE(tokens.size() == 3);
 			REQUIRE(tokens[0] == "\n");
@@ -417,28 +417,27 @@ TEST_CASE(
 	"[utils]")
 {
 	SECTION("no comments in line") {
-		REQUIRE(utils::strip_comments("") == "");
-		REQUIRE(utils::strip_comments("\t\n") == "\t\n");
-		REQUIRE(utils::strip_comments("some directive ") == "some directive ");
+		REQUIRE(utils::strip_comments(Utf8String("")) == "");
+		REQUIRE(utils::strip_comments(Utf8String("\t\n")) == "\t\n");
+		REQUIRE(utils::strip_comments(Utf8String("some directive ")) == "some directive ");
 	}
 
 	SECTION("fully commented line") {
-		REQUIRE(utils::strip_comments("#") == "");
-		REQUIRE(utils::strip_comments("# #") == "");
-		REQUIRE(utils::strip_comments("# comment") == "");
+		REQUIRE(utils::strip_comments(Utf8String("#")) == "");
+		REQUIRE(utils::strip_comments(Utf8String("# #")) == "");
+		REQUIRE(utils::strip_comments(Utf8String("# comment")) == "");
 	}
 
 	SECTION("partially commented line") {
-		REQUIRE(utils::strip_comments("directive # comment") == "directive ");
-		REQUIRE(utils::strip_comments("directive # comment # another") == "directive ");
-		REQUIRE(utils::strip_comments("directive#comment") == "directive");
+		REQUIRE(utils::strip_comments(Utf8String("directive # comment")) == "directive ");
+		REQUIRE(utils::strip_comments(Utf8String("directive # comment # another")) == "directive ");
+		REQUIRE(utils::strip_comments(Utf8String("directive#comment")) == "directive");
 	}
 }
 
 TEST_CASE("strip_comments ignores escaped # characters (\\#)")
 {
-	const auto expected =
-		std::string(R"#(one two \# three four)#");
+	const Utf8String expected = R"#(one two \# three four)#";
 	const auto input = expected + "# and a comment";
 	REQUIRE(utils::strip_comments(input) == expected);
 }
@@ -447,22 +446,19 @@ TEST_CASE("strip_comments ignores # characters inside double quotes",
 	"[utils][issue652]")
 {
 	SECTION("Real-world cases from issue 652") {
-		const auto expected1 =
-			std::string(R"#(highlight article "[-=+#_*~]{3,}.*" green default)#");
+		const Utf8String expected1 = R"#(highlight article "[-=+#_*~]{3,}.*" green default)#";
 		const auto input1 = expected1 + "# this is a comment";
 		REQUIRE(utils::strip_comments(input1) == expected1);
 
-		const auto expected2 =
-			std::string(
-				R"#(highlight all "(https?|ftp)://[\-\.,/%~_:?&=\#a-zA-Z0-9]+" blue default bold)#");
+		const Utf8String expected2 =
+			R"#(highlight all "(https?|ftp)://[\-\.,/%~_:?&=\#a-zA-Z0-9]+" blue default bold)#";
 		const auto input2 = expected2 + "#heresacomment";
 		REQUIRE(utils::strip_comments(input2) == expected2);
 	}
 
 	SECTION("Escaped double quote inside double quotes is not treated "
 		"as closing quote") {
-		const auto expected =
-			std::string(R"#(test "here \"goes # nothing\" etc" hehe)#");
+		const Utf8String expected = R"#(test "here \"goes # nothing\" etc" hehe)#";
 		const auto input = expected + "# and here is a comment";
 		REQUIRE(utils::strip_comments(input) == expected);
 	}
@@ -471,14 +467,13 @@ TEST_CASE("strip_comments ignores # characters inside double quotes",
 TEST_CASE("strip_comments ignores # characters inside backticks", "[utils]")
 {
 	SECTION("Simple case") {
-		const auto expected = std::string(R"#(one `two # three` four)#");
+		const Utf8String expected = R"#(one `two # three` four)#";
 		const auto input = expected + "# and a comment, of course";
 		REQUIRE(utils::strip_comments(input) == expected);
 	}
 
 	SECTION("Escaped backtick inside backticks is not treated as closing") {
-		const auto expected =
-			std::string(R"#(some `other \` tricky # test` hehe)#");
+		const Utf8String expected = R"#(some `other \` tricky # test` hehe)#";
 		const auto input = expected + "#here goescomment";
 		REQUIRE(utils::strip_comments(input) == expected);
 	}
@@ -488,20 +483,19 @@ TEST_CASE("strip_comments is not confused by nested double quotes and backticks"
 	"[utils]")
 {
 	{
-		const auto expected = std::string(R"#("`" ... ` `"` ")#");
+		const Utf8String expected = R"#("`" ... ` `"` ")#";
 		const auto input = expected + "#comment";
 		REQUIRE(utils::strip_comments(input) == expected);
 	}
 
 	{
-		const auto expected = std::string(R"#(aaa ` bbb "ccc ddd" e` dd)#");
+		const Utf8String expected = R"#(aaa ` bbb "ccc ddd" e` dd)#";
 		const auto input = expected + "# a comment string";
 		REQUIRE(utils::strip_comments(input) == expected);
 	}
 
 	{
-		const auto expected =
-			std::string(R"#(option "this `weird " command` for value")#");
+		const Utf8String expected = R"#(option "this `weird " command` for value")#";
 		const auto input = expected + "#and a comment";
 		REQUIRE(utils::strip_comments(input) == expected);
 	}

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -184,7 +184,8 @@ TEST_CASE(
 
 	// https://github.com/newsboat/newsboat/issues/536
 	tokens = utils::tokenize_quoted(
-			Utf8String(R"(browser "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --app %u")"));
+			Utf8String(
+				R"(browser "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --app %u")"));
 	REQUIRE(tokens.size() == 2);
 	REQUIRE(tokens[0] == "browser");
 	REQUIRE(tokens[1] ==
@@ -430,7 +431,8 @@ TEST_CASE(
 
 	SECTION("partially commented line") {
 		REQUIRE(utils::strip_comments(Utf8String("directive # comment")) == "directive ");
-		REQUIRE(utils::strip_comments(Utf8String("directive # comment # another")) == "directive ");
+		REQUIRE(utils::strip_comments(Utf8String("directive # comment # another")) ==
+			"directive ");
 		REQUIRE(utils::strip_comments(Utf8String("directive#comment")) == "directive");
 	}
 }

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -2187,3 +2187,25 @@ TEST_CASE("convert_text() converts text between encodings: ISO-8859-1 to utf8", 
 
 	verify_convert_text(input, "UTF-8", "ISO-8859-1", expected);
 }
+
+TEST_CASE("starts_with() checks if an input string starts with a given suffix", "[utils]")
+{
+	REQUIRE_FALSE(utils::starts_with("bye", "hello"));
+	REQUIRE_FALSE(utils::starts_with("bye", "hi"));
+
+	REQUIRE(utils::starts_with("", "type"));
+	REQUIRE(utils::starts_with("t", "type"));
+	REQUIRE(utils::starts_with("ty", "type"));
+	REQUIRE(utils::starts_with("typ", "type"));
+}
+
+TEST_CASE("ends_with() checks if an input string ends with a given suffix", "[utils]")
+{
+	REQUIRE_FALSE(utils::ends_with("bye", "hello"));
+	REQUIRE_FALSE(utils::ends_with("bye", "hi"));
+
+	REQUIRE(utils::ends_with("ype", "type"));
+	REQUIRE(utils::ends_with("pe", "type"));
+	REQUIRE(utils::ends_with("e", "type"));
+	REQUIRE(utils::ends_with("", "type"));
+}


### PR DESCRIPTION
An attempt at replacing `std::string` with `Utf8String` as a part of #1344.

Finally found some time to start on this one. I rebased part of the previous work including most of the `Utf8String` class.

I started with an approach that `std::string` would be replaced in interfaces & storage (functions, member variables), but implementation (function body) could internally use raw `std::string`.

This would ensure that utf8-unsafe strings stay local to a function, and that those are converted as soon as the value is passed to another function, returned or stored.


As a temporary conversion help, I added implicit conversions to and from `std::string`. I think this will make the transition much smoother and avoid a lot of churn while part of the code still uses std::string. For example this allows the `_s` macro to be used for both `std::string` and `Utf8String` values, and I suppose that macro will eventually always return an `Utf8String`.

Those implicit conversions should then be removed, and compilation errors will point out where explicit conversion is needed.


I'm not quite sure yet where the conversions to/from locale charset should happen though. For example which one should filenames be utf8 or bytes in locale encoding? Or what about printing to console?

Ps. Couple of the tests failed for me locally. Those were checking the replacement of invalid utf8 with question marks, and the number of question marks was different than expected. I didn't look into that closer.