### PR TITLE
Dependabot: update cxx and cxx-build with a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      cxx:
+        patterns:
+          - "cxx"
+          - "cxx-build"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/

I did it for cxx and cxx-build because these are always updated in sync. Perhaps there are other groups we could define, but the cxx one is the most frequently updated, so let's start with that.