### PR TITLE
Show image enclosure inline

### DIFF
--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -94,22 +94,16 @@ public:
 		feedurl_ = f;
 	}
 
-	const std::string& feedurl() const
-	{
-		return feedurl_;
-	}
-
-	const std::string& enclosure_url() const
-	{
-		return enclosure_url_;
-	}
-	const std::string& enclosure_type() const
-	{
-		return enclosure_type_;
-	}
+	const std::string& feedurl() const;
+	const std::string& enclosure_url() const;
+	const std::string& enclosure_type() const;
+	const std::string& enclosure_description() const;
+	const std::string& enclosure_description_mime_type() const;
 
 	void set_enclosure_url(const std::string& url);
 	void set_enclosure_type(const std::string& type);
+	void set_enclosure_description(const std::string& description);
+	void set_enclosure_description_mime_type(const std::string& type);
 
 	bool enqueued()
 	{
@@ -189,6 +183,8 @@ private:
 	Cache* ch;
 	std::string enclosure_url_;
 	std::string enclosure_type_;
+	std::string enclosure_description_;
+	std::string enclosure_description_mime_type_;
 	std::string flags_;
 	std::string oldflags_;
 	std::weak_ptr<RssFeed> feedptr_;

--- a/include/rssitem.h
+++ b/include/rssitem.h
@@ -154,7 +154,7 @@ public:
 	{
 		base = b;
 	}
-	const std::string& get_base()
+	const std::string& get_base() const
 	{
 		return base;
 	}

--- a/rss/atomparser.cpp
+++ b/rss/atomparser.cpp
@@ -138,6 +138,8 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 				Enclosure {
 					get_prop(node, "href"),
 					get_prop(node, "type"),
+					"",
+					"",
 				}
 				);
 			}

