### PR TITLE
Include tags in OPML feed export

### DIFF
--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -125,12 +125,15 @@ if you'd like to add support to Newsboat.)
 
 == How can I include tags when exporting to OPML?
 
-In general, you can't. OPML is a hierarchy, i.e. each "category" is either
-nested under some other category, or is at the root of the hierarchy. On the
-other hand, Newsboat's tags are just labels, with no explicit relationships
-between them. Since each feed can have multiple tags, it's not always possible
-to represent the _urls_ file as a hierarchy. Thus, we don't even try.
+You can export an OPML 2.0 file with tags using `--export-to-opml2`.
+
+Not all feed readers support OPML 2.0 files with flat tags. In this case, there
+is not a good way; OPML is primarily designed as a hierarchy, i.e. each
+"category" is either nested under some other category, or is at the root of the
+hierarchy. On the other hand, Newsboat's tags are just labels, with no explicit
+relationships between them. Since each feed can have multiple tags, it's not
+always possible to represent the _urls_ file as a hierarchy.
 
 However, if your feeds have one tag each, you can use
 https://github.com/newsboat/newsboat/blob/master/contrib/exportOPMLWithTags.py[_contrib/exportOPMLWithTags.py_
-script] which will do the job.
+script] which will export in a hierarchy your feed reader should understand.

--- a/doc/manpage-newsboat.asciidoc
+++ b/doc/manpage-newsboat.asciidoc
@@ -29,7 +29,11 @@ terminals on Unix or Unix-like systems such as GNU/Linux, BSD or macOS.
         Refresh feeds on start
 
 *-e*, *--export-to-opml*::
-        Export feeds as OPML to stdout
+        Export feeds as OPML to stdout. This currently outputs OPML 1.0, losing
+        all tag information, but this is subject to change to 2.0 in the future.
+
+*--export-to-opml2*::
+        Export feeds as OPML 2.0, including tags, to stdout
 
 *-X*, *--vacuum*::
         Compact the cache by: 1) reclaiming the space that was left empty when

--- a/include/cliargsparser.h
+++ b/include/cliargsparser.h
@@ -20,6 +20,8 @@ public:
 
 	bool do_export() const;
 
+	bool export_as_opml2() const;
+
 	bool do_vacuum() const;
 
 	bool do_cleanup() const;

--- a/include/controller.h
+++ b/include/controller.h
@@ -119,7 +119,7 @@ public:
 
 private:
 	int import_opml(const std::string& opmlFile, const std::string& urlFile);
-	void export_opml();
+	void export_opml(bool version2);
 	void rec_find_rss_outlines(xmlNode* node, std::string tag);
 	int execute_commands(const std::vector<std::string>& cmds);
 

