### PR TITLE
CI: add new compilers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,24 +127,24 @@ task:
                 cc: gcc-5
                 cxx: g++-5
                 rust_version: 1.66.1
-        - name: MSRV, GCC 12 (Ubuntu 22.04)
+        - name: MSRV, GCC 13 (Ubuntu 23.04)
           container:
             greedy: true
-            dockerfile: docker/ubuntu_22.04-build-tools.dockerfile
+            dockerfile: docker/ubuntu_23.04-build-tools.dockerfile
             docker_arguments:
-                cxx_package: g++-12
-                cc: gcc-12
-                cxx: g++-12
+                cxx_package: g++-13
+                cc: gcc-13
+                cxx: g++-13
                 rust_version: 1.66.1
 
-        - name: GCC 12, more warnings and checks (Ubuntu 22.04)
+        - name: GCC 13, more warnings and checks (Ubuntu 23.04)
           container:
             greedy: true
-            dockerfile: docker/ubuntu_22.04-build-tools.dockerfile
+            dockerfile: docker/ubuntu_23.04-build-tools.dockerfile
             docker_arguments:
-                cxx_package: g++-12
-                cc: gcc-12
-                cxx: g++-12
+                cxx_package: g++-13
+                cc: gcc-13
+                cxx: g++-13
           env: &extra_warnings_and_checks_env
             CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-all -Wstack-protector -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
         - name: Clang 14, more warnings and checks (Ubuntu 22.04)
@@ -221,6 +221,14 @@ task:
                 cxx_package: g++-12
                 cc: gcc-12
                 cxx: g++-12
+        - name: Rust stable, GCC 13 (Ubuntu 23.04)
+          container:
+            greedy: true
+            dockerfile: docker/ubuntu_23.04-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: g++-13
+                cc: gcc-13
+                cxx: g++-13
         - name: Rust stable, Clang 4.0 (Ubuntu 18.04)
           container:
             greedy: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -147,14 +147,14 @@ task:
                 cxx: g++-13
           env: &extra_warnings_and_checks_env
             CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-all -Wstack-protector -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
-        - name: Clang 14, more warnings and checks (Ubuntu 22.04)
+        - name: Clang 16, more warnings and checks (Ubuntu 23.04)
           container:
             greedy: true
-            dockerfile: docker/ubuntu_22.04-build-tools.dockerfile
+            dockerfile: docker/ubuntu_23.04-build-tools.dockerfile
             docker_arguments:
-                cxx_package: clang-14
-                cc: clang-14
-                cxx: clang++-14
+                cxx_package: clang-16
+                cc: clang-16
+                cxx: clang++-16
           env: *extra_warnings_and_checks_env
 
         - name: Rust stable, GCC 5 (Ubuntu 18.04)
@@ -317,6 +317,22 @@ task:
                 cxx_package: clang-14
                 cc: clang-14
                 cxx: clang++-14
+        - name: Rust stable, Clang 15 (Ubuntu 23.04)
+          container:
+            greedy: true
+            dockerfile: docker/ubuntu_23.04-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: clang-15
+                cc: clang-15
+                cxx: clang++-15
+        - name: Rust stable, Clang 16 (Ubuntu 23.04)
+          container:
+            greedy: true
+            dockerfile: docker/ubuntu_23.04-build-tools.dockerfile
+            docker_arguments:
+                cxx_package: clang-16
+                cc: clang-16
+                cxx: clang++-16
 
     cargo_cache: *cargo_cache
 
@@ -328,18 +344,18 @@ task:
     before_cache_script: *before_cache_script
 
 task:
-    name: AddressSanitizer (Clang 14, Ubuntu 22.04)
+    name: AddressSanitizer (Clang 16, Ubuntu 23.04)
     skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
 
     container:
       greedy: true
-      dockerfile: docker/ubuntu_22.04-build-tools.dockerfile
+      dockerfile: docker/ubuntu_23.04-build-tools.dockerfile
       docker_arguments:
