### PR TITLE
CI: fix FreeBSD 12.3 job by upgrading to 12.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,13 +5,13 @@ freebsd_resource_settings: &freebsd_resource_settings
 task:
     skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'docker/*', 'docker/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
     matrix:
-        - name: FreeBSD 12.3
+        - name: FreeBSD 12.4
           freebsd_instance:
-            image: freebsd-12-3-release-amd64
+            image: freebsd-12-4-release-amd64
             << : *freebsd_resource_settings
-        - name: FreeBSD 13.1
+        - name: FreeBSD 13.2
           freebsd_instance:
-            image: freebsd-13-1-release-amd64
+            image: freebsd-13-2-release-amd64
             << : *freebsd_resource_settings
 
     cargo_cache: &cargo_cache


### PR DESCRIPTION
FreeBSD 12.3 in our CI is currently failing to update packages:

    pkg update -f
    Updating FreeBSD repository catalogue...
    pkg: Repository FreeBSD has a wrong packagesite, need to re-create database
    Fetching meta.conf: . done
    Fetching packagesite.pkg: .......... done
    Processing entries:
    Newer FreeBSD version for package zziplib:
    To ignore this error set IGNORE_OSVERSION=yes
    - package: 1204000
    - running kernel: 1203000
    Ignore the mismatch and continue? [y/N]: pkg: repository FreeBSD contains packages for wrong OS version: FreeBSD:12:amd64
    Processing entries... done
    Unable to update repository FreeBSD
    Error updating repositories!

This is probably caused by 12.3 no longer being supported.

Fixed by upgrading to 12.4. I also upgraded 13.1 to 13.2 while I'm at it, even though 13.1 has two more months of support.