### PR TITLE
Disable transitive dependency on `time` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,11 +114,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -248,7 +245,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -791,17 +788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,12 +854,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 strprintf = { path="../strprintf" }
 regex-rs = { path="../regex-rs" }
 
-chrono = "0.4"
 fastrand = "1.8.0"
 once_cell = "1.16.0"
 url = "2.3.1"
@@ -47,6 +46,15 @@ version = "0.4.5"
 # exists even if we're linking (via libcurl) against another SSL library like
 # GnuTLS. We disable this feature to avoid the dependency.
 default-features = false
+
+[dependencies.chrono]
+version = "0.4"
+default-features = false
+# This is the same as default features for 0.4.23, minus "oldtime" and
+# "wasmbind". We disable "oldtime" to get rid of dependency on `time` 0.1,
+# which is vulnerable (CVE-2020-26235) and which we don't use. We disable
+# `wasmbind` because we don't use WASM.
+features = [ "alloc", "std", "clock" ]
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Fixes #2288.