### PR TITLE
Clarify docs for `max-items` setting

### DIFF
--- a/doc/chapter-firststeps.asciidoc
+++ b/doc/chapter-firststeps.asciidoc
@@ -107,10 +107,8 @@ You can now:
 ****
 *Local articles* Newsboat keeps the articles that it downloads.
 When you start Newsboat again and reload a feed, old articles can still be
-read even if they aren't in the current RSS feeds anymore.
-
-You can configure how many articles are kept per feed so that the article backlog doesn't
-grow endlessly by configuring <<max-items,`max-items`>>.
+read even if they aren't in the current RSS feeds anymore. The maximum number
+of articles is controlled by <<max-items,`max-items`>>.
 ****
 
 ****

--- a/doc/configcommands.dsv
+++ b/doc/configcommands.dsv
@@ -77,7 +77,7 @@ macro||<macro key> <command list> [-- "<macro description>"]||n/a||With this com
 mark-as-read-on-hover||[yes/no]||no||If set to `yes`, then all articles that get selected in the article list are marked as read.||mark-as-read-on-hover yes
 max-browser-tabs||<number>||10||Set the maximum number of articles to open in a browser when using the <<open-all-unread-in-browser,`open-all-unread-in-browser`>> or <<open-all-unread-in-browser-and-mark-read,`open-all-unread-in-browser-and-mark-read`>> commands.||max-browser-tabs 4
 max-download-speed||<number>||0||If set to a number greater than 0, the download speed per download is set to that limit (in KB/s).||max-download-speed 50
-max-items||<number>||0||Set the number of articles to maximally keep per feed. If the number is set to 0, then all articles are kept.||max-items 100
+max-items||<number>||0||Set the maximum number of articles a feed can contain. When the threshold is crossed, old articles are dropped. If the number is set to 0, then all articles are kept.||max-items 100
 miniflux-login||<username>||""||Sets the username for use with Miniflux.||miniflux-login "admin"
 miniflux-min-items||<number>||100||This variable sets the number of articles that are loaded from Miniflux per feed.||miniflux-min-items 20
 miniflux-password||<password>||""||Configures the password for use with Miniflux. Double quotes and backslashes within it <<#_using_double_quotes,should be escaped>>.||miniflux-password "here_goesAquote:\""


### PR DESCRIPTION
This replaces the confusing "per feed" wording, and makes it clear that the setting applies to any feed.

Prompted by
https://github.com/newsboat/newsboat/issues/164#issuecomment-1767484954. @Vinfall, can you please take a look and tell me what you think of this?