### PR TITLE
Update database schema version to avoid repeated schema updates

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -395,6 +395,7 @@ static const schema_patches schemaPatches{
 	},
 	{	{2, 33},
 		{
+			"UPDATE metadata SET db_schema_version_major = 2, db_schema_version_minor = 33;",
 			"ALTER TABLE rss_item ADD COLUMN enclosure_description VARCHAR(1024) NOT NULL DEFAULT \"\";",
 			"ALTER TABLE rss_item ADD COLUMN enclosure_description_mime_type VARCHAR(128) NOT NULL DEFAULT \"\";",
 		}


### PR DESCRIPTION
Looks like I forgot to update the database schema version in https://github.com/newsboat/newsboat/pull/2399.

This caused logging of "Critical" log messages:
```
[2023-08-27 14:38:35] INFO: Cache::populate_tables: DB schema version 2.22
[2023-08-27 14:38:35] INFO: Cache::populate_tables: applying DB schema patches for version 2.33
[2023-08-27 14:38:35] DEBUG: running query: UPDATE metadata SET db_schema_version_major = 2, db_schema_version_minor = 33;
[2023-08-27 14:38:35] DEBUG: running query: ALTER TABLE rss_item ADD COLUMN enclosure_description VARCHAR(1024) NOT NULL DEFAULT "";
[2023-08-27 14:38:35] CRITICAL: query "ALTER TABLE rss_item ADD COLUMN enclosure_description VARCHAR(1024) NOT NULL DEFAULT "";" failed: (1) SQL logic error
[2023-08-27 14:38:35] DEBUG: running query: ALTER TABLE rss_item ADD COLUMN enclosure_description_mime_type VARCHAR(128) NOT NULL DEFAULT "";
[2023-08-27 14:38:35] CRITICAL: query "ALTER TABLE rss_item ADD COLUMN enclosure_description_mime_type VARCHAR(128) NOT NULL DEFAULT "";" failed: (1) SQL logic error
```

It doesn't look like there  are any lasting damage from this (the repeated queries have no effect and Newsboat kept starting up fine).