### PR TITLE
Use source author if entry does not have author

### DIFF
--- a/rss/atomparser.cpp
+++ b/rss/atomparser.cpp
@@ -75,6 +75,7 @@ void AtomParser::parse_feed(Feed& f, xmlNode* rootNode)
 Item AtomParser::parse_entry(xmlNode* entryNode)
 {
 	Item it;
+	std::string author;
 	std::string summary;
 	std::string summary_mime_type;
 	std::string updated;
@@ -88,6 +89,13 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 		node = node->next) {
 		if (node_is(node, "author", ns)) {
 			parse_and_update_author(node, it.author);
+		} else if (node_is(node, "source", ns)) {
+			for (xmlNode* child = node->children; child != nullptr;
+				child = child->next) {
+				if (node_is(child, "author", ns)) {
+					parse_and_update_author(child, author);
+				}
+			}
 		} else if (node_is(node, "title", ns)) {
 			it.title = get_content(node);
 			it.title_type = get_prop(node, "type");
@@ -155,6 +163,10 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 			parse_media_node(node, it);
 		}
 	} // for
+
+	if (it.author == "") {
+		it.author = author;
+	}
 
 	if (it.description == "") {
 		it.description = summary;

--- a/test/data/atom10_feed_authors.xml
+++ b/test/data/atom10_feed_authors.xml
@@ -29,7 +29,7 @@
 
   <author>
     <name>Second Feed Author</name>
-	<uri>http://example.com/actually-illegal-since-feed-author-must-appear-before-entry</uri>
+    <uri>http://example.com/actually-illegal-since-feed-author-must-appear-before-entry</uri>
   </author>
 
   <entry>
@@ -59,6 +59,108 @@
     <author>
       <uri>http://example.com/</uri>
     </author>
+  </entry>
+
+  <entry>
+    <title>Entry With Single Source Author</title>
+    <link href="http://example.com/5.html"/>
+    <id>http://example.com/4.html</id>
+    <content type="text">Entry source author should be used.</content>
+    <source>
+      <author>
+        <name>Entry Source Author</name>
+        <uri>http://example.com/</uri>
+      </author>
+    </source>
+  </entry>
+
+  <entry>
+    <title>Entry With Multiple Source Authors</title>
+    <source>
+      <author>
+        <name>Entry Source Author 1</name>
+        <uri>http://example.com/</uri>
+      </author>
+    </source>
+    <link href="http://example.com/6.html"/>
+    <id>http://example.com/4.html</id>
+    <content type="text">All entry source authors should be used.</content>
+    <source>
+      <author>
+        <name>Entry Source Author 2</name>
+        <uri>http://example.com/actually-illegal-since-entry-must-have-at-most-one-source</uri>
+      </author>
+      <author>
+        <name>Entry Source Author 3</name>
+        <uri>http://example.com/actually-illegal-since-entry-must-have-at-most-one-source</uri>
+      </author>
+    </source>
+  </entry>
+
+  <entry>
+    <title>Entry With Empty Source Author Names</title>
+    <source>
+      <author>
+        <name></name>
+        <uri>http://example.com/</uri>
+      </author>
+    </source>
+    <link href="http://example.com/7.html"/>
+    <id>http://example.com/4.html</id>
+    <content type="text">Both feed authors should be used.</content>
+    <source>
+      <author>
+        <uri>http://example.com/actually-illegal-since-entry-must-have-at-most-one-source</uri>
+      </author>
+    </source>
+  </entry>
+
+  <entry>
+    <title>Entry With Single Author And Source Author</title>
+    <source>
+      <author>
+        <name>Entry Source Author</name>
+        <uri>http://example.com/</uri>
+      </author>
+    </source>
+    <link href="http://example.com/8.html"/>
+    <id>http://example.com/4.html</id>
+    <content type="text">Entry author should be used.</content>
+    <author>
+      <name>Entry Author</name>
+      <uri>http://example.com/</uri>
+    </author>
+  </entry>
+
+  <entry>
+    <title>Entry With Multiple Author And Source Authors</title>
+    <source>
+      <author>
+        <name>Entry Source Author 1</name>
+        <uri>http://example.com/</uri>
+      </author>
+    </source>
+    <author>
+      <name>Entry Author 1</name>
+      <uri>http://example.com/</uri>
+    </author>
+    <link href="http://example.com/9.html"/>
+    <id>http://example.com/4.html</id>
+    <content type="text">Both entry authors should be used.</content>
+    <author>
+      <name>Entry Author 2</name>
+      <uri>http://example.com/</uri>
+    </author>
+    <source>
+      <author>
+        <name>Entry Source Author 2</name>
+        <uri>http://example.com/actually-illegal-since-entry-must-have-at-most-one-source</uri>
+      </author>
+      <author>
+        <name>Entry Source Author 3</name>
+        <uri>http://example.com/actually-illegal-since-entry-must-have-at-most-one-source</uri>
+      </author>
+    </source>
   </entry>
 
 </feed>

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -304,7 +304,7 @@ TEST_CASE("Multiple links in item", "[rsspp::Parser]")
 	REQUIRE(f.items[0].link == "http://www.test.org/tests");
 }
 
