### PR TITLE
Update chrono depency version to 0.4.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,9 @@ checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.28"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -19,8 +19,8 @@ nom = "7"
 libc = "0.2"
 natord = "1.0.9"
 md5 = "0.7.0"
-
 lexopt = "0.3.0"
+chrono = "0.4"
 
 [dependencies.gettext-rs]
 version = "0.7.0"
@@ -46,15 +46,6 @@ version = "0.4.65"
 # exists even if we're linking (via libcurl) against another SSL library like
 # GnuTLS. We disable this feature to avoid the dependency.
 default-features = false
-
-[dependencies.chrono]
-version = "0.4"
-default-features = false
-# This is the same as default features for 0.4.23, minus "oldtime" and
-# "wasmbind". We disable "oldtime" to get rid of dependency on `time` 0.1,
-# which is vulnerable (CVE-2020-26235) and which we don't use. We disable
-# `wasmbind` because we don't use WASM.
-features = [ "alloc", "std", "clock" ]
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -302,7 +302,7 @@ macro_rules! log {
 mod tests {
     use super::*;
 
-    use chrono::{Duration, TimeZone};
+    use chrono::{Duration, NaiveDateTime};
     use std::io::{self, BufRead, BufReader};
     use std::path;
     use tempfile::TempDir;
@@ -491,10 +491,11 @@ mod tests {
                     let (timestamp_str, _level, message) =
                         parse_log_line(&line).expect("Failed to split the log line into parts");
 
-                    let timestamp = Local::now()
-                        .timezone()
-                        .datetime_from_str(timestamp_str, "%Y-%m-%d %H:%M:%S")
-                        .expect("Failed to parse the timestamp from the log file");
+                    let timestamp =
+                        NaiveDateTime::parse_from_str(timestamp_str, "%Y-%m-%d %H:%M:%S")
+                            .expect("Failed to parse the timestamp from the log file")
+                            .and_local_timezone(Local::now().timezone())
+                            .unwrap();
                     // `start_time` and `end_time` may have millisecond precision or better,
                     // whereas `timestamp` is limited to seconds. Therefore, we account for
                     // a situation where `start_time` is slightly bigger than `timestamp`.
@@ -821,10 +822,11 @@ mod tests {
                     let (timestamp_str, message) = parse_errorlog_line(&line)
                         .expect("Failed to split the error log line into parts");
 
-                    let timestamp = Local::now()
-                        .timezone()
-                        .datetime_from_str(timestamp_str, "%Y-%m-%d %H:%M:%S")
-                        .expect("Failed to parse the timestamp from the error log file");
+                    let timestamp =
+                        NaiveDateTime::parse_from_str(timestamp_str, "%Y-%m-%d %H:%M:%S")
+                            .expect("Failed to parse the timestamp from the log file")
+                            .and_local_timezone(Local::now().timezone())
+                            .unwrap();
                     // `start_time` and `end_time` may have millisecond precision or better,
                     // whereas `timestamp` is limited to seconds. Therefore, we account for
                     // a situation where `start_time` is slightly bigger than `timestamp`.


### PR DESCRIPTION
Replaces https://github.com/newsboat/newsboat/pull/2542. Resolves deprecation warnings caused by chrono update.