### PR TITLE
Use description as title when URL ends with digits

### DIFF
--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -551,9 +551,16 @@ pub fn make_title(rs_str: String) -> String {
 
     // Un-escape any percent-encoding, e.g. "It%27s%202017%21" -> "It's
     // 2017!"
-    match unescape_url(result) {
+    let result = match unescape_url(result) {
         None => String::new(),
         Some(f) => f,
+    };
+
+    // If it contains only digits, assume it's an id, not a proper title
+    if result.as_bytes().iter().all(u8::is_ascii_digit) {
+        String::new()
+    } else {
+        result
     }
 }
 

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -557,7 +557,7 @@ pub fn make_title(rs_str: String) -> String {
     };
 
     // If it contains only digits, assume it's an id, not a proper title
-    if result.chars().all(char::is_ascii_digit) {
+    if result.chars().all(|c| c.is_ascii_digit()) {
         String::new()
     } else {
         result

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -557,7 +557,7 @@ pub fn make_title(rs_str: String) -> String {
     };
 
     // If it contains only digits, assume it's an id, not a proper title
-    if result.as_bytes().iter().all(u8::is_ascii_digit) {
+    if result.chars().all(char::is_ascii_digit) {
         String::new()
     } else {
         result

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -289,8 +289,13 @@ void RssParser::set_item_title(std::shared_ptr<RssFeed> feed,
 {
 	std::string title = item.title;
 
-	if (item.title.empty()) {
+	if (title.empty()) {
 		title = utils::make_title(item.link);
+		if (title.empty()) {
+			title = item.description;
+			x->set_title(render_xhtml_title(title, feed->link()));
+			return;
+		}
 	}
 
 	if (is_html_type(item.title_type)) {


### PR DESCRIPTION
Showing a numeric identifier as the title is not very useful, and it happens on Mastodon RSS feeds. Use the description instead.

Fixes #2530