-TEST_CASE("Feed authors in atom feed", "[rsspp::Parser]")
+TEST_CASE("Feed authors and source authors in atom feed", "[rsspp::Parser]")
 {
 	rsspp::Parser p;
 	rsspp::Feed f;
@@ -318,7 +318,7 @@ TEST_CASE("Feed authors in atom feed", "[rsspp::Parser]")
 	REQUIRE(f.pubDate == "Mon, 28 Nov 2022 13:01:25 +0000");
 	REQUIRE(f.link == "http://example.com/");
 
-	REQUIRE(f.items.size() == 4u);
+	REQUIRE(f.items.size() == 9u);
 	REQUIRE(f.items[0].title == "Entry Without Author");
 	REQUIRE(f.items[0].description == "Feed authors should be used.");
 	REQUIRE(f.items[0].author == "First Feed Author, Second Feed Author");
@@ -334,4 +334,25 @@ TEST_CASE("Feed authors in atom feed", "[rsspp::Parser]")
 	REQUIRE(f.items[3].title == "Entry With Empty Author Names");
 	REQUIRE(f.items[3].description == "Both feed authors should be used.");
 	REQUIRE(f.items[3].author == "First Feed Author, Second Feed Author");
+
+	REQUIRE(f.items[4].title == "Entry With Single Source Author");
+	REQUIRE(f.items[4].description == "Entry source author should be used.");
+	REQUIRE(f.items[4].author == "Entry Source Author");
+
+	REQUIRE(f.items[5].title == "Entry With Multiple Source Authors");
+	REQUIRE(f.items[5].description == "All entry source authors should be used.");
+	REQUIRE(f.items[5].author ==
+		"Entry Source Author 1, Entry Source Author 2, Entry Source Author 3");
+
+	REQUIRE(f.items[6].title == "Entry With Empty Source Author Names");
+	REQUIRE(f.items[6].description == "Both feed authors should be used.");
+	REQUIRE(f.items[6].author == "First Feed Author, Second Feed Author");
+
+	REQUIRE(f.items[7].title == "Entry With Single Author And Source Author");
+	REQUIRE(f.items[7].description == "Entry author should be used.");
+	REQUIRE(f.items[7].author == "Entry Author");
+
+	REQUIRE(f.items[8].title == "Entry With Multiple Author And Source Authors");
+	REQUIRE(f.items[8].description == "Both entry authors should be used.");
+	REQUIRE(f.items[8].author == "Entry Author 1, Entry Author 2");
 }


### PR DESCRIPTION
This is the promised follow-up of #2259 from two weeks ago.

The Atom specification states in section 4.2.1 on 'The "atom:author" Element' (https://www.rfc-editor.org/rfc/rfc4287#section-4.2.1):

> If an atom:entry element does not contain atom:author elements, then
> the atom:author elements of the contained atom:source element are
> considered to apply. In an Atom Feed Document, the atom:author
> elements of the containing atom:feed element are considered to apply
> to the entry if there are no atom:author elements in the locations
> described above.

This commit addresses the source author part. The feed author was already implemented in 886c61005a96748107cfca2bdfe6492c221a3411.

Fixes #2256.

(Force-pushed to fix a code formatting violation regarding maximum line length detected by CI.)