### PR TITLE
Fix #1808: allow reading urls file from user home in .newsboat dir

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,12 @@ description: |
 grade: stable
 confinement: strict
 
+plugs:
+  dot-config-newsboat:
+    interface: personal-files
+    read: [$HOME/.newsboat]
+    write: [$HOME/.newsboat]
+
 apps:
   newsboat:
     command: usr/local/bin/newsboat
@@ -15,6 +21,7 @@ apps:
       LOCPATH: "$SNAP/usr/lib/locale"
       TERMINFO_DIRS: "$SNAP/lib/terminfo:$SNAP/usr/share/terminfo"
     plugs:
+      - dot-config-newsboat
       - network
       - home
       - desktop


### PR DESCRIPTION
Use personal-files interface in snap YAML file to grant R/W permissions on $HOME/.newsboat dir containing urls file.
refs:
-https://github.com/newsboat/newsboat/issues/1808 
-https://forum.snapcraft.io/t/the-personal-files-interface/9357