### PR TITLE
Added run-macro operation to allow single key macro execution

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -74,3 +74,4 @@ switch-focus||kbd:[TAB]||Switch focus between widgets. This is currently only ap
 goto-title||n/a||Go to item whose title contains the specified string (case-insensitive).
 prevsearchresults||kbd:[Z]||Return to previous search results (if any). This only works from `searchresultslist`.
 article-feed||n/a||Go to the feed of the currently selected article.
+run-macro||n/a||Runs the macro defined for the key bound to this operation.

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1302,6 +1302,13 @@ The macro prefix can be changed from the default "," to another key, e.g. "+"
   bind-key + macro-prefix
   unbind-key ,
 
+Macros may be executed using a single key by creating a <<bind-key,`bind-key`>>
+to a <<run-macro,`run-macro`>> operation associated with the same key as the macro:
+
+  bind-key k run-macro
+
+This binding will run the "k" macro when the "k" key is pressed.
+
 === Open Links with External Commands
 
 ==== Using Browser

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -95,6 +95,7 @@ enum Operation {
 	OP_NB_MAX,
 	OP_PREVSEARCHRESULTS,
 	OP_ARTICLEFEED,
+	OP_RUNMACRO,
 
 	// podboat-specific operations:
 	OP_PB_MIN = 1000,

--- a/include/view.h
+++ b/include/view.h
@@ -142,6 +142,7 @@ public:
 
 protected:
 	bool run_commands(const std::vector<MacroCmd>& commands);
+	void run_macro(const std::string& event);
 
 	void apply_colors(std::shared_ptr<FormAction> fa);
 

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -413,6 +413,13 @@ static const std::vector<OpDesc> opdescs = {
 		translatable("Go to the feed of the article"),
 		KM_ARTICLE | KM_ARTICLELIST | KM_SEARCHRESULTSLIST
 	},
+	{
+		OP_RUNMACRO,
+		"run-macro",
+		"",
+		translatable("Runs the macro defined for the key bound to this operation"),
+		KM_NEWSBOAT | KM_PODBOAT
+	},
 
 	{OP_OPEN_URL_1, "one", "1", translatable("Open URL 1"), KM_URLVIEW | KM_ARTICLE},
 	{OP_OPEN_URL_2, "two", "2", translatable("Open URL 2"), KM_URLVIEW | KM_ARTICLE},

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -237,11 +237,9 @@ int View::run()
 			if (OP_MACROPREFIX == op) {
 				have_macroprefix = true;
 				status_line.show_message("macro-");
-			}
-			else if (OP_RUNMACRO == op) {
+			} else if (OP_RUNMACRO == op) {
 				run_macro(event);
-			}
-			else {
+			} else {
 				// now we hand the operation to the
 				// formaction.
 				fa->process_op(op);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -150,6 +150,15 @@ bool View::run_commands(const std::vector<MacroCmd>& commands)
 	return true;
 }
 
+void View::run_macro(const std::string& event)
+{
+	status_line.show_message("");
+	LOG(Level::DEBUG,
+		"View::run: running macro `%s'",
+		event);
+	run_commands(keys->get_macro(event));
+}
+
 int View::run()
 {
 	bool have_macroprefix = false;
@@ -216,11 +225,7 @@ int View::run()
 
 		if (have_macroprefix) {
 			have_macroprefix = false;
-			status_line.show_message("");
-			LOG(Level::DEBUG,
-				"View::run: running macro `%s'",
-				event);
-			run_commands(keys->get_macro(event));
+			run_macro(event);
 		} else {
 			const Operation op = keys->get_operation(event, fa->id());
 
@@ -233,10 +238,14 @@ int View::run()
 				have_macroprefix = true;
 				status_line.show_message("macro-");
 			}
-
-			// now we handle the operation to the
-			// formaction.
-			fa->process_op(op);
+			else if (OP_RUNMACRO == op) {
+				run_macro(event);
+			}
+			else {
+				// now we hand the operation to the
+				// formaction.
+				fa->process_op(op);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR adds a new operation called run-macro. When associated with a key using bind-key, it will run any macro also associated with that key. This allows single key macro execution.

I saw #2364 and recognize that it will replace run-macro. This is a low impact change that I believe adds a useful capability until #2364 is ready.