### PR TITLE
Switch --export-to-opml to generate OPML v2.0

### DIFF
--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -44,8 +44,8 @@ void print_usage(const std::string& argv0, const std::string& config_path,
 	};
 
 	static const std::vector<arg> args = {
-		{'e', "export-to-opml", "", _s("export OPML feed to stdout")},
-		{'-', "export-to-opml2", "", _s("export OPML 2.0 feed including tags to stdout")},
+		{'-', "export-to-opml1", "", _s("export OPML feed to stdout")},
+		{'e', "export-to-opml", "", _s("export OPML 2.0 feed including tags to stdout")},
 		{'r', "refresh-on-start", "", _s("refresh feeds on start")},
 		{'i', "import-from-opml", _s("<file>"), _s("import OPML file")},
 		{

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -148,12 +148,12 @@ pub fn parse_cliargs(opts: Vec<OsString>, args: &mut CliArgsParser) -> Result<()
                 let import_file_str = parser.value()?;
                 args.importfile = resolve_path(&import_file_str);
             }
-            Short('e') | Long("export-to-opml") => {
+            Long("export-to-opml1") => {
                 args.do_export = true;
                 args.export_as_opml2 = false;
                 args.silent = true;
             }
-            Long("export-to-opml2") => {
+            Short('e') | Long("export-to-opml") => {
                 args.do_export = true;
                 args.export_as_opml2 = true;
                 args.silent = true;


### PR DESCRIPTION
Issue https://github.com/newsboat/newsboat/issues/2447
P.S. I also try to validate output(both versions) here http://scripting.com/code/opmlvalidator/ and have an error `An element must have a "text" attribute.` in every line. It's probably an issue, by fixing which we could add newsboat to that (http://opml.org/compatibleApps.opml) list of OPML compatible apps.