### PR TITLE
Always render links if there are any

### DIFF
--- a/include/links.h
+++ b/include/links.h
@@ -1,9 +1,14 @@
 #ifndef NEWSBOAT_LINKS_H_
 #define NEWSBOAT_LINKS_H_
+
 #include <vector>
 #include <utility>
 #include <string>
+
+#include "config.h"
+
 namespace newsboat {
+
 // This enum has to be kept in sync with enum LinkType in rust/libnewsboat/src/links.rs
 enum class LinkType { HREF, IMG, EMBED, IFRAME, VIDEO, AUDIO };
 
@@ -19,7 +24,7 @@ public:
 
 	unsigned int add_link(const std::string& url, LinkType type);
 
-	LinkPair& operator[] (size_t idx)
+	const LinkPair& operator[] (size_t idx) const
 	{
 		return links[idx];
 	};
@@ -57,8 +62,29 @@ public:
 		return links.empty();
 	}
 
+	static std::string type2str(LinkType type)
+	{
+		switch (type) {
+		case LinkType::HREF:
+			return _("link");
+		case LinkType::IMG:
+			return _("image");
+		case LinkType::EMBED:
+			return _("embedded flash");
+		case LinkType::IFRAME:
+			return _("iframe");
+		case LinkType::VIDEO:
+			return _("video");
+		case LinkType::AUDIO:
+			return _("audio");
+		default:
+			return _("unknown (bug)");
+		}
+	}
+
 private:
 	std::vector<LinkPair> links;
 };
+
 }
 #endif

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -1012,19 +1012,6 @@ void HtmlRenderer::render(std::istream& input,
 			add_line_nonwrappable(s, lines);
 		}
 	}
-
-	// add link list
-	if (links.size() > 0) {
-		add_line("", tables, lines);
-		add_line(_("Links: "), tables, lines);
-		for (unsigned int i = 0; i < links.size(); ++i) {
-			auto link_text = strprintf::fmt("[%u]: %s (%s)",
-					i + 1,
-					links[i].url,
-					type2str(links[i].type));
-			add_line_softwrappable(link_text, lines);
-		}
-	}
 }
 
 void HtmlRenderer::add_media_link(std::string& curline,
@@ -1041,7 +1028,7 @@ void HtmlRenderer::add_media_link(std::string& curline,
 		link_url = utils::censor_url(utils::absolute_url(url, media_url));
 	}
 
-	const std::string type_str = type2str(type);
+	const std::string type_str = Links::type2str(type);
 	const unsigned int link_num = links.add_link(link_url, type);
 	std::string output;
 
@@ -1062,26 +1049,6 @@ std::string HtmlRenderer::render_hr(const unsigned int width)
 	result += " \n";
 
 	return result;
-}
-
-std::string HtmlRenderer::type2str(LinkType type)
-{
-	switch (type) {
-	case LinkType::HREF:
-		return _("link");
-	case LinkType::IMG:
-		return _("image");
-	case LinkType::EMBED:
-		return _("embedded flash");
-	case LinkType::IFRAME:
-		return _("iframe");
-	case LinkType::VIDEO:
-		return _("video");
-	case LinkType::AUDIO:
-		return _("audio");
-	default:
-		return _("unknown (bug)");
-	}
 }
 
 void HtmlRenderer::add_nonempty_line(const std::string& curline,

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -212,6 +212,22 @@ void item_renderer::render_plaintext(
 	}
 }
 
+void render_links_summary(std::vector<std::pair<LineType, std::string>>& lines,
+	const Links& links)
+{
+	if (links.size() > 0) {
+		lines.push_back(std::make_pair(LineType::wrappable, ""));
+		lines.push_back(std::make_pair(LineType::wrappable, _("Links: ")));
+		for (unsigned int i = 0; i < links.size(); ++i) {
+			auto link_text = strprintf::fmt("[%u]: %s (%s)",
+					i + 1,
+					links[i].url,
+					Links::type2str(links[i].type));
+			lines.push_back(std::make_pair(LineType::softwrappable, link_text));
+		}
+	}
+}
+
 std::string item_renderer::to_plain_text(
 	ConfigContainer& cfg,
 	std::shared_ptr<RssItem> item)
