### PR TITLE
Prepare for "bind" command by specifying binding type instead of boolean "automatic"

### DIFF
--- a/include/dialogsformaction.h
+++ b/include/dialogsformaction.h
@@ -29,7 +29,7 @@ protected:
 
 private:
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 	void update_heading();
 };

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -34,7 +34,7 @@ protected:
 
 private:
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);
 

--- a/include/emptyformaction.h
+++ b/include/emptyformaction.h
@@ -20,7 +20,7 @@ public:
 
 protected:
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 	std::string main_widget() const override
 	{

--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -64,7 +64,7 @@ private:
 
 	int get_pos(unsigned int realidx);
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 
 	bool open_position_in_browser(unsigned int pos, bool interactive) const;

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -39,7 +39,7 @@ protected:
 
 private:
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 	void update_title(const std::string& working_directory);
 

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -31,6 +31,11 @@ enum class CommandType {
 	INVALID, 	/// differs from UNKNOWN in that no input was parsed
 };
 
+enum class BindingType {
+	BindKey,
+	Macro,
+};
+
 struct Command {
 	CommandType type;
 	std::vector<std::string> args;
@@ -61,7 +66,7 @@ public:
 	virtual void handle_cmdline(const std::string& cmd);
 
 	bool process_op(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr);
 
 	virtual void finished_qna(Operation op);
@@ -103,7 +108,7 @@ public:
 
 protected:
 	virtual bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) = 0;
 	virtual void set_keymap_hints();
 

--- a/include/helpformaction.h
+++ b/include/helpformaction.h
@@ -30,7 +30,7 @@ protected:
 
 private:
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 	std::string make_colorstring(const std::vector<std::string>& colors);
 	bool quit;

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -71,7 +71,7 @@ public:
 
 protected:
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 	std::string main_widget() const override
 	{

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -62,7 +62,7 @@ private:
 	void register_format_styles();
 
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 
 	bool open_link_in_browser(const std::string& link, const std::string& type,

--- a/include/listformaction.h
+++ b/include/listformaction.h
@@ -19,7 +19,7 @@ public:
 
 protected:
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 	nonstd::optional<std::uint8_t> open_unread_items_in_browser(
 		std::shared_ptr<RssFeed> feed,

--- a/include/searchresultslistformaction.h
+++ b/include/searchresultslistformaction.h
@@ -55,7 +55,7 @@ protected:
 		const std::string& url) override;
 
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 
 private:

--- a/include/selectformaction.h
+++ b/include/selectformaction.h
@@ -52,7 +52,7 @@ protected:
 
 private:
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 	bool quit;
 	bool is_first_draw;

--- a/include/urlviewformaction.h
+++ b/include/urlviewformaction.h
@@ -36,7 +36,7 @@ protected:
 
 private:
 	bool process_operation(Operation op,
-		bool automatic = false,
+		BindingType bindingType = BindingType::BindKey,
 		std::vector<std::string>* args = nullptr) override;
 	void open_current_position_in_browser(bool interactive);
 	void update_heading();

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -73,7 +73,7 @@ const std::vector<KeyMapHintEntry>& DialogsFormAction::get_keymap_hint() const
 }
 
 bool DialogsFormAction::process_operation(Operation op,
-	bool automatic,
+	BindingType bindingType,
 	std::vector<std::string>* args)
 {
 	switch (op) {
@@ -103,7 +103,7 @@ bool DialogsFormAction::process_operation(Operation op,
 		v->pop_current_formaction();
 		break;
 	default:
-		ListFormAction::process_operation(op, automatic, args);
+		ListFormAction::process_operation(op, bindingType, args);
 		break;
 	}
 	return true;

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -42,7 +42,7 @@ DirBrowserFormAction::DirBrowserFormAction(View* vv,
 DirBrowserFormAction::~DirBrowserFormAction() {}
 
 bool DirBrowserFormAction::process_operation(Operation op,
-	bool /* automatic */,
+	BindingType /*bindingType*/,
 	std::vector<std::string>* /* args */)
 {
 	switch (op) {

--- a/src/emptyformaction.cpp
+++ b/src/emptyformaction.cpp
@@ -33,7 +33,7 @@ const std::vector<KeyMapHintEntry>& EmptyFormAction::get_keymap_hint() const
 }
 
 bool EmptyFormAction::process_operation(Operation /*op*/,
-	bool /*automatic*/,
+	BindingType /*bindingType*/,
 	std::vector<std::string>* /*args*/)
 {
 	return false;

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -466,15 +466,18 @@ REDO:
 		}
 		break;
 	case OP_GOTO_TITLE:
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			if (args->size() >= 1) {
 				qna_responses = {args[0]};
 				finished_qna(OP_INT_GOTO_TITLE);
 			}
-		} else {
+			break;
+		case BindingType::BindKey:
 			std::vector<QnaPair> qna;
 			qna.push_back(QnaPair(_("Title: "), ""));
 			this->start_qna(qna, OP_INT_GOTO_TITLE);
+			break;
 		}
 		break;
 	case OP_CLEARFILTER:

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -86,7 +86,7 @@ void FeedListFormAction::prepare()
 }
 
 bool FeedListFormAction::process_operation(Operation op,
-	bool automatic,
+	BindingType bindingType,
 	std::vector<std::string>* args)
 {
 	unsigned int pos = 0;
@@ -466,7 +466,7 @@ REDO:
 		}
 		break;
 	case OP_GOTO_TITLE:
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			if (args->size() >= 1) {
 				qna_responses = {args[0]};
 				finished_qna(OP_INT_GOTO_TITLE);
@@ -503,7 +503,7 @@ REDO:
 			goto REDO;
 		}
 		LOG(Level::INFO, "FeedListFormAction: quitting");
-		if (automatic ||
+		if (bindingType == BindingType::Macro ||
 			!cfg->get_configvalue_as_bool("confirm-exit") ||
 			v->confirm(
 				_("Do you really want to quit (y:Yes n:No)? "),
@@ -519,7 +519,7 @@ REDO:
 		v->push_help();
 		break;
 	default:
-		ListFormAction::process_operation(op, automatic, args);
+		ListFormAction::process_operation(op, bindingType, args);
 		break;
 	}
 	if (quit) {

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -100,7 +100,7 @@ REDO:
 	switch (op) {
 	case OP_OPEN: {
 		if (f.get_focus() == "feeds") {
-			if (automatic && args->size() > 0) {
+			if (args->size() > 0) {
 				pos = utils::to_u((*args)[0]);
 			}
 			LOG(Level::INFO,
@@ -417,7 +417,7 @@ REDO:
 		break;
 	case OP_SETTAG: {
 		std::string newtag;
-		if (automatic && args->size() > 0) {
+		if (args->size() > 0) {
 			newtag = (*args)[0];
 		} else {
 			newtag = v->select_tag(tag);
@@ -431,7 +431,7 @@ REDO:
 	break;
 	case OP_SELECTFILTER:
 		if (filter_container.size() > 0) {
-			if (automatic && args->size() > 0) {
+			if (args->size() > 0) {
 				const std::string filter_name = (*args)[0];
 				const auto filter = filter_container.get_filter(filter_name);
 
@@ -450,9 +450,9 @@ REDO:
 		}
 		break;
 	case OP_SEARCH:
-		if (automatic && args->size() > 0) {
+		if (args->size() > 0) {
 			qna_responses.clear();
-			// when in automatic mode, we manually fill the
+			// If arguments are specified, we manually fill the
 			// qna_responses vector from the arguments and then run
 			// the finished_qna() by ourselves to simulate a "Q&A"
 			// session that is in fact macro-driven.
@@ -483,7 +483,7 @@ REDO:
 		save_filterpos();
 		break;
 	case OP_SETFILTER:
-		if (automatic && args->size() > 0) {
+		if (args->size() > 0) {
 			qna_responses.clear();
 			qna_responses.push_back((*args)[0]);
 			finished_qna(OP_INT_END_SETFILTER);

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -44,7 +44,7 @@ FileBrowserFormAction::FileBrowserFormAction(View* vv,
 FileBrowserFormAction::~FileBrowserFormAction() {}
 
 bool FileBrowserFormAction::process_operation(Operation op,
-	bool /* automatic */,
+	BindingType /*bindingType*/,
 	std::vector<std::string>* /* args */)
 {
 	switch (op) {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -98,7 +98,7 @@ void FormAction::start_cmdline(std::string default_value)
 }
 
 bool FormAction::process_op(Operation op,
-	bool automatic,
+	BindingType bindingType,
 	std::vector<std::string>* args)
 {
 	switch (op) {
@@ -110,7 +110,7 @@ bool FormAction::process_op(Operation op,
 		start_cmdline();
 		break;
 	case OP_INT_SET:
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			if (args && args->size() == 2) {
 				const std::string key = args->at(0);
 				const std::string value = args->at(1);
@@ -127,8 +127,7 @@ bool FormAction::process_op(Operation op,
 			return false;
 		} else {
 			LOG(Level::WARN,
-				"FormAction::process_op: got OP_INT_SET, but "
-				"not automatic");
+				"FormAction::process_op: got OP_INT_SET, but not from a macro");
 		}
 		break;
 	case OP_VIEWDIALOGS:
@@ -141,7 +140,7 @@ bool FormAction::process_op(Operation op,
 		v->goto_prev_dialog();
 		break;
 	default:
-		return this->process_operation(op, automatic, args);
+		return this->process_operation(op, bindingType, args);
 	}
 	return true;
 }

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -110,7 +110,8 @@ bool FormAction::process_op(Operation op,
 		start_cmdline();
 		break;
 	case OP_INT_SET:
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			if (args && args->size() == 2) {
 				const std::string key = args->at(0);
 				const std::string value = args->at(1);
@@ -125,9 +126,10 @@ bool FormAction::process_op(Operation op,
 			}
 			v->get_statusline().show_error(_("usage: set <config-option> <value>"));
 			return false;
-		} else {
+		case BindingType::BindKey:
 			LOG(Level::WARN,
 				"FormAction::process_op: got OP_INT_SET, but not from a macro");
+			break;
 		}
 		break;
 	case OP_VIEWDIALOGS:

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -29,7 +29,7 @@ HelpFormAction::HelpFormAction(View* vv,
 HelpFormAction::~HelpFormAction() {}
 
 bool HelpFormAction::process_operation(Operation op,
-	bool /* automatic */,
+	BindingType /*bindingType*/,
 	std::vector<std::string>* /* args */)
 {
 	bool hardquit = false;

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -318,7 +318,8 @@ bool ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO, "ItemListFormAction: bookmarking item at pos `%u'", itempos);
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				if (bindingType == BindingType::Macro) {
+				switch (bindingType) {
+				case BindingType::Macro:
 					qna_responses.clear();
 					qna_responses.push_back(
 						visible_items[itempos]
@@ -330,11 +331,13 @@ bool ItemListFormAction::process_operation(Operation op,
 						: "");
 					qna_responses.push_back(feed->title());
 					this->finished_qna(OP_INT_BM_END);
-				} else {
+					break;
+				case BindingType::BindKey:
 					this->start_bookmark_qna(
 						visible_items[itempos].first->title(),
 						visible_items[itempos].first->link(),
 						feed->title());
+					break;
 				}
 			}
 		} else {
@@ -346,7 +349,8 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_EDITFLAGS: {
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				if (bindingType == BindingType::Macro) {
+				switch (bindingType) {
+				case BindingType::Macro:
 					if (args->size() > 0) {
 						qna_responses.clear();
 						qna_responses.push_back(
@@ -354,13 +358,15 @@ bool ItemListFormAction::process_operation(Operation op,
 						finished_qna(
 							OP_INT_EDITFLAGS_END);
 					}
-				} else {
+					break;
+				case BindingType::BindKey:
 					std::vector<QnaPair> qna;
 					qna.push_back(QnaPair(_("Flags: "),
 							visible_items[itempos]
 							.first->flags()));
 					this->start_qna(
 						qna, OP_INT_EDITFLAGS_END);
+					break;
 				}
 			}
 		} else {
@@ -374,14 +380,17 @@ bool ItemListFormAction::process_operation(Operation op,
 		if (!visible_items.empty()) {
 			std::shared_ptr<RssItem> item = visible_items[itempos].first;
 			std::string filename;
-			if (bindingType == BindingType::Macro) {
+			switch (bindingType) {
+			case BindingType::Macro:
 				if (args->size() > 0) {
 					filename = (*args)[0];
 				}
-			} else {
+				break;
+			case BindingType::BindKey:
 				const auto title = utils::utf8_to_locale(item->title());
 				const auto suggestion = v->get_filename_suggestion(title);
 				filename = v->run_filebrowser(suggestion);
+				break;
 			}
 			save_article(filename, item);
 		} else {
@@ -570,17 +579,20 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_PIPE_TO:
 		if (visible_items.size() != 0) {
 			std::vector<QnaPair> qna;
-			if (bindingType == BindingType::Macro) {
+			switch (bindingType) {
+			case BindingType::Macro:
 				if (args->size() > 0) {
 					qna_responses.clear();
 					qna_responses.push_back((*args)[0]);
 					finished_qna(OP_PIPE_TO);
 				}
-			} else {
+				break;
+			case BindingType::BindKey:
 				qna.push_back(QnaPair(
 						_("Pipe article to command: "), ""));
 				this->start_qna(
 					qna, OP_PIPE_TO, &cmdlinehistory);
+				break;
 			}
 		} else {
 			v->get_statusline().show_error(_("No item selected!"));
@@ -588,29 +600,35 @@ bool ItemListFormAction::process_operation(Operation op,
 		break;
 	case OP_SEARCH: {
 		std::vector<QnaPair> qna;
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);
 				finished_qna(OP_INT_START_SEARCH);
 			}
-		} else {
+			break;
+		case BindingType::BindKey:
 			qna.push_back(QnaPair(_("Search for: "), ""));
 			this->start_qna(
 				qna, OP_INT_START_SEARCH, &searchhistory);
+			break;
 		}
 	}
 	break;
 	case OP_GOTO_TITLE:
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			if (args->size() >= 1) {
 				qna_responses = {args[0]};
 				finished_qna(OP_INT_GOTO_TITLE);
 			}
-		} else {
+			break;
+		case BindingType::BindKey:
 			std::vector<QnaPair> qna;
 			qna.push_back(QnaPair(_("Title: "), ""));
 			this->start_qna(qna, OP_INT_GOTO_TITLE);
+			break;
 		}
 		break;
 	case OP_EDIT_URLS:
@@ -639,17 +657,20 @@ bool ItemListFormAction::process_operation(Operation op,
 
 		break;
 	case OP_SETFILTER:
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);
 				this->finished_qna(OP_INT_END_SETFILTER);
 			}
-		} else {
+			break;
+		case BindingType::BindKey:
 			std::vector<QnaPair> qna;
 			qna.push_back(QnaPair(_("Filter: "), ""));
 			this->start_qna(
 				qna, OP_INT_END_SETFILTER, &filterhistory);
+			break;
 		}
 		break;
 	case OP_CLEARFILTER:

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -219,7 +219,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			try {
 				const auto message_lifetime = v->get_statusline().show_message_until_finished(
 						_("Toggling read flag for article..."));
-				if (automatic && args->size() > 0) {
+				if (args->size() > 0) {
 					if ((*args)[0] == "read") {
 						visible_items[itempos]
 						.first->set_unread(
@@ -619,7 +619,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_SELECTFILTER:
 		if (filter_container.size() > 0) {
 			std::string newfilter;
-			if (automatic && args->size() > 0) {
+			if (args->size() > 0) {
 				const std::string filter_name = (*args)[0];
 				const auto filter = filter_container.get_filter(filter_name);
 

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -50,7 +50,7 @@ ItemListFormAction::ItemListFormAction(View* vv,
 ItemListFormAction::~ItemListFormAction() {}
 
 bool ItemListFormAction::process_operation(Operation op,
-	bool automatic,
+	BindingType bindingType,
 	std::vector<std::string>* args)
 {
 	bool quit = false;
@@ -318,7 +318,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO, "ItemListFormAction: bookmarking item at pos `%u'", itempos);
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				if (automatic) {
+				if (bindingType == BindingType::Macro) {
 					qna_responses.clear();
 					qna_responses.push_back(
 						visible_items[itempos]
@@ -346,7 +346,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_EDITFLAGS: {
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				if (automatic) {
+				if (bindingType == BindingType::Macro) {
 					if (args->size() > 0) {
 						qna_responses.clear();
 						qna_responses.push_back(
@@ -374,7 +374,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		if (!visible_items.empty()) {
 			std::shared_ptr<RssItem> item = visible_items[itempos].first;
 			std::string filename;
-			if (automatic) {
+			if (bindingType == BindingType::Macro) {
 				if (args->size() > 0) {
 					filename = (*args)[0];
 				}
@@ -570,7 +570,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_PIPE_TO:
 		if (visible_items.size() != 0) {
 			std::vector<QnaPair> qna;
-			if (automatic) {
+			if (bindingType == BindingType::Macro) {
 				if (args->size() > 0) {
 					qna_responses.clear();
 					qna_responses.push_back((*args)[0]);
@@ -588,7 +588,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		break;
 	case OP_SEARCH: {
 		std::vector<QnaPair> qna;
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);
@@ -602,7 +602,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_GOTO_TITLE:
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			if (args->size() >= 1) {
 				qna_responses = {args[0]};
 				finished_qna(OP_INT_GOTO_TITLE);
@@ -639,7 +639,7 @@ bool ItemListFormAction::process_operation(Operation op,
 
 		break;
 	case OP_SETFILTER:
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);
@@ -762,7 +762,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	}
 	break;
 	default:
-		ListFormAction::process_operation(op, automatic, args);
+		ListFormAction::process_operation(op, bindingType, args);
 		break;
 	}
 	if (hardquit) {

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -397,7 +397,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 		const auto message_lifetime = v->get_statusline().show_message_until_finished(
 				_("Toggling read flag for article..."));
 		try {
-			if (automatic && args->size() > 0) {
+			if (args->size() > 0) {
 				if ((*args)[0] == "read") {
 					item->set_unread(false);
 					v->get_ctrl()->mark_article_read(item->guid(), true);

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -217,13 +217,16 @@ bool ItemViewFormAction::process_operation(Operation op,
 	case OP_SAVE: {
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: saving article");
 		std::string filename;
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			if (args->size() > 0) {
 				filename = (*args)[0];
 			}
-		} else {
+			break;
+		case BindingType::BindKey:
 			filename = v->run_filebrowser( utils::utf8_to_locale(v->get_filename_suggestion(
 							item->title())));
+			break;
 		}
 		if (filename == "") {
 			v->get_statusline().show_error(_("Aborted saving."));
@@ -255,14 +258,16 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_BOOKMARK:
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			qna_responses.clear();
 			qna_responses.push_back(item->link());
 			qna_responses.push_back(utils::utf8_to_locale(item->title()));
 			qna_responses.push_back(
 				args->size() > 0 ? (*args)[0] : "");
 			qna_responses.push_back(feed->title());
-		} else {
+			break;
+		case BindingType::BindKey:
 			this->start_bookmark_qna(
 				utils::utf8_to_locale(item->title()),
 				item->link(),
@@ -271,45 +276,54 @@ bool ItemViewFormAction::process_operation(Operation op,
 		break;
 	case OP_SEARCH: {
 		std::vector<QnaPair> qna;
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);
 				finished_qna(OP_INT_START_SEARCH);
 			}
-		} else {
+			break;
+		case BindingType::BindKey:
 			qna.push_back(QnaPair(_("Search for: "), ""));
 			this->start_qna(
 				qna, OP_INT_START_SEARCH, &searchhistory);
+			break;
 		}
 	}
 	break;
 	case OP_PIPE_TO: {
 		std::vector<QnaPair> qna;
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);
 				finished_qna(OP_PIPE_TO);
 			}
-		} else {
+			break;
+		case BindingType::BindKey:
 			qna.push_back(
 				QnaPair(_("Pipe article to command: "), ""));
 			this->start_qna(qna, OP_PIPE_TO, &cmdlinehistory);
+			break;
 		}
 	}
 	break;
 	case OP_EDITFLAGS:
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			qna_responses.clear();
 			if (args->size() > 0) {
 				qna_responses.push_back((*args)[0]);
 				this->finished_qna(OP_INT_EDITFLAGS_END);
 			}
-		} else {
+			break;
+		case BindingType::BindKey:
 			std::vector<QnaPair> qna;
 			qna.push_back(QnaPair(_("Flags: "), item->flags()));
 			this->start_qna(qna, OP_INT_EDITFLAGS_END);
+			break;
 		}
 		break;
 	case OP_SHOWURLS: {
@@ -453,15 +467,18 @@ bool ItemViewFormAction::process_operation(Operation op,
 	break;
 	case OP_GOTO_URL: {
 		std::vector<QnaPair> qna;
-		if (bindingType == BindingType::Macro) {
+		switch (bindingType) {
+		case BindingType::Macro:
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);
 				finished_qna(OP_INT_GOTO_URL);
 			}
-		} else {
+			break;
+		case BindingType::BindKey:
 			qna.push_back(QnaPair(_("Goto URL #"), ""));
 			this->start_qna(qna, OP_INT_GOTO_URL);
+			break;
 		}
 	}
 	break;

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -156,7 +156,7 @@ void ItemViewFormAction::prepare()
 }
 
 bool ItemViewFormAction::process_operation(Operation op,
-	bool automatic,
+	BindingType bindingType,
 	std::vector<std::string>* args)
 {
 	bool hardquit = false;
@@ -217,7 +217,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 	case OP_SAVE: {
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: saving article");
 		std::string filename;
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			if (args->size() > 0) {
 				filename = (*args)[0];
 			}
@@ -255,7 +255,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_BOOKMARK:
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			qna_responses.clear();
 			qna_responses.push_back(item->link());
 			qna_responses.push_back(utils::utf8_to_locale(item->title()));
@@ -271,7 +271,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 		break;
 	case OP_SEARCH: {
 		std::vector<QnaPair> qna;
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);
@@ -286,7 +286,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 	break;
 	case OP_PIPE_TO: {
 		std::vector<QnaPair> qna;
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);
@@ -300,7 +300,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_EDITFLAGS:
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			qna_responses.clear();
 			if (args->size() > 0) {
 				qna_responses.push_back((*args)[0]);
@@ -453,7 +453,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 	break;
 	case OP_GOTO_URL: {
 		std::vector<QnaPair> qna;
-		if (automatic) {
+		if (bindingType == BindingType::Macro) {
 			if (args->size() > 0) {
 				qna_responses.clear();
 				qna_responses.push_back((*args)[0]);

--- a/src/listformaction.cpp
+++ b/src/listformaction.cpp
@@ -17,7 +17,7 @@ ListFormAction::ListFormAction(View* v,
 }
 
 bool ListFormAction::process_operation(Operation op,
-	bool,
+	BindingType /*bindingType*/,
 	std::vector<std::string>*)
 {
 	switch (op) {

--- a/src/searchresultslistformaction.cpp
+++ b/src/searchresultslistformaction.cpp
@@ -34,7 +34,7 @@ void SearchResultsListFormAction::add_to_history(const std::shared_ptr<RssFeed>&
 
 bool SearchResultsListFormAction::process_operation(
 	Operation op,
-	bool automatic,
+	BindingType bindingType,
 	std::vector<std::string>* args)
 {
 	const unsigned int itempos = list.get_position();
@@ -64,7 +64,7 @@ bool SearchResultsListFormAction::process_operation(
 		}
 		break;
 	default:
-		return ItemListFormAction::process_operation(op, automatic, args);
+		return ItemListFormAction::process_operation(op, bindingType, args);
 	}
 	return true;
 }

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -52,7 +52,7 @@ void SelectFormAction::handle_cmdline(const std::string& cmd)
 }
 
 bool SelectFormAction::process_operation(Operation op,
-	bool /* automatic */,
+	BindingType /*bindingType*/,
 	std::vector<std::string>* /* args */)
 {
 	bool hardquit = false;

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -33,7 +33,7 @@ UrlViewFormAction::UrlViewFormAction(View* vv,
 UrlViewFormAction::~UrlViewFormAction() {}
 
 bool UrlViewFormAction::process_operation(Operation op,
-	bool /* automatic */,
+	BindingType /*bindingType*/,
 	std::vector<std::string>* /* args */)
 {
 	bool hardquit = false;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -142,7 +142,7 @@ bool View::run_commands(const std::vector<MacroCmd>& commands)
 		std::shared_ptr<FormAction> fa = get_current_formaction();
 		fa->prepare();
 		fa->draw_form();
-		if (!fa->process_op(command.op, true, &command.args)) {
+		if (!fa->process_op(command.op, BindingType::Macro, &command.args)) {
 			// Operation failed, abort
 			return false;
 		}

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -511,7 +511,7 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 		"bookmark-cmd", "echo > " + bookmarkFile.get_path());
 
 	bookmark_args.push_back(extra_arg);
-	REQUIRE_NOTHROW(itemlist.process_op(OP_BOOKMARK, true, &bookmark_args));
+	REQUIRE_NOTHROW(itemlist.process_op(OP_BOOKMARK, BindingType::Macro, &bookmark_args));
 
 	std::ifstream browserFileStream(bookmarkFile.get_path());
 
@@ -550,7 +550,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 		op_args.push_back(flags);
 
 		REQUIRE_NOTHROW(
-			itemlist.process_op(OP_EDITFLAGS, true, &op_args));
+			itemlist.process_op(OP_EDITFLAGS, BindingType::Macro, &op_args));
 		REQUIRE(item->flags() == flags);
 	}
 
@@ -560,7 +560,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 		op_args.push_back(flags);
 
 		REQUIRE_NOTHROW(
-			itemlist.process_op(OP_EDITFLAGS, true, &op_args));
+			itemlist.process_op(OP_EDITFLAGS, BindingType::Macro, &op_args));
 		REQUIRE(item->flags() == ordered_flags);
 	}
 
@@ -569,7 +569,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 		op_args.push_back(flags + "ddd");
 
 		REQUIRE_NOTHROW(
-			itemlist.process_op(OP_EDITFLAGS, true, &op_args));
+			itemlist.process_op(OP_EDITFLAGS, BindingType::Macro, &op_args));
 		REQUIRE(item->flags() == flags);
 	}
 
@@ -579,7 +579,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 			op_args.push_back(flags + "1236");
 
 			REQUIRE_NOTHROW(itemlist.process_op(
-					OP_EDITFLAGS, true, &op_args));
+					OP_EDITFLAGS, BindingType::Macro, &op_args));
 			REQUIRE(item->flags() == flags);
 		}
 		SECTION("Symbols") {
@@ -587,14 +587,14 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 				"%^\\*;\'\"&~#{([-|`_/@)]=}$£€µ,;:!?./§");
 
 			REQUIRE_NOTHROW(itemlist.process_op(
-					OP_EDITFLAGS, true, &op_args));
+					OP_EDITFLAGS, BindingType::Macro, &op_args));
 			REQUIRE(item->flags() == flags);
 		}
 		SECTION("Accents") {
 			op_args.push_back(flags + "¨^");
 
 			REQUIRE_NOTHROW(itemlist.process_op(
-					OP_EDITFLAGS, true, &op_args));
+					OP_EDITFLAGS, BindingType::Macro, &op_args));
 			REQUIRE(item->flags() == flags);
 		}
 	}
@@ -605,7 +605,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 		op_args.push_back(flags);
 
 		REQUIRE_NOTHROW(
-			itemlist.process_op(OP_EDITFLAGS, true, &op_args));
+			itemlist.process_op(OP_EDITFLAGS, BindingType::Macro, &op_args));
 		REQUIRE(item->flags() == flags);
 	}
 }
@@ -653,7 +653,7 @@ TEST_CASE("OP_SAVE writes an article's attributes to the specified file",
 	feed->add_item(item);
 	itemlist.set_feed(feed);
 
-	REQUIRE_NOTHROW(itemlist.process_op(OP_SAVE, true, &op_args));
+	REQUIRE_NOTHROW(itemlist.process_op(OP_SAVE, BindingType::Macro, &op_args));
 
 	test_helpers::assert_article_file_content(saveFile.get_path(),
 		test_title,
@@ -843,7 +843,7 @@ TEST_CASE("OP_PIPE_TO pipes an article's content to an external command",
 	feed->add_item(item);
 	itemlist.set_feed(feed);
 
-	REQUIRE_NOTHROW(itemlist.process_op(OP_PIPE_TO, true, &op_args));
+	REQUIRE_NOTHROW(itemlist.process_op(OP_PIPE_TO, BindingType::Macro, &op_args));
 
 	test_helpers::assert_article_file_content(articleFile.get_path(),
 		test_title,


### PR DESCRIPTION
This implements an idea by @Minoru in https://github.com/newsboat/newsboat/pull/2507#issuecomment-1715312777

This is done in preparation of adding a new "bind" command.
We would like to handle some operations differently without changing the behaviour for the current bind-key and macro bindings.

This obsoletes https://github.com/newsboat/newsboat/pull/2507
I've cherry-picked one of the commits:
> (if we end up closing this PR) https://github.com/newsboat/newsboat/commit/c51cabb77fd62c2dfa17ee1b080ac4c6ca960849 is a very good observation and I'd like to have it anyway.