### PR TITLE
add missing <cstdint> includes for gcc-13 compatibility

### DIFF
--- a/include/listwidgetbackend.h
+++ b/include/listwidgetbackend.h
@@ -1,6 +1,7 @@
 #ifndef NEWSBOAT_LISTWIDGETBACKEND_H_
 #define NEWSBOAT_LISTWIDGETBACKEND_H_
 
+#include <cstdint>
 #include <string>
 
 #include "listformatter.h"

--- a/include/matcherexception.h
+++ b/include/matcherexception.h
@@ -1,6 +1,7 @@
 #ifndef NEWSBOAT_MATCHEREXCEPTON_H_
 #define NEWSBOAT_MATCHEREXCEPTON_H_
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 


### PR DESCRIPTION
Upcoming `gcc-13` made `<string>` leaner and does not include `<cstdint>`
implicitly anymore. As a result build fails without the change as:

    include/matcherexception.h:14:14: error: elaborated-type-specifier for a scoped enum must not use the «class» keyword [-Werror]
       14 |         enum class Type : std::uint8_t { ATTRIB_UNAVAIL = 0, INVALID_REGEX = 1 };
          |         ~~~~ ^~~~~
          |              -----