@@ -231,6 +247,8 @@ std::string item_renderer::to_plain_text(
 	} else {
 		render_plaintext(body, lines, OutputFormat::PlainText);
 	}
+
+	render_links_summary(lines, links);
 
 	TextFormatter txtfmt;
 	txtfmt.add_lines(lines);
@@ -266,6 +284,8 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 	} else {
 		render_plaintext(body, lines, OutputFormat::StflRichText);
 	}
+
+	render_links_summary(lines, links);
 
 	TextFormatter txtfmt;
 	txtfmt.add_lines(lines);

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -89,13 +89,9 @@ TEST_CASE(
 		links,
 		"");
 
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 
 	REQUIRE(lines[0] == p(LineType::wrappable, "<u>slashdot</>[1]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] ==
-		p(LineType::softwrappable, "[1]: http://slashdot.org/ (link)"));
 
 	REQUIRE(links[0].url == "http://slashdot.org/");
 	REQUIRE(links[0].type == LinkType::HREF);
@@ -314,13 +310,9 @@ TEST_CASE("Flash <embed>s are added to links if `src' is set", "[HtmlRenderer]")
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[embedded flash: 1]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] ==
-		p(LineType::softwrappable,
-			"[1]: http://example.com/game.swf (embedded flash)"));
+
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].url == "http://example.com/game.swf");
 	REQUIRE(links[0].type == LinkType::EMBED);
@@ -380,12 +372,9 @@ TEST_CASE("<iframe>s are added to links if `src' is set", "[HtmlRenderer]")
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, ""));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[iframe 1 (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] == p(LineType::softwrappable,
-			"[1]: https://www.youtube.com/embed/0123456789A (iframe)"));
+
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].url == "https://www.youtube.com/embed/0123456789A");
 	REQUIRE(links[0].type == LinkType::IFRAME);
@@ -403,13 +392,10 @@ TEST_CASE("<iframe>s are rendered with a title if `title' is set",
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, ""));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable,
 			"[iframe 1: My Video (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] == p(LineType::softwrappable,
-			"[1]: https://www.youtube.com/embed/0123456789A (iframe)"));
+
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].url == "https://www.youtube.com/embed/0123456789A");
 	REQUIRE(links[0].type == LinkType::IFRAME);
@@ -504,13 +490,9 @@ TEST_CASE("<img> results in a placeholder and a link", "[HtmlRenderer]")
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[image 1 (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] ==
-		p(LineType::softwrappable,
-			"[1]: http://example.com/image.png (image)"));
+
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].url == "http://example.com/image.png");
 	REQUIRE(links[0].type == LinkType::IMG);
@@ -531,15 +513,10 @@ TEST_CASE(
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 5);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable,
 			"<u>My Page</>[1] and an image: [image 1 (link #2)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] == p(LineType::softwrappable,
-			"[1]: http://example.com/index.html (link)"));
-	REQUIRE(lines[4] == p(LineType::softwrappable,
-			"[2]: http://example.com/image.png (image)"));
+
 	REQUIRE(links.size() == 2);
 	REQUIRE(links[0].url == "http://example.com/index.html");
 	REQUIRE(links[0].type == LinkType::HREF);
@@ -561,13 +538,11 @@ TEST_CASE(
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[image 1 (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] == p(LineType::softwrappable,
-			"[1]: http://example.com/image.png (image)"));
 	REQUIRE(links.size() == 1);
+	REQUIRE(links[0].url == "http://example.com/image.png");
+	REQUIRE(links[0].type == LinkType::IMG);
 }
 
 TEST_CASE("alt is mentioned in placeholder if <img> has `alt'",
@@ -582,13 +557,9 @@ TEST_CASE("alt is mentioned in placeholder if <img> has `alt'",
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable,
 			"[image 1: Just a test image (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] == p(LineType::softwrappable,
-			"[1]: http://example.com/image.png (image)"));
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].url == "http://example.com/image.png");
 	REQUIRE(links[0].type == LinkType::IMG);
