### PR TITLE
Deduplicate textview movement handling

### DIFF
--- a/include/formaction.h
+++ b/include/formaction.h
@@ -14,6 +14,7 @@ namespace newsboat {
 
 class ConfigContainer;
 class RssFeed;
+class TextviewWidget;
 class View;
 
 typedef std::pair<std::string, std::string> QnaPair;
@@ -126,6 +127,7 @@ protected:
 	void handle_parsed_command(const Command& command);
 
 	bool handle_list_operations(ListWidget& list, Operation op);
+	bool handle_textview_operations(TextviewWidget& textview, Operation op);
 
 	View* v;
 	ConfigContainer* cfg;

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -12,6 +12,7 @@
 #include "logger.h"
 #include "matcherexception.h"
 #include "strprintf.h"
+#include "textviewwidget.h"
 #include "utils.h"
 #include "view.h"
 
@@ -368,6 +369,39 @@ bool FormAction::handle_list_operations(ListWidget& list, Operation op)
 		return false;
 	}
 	return false;
+}
+
+bool FormAction::handle_textview_operations(TextviewWidget& textview, Operation op)
+{
+	switch (op) {
+	case OP_SK_UP:
+		textview.scroll_up();
+		break;
+	case OP_SK_DOWN:
+		textview.scroll_down();
+		break;
+	case OP_SK_HOME:
+		textview.scroll_to_top();
+		break;
+	case OP_SK_END:
+		textview.scroll_to_bottom();
+		break;
+	case OP_SK_PGUP:
+		textview.scroll_page_up();
+		break;
+	case OP_SK_PGDOWN:
+		textview.scroll_page_down();
+		break;
+	case OP_SK_HALF_PAGE_UP:
+		textview.scroll_halfpage_up();
+		break;
+	case OP_SK_HALF_PAGE_DOWN:
+		textview.scroll_halfpage_down();
+		break;
+	default:
+		return false;
+	}
+	return true;
 }
 
 bool FormAction::handle_single_argument_set(std::string argument)

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -34,30 +34,6 @@ bool HelpFormAction::process_operation(Operation op,
 {
 	bool hardquit = false;
 	switch (op) {
-	case OP_SK_UP:
-		textview.scroll_up();
-		break;
-	case OP_SK_DOWN:
-		textview.scroll_down();
-		break;
-	case OP_SK_HOME:
-		textview.scroll_to_top();
-		break;
-	case OP_SK_END:
-		textview.scroll_to_bottom();
-		break;
-	case OP_SK_PGUP:
-		textview.scroll_page_up();
-		break;
-	case OP_SK_PGDOWN:
-		textview.scroll_page_down();
-		break;
-	case OP_SK_HALF_PAGE_UP:
-		textview.scroll_halfpage_up();
-		break;
-	case OP_SK_HALF_PAGE_DOWN:
-		textview.scroll_halfpage_down();
-		break;
 	case OP_QUIT:
 		quit = true;
 		break;
@@ -75,6 +51,9 @@ bool HelpFormAction::process_operation(Operation op,
 		do_redraw = true;
 		break;
 	default:
+		if (handle_textview_operations(textview, op)) {
+			break;
+		}
 		break;
 	}
 	if (hardquit) {

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -182,30 +182,6 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 
 	switch (op) {
-	case OP_SK_UP:
-		textview.scroll_up();
-		break;
-	case OP_SK_DOWN:
-		textview.scroll_down();
-		break;
-	case OP_SK_HOME:
-		textview.scroll_to_top();
-		break;
-	case OP_SK_END:
-		textview.scroll_to_bottom();
-		break;
-	case OP_SK_PGUP:
-		textview.scroll_page_up();
-		break;
-	case OP_SK_PGDOWN:
-		textview.scroll_page_down();
-		break;
-	case OP_SK_HALF_PAGE_UP:
-		textview.scroll_halfpage_up();
-		break;
-	case OP_SK_HALF_PAGE_DOWN:
-		textview.scroll_halfpage_down();
-		break;
 	case OP_TOGGLESOURCEVIEW:
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: toggling source view");
 		show_source = !show_source;
@@ -497,6 +473,9 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 	break;
 	default:
+		if (handle_textview_operations(textview, op)) {
+			break;
+		}
 		break;
 	}
 


### PR DESCRIPTION
Deduplicate movement handling to make it a bit easier to extend the list of movement options (like https://github.com/newsboat/newsboat/issues/215, although that issue is about lists instead of textviews).