--- a/include/opml.h
+++ b/include/opml.h
@@ -9,7 +9,7 @@
 namespace newsboat {
 
 namespace opml {
-xmlDocPtr generate(const FeedContainer& feedcontainer);
+xmlDocPtr generate(const FeedContainer& feedcontainer, bool version2);
 nonstd::optional<std::string> import(
 	const std::string& filename,
 	FileUrlReader& urlcfg);

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -116,7 +116,7 @@ public:
 
 	void set_tags(const std::vector<std::string>& tags);
 	bool matches_tag(const std::string& tag);
-	std::string get_tags() const;
+	std::vector<std::string> get_tags() const;
 	std::string get_firsttag();
 
 	nonstd::optional<std::string> attribute_value(const std::string& attr) const

--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -45,6 +45,7 @@ void print_usage(const std::string& argv0, const std::string& config_path,
 
 	static const std::vector<arg> args = {
 		{'e', "export-to-opml", "", _s("export OPML feed to stdout")},
+		{'-', "export-to-opml2", "", _s("export OPML 2.0 feed including tags to stdout")},
 		{'r', "refresh-on-start", "", _s("refresh feeds on start")},
 		{'i', "import-from-opml", _s("<file>"), _s("import OPML file")},
 		{

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -28,6 +28,7 @@ mod bridged {
 
         fn do_import(cliargsparser: &CliArgsParser) -> bool;
         fn do_export(cliargsparser: &CliArgsParser) -> bool;
+        fn export_as_opml2(cliargsparser: &CliArgsParser) -> bool;
         fn do_vacuum(cliargsparser: &CliArgsParser) -> bool;
         fn do_cleanup(cliargsparser: &CliArgsParser) -> bool;
         fn do_show_version(cliargsparser: &CliArgsParser) -> u64;
@@ -81,6 +82,10 @@ fn do_import(cliargsparser: &CliArgsParser) -> bool {
 
 fn do_export(cliargsparser: &CliArgsParser) -> bool {
     cliargsparser.0.do_export
+}
+
+fn export_as_opml2(cliargsparser: &CliArgsParser) -> bool {
+    cliargsparser.0.export_as_opml2
 }
 
 fn do_vacuum(cliargsparser: &CliArgsParser) -> bool {

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -12,6 +12,7 @@ use strprintf::fmt;
 #[derive(Default)]
 pub struct CliArgsParser {
     pub do_export: bool,
+    pub export_as_opml2: bool,
     pub do_vacuum: bool,
     pub do_cleanup: bool,
     pub program_name: String,
@@ -149,6 +150,12 @@ pub fn parse_cliargs(opts: Vec<OsString>, args: &mut CliArgsParser) -> Result<()
             }
             Short('e') | Long("export-to-opml") => {
                 args.do_export = true;
+                args.export_as_opml2 = false;
+                args.silent = true;
+            }
+            Long("export-to-opml2") => {
+                args.do_export = true;
+                args.export_as_opml2 = true;
                 args.silent = true;
             }
             Short('r') | Long("refresh-on-start") => args.refresh_on_start = true,

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -36,6 +36,11 @@ bool CliArgsParser::do_export() const
 	return newsboat::cliargsparser::bridged::do_export(*rs_object);
 }
 
+bool CliArgsParser::export_as_opml2() const
+{
+	return newsboat::cliargsparser::bridged::export_as_opml2(*rs_object);
+}
+
 bool CliArgsParser::do_vacuum() const
 {
 	return newsboat::cliargsparser::bridged::do_vacuum(*rs_object);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -502,7 +502,7 @@ int Controller::run(const CliArgsParser& args)
 	feedcontainer.sort_feeds(cfg.get_feed_sort_strategy());
 
 	if (args.do_export()) {
-		export_opml();
+		export_opml(args.export_as_opml2());
 		return EXIT_SUCCESS;
 	}
 
@@ -760,9 +760,9 @@ int Controller::import_opml(const std::string& opmlFile,
 	}
 }
 
-void Controller::export_opml()
+void Controller::export_opml(bool version2)
 {
-	xmlDocPtr root = opml::generate(feedcontainer);
+	xmlDocPtr root = opml::generate(feedcontainer, version2);
 
 	xmlSaveCtxtPtr savectx = xmlSaveToFd(1, nullptr, 1);
 	xmlSaveDoc(savectx, root);

--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -9,12 +9,14 @@
 
 namespace newsboat {
 
-xmlDocPtr opml::generate(const FeedContainer& feedcontainer)
+xmlDocPtr opml::generate(const FeedContainer& feedcontainer, bool version2)
 {
 	xmlDocPtr root = xmlNewDoc((const xmlChar*)"1.0");
 	xmlNodePtr opml_node =
 		xmlNewDocNode(root, nullptr, (const xmlChar*)"opml", nullptr);
-	xmlSetProp(opml_node, (const xmlChar*)"version", (const xmlChar*)"1.0");
+	xmlSetProp(opml_node,
+		(const xmlChar*)"version",
+		(const xmlChar*)(version2 ? "2.0" : "1.0"));
 	xmlDocSetRootElement(root, opml_node);
 
 	xmlNodePtr head = xmlNewTextChild(
@@ -48,6 +50,27 @@ xmlDocPtr opml::generate(const FeedContainer& feedcontainer)
 			xmlSetProp(outline,
 				(const xmlChar*)"title",
 				(const xmlChar*)title.c_str());
+
+			if (version2) {
+				// OPML 2.0 supports including tags
+				std::vector<std::string> tags = feed->get_tags();
+				std::string opml_tags;
+
+				bool first_tag = true;
+				for (auto t : tags) {
+					utils::trim(t);
+					t = utils::replace_all(t, ",", "_");
+					if (first_tag) {
+						first_tag = false;
+					} else {
+						opml_tags.append(",");
+					}
+					opml_tags.append(t);
+				}
+				xmlSetProp(outline,
+					(const xmlChar*)"category",
+					(const xmlChar*)opml_tags.c_str());
+			}
 		}
 	}
 

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -107,13 +107,12 @@ std::string RssFeed::get_firsttag()
 	return "";
 }
 
-std::string RssFeed::get_tags() const
+std::vector<std::string> RssFeed::get_tags() const
 {
-	std::string tags;
+	std::vector<std::string> tags;
 	for (const auto& t : tags_) {
 		if (t.substr(0, 1) != "~" && t.substr(0, 1) != "!") {
-			tags.append(t);
-			tags.append(" ");
+			tags.push_back(t);
 		}
 	}
 	return tags;
@@ -190,7 +189,12 @@ nonstd::optional<std::string> RssFeed::attribute_value(const std::string&
 	} else if (attribname == "total_count") {
 		return std::to_string(items_.size());
 	} else if (attribname == "tags") {
-		return get_tags();
+		std::string tags;
+		for (const std::string& t : get_tags()) {
+			tags.append(t);
+			tags.append(" ");
+		}
+		return tags;
 	} else if (attribname == "feedindex") {
 		return std::to_string(idx);
 	}

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -338,10 +338,10 @@ TEST_CASE("RssFeed::set_tags() sets tags for a feed", "[RssFeed]")
 
 	std::vector<std::string> tags = {"One", "Two"};
 	f.set_tags(tags);
+	REQUIRE(f.get_tags() == tags);
 	tags = {"One", "Three"};
-	REQUIRE(f.get_tags() == "One Two ");
 	f.set_tags(tags);
-	REQUIRE(f.get_tags() == "One Three ");
+	REQUIRE(f.get_tags() == tags);
 }
 
 TEST_CASE(


### PR DESCRIPTION
OPML, while primarily using a hierarchy of outlines, also supports tags in version 2.0 (http://opml.org/spec2.opml#1629042387000):

> category is a string of comma-separated slash-delimited category strings, in the format defined by the RSS 2.0 category element. To represent a "tag," the category string should contain no slashes. Examples: 1. category="/Boston/Weather". 2. category="/Harvard/Berkman,/Politics".

By exporting as OPML 2.0 we can include the tags in a way other programs understand. Commas are replaced with underscores. Slashes are left as-is, so when newsboat imports a hierarchical OPML file and then exports it again, that hierarchy isn't lost.

Fixes #871