### PR TITLE
Make asciidoctor truly optional

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -113,7 +113,6 @@ check_pkg "sqlite3" || fail "sqlite3"
 check_pkg "libcurl" || check_custom "libcurl" "curl-config" || fail "libcurl"
 check_pkg "libxml-2.0" || check_custom "libxml2" "xml2-config" || fail "libxml2"
 check_pkg "stfl" || fail "stfl"
-check_cmd "asciidoctor" || fail "asciidoctor"
 check_cmd "cargo" || fail "cargo"
 ( check_pkg "json" "" 0.11 || check_pkg "json-c" "" 0.11 ) || fail "json-c"
 

--- a/config.sh
+++ b/config.sh
@@ -6,7 +6,7 @@ PKG_CONFIG=${PKG_CONFIG:-pkg-config}
 check_cmd() {
 	cmd=$1
 	printf "Checking for command ${cmd}... "
-    if command -v ${cmd} &> /dev/null ; then
+    if command -v ${cmd} > /dev/null 2>&1 ; then
         echo "found"
     else
         echo "not found"


### PR DESCRIPTION
https://github.com/newsboat/newsboat/commit/dcb6038ee0222274e4b9f02a10fbacb462d4765e introduced a check for commands needed to build Newsboat: Asciidoctor and Cargo. However, Asciidoctor is optional because it's only used for building docs (https://github.com/newsboat/newsboat/issues/1885). This commit removes the check, so Newsboat can truly be built with just the necessary dependencies installed.

This makes the build process slightly less nice, because the user won't get an up-front warning about the missing Asciidoctor. To regain that warning, I think we'd need to check for the program from within Makefile iff `doc` target is being built (or any target that depends on `doc`). This sounds too complicated to be worthwhile, though.

Fixes #2353.