-          # We need llvm-symbolizer from llvm-14-tools to demangle symbols in
-          # sanitizer's reports
-          cxx_package: "clang-14 llvm-14"
-          cc: clang-14
-          cxx: clang++-14
+          # We need llvm-symbolizer from llvm-16-tools to demangle symbols in
+          # sanitizer's reports. ASAN library is in libclang-rt-dev
+          cxx_package: "clang-16 llvm-16 libclang-rt-16-dev"
+          cc: clang-16
+          cxx: clang++-16
 
     env:
       CXXFLAGS: "-fsanitize=address -fsanitize-address-use-after-scope -fno-omit-frame-pointer -fno-optimize-sibling-calls -g"
@@ -357,18 +373,18 @@ task:
     before_cache_script: *before_cache_script
 
 task:
-    name: UB Sanitizer (Clang 14, Ubuntu 22.04)
+    name: UB Sanitizer (Clang 16, Ubuntu 23.04)
     skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
 
     container:
       greedy: true
-      dockerfile: docker/ubuntu_22.04-build-tools.dockerfile
+      dockerfile: docker/ubuntu_23.04-build-tools.dockerfile
       docker_arguments:
-          # We need llvm-symbolizer from llvm-14-tools to demangle symbols in
-          # sanitizer's reports
-          cxx_package: "clang-14 llvm-14"
-          cc: clang-14
-          cxx: clang++-14
+          # We need llvm-symbolizer from llvm-16-tools to demangle symbols in
+          # sanitizer's reports. UB sanitizer library is in libclang-rt-dev
+          cxx_package: "clang-16 llvm-16 libclang-rt-16-dev"
+          cc: clang-16
+          cxx: clang++-16
 
     env:
       CXXFLAGS: "-fsanitize=undefined -g -fno-omit-frame-pointer"

--- a/docker/ubuntu_23.04-build-tools.dockerfile
+++ b/docker/ubuntu_23.04-build-tools.dockerfile
@@ -1,0 +1,67 @@
+# All the programs and libraries necessary to build Newsboat with newer
+# compilers. Contains GCC 13 and Rust 1.70.0 by default.
+#
+# Configurable via build-args:
+#
+# - cxx_package -- additional Ubuntu packages to install. Default: g++-13
+# - rust_version -- Rust version to install. Default: 1.70.0
+# - cc -- C compiler to use. This gets copied into CC environment variable.
+#       Default: gcc-13
+# - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
+#       Default: g++-13
+#
+# For now, this Dockerfile can only be used in our CI.
+
+FROM ubuntu:23.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PATH /home/builder/.cargo/bin:$PATH
+
+RUN apt-get update \
+    && apt-get upgrade --assume-yes \
+    && apt install --assume-yes --no-install-recommends ca-certificates wget gnupg2
+
+ARG cxx_package=g++-13
+
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends \
+        build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
+        libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
+        pkg-config zlib1g-dev asciidoctor \
+    && apt-get autoremove \
+    && apt-get clean
+
+RUN addgroup builder \
+    && adduser --home /home/builder --ingroup builder \
+        --disabled-password --shell /bin/bash builder \
+    && mkdir -p /home/builder/src \
+    && chown -R builder:builder /home/builder
+
+RUN apt-get install locales \
+    && echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
+    && echo 'ru_RU.KOI8-R KOI8-R' >> /etc/locale.gen \
+    && echo 'ru_RU.CP1251 CP1251' >> /etc/locale.gen \
+    && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+USER builder
+WORKDIR /home/builder/src
+
+ARG rust_version=1.70.0
+
+RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
+    && chmod +x $HOME/rustup.sh \
+    && $HOME/rustup.sh -y \
+        --default-host x86_64-unknown-linux-gnu \
+        --default-toolchain $rust_version \
+    && chmod a+w $HOME/.cargo
+
+ENV HOME /home/builder
+
+ARG cc=gcc-13
+ARG cxx=g++-13
+
+ENV CC=$cc
+ENV CXX=$cxx


### PR DESCRIPTION
The new Dockerfile with Ubuntu 23.04 can't be used outside CI at the
moment because the `docker run ... --user $(id -u):$(id -g)` command
doesn't work with Ubuntu 23.04: Dockerfile attempts to create a user
with GID and UID that already exist. I want to concentrate on the new
release for now, so this issue will get addressed later (https://github.com/newsboat/newsboat/issues/2474).