### PR TITLE
Use CURL_WRITEFUNC_ERROR to correctly indicate write callback error

### DIFF
--- a/src/poddlthread.cpp
+++ b/src/poddlthread.cpp
@@ -169,7 +169,7 @@ size_t PodDlThread::write_data(void* buffer, size_t size, size_t nmemb)
 		"PodDlThread::write_data: bad = %u size = %" PRIu64,
 		f->bad(),
 		static_cast<uint64_t>(size * nmemb));
-	return f->bad() ? 0 : size * nmemb;
+	return f->bad() ? CURL_WRITEFUNC_ERROR : size * nmemb;
 }
 
 int PodDlThread::progress(double dlnow, double dltotal)


### PR DESCRIPTION
Hello!

Recently [curl introduced](https://github.com/curl/curl/pull/9874) CURL_WRITEFUNC_ERROR macro to make error handling in write callbacks more robust. I found out that there's one place in Newsboat where that could be used so here goes the PR ;)