### PR TITLE
Avoid deadlock in `utils::run_program` with large inputs

### DIFF
--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -84,7 +84,7 @@ mod bridged {
 
         fn podcast_mime_to_link_type(mime_type: &str, result: &mut i64) -> bool;
 
-        fn run_program(argv: &[&str], input: &str) -> String;
+        fn run_program(argv: &[&str], input: String) -> String;
 
         fn translit(tocode: &str, fromcode: &str) -> String;
         fn utf8_to_locale(text: &str) -> Vec<u8>;

--- a/rust/libnewsboat/tests/run_program_works_for_large_inputs.rs
+++ b/rust/libnewsboat/tests/run_program_works_for_large_inputs.rs
@@ -1,0 +1,17 @@
+use libnewsboat::utils::run_program;
+use std::thread::{sleep, spawn};
+
+#[test]
+fn t_run_program_works_for_large_inputs() {
+    // 10 characters repeated 100k times is about 1 megabyte of text
+    let large_input = "helloworld".repeat(100_000);
+    let runner = {
+        let input = large_input.clone();
+        spawn(move || run_program(&["sh", "-c", "cat"], input))
+    };
+    // cat should be able to process 1MB of input in under a second
+    sleep(std::time::Duration::from_secs(1));
+    assert!(runner.is_finished());
+    let result = runner.join().expect("Runner thread panicked");
+    assert_eq!(result, large_input);
+}


### PR DESCRIPTION
Previous implementation attempted to write the entire input to the program's stdin before reading anything from its stdout. With programs that work in a streaming fashion (such as `sed` and `cat`), this would deadlock on large inputs as the program is waiting to write to its stdout while Newsboat is waiting to write to program's stdin.

This affected `filter:` feeds, and could also affect bookmarks and rendering.

Fixed by moving the write into a separate thread as described in https://doc.rust-lang.org/std/process/index.html#handling-io Would be nice to do this in a single thread with non-blocking I/O, but `std::process::ChildStdout` doesn't seem to have a non-blocking `read`.

Reported by B-| on IRC (the `filter:` variant). Kudos to Dennis van der Schagt for the discussion and the suggested fix.

<hr>

C++ test looks uglier than Rust one because in C++, `std::thread::~thread()` doesn't kill the running thread and actually calls `std::terminate` if one is running; `impl Drop for Thread` kills the thread so the code is much more streamlined.