@@ -606,13 +577,9 @@ TEST_CASE("alt is mentioned in placeholder if <img> has `alt' and `title",
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable,
 			"[image 1: Just a test image (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] == p(LineType::softwrappable,
-			"[1]: http://example.com/image.png (image)"));
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].url == "http://example.com/image.png");
 	REQUIRE(links[0].type == LinkType::IMG);
@@ -631,14 +598,9 @@ TEST_CASE(
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] ==
 		p(LineType::wrappable, "[image 1: Just a test image (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] ==
-		p(LineType::softwrappable,
-			"[1]: http://example.com/image.png (image)"));
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].url == "http://example.com/image.png");
 	REQUIRE(links[0].type == LinkType::IMG);
@@ -659,12 +621,8 @@ TEST_CASE(
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[image 1: Red dot (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] ==
-		p(LineType::softwrappable, "[1]: inline image (image)"));
 	REQUIRE(links.size() == 1);
 	REQUIRE(links[0].url == "inline image");
 	REQUIRE(links[0].type == LinkType::IMG);
@@ -686,18 +644,12 @@ TEST_CASE(
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 9);
+	REQUIRE(lines.size() == 5);
 	REQUIRE(lines[0] == p(LineType::wrappable, "<u>[image 1 (link #1)]</>[1]"));
 	REQUIRE(lines[1] == p(LineType::wrappable, ""));
 	REQUIRE(lines[2] == p(LineType::wrappable, "Check out <u>this amazing site</>[2]!"));
 	REQUIRE(lines[3] == p(LineType::wrappable, ""));
 	REQUIRE(lines[4] == p(LineType::wrappable, "[iframe 1 (link #2)]"));
-	REQUIRE(lines[5] == p(LineType::wrappable, ""));
-	REQUIRE(lines[6] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[7] ==
-		p(LineType::softwrappable, "[1]: https://example.com/test.jpg (image)"));
-	REQUIRE(lines[8] ==
-		p(LineType::softwrappable, "[2]: https://attachment.zip/ (iframe)"));
 	REQUIRE(links.size() == 2);
 	REQUIRE(links[0].url == "https://example.com/test.jpg");
 	REQUIRE(links[0].type == LinkType::IMG);
@@ -1431,21 +1383,10 @@ TEST_CASE("<video> results in a placeholder and a link for each valid source",
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 8);
+	REQUIRE(lines.size() == 3);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[video 1 (link #1)]"));
 	REQUIRE(lines[1] == p(LineType::wrappable, "[video 2 (link #2)]"));
 	REQUIRE(lines[2] == p(LineType::wrappable, "[video 2 (link #3)]"));
-	REQUIRE(lines[3] == p(LineType::wrappable, ""));
-	REQUIRE(lines[4] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[5] ==
-		p(LineType::softwrappable,
-			"[1]: http://example.com/video.avi (video)"));
-	REQUIRE(lines[6] ==
-		p(LineType::softwrappable,
-			"[2]: http://example.com/video2.avi (video)"));
-	REQUIRE(lines[7] ==
-		p(LineType::softwrappable,
-			"[3]: http://example.com/video2.mkv (video)"));
 	REQUIRE(links.size() == 3);
 	REQUIRE(links[0].url == "http://example.com/video.avi");
 	REQUIRE(links[0].type == LinkType::VIDEO);
@@ -1467,13 +1408,11 @@ TEST_CASE("<video>s without valid sources are ignored", "[HtmlRenderer]")
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[video 1 (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] == p(LineType::softwrappable,
-			"[1]: http://example.com/video.avi (video)"));
 	REQUIRE(links.size() == 1);
+	REQUIRE(links[0].url == "http://example.com/video.avi");
+	REQUIRE(links[0].type == LinkType::VIDEO);
 }
 
 TEST_CASE("<audio> results in a placeholder and a link for each valid source",
@@ -1491,21 +1430,10 @@ TEST_CASE("<audio> results in a placeholder and a link for each valid source",
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 8);
+	REQUIRE(lines.size() == 3);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[audio 1 (link #1)]"));
 	REQUIRE(lines[1] == p(LineType::wrappable, "[audio 2 (link #2)]"));
 	REQUIRE(lines[2] == p(LineType::wrappable, "[audio 2 (link #3)]"));
-	REQUIRE(lines[3] == p(LineType::wrappable, ""));
-	REQUIRE(lines[4] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[5] ==
-		p(LineType::softwrappable,
-			"[1]: http://example.com/audio.oga (audio)"));
-	REQUIRE(lines[6] ==
-		p(LineType::softwrappable,
-			"[2]: http://example.com/audio2.mp3 (audio)"));
-	REQUIRE(lines[7] ==
-		p(LineType::softwrappable,
-			"[3]: http://example.com/audio2.m4a (audio)"));
 	REQUIRE(links.size() == 3);
 	REQUIRE(links[0].url == "http://example.com/audio.oga");
 	REQUIRE(links[0].type == LinkType::AUDIO);
@@ -1527,13 +1455,11 @@ TEST_CASE("<audio>s without valid sources are ignored", "[HtmlRenderer]")
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 4);
+	REQUIRE(lines.size() == 1);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[audio 1 (link #1)]"));
-	REQUIRE(lines[1] == p(LineType::wrappable, ""));
-	REQUIRE(lines[2] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[3] == p(LineType::softwrappable,
-			"[1]: http://example.com/audio.oga (audio)"));
 	REQUIRE(links.size() == 1);
+	REQUIRE(links[0].url == "http://example.com/audio.oga");
+	REQUIRE(links[0].type == LinkType::AUDIO);
 }
 
 TEST_CASE("Unclosed <video> and <audio> tags are closed upon encounter with a "
@@ -1561,30 +1487,13 @@ TEST_CASE("Unclosed <video> and <audio> tags are closed upon encounter with a "
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 13);
+	REQUIRE(lines.size() == 6);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[video 1 (link #1)]"));
 	REQUIRE(lines[1] == p(LineType::wrappable, "[video 2 (link #2)]"));
 	REQUIRE(lines[2] == p(LineType::wrappable, "[audio 1 (link #3)]"));
 	REQUIRE(lines[3] == p(LineType::wrappable, "[audio 1 (link #4)]"));
 	REQUIRE(lines[4] == p(LineType::wrappable, "[audio 2 (link #5)]"));
 	REQUIRE(lines[5] == p(LineType::wrappable, "Here comes the text!"));
-	REQUIRE(lines[6] == p(LineType::wrappable, ""));
-	REQUIRE(lines[7] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[8] ==
-		p(LineType::softwrappable,
-			"[1]: http://example.com/video.avi (video)"));
-	REQUIRE(lines[9] ==
-		p(LineType::softwrappable,
-			"[2]: http://example.com/video2.avi (video)"));
-	REQUIRE(lines[10] ==
-		p(LineType::softwrappable,
-			"[3]: http://example.com/audio.oga (audio)"));
-	REQUIRE(lines[11] ==
-		p(LineType::softwrappable,
-			"[4]: http://example.com/audio.m4a (audio)"));
-	REQUIRE(lines[12] ==
-		p(LineType::softwrappable,
-			"[5]: http://example.com/audio2.mp3 (audio)"));
 	REQUIRE(links.size() == 5);
 	REQUIRE(links[0].url == "http://example.com/video.avi");
 	REQUIRE(links[0].type == LinkType::VIDEO);
@@ -1622,25 +1531,11 @@ TEST_CASE("Empty <source> tags do not increase the link count. Media elements"
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 10);
+	REQUIRE(lines.size() == 4);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[video 1 (link #1)]"));
 	REQUIRE(lines[1] == p(LineType::wrappable, "[video 1 (link #2)]"));
 	REQUIRE(lines[2] == p(LineType::wrappable, "[audio 1 (link #3)]"));
 	REQUIRE(lines[3] == p(LineType::wrappable, "[audio 1 (link #4)]"));
-	REQUIRE(lines[4] == p(LineType::wrappable, ""));
-	REQUIRE(lines[5] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[6] ==
-		p(LineType::softwrappable,
-			"[1]: http://example.com/video.avi (video)"));
-	REQUIRE(lines[7] ==
-		p(LineType::softwrappable,
-			"[2]: http://example.com/video.mkv (video)"));
-	REQUIRE(lines[8] ==
-		p(LineType::softwrappable,
-			"[3]: http://example.com/audio.mp3 (audio)"));
-	REQUIRE(lines[9] ==
-		p(LineType::softwrappable,
-			"[4]: http://example.com/audio.oga (audio)"));
 	REQUIRE(links.size() == 4);
 	REQUIRE(links[0].url == "http://example.com/video.avi");
 	REQUIRE(links[0].type == LinkType::VIDEO);
@@ -1665,17 +1560,9 @@ TEST_CASE("Back-to-back <video> and <audio> tags are seperated by a new line",
 	Links links;
 
 	REQUIRE_NOTHROW(r.render(input, lines, links, url));
-	REQUIRE(lines.size() == 6);
+	REQUIRE(lines.size() == 2);
 	REQUIRE(lines[0] == p(LineType::wrappable, "[video 1 (link #1)]"));
 	REQUIRE(lines[1] == p(LineType::wrappable, "[audio 1 (link #2)]"));
-	REQUIRE(lines[2] == p(LineType::wrappable, ""));
-	REQUIRE(lines[3] == p(LineType::wrappable, "Links: "));
-	REQUIRE(lines[4] ==
-		p(LineType::softwrappable,
-			"[1]: https://example.com/video.mp4 (video)"));
-	REQUIRE(lines[5] ==
-		p(LineType::softwrappable,
-			"[2]: https://example.com/audio.mp3 (audio)"));
 	REQUIRE(links.size() == 2);
 	REQUIRE(links[0].url == "https://example.com/video.mp4");
 	REQUIRE(links[0].type == LinkType::VIDEO);

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -183,6 +183,31 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 
 		REQUIRE(result == expected);
 	}
+
+	SECTION("Item with enclosure and plaintext description") {
+		item->set_description(ITEM_DESCRIPTON, "text/plain");
+		item->set_enclosure_url("https://example.com/test.png");
+		item->set_enclosure_type("image/png");
+
+		const auto result = item_renderer::to_plain_text(cfg, item);
+
+		const auto expected = std::string() +
+			"Feed: " + FEED_TITLE + '\n' +
+			"Title: " + ITEM_TITLE + '\n' +
+			"Author: " + ITEM_AUTHOR + '\n' +
+			"Date: Sun, 30 Sep 2018 19:34:25 +0000\n" +
+			"Link: " + ITEM_LINK + '\n' +
+			"Flags: " + ITEM_FLAGS_RENDERED + '\n' +
+			" \n" +
+			"Image[1]\n" +
+			" \n" +
+			ITEM_DESCRIPTON + '\n' +
+			" \n" +
+			"Links: \n" +
+			"[1]: https://example.com/test.png (image)\n";
+
+		REQUIRE(result == expected);
+	}
 }
 
 TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "


### PR DESCRIPTION
Mainly moved code from `HtmlRenderer` to `Links` and `ItemRenderer`.
`ItemRenderer` already had some tests with rendered links.

Fixes https://github.com/newsboat/newsboat/issues/2541