--- a/rss/item.h
+++ b/rss/item.h
@@ -10,6 +10,8 @@ namespace rsspp {
 struct Enclosure {
 	std::string url;
 	std::string type;
+	std::string description;
+	std::string description_mime_type;
 };
 
 class Item {

--- a/rss/medianamespace.cpp
+++ b/rss/medianamespace.cpp
@@ -16,7 +16,7 @@ bool is_media_node(xmlNode* node)
 	return has_namespace(node, MEDIA_RSS_URI);
 }
 
-void parse_media_node(xmlNode* node, Item& it)
+void parse_media_node(xmlNode* node, Item& it, Enclosure* enclosure)
 {
 	if (node_is(node, "group", MEDIA_RSS_URI)) {
 		for (xmlNode* mnode = node->children; mnode != nullptr; mnode = mnode->next) {
@@ -27,24 +27,47 @@ void parse_media_node(xmlNode* node, Item& it)
 		Enclosure {
 			get_prop(node, "url"),
 			get_prop(node, "type"),
+			"",
+			"",
 		}
 		);
 		for (xmlNode* mnode = node->children; mnode != nullptr; mnode = mnode->next) {
-			parse_media_node(mnode, it);
+			parse_media_node(mnode, it, &it.enclosures.back());
 		}
 	} else if (node_is(node, "description", MEDIA_RSS_URI)) {
+		const std::string description = get_content(node);
 		const std::string type = get_prop(node, "type");
+		const std::string mime_type = (type == "html" ? "text/html" : "text/plain");
 		if (it.description.empty()) {
-			it.description = get_content(node);
-			if (type == "html") {
-				it.description_mime_type = "text/html";
-			} else {
-				it.description_mime_type = "text/plain";
+			it.description = description;
+			it.description_mime_type = mime_type;
+		}
+		if (enclosure) {
+			enclosure->description = description;
+			enclosure->description_mime_type = mime_type;
+		} else {
+			if (it.description.empty()) {
+				it.description = description;
+				it.description_mime_type = mime_type;
 			}
 		}
 	} else if (node_is(node, "title", MEDIA_RSS_URI)) {
+		const std::string title = get_content(node);
+		const std::string type = get_prop(node, "type");
+		const std::string mime_type = (type == "html" ? "text/html" : "text/plain");
 		if (it.title.empty()) {
-			it.title = get_content(node);
+			it.title = title;
+			it.title_type = type;
+		}
+		if (enclosure) {
+			if (enclosure->description.empty()) {
+				enclosure->description = title;
+				enclosure->description_mime_type = mime_type;
+			}
+		} else {
+			if (it.title.empty()) {
+				it.title = title;
+			}
 		}
 	} else if (node_is(node, "player", MEDIA_RSS_URI)) {
 		if (it.link.empty()) {

--- a/rss/medianamespace.cpp
+++ b/rss/medianamespace.cpp
@@ -45,11 +45,6 @@ void parse_media_node(xmlNode* node, Item& it, Enclosure* enclosure)
 		if (enclosure) {
 			enclosure->description = description;
 			enclosure->description_mime_type = mime_type;
-		} else {
-			if (it.description.empty()) {
-				it.description = description;
-				it.description_mime_type = mime_type;
-			}
 		}
 	} else if (node_is(node, "title", MEDIA_RSS_URI)) {
 		const std::string title = get_content(node);
@@ -63,10 +58,6 @@ void parse_media_node(xmlNode* node, Item& it, Enclosure* enclosure)
 			if (enclosure->description.empty()) {
 				enclosure->description = title;
 				enclosure->description_mime_type = mime_type;
-			}
-		} else {
-			if (it.title.empty()) {
-				it.title = title;
 			}
 		}
 	} else if (node_is(node, "player", MEDIA_RSS_URI)) {

--- a/rss/medianamespace.h
+++ b/rss/medianamespace.h
@@ -8,7 +8,7 @@
 namespace rsspp {
 
 bool is_media_node(xmlNode* node);
-void parse_media_node(xmlNode* node, Item& it);
+void parse_media_node(xmlNode* node, Item& it, Enclosure* enclosure = nullptr);
 
 } // namespace rsspp
 

--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -119,6 +119,8 @@ Item Rss09xParser::parse_item(xmlNode* itemNode)
 			Enclosure {
 				get_prop(node, "url"),
 				get_prop(node, "type"),
+				"",
+				"",
 			}
 			);
 		} else if (is_media_node(node)) {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -393,7 +393,7 @@ static const schema_patches schemaPatches{
 			"ALTER TABLE rss_item ADD COLUMN content_mime_type VARCHAR(255) NOT NULL DEFAULT \"\";"
 		}
 	},
-	{	{2, 32},
+	{	{2, 33},
 		{
 			"ALTER TABLE rss_item ADD COLUMN enclosure_description VARCHAR(1024) NOT NULL DEFAULT \"\";",
 			"ALTER TABLE rss_item ADD COLUMN enclosure_description_mime_type VARCHAR(128) NOT NULL DEFAULT \"\";",

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -299,7 +299,7 @@ void Cache::set_pragmas()
 static const schema_patches schemaPatches{
 	{	{2, 10},
 		{
-			"CREATE TABLE rss_feed ( "
+			"CREATE TABLE rss_feed ( " // NOLINT(bugprone-suspicious-missing-comma)
 			" rssurl VARCHAR(1024) PRIMARY KEY NOT NULL, "
 			" url VARCHAR(1024) NOT NULL, "
 			" title VARCHAR(1024) NOT NULL ); ",

--- a/src/freshrssapi.cpp
+++ b/src/freshrssapi.cpp
@@ -517,6 +517,8 @@ rsspp::Feed FreshRssApi::fetch_feed(const std::string& id, CurlHandle& cached_ha
 						rsspp::Enclosure {
 							a["href"],
 							a["type"],
+							"",
+							"",
 						}
 						);
 						break;

--- a/src/ocnewsapi.cpp
+++ b/src/ocnewsapi.cpp
@@ -286,6 +286,8 @@ rsspp::Feed OcNewsApi::fetch_feed(const std::string& feed_id)
 				rsspp::Enclosure {
 					url,
 					type,
+					"",
+					"",
 				}
 				);
 			}

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -127,6 +127,31 @@ std::string RssItem::pubDate() const
 	return utils::mt_strf_localtime(_("%a, %d %b %Y %T %z"), pubDate_);
 }
 
+const std::string& RssItem::feedurl() const
+{
+	return feedurl_;
+}
+
+const std::string& RssItem::enclosure_url() const
+{
+	return enclosure_url_;
+}
+
+const std::string& RssItem::enclosure_type() const
+{
+	return enclosure_type_;
+}
+
+const std::string& RssItem::enclosure_description() const
+{
+	return enclosure_description_;
+}
+
+const std::string& RssItem::enclosure_description_mime_type() const
+{
+	return enclosure_description_mime_type_;
+}
+
 void RssItem::set_enclosure_url(const std::string& url)
 {
 	enclosure_url_ = url;
@@ -135,6 +160,16 @@ void RssItem::set_enclosure_url(const std::string& url)
 void RssItem::set_enclosure_type(const std::string& type)
 {
 	enclosure_type_ = type;
+}
+
+void RssItem::set_enclosure_description(const std::string& description)
+{
+	enclosure_description_ = description;
+}
+
+void RssItem::set_enclosure_description_mime_type(const std::string& type)
+{
+	enclosure_description_mime_type_ = type;
 }
 
 nonstd::optional<std::string> RssItem::attribute_value(const std::string&

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -394,6 +394,8 @@ void RssParser::set_item_enclosure(std::shared_ptr<RssItem> x,
 {
 	std::string enclosure_url;
 	std::string enclosure_type;
+	std::string enclosure_description;
+	std::string enclosure_description_mime_type;
 	bool found_valid_enclosure = false;
 
 	for (const auto& enclosure : item.enclosures) {
@@ -401,14 +403,20 @@ void RssParser::set_item_enclosure(std::shared_ptr<RssItem> x,
 			found_valid_enclosure = true;
 			enclosure_url = enclosure.url;
 			enclosure_type = enclosure.type;
+			enclosure_description = enclosure.description;
+			enclosure_description_mime_type = enclosure.description_mime_type;
 		} else if (!found_valid_enclosure) {
 			enclosure_url = enclosure.url;
 			enclosure_type = enclosure.type;
+			enclosure_description = enclosure.description;
+			enclosure_description_mime_type = enclosure.description_mime_type;
 		}
 	}
 
 	x->set_enclosure_url(enclosure_url);
 	x->set_enclosure_type(enclosure_type);
+	x->set_enclosure_description(enclosure_description);
+	x->set_enclosure_description_mime_type(enclosure_description_mime_type);
 	LOG(Level::DEBUG,
 		"RssParser::parse: found enclosure_url: %s",
 		enclosure_url);

--- a/src/ttrssapi.cpp
+++ b/src/ttrssapi.cpp
@@ -421,6 +421,8 @@ rsspp::Feed TtRssApi::fetch_feed(const std::string& id, CurlHandle& cached_handl
 						rsspp::Enclosure {
 							a["content_url"],
 							a["content_type"],
+							"",
+							"",
 						}
 						);
 						break;

--- a/test/data/atom10_2.xml
+++ b/test/data/atom10_2.xml
@@ -55,4 +55,13 @@
     <media:player url="http://example.com/player.html"/>
   </entry>
 
+  <entry>
+    <title>using media:content</title>
+    <link href="http://example.com/4.html"/>
+    <id>tag:example.com,2008-12-30:/4</id>
+    <content type="html">regular content</content>
+    <media:content url="http://example.com/media-test.png" type="image/png" />
+    <media:content url="http://example.com/movie.mov" type="video/quicktime" />
+  </entry>
+
 </feed>

--- a/test/data/rss20_2.xml
+++ b/test/data/rss20_2.xml
@@ -31,5 +31,15 @@
       </media:content>
     </media:group>
 </item>
+
+<item>
+    <comments>http://example.com/blog/this_is_an_item.html#comments</comments>
+    <author>blog@synflood.at (Andreas Krennmair)</author>
+    <pubDate>Fri, 12 Dec 2008 02:36:10 +0100</pubDate>
+    <guid isPermaLink="false">http://example.com/blog/using-media-content.html</guid>
+
+    <media:content url="http://example.com/media-test.png" type="image/png" />
+    <media:content url="http://example.com/movie.mov" type="video/quicktime" />
+</item>
 </channel>
 </rss>

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -30,9 +30,12 @@ static const auto ITEM_PUBDATE = time_t
 static const auto ITEM_LINK = std::string("https://example.com/see-more");
 static const auto ITEM_DESCRIPTON = std::string("<p>Hello, world!</p>");
 static const auto ITEM_DESCRIPTON_RENDERED = std::string("Hello, world!");
-static const auto ITEM_ENCLOSURE_URL =
+static const auto ITEM_PODCAST_ENCLOSURE_URL =
 	std::string("https://example.com/see-more.mp3");
-static const auto ITEM_ENCLOSURE_TYPE = std::string("audio/mpeg");
+static const auto ITEM_IMAGE_ENCLOSURE_URL =
+	std::string("https://example.com/see-more.png");
+static const auto ITEM_PODCAST_ENCLOSURE_TYPE = std::string("audio/mpeg");
+static const auto ITEM_IMAGE_ENCLOSURE_TYPE = std::string("image/png");
 static const auto ITEM_FLAGS = std::string("wasdhjkl");
 // Flags are sorted for rendering.
 static const auto ITEM_FLAGS_RENDERED = std::string("adhjklsw");
@@ -91,7 +94,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 
 	SECTION("Item with an enclosure") {
 		item->set_description(ITEM_DESCRIPTON, "text/html");
-		item->set_enclosure_url(ITEM_ENCLOSURE_URL);
+		item->set_enclosure_url(ITEM_PODCAST_ENCLOSURE_URL);
 
 		const auto result = item_renderer::to_plain_text(cfg, item);
 
@@ -102,17 +105,17 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 			"Link: " + ITEM_LINK + '\n' +
 			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
-			"Podcast Download URL: " + ITEM_ENCLOSURE_URL + '\n' +
+			"Podcast Download URL: " + ITEM_PODCAST_ENCLOSURE_URL + '\n' +
 			" \n" +
 			ITEM_DESCRIPTON_RENDERED + '\n';
 
 		REQUIRE(result == expected);
 	}
 
-	SECTION("Item with an enclosure that has a MIME type") {
+	SECTION("Item with an enclosure that has a podcast MIME type") {
 		item->set_description(ITEM_DESCRIPTON, "text/html");
-		item->set_enclosure_url(ITEM_ENCLOSURE_URL);
-		item->set_enclosure_type(ITEM_ENCLOSURE_TYPE);
+		item->set_enclosure_url(ITEM_PODCAST_ENCLOSURE_URL);
+		item->set_enclosure_type(ITEM_PODCAST_ENCLOSURE_TYPE);
 
 		const auto result = item_renderer::to_plain_text(cfg, item);
 
@@ -123,10 +126,35 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
 			"Link: " + ITEM_LINK + '\n' +
 			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
-			"Podcast Download URL: " + ITEM_ENCLOSURE_URL
-			+ " (type: " + ITEM_ENCLOSURE_TYPE + ")\n" +
+			"Podcast Download URL: " + ITEM_PODCAST_ENCLOSURE_URL
+			+ " (type: " + ITEM_PODCAST_ENCLOSURE_TYPE + ")\n" +
 			" \n" +
 			ITEM_DESCRIPTON_RENDERED + '\n';
+
+		REQUIRE(result == expected);
+	}
+
+	SECTION("Item with an enclosure that has an image MIME type") {
+		item->set_description(ITEM_DESCRIPTON, "text/html");
+		item->set_enclosure_url(ITEM_IMAGE_ENCLOSURE_URL);
+		item->set_enclosure_type(ITEM_IMAGE_ENCLOSURE_TYPE);
+
+		const auto result = item_renderer::to_plain_text(cfg, item);
+
+		const auto expected = std::string() +
+			"Feed: " + FEED_TITLE + '\n' +
+			"Title: " + ITEM_TITLE + '\n' +
+			"Author: " + ITEM_AUTHOR + '\n' +
+			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
+			"Link: " + ITEM_LINK + '\n' +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
+			" \n" +
+			"Image[1]\n" +
+			" \n" +
+			ITEM_DESCRIPTON_RENDERED + '\n' +
+			" \n" +
+			"Links: \n" +
+			"[1]: " + ITEM_IMAGE_ENCLOSURE_URL + " (image)\n";
 
 		REQUIRE(result == expected);
 	}

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -232,7 +232,7 @@ TEST_CASE("Extracts data from media:... tags in atom feed", "[rsspp::Parser]")
 	REQUIRE(f.pubDate == "Tue, 30 Dec 2008 18:26:15 +0000");
 	REQUIRE(f.link == "http://example.com/");
 
-	REQUIRE(f.items.size() == 5u);
+	REQUIRE(f.items.size() == 6u);
 	REQUIRE(f.items[0].title == "using regular content");
 	REQUIRE(f.items[0].description == "regular html content");
 	REQUIRE(f.items[0].description_mime_type == "text/html");
@@ -263,6 +263,16 @@ TEST_CASE("Extracts data from media:... tags in atom feed", "[rsspp::Parser]")
 		REQUIRE(f.items[4].link == "http://example.com/regular-link");
 		REQUIRE(f.items[4].author == "John Doe");
 	}
+
+	REQUIRE(f.items[5].title == "using media:content");
+	REQUIRE(f.items[5].description == "regular content");
+	REQUIRE(f.items[5].description_mime_type == "text/html");
+	REQUIRE(f.items[5].link == "http://example.com/4.html");
+	REQUIRE(f.items[5].enclosures.size() == 2);
+	REQUIRE(f.items[5].enclosures[0].url == "http://example.com/media-test.png");
+	REQUIRE(f.items[5].enclosures[0].type == "image/png");
+	REQUIRE(f.items[5].enclosures[1].url == "http://example.com/movie.mov");
+	REQUIRE(f.items[5].enclosures[1].type == "video/quicktime");
 }
 
 TEST_CASE("Extracts data from media:... tags in  RSS 2.0 feeds",

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -255,6 +255,9 @@ TEST_CASE("Extracts data from media:... tags in atom feed", "[rsspp::Parser]")
 	REQUIRE(f.items[3].description_mime_type == "text/html");
 	REQUIRE(f.items[3].link == "http://example.com/player.html");
 	REQUIRE(f.items[3].author == "John Doe");
+	REQUIRE(f.items[3].enclosures.size() == 1);
+	REQUIRE(f.items[3].enclosures[0].description == "nested media html content");
+	REQUIRE(f.items[3].enclosures[0].description_mime_type == "text/html");
 
 	SECTION("media:{title,description,player} does not overwrite regular title, description, and link if they exist") {
 		REQUIRE(f.items[4].title == "regular title");
@@ -287,7 +290,7 @@ TEST_CASE("Extracts data from media:... tags in  RSS 2.0 feeds",
 	REQUIRE(f.link == "http://example.com/blog/");
 	REQUIRE(f.description == "my description");
 
-	REQUIRE(f.items.size() == 2u);
+	REQUIRE(f.items.size() == 3u);
 
 	REQUIRE(f.items[0].title == "using multiple media tags");
 	REQUIRE(f.items[0].description == "media html content");
@@ -299,6 +302,15 @@ TEST_CASE("Extracts data from media:... tags in  RSS 2.0 feeds",
 	REQUIRE(f.items[1].description == "nested media html content");
 	REQUIRE(f.items[1].description_mime_type == "text/html");
 	REQUIRE(f.items[1].link == "http://example.com/player.html");
+	REQUIRE(f.items[1].enclosures.size() == 1);
+	REQUIRE(f.items[1].enclosures[0].description == "nested media html content");
+	REQUIRE(f.items[1].enclosures[0].description_mime_type == "text/html");
+
+	REQUIRE(f.items[2].enclosures.size() == 2);
+	REQUIRE(f.items[2].enclosures[0].url == "http://example.com/media-test.png");
+	REQUIRE(f.items[2].enclosures[0].type == "image/png");
+	REQUIRE(f.items[2].enclosures[1].url == "http://example.com/movie.mov");
+	REQUIRE(f.items[2].enclosures[1].type == "video/quicktime");
 }
 
 TEST_CASE("Multiple links in item", "[rsspp::Parser]")


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2305 and resolves https://github.com/newsboat/newsboat/issues/2495

Side-by-side view of rendered output for old (left, before this PR) and new (right, with this PR):
![image](https://user-images.githubusercontent.com/4629607/230669725-88d37c87-8cf8-4a34-b4db-dd14edbf34e0.png)

My idea here is to show the enclosure's description if it is available, directly above the regular text.
This seems to work well for posts from Mastodon, e.g. from the feed for Minimus' posts: https://yt.artemislena.eu/feed/channel/UCXIJgqnII2ZOINSWNOGFThA
Other than that, I tried to change as little as possible.
Specifically, the enclosure description is still shown as content if no regular content element is available (just implemented in a different location).

