### PR TITLE
Fix cppcheck warnings

### DIFF
--- a/include/tagsouppullparser.h
+++ b/include/tagsouppullparser.h
@@ -19,7 +19,7 @@ public:
 		TEXT
 	};
 
-	TagSoupPullParser(std::istream& is);
+	explicit TagSoupPullParser(std::istream& is);
 	virtual ~TagSoupPullParser();
 	nonstd::optional<std::string> get_attribute_value(const std::string& name) const;
 	Event get_event_type() const;

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -256,19 +256,17 @@ TEST_CASE(
 	std::vector<std::string> result;
 
 	SECTION("By default, simply enumerates all settings") {
-		std::unordered_set<std::string> expected{
-			"always-display-description false",
-			"download-timeout 30",
-			"ignore-mode \"download\"",
-			"newsblur-min-items 20",
-			"oldreader-password \"\"",
-			"proxy-type \"http\"",
-			"ttrss-mode \"multi\""};
-
 		REQUIRE_NOTHROW(cfg.dump_config(result));
 		{
-			INFO("Checking that all the expected values were "
-				"found");
+			INFO("Checking that all the expected values were found");
+			std::unordered_set<std::string> expected{
+				"always-display-description false",
+				"download-timeout 30",
+				"ignore-mode \"download\"",
+				"newsblur-min-items 20",
+				"oldreader-password \"\"",
+				"proxy-type \"http\"",
+				"ttrss-mode \"multi\""};
 			REQUIRE(all_values_found(expected, result));
 		}
 	}
@@ -278,15 +276,13 @@ TEST_CASE(
 		cfg.set_configvalue("download-timeout", "100");
 		cfg.set_configvalue("http-auth-method", "digest");
 
-		std::unordered_set<std::string> expected{
-			"download-timeout 100 # default: 30",
-			"http-auth-method \"digest\" # default: any",
-		};
-
 		REQUIRE_NOTHROW(cfg.dump_config(result));
 		{
-			INFO("Checking that all the expected values were "
-				"found");
+			INFO("Checking that all the expected values were found");
+			std::unordered_set<std::string> expected{
+				"download-timeout 100 # default: 30",
+				"http-auth-method \"digest\" # default: any",
+			};
 			REQUIRE(all_values_found(expected, result));
 		}
 	}

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -202,13 +202,13 @@ TEST_CASE("toggle() inverts the value of a boolean setting",
 	SECTION("\"true\" becomes \"false\"") {
 		cfg.set_configvalue(key, "true");
 		REQUIRE_NOTHROW(cfg.toggle(key));
-		REQUIRE(cfg.get_configvalue_as_bool(key) == false);
+		REQUIRE_FALSE(cfg.get_configvalue_as_bool(key));
 	}
 
 	SECTION("\"false\" becomes \"true\"") {
 		cfg.set_configvalue(key, "false");
 		REQUIRE_NOTHROW(cfg.toggle(key));
-		REQUIRE(cfg.get_configvalue_as_bool(key) == true);
+		REQUIRE(cfg.get_configvalue_as_bool(key));
 	}
 }
 

--- a/test/fslock.cpp
+++ b/test/fslock.cpp
@@ -16,7 +16,7 @@ using namespace newsboat;
 // Forks and calls FsLock::try_lock() in the child process.
 class LockProcess {
 public:
-	LockProcess(std::string lock_location)
+	explicit LockProcess(std::string lock_location)
 	{
 		sem_start = sem_open(sem_start_name, O_CREAT, 0644, 0);
 		sem_stop = sem_open(sem_stop_name, O_CREAT, 0644, 0);

--- a/test/fslock.cpp
+++ b/test/fslock.cpp
@@ -16,7 +16,7 @@ using namespace newsboat;
 // Forks and calls FsLock::try_lock() in the child process.
 class LockProcess {
 public:
-	explicit LockProcess(std::string lock_location)
+	explicit LockProcess(const std::string& lock_location)
 	{
 		sem_start = sem_open(sem_start_name, O_CREAT, 0644, 0);
 		sem_stop = sem_open(sem_stop_name, O_CREAT, 0644, 0);

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -492,8 +492,6 @@ TEST_CASE("dump_config() stores a description if it is present", "[KeyMap]")
 {
 	KeyMap k(KM_NEWSBOAT);
 
-	std::vector<std::string> dumpOutput;
-
 	GIVEN("a few macros, some with a description") {
 		k.unset_all_keys("all");
 
@@ -502,6 +500,7 @@ TEST_CASE("dump_config() stores a description if it is present", "[KeyMap]")
 		k.handle_action("macro", R"(z set var I)");
 
 		WHEN("calling dump_config()") {
+			std::vector<std::string> dumpOutput;
 			k.dump_config(dumpOutput);
 
 			THEN("there is one line per configured macro ; all given descriptions are included") {

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -660,7 +660,7 @@ TEST_CASE("Regexes are matched case-insensitively", "[Matcher]")
 {
 	// Inspired by https://github.com/newsboat/newsboat/issues/642
 
-	const auto require_matches = [](std::string regex) {
+	const auto require_matches = [](const std::string& regex) {
 		MatcherMockMatchable mock({{"abcd", "xyz"}});
 		Matcher m;
 
@@ -798,7 +798,7 @@ TEST_CASE("get_parse_error() returns textual description of last "
 TEST_CASE("Space characters in filter expression don't affect parsing",
 	"[Matcher]")
 {
-	const auto check = [](std::string expression) {
+	const auto check = [](const std::string& expression) {
 		INFO("input expression: " << expression);
 
 		MatcherMockMatchable mock({{"array", "foo bar baz"}});
@@ -820,7 +820,7 @@ TEST_CASE("Space characters in filter expression don't affect parsing",
 TEST_CASE("Only space characters are considered whitespace by filter parser",
 	"[Matcher]")
 {
-	const auto check = [](std::string expression) {
+	const auto check = [](const std::string& expression) {
 		INFO("input expression: " << expression);
 
 		MatcherMockMatchable mock({{"attr", "value"}});

--- a/test/matcher.cpp
+++ b/test/matcher.cpp
@@ -62,13 +62,13 @@ TEST_CASE("Operator `=` checks if field has given value", "[Matcher]")
 		REQUIRE_FALSE(m.matches(&mock));
 
 		SECTION("...but converts arguments to strings to compare") {
-			MatcherMockMatchable mock({{"agent", "007"}});
+			MatcherMockMatchable mock2({{"agent", "007"}});
 
 			REQUIRE(m.parse("agent = 7"));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 
 			REQUIRE(m.parse("agent = 007"));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 		}
 	}
 
@@ -113,13 +113,13 @@ TEST_CASE("Operator `!=` checks if field doesn't have given value", "[Matcher]")
 		REQUIRE_FALSE(m.matches(&mock));
 
 		SECTION("...but converts arguments to strings to compare") {
-			MatcherMockMatchable mock({{"agent", "007"}});
+			MatcherMockMatchable mock2({{"agent", "007"}});
 
 			REQUIRE(m.parse("agent != 7"));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 
 			REQUIRE(m.parse("agent != 007"));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 		}
 	}
 
@@ -501,50 +501,50 @@ TEST_CASE(
 		}
 
 		SECTION("Only numeric prefix is used for conversion") {
-			MatcherMockMatchable mock({{"AAAA", "12345xx"}});
+			MatcherMockMatchable mock2({{"AAAA", "12345xx"}});
 
 			REQUIRE(m.parse("AAAA >= \"12345\""));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 
 			REQUIRE(m.parse("AAAA > \"1234a\""));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 
 			REQUIRE(m.parse("AAAA < \"12345a\""));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 
 			REQUIRE(m.parse("AAAA < \"1234a\""));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 
 			REQUIRE(m.parse("AAAA < \"9999b\""));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 		}
 
 		SECTION("If conversion fails, zero is used") {
-			MatcherMockMatchable mock({{"zero", "0"}, {"same_zero", "yeah"}});
+			MatcherMockMatchable mock2({{"zero", "0"}, {"same_zero", "yeah"}});
 
 			REQUIRE(m.parse("zero < \"unknown\""));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 
 			REQUIRE(m.parse("zero > \"unknown\""));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 
 			REQUIRE(m.parse("zero <= \"unknown\""));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 
 			REQUIRE(m.parse("zero >= \"unknown\""));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 
 			REQUIRE(m.parse("same_zero < \"0\""));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 
 			REQUIRE(m.parse("same_zero > \"0\""));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 
 			REQUIRE(m.parse("same_zero <= \"0\""));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 
 			REQUIRE(m.parse("same_zero >= \"0\""));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 		}
 	}
 
@@ -628,19 +628,19 @@ TEST_CASE("Operator `between` checks if field's value is in given range",
 		REQUIRE(m.matches(&mock));
 
 		SECTION("...converting numeric prefix of the attribute if necessary") {
-			MatcherMockMatchable mock({{"value", "123four"}, {"practically_zero", "sure"}});
+			MatcherMockMatchable mock2({{"value", "123four"}, {"practically_zero", "sure"}});
 
 			REQUIRE(m.parse("value between 122:124"));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 
 			REQUIRE(m.parse("value between 124:130"));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 
 			REQUIRE(m.parse("practically_zero between 0:1"));
-			REQUIRE(m.matches(&mock));
+			REQUIRE(m.matches(&mock2));
 
 			REQUIRE(m.parse("practically_zero between 1:100"));
-			REQUIRE_FALSE(m.matches(&mock));
+			REQUIRE_FALSE(m.matches(&mock2));
 		}
 	}
 }

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -16,12 +16,10 @@ using namespace podboat;
 bool contains_download_with_status(const std::vector<Download>& downloads,
 	DlStatus status)
 {
-	for (const Download& d : downloads) {
-		if (d.status() == status) {
-			return true;
-		}
-	}
-	return false;
+	return std::any_of(
+			std::begin(downloads),
+			std::end(downloads),
+			[status](const Download& d) -> bool { return d.status() == status; });
 }
 
 TEST_CASE("Passes the callback to Download objects", "[QueueLoader]")

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -11,9 +11,9 @@ using namespace newsboat;
 TEST_CASE("RegexManager throws on invalid command", "[RegexManager]")
 {
 	RegexManager rxman;
-	std::vector<std::string> params;
 
 	SECTION("on invalid command") {
+		std::vector<std::string> params;
 		REQUIRE_THROWS_AS(
 			rxman.handle_action("an-invalid-command", params),
 			ConfigHandlerException);
@@ -1030,7 +1030,6 @@ TEST_CASE("insert_style_tags() does not crash on invalid input",
 	"[RegexManager]")
 {
 	RegexManager rxman;
-	std::string input = "test this";
 
 	SECTION("tags with a position outside  of the string are ignored") {
 		std::map<size_t, std::string> tags = {
@@ -1038,6 +1037,7 @@ TEST_CASE("insert_style_tags() does not crash on invalid input",
 			{9, "<in>"},
 			{10, "<out>"},
 		};
+		std::string input = "test this";
 		const std::string output = "<test>test this<in>";
 		rxman.insert_style_tags(input, tags);
 		REQUIRE(input == output);
@@ -1114,10 +1114,10 @@ TEST_CASE("merge_style_tag() does not crash on invalid input",
 	"[RegexManager]")
 {
 	RegexManager rxman;
-	std::map<size_t, std::string> tags;
-	const std::string new_tag = "<test>";
 
 	SECTION("ignore tag merging if `end <= start`") {
+		std::map<size_t, std::string> tags;
+		const std::string new_tag = "<test>";
 		rxman.merge_style_tag(tags, new_tag, 0, 0);
 		rxman.merge_style_tag(tags, new_tag, 1, 0);
 		rxman.merge_style_tag(tags, new_tag, 5, 4);

--- a/test/remoteapi.cpp
+++ b/test/remoteapi.cpp
@@ -14,7 +14,7 @@ using namespace newsboat;
  */
 class test_api : public RemoteApi {
 public:
-	test_api(ConfigContainer* c)
+	explicit test_api(ConfigContainer* c)
 		: RemoteApi(c)
 	{
 	}

--- a/test/remoteapi.cpp
+++ b/test/remoteapi.cpp
@@ -26,29 +26,29 @@ public:
 	{
 		return get_credentials(scope, name).pass;
 	}
-	bool authenticate()
+	bool authenticate() override
 	{
 		throw 0;
 	}
-	std::vector<TaggedFeedUrl> get_subscribed_urls()
+	std::vector<TaggedFeedUrl> get_subscribed_urls() override
 	{
 		throw 0;
 	}
-	void add_custom_headers(curl_slist**)
+	void add_custom_headers(curl_slist**) override
 	{
 		throw 0;
 	}
-	bool mark_all_read(const std::string&)
+	bool mark_all_read(const std::string&) override
 	{
 		throw 0;
 	}
-	bool mark_article_read(const std::string&, bool)
+	bool mark_article_read(const std::string&, bool) override
 	{
 		throw 0;
 	}
 	bool update_article_flags(const std::string&,
 		const std::string&,
-		const std::string&)
+		const std::string&) override
 	{
 		throw 0;
 	}

--- a/test/test_helpers/envvar.cpp
+++ b/test/test_helpers/envvar.cpp
@@ -3,11 +3,11 @@
 #include "3rd-party/catch.hpp"
 
 test_helpers::EnvVar::EnvVar(std::string name_)
-	: EnvVar(name_, true)
+	: EnvVar(std::move(name_), true)
 {
-	if (name_ == "TZ") {
+	if (name == "TZ") {
 		throw std::invalid_argument("Using EnvVar(\"TZ\") is discouraged. Try test_helpers::TzEnvVar instead.");
-	} else if (name_ == "LC_CTYPE") {
+	} else if (name == "LC_CTYPE") {
 		throw std::invalid_argument("Using EnvVar(\"LC_CTYPE\") is discouraged. Try test_helpers::LcCtypeEnvVar instead.");
 	}
 }

--- a/test/test_helpers/envvar.h
+++ b/test/test_helpers/envvar.h
@@ -51,14 +51,14 @@ public:
 	/// restore the variable when the test finished running. The variable is
 	/// always restored to the state it was in when EnvVar object was
 	/// constructed.
-	virtual void set(const std::string& new_value) const;
+	void set(const std::string& new_value) const;
 
 	/// \brief Unsets the environment variable.
 	///
 	/// \note This does \emph{not} change the value to which EnvVar will
 	/// restore the variable when the test finished running. The variable is
 	/// always restored to the state it was in when EnvVar object was
-	virtual void unset() const;
+	void unset() const;
 
 	/// \brief Specifies a function that should be ran after each call to set()
 	/// or unset() methods, and also during object destruction.
@@ -70,7 +70,7 @@ public:
 	/// - nonstd::nullopt  --  meaning the environment variable is now unset
 	/// - std::string      --  meaning the environment variable is now set to
 	///                        this value
-	virtual void on_change(std::function<void(nonstd::optional<std::string> new_value)> fn);
+	void on_change(std::function<void(nonstd::optional<std::string> new_value)> fn);
 
 protected:
 	// The main constructor throws for some values of `name`; this one doesn't.


### PR DESCRIPTION
These were found with cppcheck 2.10. There were a bunch of false positives in Catch2 macros, but I didn't find energy to figure out how to suppress them.

The only important commit here is 0c7bddfb206dbde217d6bb4d00d8cd2d842e0407, because it fixes a potential problem. The rest are just readability and performance churn.