### PR TITLE
Remove distinction between "automatic" execution (macros) and "non-automatic" (bind-key)

### DIFF
--- a/include/dialogsformaction.h
+++ b/include/dialogsformaction.h
@@ -27,9 +27,7 @@ protected:
 	}
 
 private:
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 	void update_heading();
 };
 

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -33,9 +33,7 @@ protected:
 	}
 
 private:
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);
 
 	void add_directory(ListFormatter& listfmt,

--- a/include/emptyformaction.h
+++ b/include/emptyformaction.h
@@ -19,9 +19,7 @@ public:
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
 
 protected:
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 	std::string main_widget() const override
 	{
 		return "lastline";

--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -63,9 +63,7 @@ private:
 	unsigned int count_unread_articles();
 
 	int get_pos(unsigned int realidx);
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 
 	bool open_position_in_browser(unsigned int pos, bool interactive) const;
 

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -38,9 +38,7 @@ protected:
 	}
 
 private:
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);
 
 	void add_file(ListFormatter& listfmt,

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -60,9 +60,7 @@ public:
 
 	virtual void handle_cmdline(const std::string& cmd);
 
-	bool process_op(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr);
+	bool process_op(Operation op, std::vector<std::string>* args = nullptr);
 
 	virtual void finished_qna(Operation op);
 
@@ -102,9 +100,7 @@ public:
 		const std::string& feed_title);
 
 protected:
-	virtual bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) = 0;
+	virtual bool process_operation(Operation op, std::vector<std::string>* args = nullptr) = 0;
 	virtual void set_keymap_hints();
 
 	/// The name of the "main" STFL widget, i.e. the one that should be focused

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -113,7 +113,8 @@ protected:
 
 	void start_bookmark_qna(const std::string& default_title,
 		const std::string& default_url,
-		const std::string& default_feed_title);
+		const std::string& default_feed_title,
+		const std::string& default_description);
 
 	static Command parse_command(const std::string& input,
 		std::string delimiters = " \r\n\t");

--- a/include/helpformaction.h
+++ b/include/helpformaction.h
@@ -29,9 +29,7 @@ protected:
 	}
 
 private:
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 	std::string make_colorstring(const std::vector<std::string>& colors);
 	bool quit;
 	bool apply_search;

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -70,9 +70,7 @@ public:
 	void restore_selected_position();
 
 protected:
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 	std::string main_widget() const override
 	{
 		return "items";

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -61,9 +61,7 @@ protected:
 private:
 	void register_format_styles();
 
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 
 	bool open_link_in_browser(const std::string& link, const std::string& type,
 		const std::string& title, bool interactive) const;

--- a/include/listformaction.h
+++ b/include/listformaction.h
@@ -16,9 +16,7 @@ public:
 		ConfigContainer* cfg);
 
 protected:
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 	nonstd::optional<std::uint8_t> open_unread_items_in_browser(
 		std::shared_ptr<RssFeed> feed,
 		bool markread);

--- a/include/searchresultslistformaction.h
+++ b/include/searchresultslistformaction.h
@@ -54,9 +54,7 @@ protected:
 		unsigned int total,
 		const std::string& url) override;
 
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 
 private:
 	std::stack<SearchResult> search_results;

--- a/include/selectformaction.h
+++ b/include/selectformaction.h
@@ -51,9 +51,7 @@ protected:
 	}
 
 private:
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 	bool quit;
 	bool is_first_draw;
 	SelectionType type;

--- a/include/urlviewformaction.h
+++ b/include/urlviewformaction.h
@@ -35,9 +35,7 @@ protected:
 	}
 
 private:
-	bool process_operation(Operation op,
-		bool automatic = false,
-		std::vector<std::string>* args = nullptr) override;
+	bool process_operation(Operation op, std::vector<std::string>* args = nullptr) override;
 	void open_current_position_in_browser(bool interactive);
 	void update_heading();
 

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -79,9 +79,7 @@ const std::vector<KeyMapHintEntry>& DialogsFormAction::get_keymap_hint() const
 	return hints;
 }
 
