### PR TITLE
Convert feed into utf-8 if charset is specified in HTTP Content-Type header

### DIFF
--- a/include/curlheadercontainer.h
+++ b/include/curlheadercontainer.h
@@ -11,7 +11,7 @@ namespace newsboat {
 
 class CurlHeaderContainer {
 public:
-	[[nodiscard("Registration is only valid as long as the pointer is alive")]]
+	// Registration is cleaned up on destruction
 	static std::unique_ptr<CurlHeaderContainer> register_header_handler(
 		CurlHandle& curlHandle);
 

--- a/include/curlheadercontainer.h
+++ b/include/curlheadercontainer.h
@@ -16,6 +16,7 @@ public:
 		CurlHandle& curlHandle);
 
 	const std::vector<std::string>& get_header_lines() const;
+	std::vector<std::string> get_header_lines(const std::string& key) const;
 	virtual ~CurlHeaderContainer();
 
 protected:

--- a/include/curlheadercontainer.h
+++ b/include/curlheadercontainer.h
@@ -1,0 +1,39 @@
+#ifndef NEWSBOAT_CURLHEADERCONTAINER_H_
+#define NEWSBOAT_CURLHEADERCONTAINER_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "curlhandle.h"
+
+namespace newsboat {
+
+class CurlHeaderContainer {
+public:
+	[[nodiscard("Registration is only valid as long as the pointer is alive")]]
+	static std::unique_ptr<CurlHeaderContainer> register_header_handler(
+		CurlHandle& curlHandle);
+
+	const std::vector<std::string>& get_header_lines() const;
+	virtual ~CurlHeaderContainer();
+
+protected:
+	explicit CurlHeaderContainer(CurlHandle& curlHandle);
+	void handle_header(const std::string& line);
+
+	CurlHeaderContainer(const CurlHeaderContainer&) = delete;
+	CurlHeaderContainer(CurlHeaderContainer&&) = delete;
+	CurlHeaderContainer& operator=(const CurlHeaderContainer&) = delete;
+	CurlHeaderContainer& operator=(CurlHeaderContainer&&) = delete;
+
+private:
+	static size_t handle_headers(char* buffer, size_t size, size_t nitems, void* data);
+
+	CurlHandle& mCurlHandle;
+	std::vector<std::string> mHeaderLines;
+};
+
+} // namespace newsboat
+
+#endif /* NEWSBOAT_CURLHEADERCONTAINER_H_ */

--- a/include/utils.h
+++ b/include/utils.h
@@ -86,6 +86,8 @@ std::string replace_all(std::string str,
 std::string replace_all(const std::string& str,
 	const std::vector<std::pair<std::string, std::string>> from_to_pairs);
 
+std::string to_lowercase(const std::string& input);
+
 std::wstring str2wstr(const std::string& str);
 std::string wstr2str(const std::wstring& wstr);
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -58,6 +58,9 @@ std::string utf8_to_locale(const std::string& text);
 /// nl_langinfo(CODESET)) to UTF-8.
 std::string locale_to_utf8(const std::string& text);
 
+std::string convert_text(const std::string& text, const std::string& tocode,
+	const std::string& fromcode);
+
 std::string get_command_output(const std::string& cmd);
 std::string http_method_str(const HTTPMethod method);
 std::string link_type_str(LinkType type);

--- a/mk/newsboat.deps
+++ b/mk/newsboat.deps
@@ -4,6 +4,7 @@ src/cliargsparser.cpp
 src/configactionhandler.cpp
 src/configpaths.cpp
 src/controller.cpp
+src/curlheadercontainer.cpp
 src/dialogsformaction.cpp
 src/dirbrowserformaction.cpp
 src/emptyformaction.cpp

--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -1,14 +1,17 @@
 #include "parser.h"
 
+#include <algorithm>
 #include <cinttypes>
 #include <cstring>
 #include <curl/curl.h>
+#include <iterator>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 
 #include "config.h"
 #include "curldatareceiver.h"
 #include "curlhandle.h"
+#include "curlheadercontainer.h"
 #include "exception.h"
 #include "logger.h"
 #include "remoteapi.h"
@@ -44,54 +47,6 @@ Parser::~Parser()
 	if (doc) {
 		xmlFreeDoc(doc);
 	}
-}
-
-struct HeaderValues {
-	time_t lastmodified;
-	std::string etag;
-
-	HeaderValues()
-		: lastmodified(0)
-	{
-	}
-};
-
-static size_t handle_headers(void* ptr, size_t size, size_t nmemb, void* data)
-{
-	char* header = new char[size * nmemb + 1];
-	HeaderValues* values = static_cast<HeaderValues*>(data);
-
-	memcpy(header, ptr, size * nmemb);
-	header[size * nmemb] = '\0';
-
-	if (!strncasecmp("Last-Modified:", header, 14)) {
-		time_t r = curl_getdate(header + 14, nullptr);
-		if (r == -1) {
-			LOG(Level::DEBUG,
-				"handle_headers: last-modified %s "
-				"(curl_getdate "
-				"FAILED)",
-				header + 14);
-		} else {
-			values->lastmodified =
-				curl_getdate(header + 14, nullptr);
-			LOG(Level::DEBUG,
-				"handle_headers: got last-modified %s (%" PRId64 ")",
-				header + 14,
-				// On GCC, `time_t` is `long int`, which is at least 32 bits.
-				// On x86_64, it's 64 bits. Thus, this cast is either a no-op,
-				// or an up-cast which is always safe.
-				static_cast<int64_t>(values->lastmodified));
-		}
-	} else if (!strncasecmp("ETag:", header, 5)) {
-		values->etag = std::string(header + 5);
-		utils::trim(values->etag);
-		LOG(Level::DEBUG, "handle_headers: got etag %s", values->etag);
-	}
-
-	delete[] header;
-
-	return size * nmemb;
 }
 
 Feed Parser::parse_url(const std::string& url,
@@ -156,9 +111,7 @@ Feed Parser::parse_url(const std::string& url,
 		curl_easy_setopt(easyhandle.ptr(), CURLOPT_CAINFO, curl_ca_bundle);
 	}
 
-	HeaderValues hdrs;
-	curl_easy_setopt(easyhandle.ptr(), CURLOPT_HEADERDATA, &hdrs);
-	curl_easy_setopt(easyhandle.ptr(), CURLOPT_HEADERFUNCTION, handle_headers);
+	auto curlHeaderHandler = CurlHeaderContainer::register_header_handler(easyhandle);
 	auto curlDataReceiver = CurlDataReceiver::register_data_handler(easyhandle);
 
 	if (lastmodified != 0) {
@@ -186,8 +139,36 @@ Feed Parser::parse_url(const std::string& url,
 
 	ret = curl_easy_perform(easyhandle.ptr());
 
-	lm = hdrs.lastmodified;
-	et = hdrs.etag;
+	const auto& header_lines = curlHeaderHandler->get_header_lines();
+	for (const auto& header_line : header_lines) {
+		std::string lower_case_line;
+		std::transform(header_line.begin(), header_line.end(), std::back_inserter(lower_case_line),
+		[](unsigned char c) {
+			return std::tolower(c);
+		});
+		if (lower_case_line.find("etag:") == 0) {
+			std::string etag = header_line.substr(std::string("ETag:").length());
+			utils::trim(etag);
+			LOG(Level::DEBUG, "parse_url: got etag %s", etag);
+			et = etag;
+		} else if (lower_case_line.find("last-modified:") == 0) {
+			const std::string header_value = header_line.substr(
+					std::string("Last-Modified:").length());
+			time_t time = curl_getdate(header_value.c_str(), nullptr);
+			if (time == -1) {
+				LOG(Level::DEBUG, "parse_url: last-modified %s (curl_getdate FAILED)", header_value);
+			} else {
+				LOG(Level::DEBUG,
+					"parse_url: got last-modified %s (%" PRId64 ")",
+					header_value,
+					// On GCC, `time_t` is `long int`, which is at least 32 bits.
+					// On x86_64, it's 64 bits. Thus, this cast is either a no-op,
+					// or an up-cast which is always safe.
+					static_cast<int64_t>(time));
+				lm = time;
+			}
+		}
+	}
 
 	if (custom_headers) {
 		curl_easy_setopt(easyhandle.ptr(), CURLOPT_HTTPHEADER, 0);

--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -139,34 +139,29 @@ Feed Parser::parse_url(const std::string& url,
 
 	ret = curl_easy_perform(easyhandle.ptr());
 
-	const auto& header_lines = curlHeaderHandler->get_header_lines();
-	for (const auto& header_line : header_lines) {
-		std::string lower_case_line;
-		std::transform(header_line.begin(), header_line.end(), std::back_inserter(lower_case_line),
-		[](unsigned char c) {
-			return std::tolower(c);
-		});
-		if (lower_case_line.find("etag:") == 0) {
-			std::string etag = header_line.substr(std::string("ETag:").length());
-			utils::trim(etag);
-			LOG(Level::DEBUG, "parse_url: got etag %s", etag);
-			et = etag;
-		} else if (lower_case_line.find("last-modified:") == 0) {
-			const std::string header_value = header_line.substr(
-					std::string("Last-Modified:").length());
-			time_t time = curl_getdate(header_value.c_str(), nullptr);
-			if (time == -1) {
-				LOG(Level::DEBUG, "parse_url: last-modified %s (curl_getdate FAILED)", header_value);
-			} else {
-				LOG(Level::DEBUG,
-					"parse_url: got last-modified %s (%" PRId64 ")",
-					header_value,
-					// On GCC, `time_t` is `long int`, which is at least 32 bits.
-					// On x86_64, it's 64 bits. Thus, this cast is either a no-op,
-					// or an up-cast which is always safe.
-					static_cast<int64_t>(time));
-				lm = time;
-			}
+	const auto etag_headers = curlHeaderHandler->get_header_lines("ETag");
+	if (etag_headers.size() >= 1) {
+		std::string etag = etag_headers.back();
+		utils::trim(etag);
+		LOG(Level::DEBUG, "parse_url: got etag %s", etag);
+		et = etag;
+	}
+
+	const auto last_modified_headers = curlHeaderHandler->get_header_lines("Last-Modified");
+	if (last_modified_headers.size() >= 1) {
+		const std::string header_value = last_modified_headers.back();
+		time_t time = curl_getdate(header_value.c_str(), nullptr);
+		if (time == -1) {
+			LOG(Level::DEBUG, "parse_url: last-modified %s (curl_getdate FAILED)", header_value);
+		} else {
+			LOG(Level::DEBUG,
+				"parse_url: got last-modified %s (%" PRId64 ")",
+				header_value,
+				// On GCC, `time_t` is `long int`, which is at least 32 bits.
+				// On x86_64, it's 64 bits. Thus, this cast is either a no-op,
+				// or an up-cast which is always safe.
+				static_cast<int64_t>(time));
+			lm = time;
 		}
 	}
 

--- a/rss/parser.h
+++ b/rss/parser.h
@@ -37,7 +37,8 @@ public:
 		newsboat::RemoteApi* api = 0,
 		const std::string& cookie_cache = "");
 	Feed parse_buffer(const std::string& buffer,
-		const std::string& url = "");
+		const std::string& url = "",
+		const std::string& charset = "");
 	Feed parse_file(const std::string& filename);
 	time_t get_last_modified()
 	{

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -89,6 +89,7 @@ mod bridged {
         fn translit(tocode: &str, fromcode: &str) -> String;
         fn utf8_to_locale(text: &str) -> Vec<u8>;
         fn locale_to_utf8(text: &[u8]) -> String;
+        fn convert_text(text: &[u8], tocode: &str, fromcode: &str) -> Vec<u8>;
     }
 
     extern "C++" {

--- a/src/curlheadercontainer.cpp
+++ b/src/curlheadercontainer.cpp
@@ -1,0 +1,53 @@
+#include "curlheadercontainer.h"
+
+#include <curl/curl.h>
+
+namespace newsboat {
+
+std::unique_ptr<CurlHeaderContainer> CurlHeaderContainer::register_header_handler(
+	CurlHandle& curlHandle)
+{
+	return std::unique_ptr<CurlHeaderContainer>(new CurlHeaderContainer(curlHandle));
+}
+
+const std::vector<std::string>& CurlHeaderContainer::get_header_lines() const
+{
+	return mHeaderLines;
+}
+
+CurlHeaderContainer::CurlHeaderContainer(CurlHandle& curlHandle)
+	: mCurlHandle(curlHandle)
+{
+	curl_easy_setopt(mCurlHandle.ptr(), CURLOPT_HEADERDATA, this);
+	curl_easy_setopt(mCurlHandle.ptr(), CURLOPT_HEADERFUNCTION,
+		&CurlHeaderContainer::handle_headers);
+}
+
+CurlHeaderContainer::~CurlHeaderContainer()
+{
+	curl_easy_setopt(mCurlHandle.ptr(), CURLOPT_HEADERDATA, nullptr);
+	curl_easy_setopt(mCurlHandle.ptr(), CURLOPT_HEADERFUNCTION, nullptr);
+}
+
+size_t CurlHeaderContainer::handle_headers(char* buffer, size_t size, size_t nitems,
+	void* data)
+{
+	auto header_container = static_cast<CurlHeaderContainer*>(data);
+	const auto header_line = std::string(buffer, nitems * size);
+
+	header_container->handle_header(header_line);
+
+	return nitems * size;
+}
+
+void CurlHeaderContainer::handle_header(const std::string& line)
+{
+	if (line.find("HTTP/") == 0) {
+		// Reset headers if a new response is detected (there might be multiple responses per request in case of a redirect)
+		mHeaderLines.clear();
+	}
+
+	mHeaderLines.push_back(line);
+}
+
+} // namespace newsboat

--- a/src/curlheadercontainer.cpp
+++ b/src/curlheadercontainer.cpp
@@ -1,6 +1,9 @@
 #include "curlheadercontainer.h"
 
+#include <algorithm>
 #include <curl/curl.h>
+
+#include "utils.h"
 
 namespace newsboat {
 
@@ -13,6 +16,22 @@ std::unique_ptr<CurlHeaderContainer> CurlHeaderContainer::register_header_handle
 const std::vector<std::string>& CurlHeaderContainer::get_header_lines() const
 {
 	return mHeaderLines;
+}
+
+std::vector<std::string> CurlHeaderContainer::get_header_lines(const std::string& key)
+const
+{
+	std::vector<std::string> values;
+	std::string search_string = utils::to_lowercase(key) + ":";
+
+	for (const auto& header_line : mHeaderLines) {
+		if (utils::to_lowercase(header_line).find(search_string) == 0) {
+			std::string value = header_line.substr(search_string.length());
+			utils::trim(value);
+			values.push_back(value);
+		}
+	}
+	return values;
 }
 
 CurlHeaderContainer::CurlHeaderContainer(CurlHandle& curlHandle)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -31,6 +31,7 @@
 #include "curldatareceiver.h"
 #include "curlhandle.h"
 #include "htmlrenderer.h"
+#include "libnewsboat-ffi/src/utils.rs.h"
 #include "logger.h"
 #include "strprintf.h"
 
@@ -185,6 +186,19 @@ std::string utils::locale_to_utf8(const std::string& text)
 			reinterpret_cast<const unsigned char*>(text.c_str()),
 			text.length());
 	return std::string(utils::bridged::locale_to_utf8(text_slice));
+}
+
+std::string utils::convert_text(const std::string& text, const std::string& tocode,
+	const std::string& fromcode)
+{
+	const auto text_slice =
+		rust::Slice<const unsigned char>(
+			reinterpret_cast<const unsigned char*>(text.c_str()),
+			text.length());
+
+	const auto result = utils::bridged::convert_text(text_slice, tocode, fromcode);
+
+	return std::string(reinterpret_cast<const char*>(result.data()), result.size());
 }
 
 std::string utils::get_command_output(const std::string& cmd)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -392,6 +392,17 @@ std::string utils::replace_all(const std::string& str,
 	return output;
 }
 
+std::string utils::to_lowercase(const std::string& input)
+{
+	std::string output;
+	std::transform(input.begin(), input.end(), std::back_inserter(output),
+	[](unsigned char c) {
+		return std::tolower(c);
+	});
+
+	return output;
+}
+
 std::string utils::preserve_quotes(const std::string& str)
 {
 	std::string escaped_string = "";

--- a/test/curlheadercontainer.cpp
+++ b/test/curlheadercontainer.cpp
@@ -1,0 +1,70 @@
+#include "curlheadercontainer.h"
+
+#include "3rd-party/catch.hpp"
+#include "curlhandle.h"
+
+using namespace newsboat;
+
+class CurlHeaderContainerForTesting : public CurlHeaderContainer {
+public:
+	CurlHeaderContainerForTesting(CurlHandle& curlHandle)
+		: CurlHeaderContainer(curlHandle)
+	{
+	}
+
+	using CurlHeaderContainer::handle_header;
+};
+
+TEST_CASE("CurlHeaderContainer::handle_header() stores incoming headers",
+	"[CurlHeaderContainer]")
+{
+	CurlHandle curlHandle;
+
+	GIVEN("A CurlHeaderContainer") {
+		CurlHeaderContainerForTesting curlHeaderContainer(curlHandle);
+
+		WHEN("handle_header() is called repeatedly") {
+			curlHeaderContainer.handle_header("first header");
+			curlHeaderContainer.handle_header("location: test");
+			curlHeaderContainer.handle_header("");
+
+			THEN("all headers can be retrieved") {
+				const auto headers = curlHeaderContainer.get_header_lines();
+
+				REQUIRE(headers.size() == 3);
+				REQUIRE(headers[0] == "first header");
+				REQUIRE(headers[1] == "location: test");
+				REQUIRE(headers[2] == "");
+			}
+		}
+	}
+}
+
+TEST_CASE("CurlHeaderContainer::handle_header() discards previous headers when receiving an HTTP status line",
+	"[CurlHeaderContainer]")
+{
+	CurlHandle curlHandle;
+
+	GIVEN("A CurlHeaderContainer") {
+		CurlHeaderContainerForTesting curlHeaderContainer(curlHandle);
+
+		WHEN("handle_header() is called repeatedly with an HTTP status line in between") {
+			curlHeaderContainer.handle_header("HTTP/1.1 301 Moved Permanently");
+			curlHeaderContainer.handle_header("header of first response");
+			curlHeaderContainer.handle_header("location: somewhere else");
+			curlHeaderContainer.handle_header("");
+			curlHeaderContainer.handle_header("HTTP/1.1 200 OK");
+			curlHeaderContainer.handle_header("header of second response");
+			curlHeaderContainer.handle_header("");
+
+			THEN("all headers can be retrieved") {
+				const auto headers = curlHeaderContainer.get_header_lines();
+
+				REQUIRE(headers.size() == 3);
+				REQUIRE(headers[0] == "HTTP/1.1 200 OK");
+				REQUIRE(headers[1] == "header of second response");
+				REQUIRE(headers[2] == "");
+			}
+		}
+	}
+}

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.h"
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <condition_variable>
 #include <ctype.h>
@@ -2052,4 +2053,209 @@ TEST_CASE("translit() always returns the same value for the same inputs",
 			REQUIRE(utils::translit(tocode, fromcode) == results.at(std::make_pair(fromcode, tocode)));
 		}
 	}
+}
+
+void verify_convert_text(const std::vector<unsigned char>& input,
+	const std::string& tocode, const std::string& fromcode,
+	const std::vector<unsigned char>& expected_output)
+{
+	const std::string input_str = std::string(reinterpret_cast<const char*>(input.data()),
+			input.size());
+	const std::string expected_str = std::string(reinterpret_cast<const char*>
+			(expected_output.data()), expected_output.size());
+
+	REQUIRE(utils::convert_text(input_str, tocode, fromcode) == expected_str);
+}
+
+TEST_CASE("convert_text() returns input string if fromcode and tocode are the same",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// \x81 is not valid UTF-8
+		0x81, 0x13, 0x41,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3f, 0x13, 0x41,
+	};
+
+	verify_convert_text(input, "UTF-8", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() replaces incomplete multibyte sequences with a question mark: utf8 to utf16le",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "ой", "oops" in Russian, but the last byte is missing
+		0xd0, 0xbe, 0xd0,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3e, 0x04, 0x3f, 0x00,
+	};
+
+	verify_convert_text(input, "UTF-16LE", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() replaces incomplete multibyte sequences with a question mark: utf16le to utf8",
+	"[utils]")
+{
+	SECTION("input includes zero byte") {
+		std::vector<unsigned char> input = {
+			// "hi", but the last byte is missing
+			0x68, 0x00, 0x69,
+		};
+
+		std::vector<unsigned char> expected = {
+			0x68, 0x3f,
+		};
+
+		verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+	}
+
+	SECTION("input does not include zero byte") {
+		std::vector<unsigned char> input = {
+			// "эй", "hey" in Russian, but the last byte is missing
+			0x4d, 0x04, 0x39,
+		};
+
+		std::vector<unsigned char> expected = {
+			0xd1, 0x8d, 0x3f,
+		};
+
+		verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+	}
+}
+
+TEST_CASE("convert_text() replaces invalid multibyte sequences with a question mark: utf8 to utf16le",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "日本", "Japan", but the third byte of the first character (0xa5) is
+		// missing, making the whole first character an illegal sequence.
+		0xe6, 0x97, 0xe6, 0x9c, 0xac,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3f, 0x00, 0x3f, 0x00, 0x2c, 0x67,
+	};
+
+	verify_convert_text(input, "UTF-16LE", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() replaces invalid multibyte sequences with a question mark: utf16le to utf8",
+	"[utils]")
+{
+	std::vector<unsigned char> input = {
+		// The first two bytes here are part of a surrogate pair, i.e. they
+		// imply that the next two bytes encode additional info. However, the
+		// next two bytes are an ordinary character. This breaks the decoding
+		// process, so some things get turned into a question mark while others
+		// are decoded incorrectly.
+		0x01, 0xd8, 0xd7, 0x03,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x3f, 0xed, 0x9f, 0x98, 0x3f,
+	};
+
+	verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf8 to utf16le", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "Тестирую", "Testing" in Russian.
+		0xd0, 0xa2, 0xd0, 0xb5, 0xd1, 0x81, 0xd1, 0x82, 0xd0, 0xb8, 0xd1, 0x80, 0xd1, 0x83,
+		0xd1, 0x8e,
+	};
+
+	std::vector<unsigned char> expected = {
+		0x22, 0x04, 0x35, 0x04, 0x41, 0x04, 0x42, 0x04, 0x38, 0x04, 0x40, 0x04, 0x43, 0x04,
+		0x4e, 0x04,
+	};
+
+	verify_convert_text(input, "UTF-16LE", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf8 to koi8r", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "Проверка", "Check" in Russian.
+		0xd0, 0x9f, 0xd1, 0x80, 0xd0, 0xbe, 0xd0, 0xb2, 0xd0, 0xb5, 0xd1, 0x80, 0xd0, 0xba,
+		0xd0, 0xb0,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xf0, 0xd2, 0xcf, 0xd7, 0xc5, 0xd2, 0xcb, 0xc1,
+	};
+
+	verify_convert_text(input, "KOI8-R", "UTF-8", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf8 to ISO-8859-1", "[utils]")
+{
+	// Some symbols in the result will be transliterated.
+
+	std::vector<unsigned char> input = {
+		// "вау °±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃ": a mix of Cyrillic (unsupported by
+		// ISO-8859-1) and ISO-8859-1 characters.
+		0xd0, 0xb2, 0xd0, 0xb0, 0xd1, 0x83, 0x20, 0xc2, 0xb0, 0xc2, 0xb1, 0xc2, 0xb2, 0xc2,
+		0xb3, 0xc2, 0xb4, 0xc2, 0xb5, 0xc2, 0xb6, 0xc2, 0xb7, 0xc2, 0xb8, 0xc2, 0xb9, 0xc2,
+		0xba, 0xc2, 0xbb, 0xc2, 0xbc, 0xc2, 0xbd, 0xc2, 0xbe, 0xc2, 0xbf, 0xc3, 0x80, 0xc3,
+		0x81, 0xc3, 0x82, 0xc3, 0x83,
+	};
+
+	const std::string input_str = std::string(reinterpret_cast<const char*>(input.data()),
+			input.size());
+
+	const auto result = utils::convert_text(input_str, "ISO-8859-1", "UTF-8");
+
+	// We can't spell out an expected result because different platforms
+	// might follow different transliteration rules.
+	REQUIRE(result != "");
+	REQUIRE(result != input_str);
+}
+
+TEST_CASE("convert_text() converts text between encodings: utf16le to utf8", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "Успех", "Success" in Russian.
+		0xff, 0xfe, 0x23, 0x04, 0x41, 0x04, 0x3f, 0x04, 0x35, 0x04, 0x45, 0x04,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xef, 0xbb, 0xbf, 0xd0, 0xa3, 0xd1, 0x81, 0xd0, 0xbf, 0xd0, 0xb5, 0xd1, 0x85,
+	};
+
+	verify_convert_text(input, "UTF-8", "UTF-16LE", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: koi8r to utf8", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "История", "History" in Russian.
+		0xe9, 0xd3, 0xd4, 0xcf, 0xd2, 0xc9, 0xd1,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xd0, 0x98, 0xd1, 0x81, 0xd1, 0x82, 0xd0, 0xbe, 0xd1, 0x80, 0xd0, 0xb8, 0xd1, 0x8f,
+	};
+
+	verify_convert_text(input, "UTF-8", "KOI8-R", expected);
+}
+
+TEST_CASE("convert_text() converts text between encodings: ISO-8859-1 to utf8", "[utils]")
+{
+	std::vector<unsigned char> input = {
+		// "ÄÅÆÇÈÉÊËÌÍÎÏ": some umlauts and Latin letters.
+		0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf,
+	};
+
+	std::vector<unsigned char> expected = {
+		0xc3, 0x84, 0xc3, 0x85, 0xc3, 0x86, 0xc3, 0x87, 0xc3, 0x88, 0xc3, 0x89, 0xc3, 0x8a,
+		0xc3, 0x8b, 0xc3, 0x8c, 0xc3, 0x8d, 0xc3, 0x8e, 0xc3, 0x8f,
+	};
+
+	verify_convert_text(input, "UTF-8", "ISO-8859-1", expected);
 }

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1018,13 +1018,13 @@ TEST_CASE("join()", "[utils]")
 	}
 }
 
-TEST_CASE("trim()", "[utils]")
+TEST_CASE("trim() removes whitespace at start and end of string", "[utils]")
 {
 	std::string str = "  xxx\r\n";
 	utils::trim(str);
 	REQUIRE(str == "xxx");
 
-	str = "\n\n abc  foobar\n";
+	str = "\n\n \tabc  foobar\n";
 	utils::trim(str);
 	REQUIRE(str == "abc  foobar");
 


### PR DESCRIPTION
Previous attempts at implementing encoding fixes (https://github.com/newsboat/newsboat/pull/2214 + https://github.com/newsboat/newsboat/pull/2243) had some  issues when encodings were specified both in the HTTP headers and in the XML header.
https://github.com/newsboat/newsboat/commit/fa363edd2d61e598aff0de5848ae955a5b35d3c0 reverts those problematic changes.
In this PR, I redo most of the reverted changes while implementing the idea proposed near the end of https://github.com/newsboat/newsboat/issues/1436#issuecomment-1367995038.

For now, I've only checked the `Content-Type` header in `rsspp::Parser::parse_url()`.
I prefer to fix the other places (at least `Utils::retrieve_url()`) in a separate PR.

There are a few more locations where HTTP transfers occurs, mainly in the external APIs.
I prefer to also pick those up in a separate PR (maybe letting them reuse the `Utils::retrieve_url()`, tracked in https://github.com/newsboat/newsboat/issues/2227).

Related issue:
- https://github.com/newsboat/newsboat/issues/1436 (this PR fixes it, but it might be useful to keep it open until we take care of the Content-Type in all relevant locations)