### PR TITLE
Add an image pager (using feh) to contrib

### DIFF
--- a/contrib/image-pager/README.md
+++ b/contrib/image-pager/README.md
@@ -1,0 +1,30 @@
+# Generic Image Pager
+This contrib includes a scala script and a bash script which runs it.
+Depending on the first argument it can be configured to use either
+kitty's icat or feh for viewing the image (true = kitty, false = feh).
+
+## How to use?
+1. Assuming you move this folder (image-pager) into `~/.config/image-pager`, you can use this:
+``` sh
+# IMPORTANT: You usually do not want to use a relative path here!
+macro i set pager "$XDG_CONFIG_HOME/image-pager/bootstrap_image_pager.sh false %f"; open; set pager internal
+```
+If you moved it to some other directory, make sure to reflect that in the macro.
+2. Change the false to true if you are using the kitty terminal, otherwise you'd need `feh` for
+the images.
+3. Make sure your `image-pager/bootstrap_image_pager.sh` is executable,
+cd into the `image-pager` directory and use `chmod +x bootstrap_image_pager.sh` for that.
+4. Make sure you have both `scala` and `scalac` installed, then `cd` into the `image-pager` directory,
+and compile into bytecode using `scalac imagePager.scala`, the bash script will take care of running
+the resulting bytecode using `scala`.
+5. Now you should be able to use `Comma + i` when hovering over a feed entry to display *all* images,
+even thumbnails and whatnot, and images that are not obviously images from the URL (e.g. https://thumbnails.lbry.com/tszI9GrH1u0 )
+
+## Dependencies
+1. feh or kitty
+2. newsboat
+
+### Notes
+- This script internally uses some code from another image pager written for only kitty
+(available in contrib/kitty-img-pager.sh and contributed by heussd), the main issues with it
+are that it only supports kitty and that it can only display *some* images.

--- a/contrib/image-pager/README.md
+++ b/contrib/image-pager/README.md
@@ -22,7 +22,8 @@ even thumbnails and whatnot, and images that are not obviously images from the U
 
 ## Dependencies
 1. feh or kitty
-2. newsboat
+2. scala and scalac
+3. newsboat
 
 ### Notes
 - This script internally uses some code from another image pager written for only kitty

--- a/contrib/image-pager/README.md
+++ b/contrib/image-pager/README.md
@@ -10,13 +10,17 @@ kitty's icat or feh for viewing the image (true = kitty, false = feh).
 macro i set pager "$XDG_CONFIG_HOME/image-pager/bootstrap_image_pager.sh false %f"; open; set pager internal
 ```
 If you moved it to some other directory, make sure to reflect that in the macro.
+
 2. Change the false to true if you are using the kitty terminal, otherwise you'd need `feh` for
 the images.
+
 3. Make sure your `image-pager/bootstrap_image_pager.sh` is executable,
 cd into the `image-pager` directory and use `chmod +x bootstrap_image_pager.sh` for that.
+
 4. Make sure you have both `scala` and `scalac` installed, then `cd` into the `image-pager` directory,
 and compile into bytecode using `scalac imagePager.scala`, the bash script will take care of running
 the resulting bytecode using `scala`.
+
 5. Now you should be able to use `Comma + i` when hovering over a feed entry to display *all* images,
 even thumbnails and whatnot, and images that are not obviously images from the URL (e.g. https://thumbnails.lbry.com/tszI9GrH1u0 )
 

--- a/contrib/image-pager/bootstrap_image_pager.sh
+++ b/contrib/image-pager/bootstrap_image_pager.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+# Set the classpath to the directory containing the script
+classpath="$(dirname "$0")"
+
 # Run the Scala program and capture its output
-scala -classpath "$(dirname "$0")" imagePager "$@" | read command
+result=$(scala -classpath "$classpath" imagePager "$@")
 
-echo "Command: $command"
+# Print the result
+#echo "Received result: $result"
 
-# Run the command returned by the Scala program
-eval "$command"
+eval "$result"

--- a/contrib/image-pager/bootstrap_image_pager.sh
+++ b/contrib/image-pager/bootstrap_image_pager.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Run the Scala program and capture its output
+scala -classpath "$(dirname "$0")" imagePager "$@" | read command
+
+echo "Command: $command"
+
+# Run the command returned by the Scala program
+eval "$command"

--- a/contrib/image-pager/imagePager.scala
+++ b/contrib/image-pager/imagePager.scala
@@ -1,0 +1,60 @@
+import scala.io.Source
+import java.net.URL
+import sys.process._
+import scala.io.Source
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+def isImage(url: String): Boolean = {
+    val connection = URL(url).openConnection()
+    connection.setDoOutput(false)
+    val contentType = connection.getHeaderField("Content-Type")
+
+    contentType match {
+        case null => return false
+        case contentType: String => contentType.startsWith("image/")
+    }
+}
+
+@main
+def imagePager(kittyString: String, newsboatArticle: String) = {
+    val kitty = kittyString.toBoolean
+
+    val urlPattern = """https?://\S+""".r
+
+    val images = Source.fromFile(newsboatArticle)
+        .getLines
+        .flatMap(urlPattern.findAllIn(_))
+        .map(url => Future { (url, isImage(url)) })
+        .toList
+
+    val filteredImages = Await.result(Future.sequence(images), Duration.Inf)
+        .collect { case (url, true) => url }
+        .mkString(" ")
+
+    if (!filteredImages.isEmpty) {
+        kitty match {
+            case true => {
+                //val cols = s"tput cols".!!
+                //val lines = s"tput lines".!!
+                //val dimensions = s"${cols}x${lines}@0x0".replaceAll("\n", "")
+
+                for (command <- Seq(
+                    // This code is mostly from @heussd's kitty-imager-pager.sh bash script
+                    // for rendering images with kitty (pull request #1956 on newsboat)
+                    "dims=\"$(tput cols)x$(tput lines)@0x0\"",
+                    "clear",
+                    "kitty +kitten icat --clear",
+                    s"kitty +kitten icat --hold --scale-up --place \"$$dims\" $filteredImages",
+                    "clear",
+                )) {
+                    // Pass the command to `bootstrap_image_pager.sh`
+                    println(command)
+                }
+            }
+            case false => s"feh $filteredImages".!!
+        }
+    }
+}

--- a/contrib/image-pager/imagePager.scala
+++ b/contrib/image-pager/imagePager.scala
@@ -32,7 +32,6 @@ def imagePager(kittyString: String, newsboatArticle: String) = {
 
     val filteredImages = Await.result(Future.sequence(images), Duration.Inf)
         .collect { case (url, true) => url }
-        .mkString(" ")
 
     if (!filteredImages.isEmpty) {
         kitty match {
@@ -41,20 +40,19 @@ def imagePager(kittyString: String, newsboatArticle: String) = {
                 //val lines = s"tput lines".!!
                 //val dimensions = s"${cols}x${lines}@0x0".replaceAll("\n", "")
 
-                for (command <- Seq(
-                    // This code is mostly from @heussd's kitty-imager-pager.sh bash script
-                    // for rendering images with kitty (pull request #1956 on newsboat)
+                // This code is mostly from @heussd's kitty-imager-pager.sh bash script
+                // for rendering images with kitty (pull request #1956 on newsboat)
+                val kittyImages = filteredImages
+                    .map(image => s"kitty +kitten icat --hold --scale-up --place \"$$dims\" $image")
+                    .toSeq
+
+                (Seq(
                     "dims=\"$(tput cols)x$(tput lines)@0x0\"",
                     "clear",
                     "kitty +kitten icat --clear",
-                    s"kitty +kitten icat --hold --scale-up --place \"$$dims\" $filteredImages",
-                    "clear",
-                )) {
-                    // Pass the command to `bootstrap_image_pager.sh`
-                    println(command)
-                }
+                ) ++ kittyImages :+ "clear").foreach(println)
             }
-            case false => s"feh $filteredImages".!!
+            case false => s"feh ${filteredImages.mkString(" ")}".!!
         }
     }
 }


### PR DESCRIPTION
This adds an image pager that looks at all of the links asynchronously, finds which ones are images, and displays them using either feh or the kitty terminal in the same way as kitty-img-pager.sh.

Other than being able to display images using feh, this differs from kitty-img-pager.sh in the following ways:
- Can spot all images in a feed, for some reason I had trouble with kitty-img-pager.sh when trying to spot images such as thumbnails in Odysee and YouTube feeds.
- Can find multiple links in one line. (I don't know if kitty-img-pager.sh does that too or not, I can't tell)

Instructions on how to use it are in the README.md of the folder.