### PR TITLE
Fix clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ https://newsboat.org/
 
 Alternatively, you can check out the latest version from the Git repository:
 
-	$ git clone git://github.com/newsboat/newsboat.git
+	$ git clone https://github.com/newsboat/newsboat.git
 
 Dependencies
 ------------

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -56,7 +56,7 @@ Newsboat binaries are available in a number of repositories:
 The most up-to-date source code can always be downloaded from the Git
 repository:
 
-	$ git clone git://github.com/newsboat/newsboat.git
+	$ git clone https://github.com/newsboat/newsboat.git
 
 There are also signed release tarballs available from https://newsboat.org/[our
 website].


### PR DESCRIPTION
This would be the right syntax when using the `git` protocol.

Alternatively, we could have kept the existing url and changed the protocol to `https`, but I think probably `git` is the preferred (to force the use of SSH key).