### PR TITLE
Log timing information for reloading individual feeds

### DIFF
--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -232,7 +232,7 @@ Feed Parser::parse_url(const std::string& url,
 	}
 
 	const std::string buf = curlDataReceiver->get_data();
-	LOG(Level::INFO,
+	LOG(Level::DEBUG,
 		"Parser::parse_url: retrieved data for %s: %s",
 		url,
 		buf);


### PR DESCRIPTION
Got inspired to add this by a question on our IRC channel.
This turned out not to be useful in that case, but might still be useful for other users to find/debug slow reloads.

Example output:
```
$ grep 'ScopeMeasure: function `Reloader::reload\|Reloader::reload: starting reload of' newsboat_2023-10-28_11.00.12.log
[2023-10-28 11:00:13] INFO: Reloader::reload: starting reload of https://newsboat.org/news.atom
[2023-10-28 11:00:13] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start retrieving') took 0.005880 s so far
[2023-10-28 11:00:14] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start parsing') took 0.236893 s so far
[2023-10-28 11:00:14] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start replacing feed') took 0.251727 s so far
[2023-10-28 11:00:14] DEBUG: ScopeMeasure: function `Reloader::reload' took 0.274651 s
[2023-10-28 11:00:14] INFO: Reloader::reload: starting reload of https://www.archlinux.org/feeds/news/
[2023-10-28 11:00:14] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start retrieving') took 0.002085 s so far
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start parsing') took 0.944123 s so far
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start replacing feed') took 0.944998 s so far
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' took 0.949789 s
[2023-10-28 11:00:15] INFO: Reloader::reload: starting reload of https://archaeo.social/@Minimus.rss
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start retrieving') took 0.001600 s so far
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start parsing') took 0.463406 s so far
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start replacing feed') took 0.500435 s so far
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' took 0.511655 s
[2023-10-28 11:00:15] INFO: Reloader::reload: starting reload of https://www.youtube.com/feeds/videos.xml?channel_id=UCsU15yvILBmnHPeAf4SFVaQ
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start retrieving') took 0.002084 s so far
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start parsing') took 0.051783 s so far
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start replacing feed') took 0.053685 s so far
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' took 0.063865 s
[2023-10-28 11:00:15] INFO: Reloader::reload: starting reload of https://blog.wolfram.com/feed/
[2023-10-28 11:00:15] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start retrieving') took 0.002765 s so far
[2023-10-28 11:00:16] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start parsing') took 0.790293 s so far
[2023-10-28 11:00:16] DEBUG: ScopeMeasure: function `Reloader::reload' (stop over `start replacing feed') took 0.794794 s so far
[2023-10-28 11:00:16] DEBUG: ScopeMeasure: function `Reloader::reload' took 0.816735 s
[2023-10-28 11:00:16] DEBUG: ScopeMeasure: function `Reloader::reload_all' took 2.624459 s
```