### PR TITLE
Prevent tests from (ocasionally) sigkilling themselves

### DIFF
--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -5,8 +5,8 @@
 #include <condition_variable>
 #include <ctype.h>
 #include <fstream>
+#include <memory>
 #include <mutex>
-#include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <thread>
@@ -595,60 +595,44 @@ TEST_CASE("run_program()", "[utils]")
 
 TEST_CASE("run_program() works for large inputs", "[utils]")
 {
-	const std::string large_input(1000000, 'a');
+	const auto large_input = std::make_shared<std::string>(1000000, 'a');
 
-	// Calling std::thread::~thread() on a thread that's still running will
-	// make it call `std::terminate`, crashing our entire test suite. To avoid
-	// that, this wrapper kills the thread with SIGKILL and detaches it from
-	// the thread handle.
-	struct Runner {
-		std::thread runner;
-
-		Runner(std::thread runner)
-			: runner(std::move(runner))
-		{}
-
-		~Runner()
-		{
-			pthread_kill(runner.native_handle(), SIGKILL);
-			runner.detach();
-		}
-	};
-
-	struct {
-		bool flag = false;
+	struct Sync {
+		bool thread_finished = false;
 		std::mutex mtx;
 		std::condition_variable condvar;
-	} thread_finished;
-	std::string result;
-	Runner runner(std::thread([large_input, &thread_finished, &result]() {
+		std::string output;
+	};
+	auto sync = std::make_shared<Sync>();
+
+	std::thread([large_input, sync]() {
 		const char* argv[4];
 		argv[0] = "sh";
 		argv[1] = "-c";
 		argv[2] = "cat";
 		argv[3] = nullptr;
-		result = utils::run_program(argv, large_input);
+		sync->output = utils::run_program(argv, *large_input);
 
 		{
-			std::lock_guard<std::mutex> g(thread_finished.mtx);
-			thread_finished.flag = true;
+			std::lock_guard<std::mutex> g(sync->mtx);
+			sync->thread_finished = true;
 		}
-		thread_finished.condvar.notify_one();
-	}));
+		sync->condvar.notify_one();
+	}).detach();
 
 	{
-		std::unique_lock<std::mutex> g(thread_finished.mtx);
+		std::unique_lock<std::mutex> g(sync->mtx);
 		// cat should be able to process 1MB of input in under a second
-		thread_finished.condvar.wait_for(g, std::chrono::seconds(1), [&]() {
-			return thread_finished.flag;
+		sync->condvar.wait_for(g, std::chrono::seconds(1), [&]() {
+			return sync->thread_finished;
 		});
 	}
 
 	{
-		std::lock_guard<std::mutex> g(thread_finished.mtx);
-		REQUIRE(thread_finished.flag);
+		std::lock_guard<std::mutex> g(sync->mtx);
+		REQUIRE(sync->thread_finished);
 	}
-	REQUIRE(result == large_input);
+	REQUIRE(sync->output == *large_input);
 }
 
 TEST_CASE("run_command() executes the given command with a given argument",

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -620,18 +620,13 @@ TEST_CASE("run_program() works for large inputs", "[utils]")
 		sync->condvar.notify_one();
 	}).detach();
 
-	{
-		std::unique_lock<std::mutex> g(sync->mtx);
-		// cat should be able to process 1MB of input in under a second
-		sync->condvar.wait_for(g, std::chrono::seconds(1), [&]() {
-			return sync->thread_finished;
-		});
-	}
+	std::unique_lock<std::mutex> g(sync->mtx);
+	// cat should be able to process 1MB of input in under a second
+	sync->condvar.wait_for(g, std::chrono::seconds(1), [&]() {
+		return sync->thread_finished;
+	});
 
-	{
-		std::lock_guard<std::mutex> g(sync->mtx);
-		REQUIRE(sync->thread_finished);
-	}
+	REQUIRE(sync->thread_finished);
 	REQUIRE(sync->output == *large_input);
 }
 


### PR DESCRIPTION
Fixes an issue introduced in #2511. See the first commit message for all the details.