-bool DialogsFormAction::process_operation(Operation op,
-	bool automatic,
-	std::vector<std::string>* args)
+bool DialogsFormAction::process_operation(Operation op, std::vector<std::string>* args)
 {
 	switch (op) {
 	case OP_OPEN: {
@@ -110,7 +108,7 @@ bool DialogsFormAction::process_operation(Operation op,
 		v->pop_current_formaction();
 		break;
 	default:
-		ListFormAction::process_operation(op, automatic, args);
+		ListFormAction::process_operation(op, args);
 		break;
 	}
 	return true;

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -41,7 +41,6 @@ DirBrowserFormAction::DirBrowserFormAction(View* vv,
 DirBrowserFormAction::~DirBrowserFormAction() {}
 
 bool DirBrowserFormAction::process_operation(Operation op,
-	bool /* automatic */,
 	std::vector<std::string>* /* args */)
 {
 	switch (op) {

--- a/src/emptyformaction.cpp
+++ b/src/emptyformaction.cpp
@@ -33,7 +33,6 @@ const std::vector<KeyMapHintEntry>& EmptyFormAction::get_keymap_hint() const
 }
 
 bool EmptyFormAction::process_operation(Operation /*op*/,
-	bool /*automatic*/,
 	std::vector<std::string>* /*args*/)
 {
 	return false;

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -84,9 +84,7 @@ void FeedListFormAction::prepare()
 	}
 }
 
-bool FeedListFormAction::process_operation(Operation op,
-	bool automatic,
-	std::vector<std::string>* args)
+bool FeedListFormAction::process_operation(Operation op, std::vector<std::string>* args)
 {
 	unsigned int pos = 0;
 	if (visible_feeds.size() >= 1) {
@@ -515,7 +513,7 @@ REDO:
 		v->push_help();
 		break;
 	default:
-		ListFormAction::process_operation(op, automatic, args);
+		ListFormAction::process_operation(op, args);
 		break;
 	}
 	if (quit) {

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -99,7 +99,7 @@ REDO:
 	switch (op) {
 	case OP_OPEN: {
 		if (f.get_focus() == "feeds") {
-			if (automatic && args->size() > 0) {
+			if (args->size() > 0) {
 				pos = utils::to_u((*args)[0]);
 			}
 			LOG(Level::INFO,
@@ -416,7 +416,7 @@ REDO:
 		break;
 	case OP_SETTAG: {
 		std::string newtag;
-		if (automatic && args->size() > 0) {
+		if (args->size() > 0) {
 			newtag = (*args)[0];
 		} else {
 			newtag = v->select_tag(tag);
@@ -430,7 +430,7 @@ REDO:
 	break;
 	case OP_SELECTFILTER:
 		if (filter_container.size() > 0) {
-			if (automatic && args->size() > 0) {
+			if (args->size() > 0) {
 				const std::string filter_name = (*args)[0];
 				const auto filter = filter_container.get_filter(filter_name);
 
@@ -449,9 +449,9 @@ REDO:
 		}
 		break;
 	case OP_SEARCH:
-		if (automatic && args->size() > 0) {
+		if (args->size() > 0) {
 			qna_responses.clear();
-			// when in automatic mode, we manually fill the
+			// If arguments are specified, we manually fill the
 			// qna_responses vector from the arguments and then run
 			// the finished_qna() by ourselves to simulate a "Q&A"
 			// session that is in fact macro-driven.
@@ -482,7 +482,7 @@ REDO:
 		save_filterpos();
 		break;
 	case OP_SETFILTER:
-		if (automatic && args->size() > 0) {
+		if (args->size() > 0) {
 			qna_responses.clear();
 			qna_responses.push_back((*args)[0]);
 			finished_qna(OP_INT_END_SETFILTER);

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -465,11 +465,9 @@ REDO:
 		}
 		break;
 	case OP_GOTO_TITLE:
-		if (automatic) {
-			if (args->size() >= 1) {
-				qna_responses = {args[0]};
-				finished_qna(OP_INT_GOTO_TITLE);
-			}
+		if (args->size() >= 1) {
+			qna_responses = {args[0]};
+			finished_qna(OP_INT_GOTO_TITLE);
 		} else {
 			std::vector<QnaPair> qna;
 			qna.push_back(QnaPair(_("Title: "), ""));

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -500,8 +500,7 @@ REDO:
 			goto REDO;
 		}
 		LOG(Level::INFO, "FeedListFormAction: quitting");
-		if (automatic ||
-			!cfg->get_configvalue_as_bool("confirm-exit") ||
+		if (!cfg->get_configvalue_as_bool("confirm-exit") ||
 			v->confirm(
 				_("Do you really want to quit (y:Yes n:No)? "),
 				_("yn")) == *_("y")) {

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -43,7 +43,6 @@ FileBrowserFormAction::FileBrowserFormAction(View* vv,
 FileBrowserFormAction::~FileBrowserFormAction() {}
 
 bool FileBrowserFormAction::process_operation(Operation op,
-	bool /* automatic */,
 	std::vector<std::string>* /* args */)
 {
 	switch (op) {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -503,7 +503,8 @@ void FormAction::finished_qna(Operation op)
 
 void FormAction::start_bookmark_qna(const std::string& default_title,
 	const std::string& default_url,
-	const std::string& default_feed_title)
+	const std::string& default_feed_title,
+	const std::string& default_description)
 {
 	LOG(Level::DEBUG,
 		"FormAction::start_bookmark_qna: starting bookmark Q&A... "
@@ -522,7 +523,7 @@ void FormAction::start_bookmark_qna(const std::string& default_title,
 	} else {
 		prompts.push_back(QnaPair(_("Title: "), utils::utf8_to_locale(default_title)));
 	}
-	prompts.push_back(QnaPair(_("Description: "), ""));
+	prompts.push_back(QnaPair(_("Description: "), default_description));
 	prompts.push_back(QnaPair(_("Feed title: "), default_feed_title));
 
 	if (is_bm_autopilot) { // If bookmarking is set to autopilot don't prompt for url, title, desc
@@ -541,7 +542,7 @@ void FormAction::start_bookmark_qna(const std::string& default_title,
 			v->get_statusline().show_message(_("Saving bookmark on autopilot..."));
 			std::string retval = bookmark(default_url,
 					title,
-					"",
+					default_description,
 					default_feed_title);
 			if (retval.length() == 0) {
 				v->get_statusline().show_message(_("Saved bookmark."));

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -111,26 +111,27 @@ bool FormAction::process_op(Operation op,
 		start_cmdline();
 		break;
 	case OP_INT_SET:
-		if (automatic) {
-			if (args && args->size() == 2) {
+		if (args && args->size() > 0) {
+			if (args->size() == 2) {
 				const std::string key = args->at(0);
 				const std::string value = args->at(1);
 				cfg->set_configvalue(key, value);
 				set_redraw(true);
 				return true;
 			}
-			if (args && args->size() == 1) {
+			if (args->size() == 1) {
 				if (handle_single_argument_set(args->at(0))) {
 					return true;
 				}
+				return false;
 			}
-			v->get_statusline().show_error(_("usage: set <config-option> <value>"));
-			return false;
-		} else {
 			LOG(Level::WARN,
-				"FormAction::process_op: got OP_INT_SET, but "
-				"not automatic");
+				"FormAction::process_op: got OP_INT_SET, but incorrect number of arguments");
+		} else {
+			LOG(Level::WARN, "FormAction::process_op: got OP_INT_SET, but no arguments");
 		}
+		v->get_statusline().show_error(_("usage: set <config-option> <value>"));
+		return false;
 		break;
 	case OP_VIEWDIALOGS:
 		v->view_dialogs();

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -98,9 +98,7 @@ void FormAction::start_cmdline(std::string default_value)
 	this->start_qna(qna, OP_INT_END_CMDLINE, &FormAction::cmdlinehistory);
 }
 
-bool FormAction::process_op(Operation op,
-	bool automatic,
-	std::vector<std::string>* args)
+bool FormAction::process_op(Operation op, std::vector<std::string>* args)
 {
 	switch (op) {
 	case OP_REDRAW:
@@ -143,7 +141,7 @@ bool FormAction::process_op(Operation op,
 		v->goto_prev_dialog();
 		break;
 	default:
-		return this->process_operation(op, automatic, args);
+		return this->process_operation(op, args);
 	}
 	return true;
 }

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -28,9 +28,7 @@ HelpFormAction::HelpFormAction(View* vv,
 
 HelpFormAction::~HelpFormAction() {}
 
-bool HelpFormAction::process_operation(Operation op,
-	bool /* automatic */,
-	std::vector<std::string>* /* args */)
+bool HelpFormAction::process_operation(Operation op, std::vector<std::string>* /* args */)
 {
 	bool hardquit = false;
 	switch (op) {

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -346,21 +346,18 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_EDITFLAGS: {
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				if (automatic) {
-					if (args->size() > 0) {
-						qna_responses.clear();
-						qna_responses.push_back(
-							(*args)[0]);
-						finished_qna(
-							OP_INT_EDITFLAGS_END);
-					}
+				if (args->size() > 0) {
+					qna_responses.clear();
+					qna_responses.push_back(
+						(*args)[0]);
+					finished_qna(
+						OP_INT_EDITFLAGS_END);
 				} else {
 					std::vector<QnaPair> qna;
 					qna.push_back(QnaPair(_("Flags: "),
 							visible_items[itempos]
 							.first->flags()));
-					this->start_qna(
-						qna, OP_INT_EDITFLAGS_END);
+					this->start_qna(qna, OP_INT_EDITFLAGS_END);
 				}
 			}
 		} else {
@@ -374,10 +371,8 @@ bool ItemListFormAction::process_operation(Operation op,
 		if (!visible_items.empty()) {
 			std::shared_ptr<RssItem> item = visible_items[itempos].first;
 			std::string filename;
-			if (automatic) {
-				if (args->size() > 0) {
-					filename = (*args)[0];
-				}
+			if (args->size() > 0) {
+				filename = (*args)[0];
 			} else {
 				const auto title = utils::utf8_to_locale(item->title());
 				const auto suggestion = v->get_filename_suggestion(title);
@@ -570,17 +565,13 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_PIPE_TO:
 		if (visible_items.size() != 0) {
 			std::vector<QnaPair> qna;
-			if (automatic) {
-				if (args->size() > 0) {
-					qna_responses.clear();
-					qna_responses.push_back((*args)[0]);
-					finished_qna(OP_PIPE_TO);
-				}
+			if (args->size() > 0) {
+				qna_responses.clear();
+				qna_responses.push_back((*args)[0]);
+				finished_qna(OP_PIPE_TO);
 			} else {
-				qna.push_back(QnaPair(
-						_("Pipe article to command: "), ""));
-				this->start_qna(
-					qna, OP_PIPE_TO, &cmdlinehistory);
+				qna.push_back(QnaPair(_("Pipe article to command: "), ""));
+				this->start_qna(qna, OP_PIPE_TO, &cmdlinehistory);
 			}
 		} else {
 			v->get_statusline().show_error(_("No item selected!"));
@@ -588,25 +579,20 @@ bool ItemListFormAction::process_operation(Operation op,
 		break;
 	case OP_SEARCH: {
 		std::vector<QnaPair> qna;
-		if (automatic) {
-			if (args->size() > 0) {
-				qna_responses.clear();
-				qna_responses.push_back((*args)[0]);
-				finished_qna(OP_INT_START_SEARCH);
-			}
+		if (args->size() > 0) {
+			qna_responses.clear();
+			qna_responses.push_back((*args)[0]);
+			finished_qna(OP_INT_START_SEARCH);
 		} else {
 			qna.push_back(QnaPair(_("Search for: "), ""));
-			this->start_qna(
-				qna, OP_INT_START_SEARCH, &searchhistory);
+			this->start_qna(qna, OP_INT_START_SEARCH, &searchhistory);
 		}
 	}
 	break;
 	case OP_GOTO_TITLE:
-		if (automatic) {
-			if (args->size() >= 1) {
-				qna_responses = {args[0]};
-				finished_qna(OP_INT_GOTO_TITLE);
-			}
+		if (args->size() >= 1) {
+			qna_responses = {args[0]};
+			finished_qna(OP_INT_GOTO_TITLE);
 		} else {
 			std::vector<QnaPair> qna;
 			qna.push_back(QnaPair(_("Title: "), ""));
@@ -639,17 +625,14 @@ bool ItemListFormAction::process_operation(Operation op,
 
 		break;
 	case OP_SETFILTER:
-		if (automatic) {
-			if (args->size() > 0) {
-				qna_responses.clear();
-				qna_responses.push_back((*args)[0]);
-				this->finished_qna(OP_INT_END_SETFILTER);
-			}
+		if (args->size() > 0) {
+			qna_responses.clear();
+			qna_responses.push_back((*args)[0]);
+			this->finished_qna(OP_INT_END_SETFILTER);
 		} else {
 			std::vector<QnaPair> qna;
 			qna.push_back(QnaPair(_("Filter: "), ""));
-			this->start_qna(
-				qna, OP_INT_END_SETFILTER, &filterhistory);
+			this->start_qna(qna, OP_INT_END_SETFILTER, &filterhistory);
 		}
 		break;
 	case OP_CLEARFILTER:

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -318,24 +318,11 @@ bool ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO, "ItemListFormAction: bookmarking item at pos `%u'", itempos);
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				if (automatic) {
-					qna_responses.clear();
-					qna_responses.push_back(
-						visible_items[itempos]
-						.first->link());
-					qna_responses.push_back(utils::utf8_to_locale(
-							visible_items[itempos].first->title()));
-					qna_responses.push_back(args->size() > 0
-						? (*args)[0]
-						: "");
-					qna_responses.push_back(feed->title());
-					this->finished_qna(OP_INT_BM_END);
-				} else {
-					this->start_bookmark_qna(
-						visible_items[itempos].first->title(),
-						visible_items[itempos].first->link(),
-						feed->title());
-				}
+				this->start_bookmark_qna(
+					visible_items[itempos].first->title(),
+					visible_items[itempos].first->link(),
+					feed->title(),
+					args->size() > 0 ? args->front() : "");
 			}
 		} else {
 			v->get_statusline().show_error(

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -219,7 +219,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			try {
 				const auto message_lifetime = v->get_statusline().show_message_until_finished(
 						_("Toggling read flag for article..."));
-				if (automatic && args->size() > 0) {
+				if (args->size() > 0) {
 					if ((*args)[0] == "read") {
 						visible_items[itempos]
 						.first->set_unread(
@@ -619,7 +619,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_SELECTFILTER:
 		if (filter_container.size() > 0) {
 			std::string newfilter;
-			if (automatic && args->size() > 0) {
+			if (args->size() > 0) {
 				const std::string filter_name = (*args)[0];
 				const auto filter = filter_container.get_filter(filter_name);
 

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -49,9 +49,7 @@ ItemListFormAction::ItemListFormAction(View* vv,
 
 ItemListFormAction::~ItemListFormAction() {}
 
-bool ItemListFormAction::process_operation(Operation op,
-	bool automatic,
-	std::vector<std::string>* args)
+bool ItemListFormAction::process_operation(Operation op, std::vector<std::string>* args)
 {
 	bool quit = false;
 	bool hardquit = false;
@@ -732,7 +730,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	}
 	break;
 	default:
-		ListFormAction::process_operation(op, automatic, args);
+		ListFormAction::process_operation(op, args);
 		break;
 	}
 	if (hardquit) {

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -156,7 +156,7 @@ void ItemViewFormAction::prepare()
 }
 
 bool ItemViewFormAction::process_operation(Operation op,
-	bool automatic,
+	bool /* automatic */,
 	std::vector<std::string>* args)
 {
 	bool hardquit = false;
@@ -253,19 +253,11 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_BOOKMARK:
-		if (automatic) {
-			qna_responses.clear();
-			qna_responses.push_back(item->link());
-			qna_responses.push_back(utils::utf8_to_locale(item->title()));
-			qna_responses.push_back(
-				args->size() > 0 ? (*args)[0] : "");
-			qna_responses.push_back(feed->title());
-		} else {
-			this->start_bookmark_qna(
-				utils::utf8_to_locale(item->title()),
-				item->link(),
-				feed->title());
-		}
+		this->start_bookmark_qna(
+			utils::utf8_to_locale(item->title()),
+			item->link(),
+			feed->title(),
+			args->size() > 0 ? args->front() : "");
 		break;
 	case OP_SEARCH: {
 		std::vector<QnaPair> qna;

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -397,7 +397,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 		const auto message_lifetime = v->get_statusline().show_message_until_finished(
 				_("Toggling read flag for article..."));
 		try {
-			if (automatic && args->size() > 0) {
+			if (args->size() > 0) {
 				if ((*args)[0] == "read") {
 					item->set_unread(false);
 					v->get_ctrl()->mark_article_read(item->guid(), true);

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -155,9 +155,7 @@ void ItemViewFormAction::prepare()
 	}
 }
 
-bool ItemViewFormAction::process_operation(Operation op,
-	bool /* automatic */,
-	std::vector<std::string>* args)
+bool ItemViewFormAction::process_operation(Operation op, std::vector<std::string>* args)
 {
 	bool hardquit = false;
 	bool quit = false;

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -217,10 +217,8 @@ bool ItemViewFormAction::process_operation(Operation op,
 	case OP_SAVE: {
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: saving article");
 		std::string filename;
-		if (automatic) {
-			if (args->size() > 0) {
-				filename = (*args)[0];
-			}
+		if (args->size() > 0) {
+			filename = (*args)[0];
 		} else {
 			filename = v->run_filebrowser( utils::utf8_to_locale(v->get_filename_suggestion(
 							item->title())));
@@ -271,27 +269,22 @@ bool ItemViewFormAction::process_operation(Operation op,
 		break;
 	case OP_SEARCH: {
 		std::vector<QnaPair> qna;
-		if (automatic) {
-			if (args->size() > 0) {
-				qna_responses.clear();
-				qna_responses.push_back((*args)[0]);
-				finished_qna(OP_INT_START_SEARCH);
-			}
+		if (args->size() > 0) {
+			qna_responses.clear();
+			qna_responses.push_back((*args)[0]);
+			finished_qna(OP_INT_START_SEARCH);
 		} else {
 			qna.push_back(QnaPair(_("Search for: "), ""));
-			this->start_qna(
-				qna, OP_INT_START_SEARCH, &searchhistory);
+			this->start_qna(qna, OP_INT_START_SEARCH, &searchhistory);
 		}
 	}
 	break;
 	case OP_PIPE_TO: {
 		std::vector<QnaPair> qna;
-		if (automatic) {
-			if (args->size() > 0) {
-				qna_responses.clear();
-				qna_responses.push_back((*args)[0]);
-				finished_qna(OP_PIPE_TO);
-			}
+		if (args->size() > 0) {
+			qna_responses.clear();
+			qna_responses.push_back((*args)[0]);
+			finished_qna(OP_PIPE_TO);
 		} else {
 			qna.push_back(
 				QnaPair(_("Pipe article to command: "), ""));
@@ -300,12 +293,10 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_EDITFLAGS:
-		if (automatic) {
+		if (args->size() > 0) {
 			qna_responses.clear();
-			if (args->size() > 0) {
-				qna_responses.push_back((*args)[0]);
-				this->finished_qna(OP_INT_EDITFLAGS_END);
-			}
+			qna_responses.push_back((*args)[0]);
+			this->finished_qna(OP_INT_EDITFLAGS_END);
 		} else {
 			std::vector<QnaPair> qna;
 			qna.push_back(QnaPair(_("Flags: "), item->flags()));
@@ -453,12 +444,10 @@ bool ItemViewFormAction::process_operation(Operation op,
 	break;
 	case OP_GOTO_URL: {
 		std::vector<QnaPair> qna;
-		if (automatic) {
-			if (args->size() > 0) {
-				qna_responses.clear();
-				qna_responses.push_back((*args)[0]);
-				finished_qna(OP_INT_GOTO_URL);
-			}
+		if (args->size() > 0) {
+			qna_responses.clear();
+			qna_responses.push_back((*args)[0]);
+			finished_qna(OP_INT_GOTO_URL);
 		} else {
 			qna.push_back(QnaPair(_("Goto URL #"), ""));
 			this->start_qna(qna, OP_INT_GOTO_URL);

--- a/src/listformaction.cpp
+++ b/src/listformaction.cpp
@@ -15,9 +15,7 @@ ListFormAction::ListFormAction(View* v,
 {
 }
 
-bool ListFormAction::process_operation(Operation op,
-	bool,
-	std::vector<std::string>*)
+bool ListFormAction::process_operation(Operation op, std::vector<std::string>*)
 {
 	switch (op) {
 	case OP_CMD_START_1:

--- a/src/searchresultslistformaction.cpp
+++ b/src/searchresultslistformaction.cpp
@@ -32,9 +32,7 @@ void SearchResultsListFormAction::add_to_history(const std::shared_ptr<RssFeed>&
 	}
 }
 
-bool SearchResultsListFormAction::process_operation(
-	Operation op,
-	bool automatic,
+bool SearchResultsListFormAction::process_operation(Operation op,
 	std::vector<std::string>* args)
 {
 	const unsigned int itempos = list.get_position();
@@ -64,7 +62,7 @@ bool SearchResultsListFormAction::process_operation(
 		}
 		break;
 	default:
-		return ItemListFormAction::process_operation(op, automatic, args);
+		return ItemListFormAction::process_operation(op, args);
 	}
 	return true;
 }

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -52,7 +52,6 @@ void SelectFormAction::handle_cmdline(const std::string& cmd)
 }
 
 bool SelectFormAction::process_operation(Operation op,
-	bool /* automatic */,
 	std::vector<std::string>* /* args */)
 {
 	bool hardquit = false;

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -34,7 +34,7 @@ UrlViewFormAction::~UrlViewFormAction() {}
 
 bool UrlViewFormAction::process_operation(Operation op,
 	bool /* automatic */,
-	std::vector<std::string>* /* args */)
+	std::vector<std::string>* args)
 {
 	bool hardquit = false;
 	switch (op) {
@@ -59,7 +59,11 @@ bool UrlViewFormAction::process_operation(Operation op,
 	case OP_BOOKMARK: {
 		if (!links.empty()) {
 			const unsigned int pos = urls_list.get_position();
-			this->start_bookmark_qna("", links[pos].url, feed->title());
+			this->start_bookmark_qna(
+				"",
+				links[pos].url,
+				feed->title(),
+				args->size() > 0 ? args->front() : "");
 		} else {
 			v->get_statusline().show_error(_("No links available!"));
 		}

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -32,9 +32,7 @@ UrlViewFormAction::UrlViewFormAction(View* vv,
 
 UrlViewFormAction::~UrlViewFormAction() {}
 
-bool UrlViewFormAction::process_operation(Operation op,
-	bool /* automatic */,
-	std::vector<std::string>* args)
+bool UrlViewFormAction::process_operation(Operation op, std::vector<std::string>* args)
 {
 	bool hardquit = false;
 	switch (op) {

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -142,7 +142,7 @@ bool View::run_commands(const std::vector<MacroCmd>& commands)
 		std::shared_ptr<FormAction> fa = get_current_formaction();
 		fa->prepare();
 		fa->draw_form();
-		if (!fa->process_op(command.op, true, &command.args)) {
+		if (!fa->process_op(command.op, &command.args)) {
 			// Operation failed, abort
 			return false;
 		}

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -507,8 +507,8 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 	feed->add_item(item);
 	itemlist.set_feed(feed);
 
-	cfg.set_configvalue(
-		"bookmark-cmd", "echo > " + bookmarkFile.get_path());
+	cfg.set_configvalue("bookmark-cmd", "echo > " + bookmarkFile.get_path());
+	cfg.set_configvalue("bookmark-autopilot", "yes");
 
 	bookmark_args.push_back(extra_arg);
 	REQUIRE_NOTHROW(itemlist.process_op(OP_BOOKMARK, true, &bookmark_args));

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -511,7 +511,7 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 	cfg.set_configvalue("bookmark-autopilot", "yes");
 
 	bookmark_args.push_back(extra_arg);
-	REQUIRE_NOTHROW(itemlist.process_op(OP_BOOKMARK, true, &bookmark_args));
+	REQUIRE_NOTHROW(itemlist.process_op(OP_BOOKMARK, &bookmark_args));
 
 	std::ifstream browserFileStream(bookmarkFile.get_path());
 
@@ -550,7 +550,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 		op_args.push_back(flags);
 
 		REQUIRE_NOTHROW(
-			itemlist.process_op(OP_EDITFLAGS, true, &op_args));
+			itemlist.process_op(OP_EDITFLAGS, &op_args));
 		REQUIRE(item->flags() == flags);
 	}
 
@@ -560,7 +560,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 		op_args.push_back(flags);
 
 		REQUIRE_NOTHROW(
-			itemlist.process_op(OP_EDITFLAGS, true, &op_args));
+			itemlist.process_op(OP_EDITFLAGS, &op_args));
 		REQUIRE(item->flags() == ordered_flags);
 	}
 
@@ -569,7 +569,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 		op_args.push_back(flags + "ddd");
 
 		REQUIRE_NOTHROW(
-			itemlist.process_op(OP_EDITFLAGS, true, &op_args));
+			itemlist.process_op(OP_EDITFLAGS, &op_args));
 		REQUIRE(item->flags() == flags);
 	}
 
@@ -579,7 +579,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 			op_args.push_back(flags + "1236");
 
 			REQUIRE_NOTHROW(itemlist.process_op(
-					OP_EDITFLAGS, true, &op_args));
+					OP_EDITFLAGS, &op_args));
 			REQUIRE(item->flags() == flags);
 		}
 		SECTION("Symbols") {
@@ -587,14 +587,14 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 				"%^\\*;\'\"&~#{([-|`_/@)]=}$£€µ,;:!?./§");
 
 			REQUIRE_NOTHROW(itemlist.process_op(
-					OP_EDITFLAGS, true, &op_args));
+					OP_EDITFLAGS, &op_args));
 			REQUIRE(item->flags() == flags);
 		}
 		SECTION("Accents") {
 			op_args.push_back(flags + "¨^");
 
 			REQUIRE_NOTHROW(itemlist.process_op(
-					OP_EDITFLAGS, true, &op_args));
+					OP_EDITFLAGS, &op_args));
 			REQUIRE(item->flags() == flags);
 		}
 	}
@@ -605,7 +605,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 		op_args.push_back(flags);
 
 		REQUIRE_NOTHROW(
-			itemlist.process_op(OP_EDITFLAGS, true, &op_args));
+			itemlist.process_op(OP_EDITFLAGS, &op_args));
 		REQUIRE(item->flags() == flags);
 	}
 }
@@ -653,7 +653,7 @@ TEST_CASE("OP_SAVE writes an article's attributes to the specified file",
 	feed->add_item(item);
 	itemlist.set_feed(feed);
 
-	REQUIRE_NOTHROW(itemlist.process_op(OP_SAVE, true, &op_args));
+	REQUIRE_NOTHROW(itemlist.process_op(OP_SAVE, &op_args));
 
 	test_helpers::assert_article_file_content(saveFile.get_path(),
 		test_title,
@@ -843,7 +843,7 @@ TEST_CASE("OP_PIPE_TO pipes an article's content to an external command",
 	feed->add_item(item);
 	itemlist.set_feed(feed);
 
-	REQUIRE_NOTHROW(itemlist.process_op(OP_PIPE_TO, true, &op_args));
+	REQUIRE_NOTHROW(itemlist.process_op(OP_PIPE_TO, &op_args));
 
 	test_helpers::assert_article_file_content(articleFile.get_path(),
 		test_title,


### PR DESCRIPTION
When running operations, we have an `automatic` flag which is set to true if executing from macros, and false when executed from regular `bind-key` keypresses.
The new `bind` option suggested in https://github.com/newsboat/newsboat/issues/1165 has some similarities to both macros and the regular key bindings, so it was not directly clear if `automatic` should be true or false for these new bindings.
I decided to remove the `automatic` keyword altogether.
Almost all behavior is kept the same, I've tried to remark on behaviour changes in the individual commit messages.

This resolves one of the TODOs of https://github.com/newsboat/newsboat/pull/2364.