### PR TITLE
Title fallback: Use content_encoded if description is empty

### DIFF
--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -292,9 +292,14 @@ void RssParser::set_item_title(std::shared_ptr<RssFeed> feed,
 	if (title.empty()) {
 		title = utils::make_title(item.link);
 		if (title.empty()) {
-			title = item.description;
-			x->set_title(render_xhtml_title(title, feed->link()));
-			return;
+			if (!item.description.empty()) {
+				x->set_title(render_xhtml_title(item.description, feed->link()));
+				return;
+			}
+			if (!item.content_encoded.empty()) {
+				x->set_title(render_xhtml_title(item.content_encoded, feed->link()));
+				return;
+			}
 		}
 	}
 

--- a/test/rssparser.cpp
+++ b/test/rssparser.cpp
@@ -145,9 +145,20 @@ TEST_CASE("parse() generates a title when title element is missing",
 
 	SECTION("creates a title from the content if the URL is numeric") {
 		upstream_item.link = "http://example.com/1234567";
-		const auto feed = parser.parse(upstream_feed);
-		auto item = feed->items()[0];
-		REQUIRE(item->title() == "Just saying hello");
+
+		SECTION("title from description") {
+			const auto feed = parser.parse(upstream_feed);
+			auto item = feed->items()[0];
+			REQUIRE(item->title() == "Just saying hello");
+		}
+
+		SECTION("title from content_encoded") {
+			upstream_item.description.clear();
+			upstream_item.content_encoded = "<b>article text</b>";
+			const auto feed = parser.parse(upstream_feed);
+			auto item = feed->items()[0];
+			REQUIRE(item->title() == "article text");
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/2573