### PR TITLE
Make newsboat/podboat logfile handling consistent; document behaviour

### DIFF
--- a/doc/manpage-newsboat.asciidoc
+++ b/doc/manpage-newsboat.asciidoc
@@ -71,8 +71,10 @@ the _urls_ file).
        commands are _reload_ and _print-unread_.
 
 *-l* _loglevel_, *--log-level*=_loglevel_::
-       Generate a logfile with a certain _loglevel_. Valid loglevels are 1 to 6. An
-       actual logfile will only be written when you provide a logfile name.
+       Generate a logfile with a certain _loglevel_ (valid values: 1 to 6, for user error,
+       critical, error, warning, info, and debug respectively).
+       Filename can be specified using the *--log-file* option. If not specified,
+       a filename is generated of the form newsboat_<date-time>.log
 
 *-d* _logfile_, *--log-file*=_logfile_::
        Use this _logfile_ as output when logging debug messages. Please note that this

--- a/doc/manpage-podboat.asciidoc
+++ b/doc/manpage-podboat.asciidoc
@@ -34,8 +34,10 @@ can then be download with _Podboat_.
        Start automatic download of all queued files on startup
 
 *-l* _loglevel_, *--log-level*=_loglevel_::
-       Generate a logfile with a certain _loglevel_. Valid loglevels are 1 to 6. An
-       actual logfile will only be written when you provide a logfile name.
+       Generate a logfile with a certain _loglevel_ (valid values: 1 to 6, for user error,
+       critical, error, warning, info, and debug respectively).
+       Filename can be specified using the *--log-file* option. If not specified,
+       a filename is generated of the form podboat_<date-time>.log
 
 *-d* _logfile_, *--log-file*=_logfile_::
        Use this _logfile_ as output when logging debug messages. Please note that this

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -14,6 +14,7 @@
 #include <thread>
 #include <unistd.h>
 
+#include "3rd-party/optional.hpp"
 #include "config.h"
 #include "configcontainer.h"
 #include "configexception.h"
@@ -189,6 +190,8 @@ void PbController::initialize(int argc, char* argv[])
 		{"version", no_argument, 0, 'v'},
 		{0, 0, 0, 0}
 	};
+	nonstd::optional<Level> log_level;
+	nonstd::optional<std::string> log_file;
 
 	while ((c = ::getopt_long(argc, argv, getopt_str, longopts, nullptr)) !=
 		-1) {
@@ -207,17 +210,15 @@ void PbController::initialize(int argc, char* argv[])
 			automatic_dl = true;
 			break;
 		case 'd':
-			logger::set_logfile(optarg);
+			log_file = optarg;
 			break;
 		case 'l': {
-			Level l = static_cast<Level>(atoi(optarg));
-			if (l >= Level::USERERROR && l <= Level::DEBUG) {
-				logger::set_loglevel(l);
-			} else {
+			log_level = static_cast<Level>(atoi(optarg));
+			if (log_level < Level::USERERROR || log_level > Level::DEBUG) {
 				std::cerr << strprintf::fmt(_("%s: %d: invalid "
 							"loglevel value"),
 						argv[0],
-						static_cast<int>(l))
+						static_cast<int>(log_level.value()))
 					<< std::endl;
 				exit(EXIT_FAILURE);
 			}
@@ -228,6 +229,21 @@ void PbController::initialize(int argc, char* argv[])
 			exit(EXIT_SUCCESS);
 		}
 	};
+
+	if (log_level.has_value()) {
+		logger::set_loglevel(log_level.value());
+	}
+
+	if (log_file.has_value()) {
+		logger::set_logfile(log_file.value());
+	}
+
+	if (!log_file.has_value() && log_level.has_value()) {
+		const std::string date_time_string = utils::mt_strf_localtime("%Y-%m-%d_%H.%M.%S",
+				std::time(nullptr));
+		const std::string filename = "podboat_" + date_time_string + ".log";
+		logger::set_logfile(filename);
+	}
 
 	std::cout << strprintf::fmt(
 			_("Starting %s %s..."), "Podboat", utils::program_version())
@@ -346,9 +362,8 @@ void PbController::print_usage(const char* argv0)
 			'l',
 			"log-level",
 			_s("<loglevel>"),
-			_s("write a log with a certain loglevel (valid values: "
-				"1 to "
-				"6)")
+			_s("write a log with a certain log level (valid values: 1 to 6,"
+				" for user error, critical, error, warning, info, and debug respectively)")
 		},
 		{
 			'd',


### PR DESCRIPTION
https://github.com/newsboat/newsboat/pull/2324 documented the different log-levels for newsboat. It also introduced automatic generation of a filename if `--log-level` was specified without `--log-file`.
This PR applies the same changes to podboat and updates both manpages.