### PR TITLE
Drop `once_cell` dependency in favor of built-in OnceCell/OnceLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,6 @@ dependencies = [
  "md5",
  "natord",
  "nom",
- "once_cell",
  "percent-encoding",
  "proptest",
  "regex-rs",

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -9,7 +9,6 @@ strprintf = { path="../strprintf" }
 regex-rs = { path="../regex-rs" }
 
 fastrand = "2.0.0"
-once_cell = "1.18.0"
 url = "2.5.0"
 percent-encoding = "2.3.1"
 xdg = "2.5.2"

--- a/rust/libnewsboat/src/filterparser.rs
+++ b/rust/libnewsboat/src/filterparser.rs
@@ -10,8 +10,8 @@ use nom::{
     sequence::{delimited, separated_pair, terminated, tuple},
     IResult, Offset, Parser,
 };
-use once_cell::unsync::OnceCell;
 use regex_rs::Regex;
+use std::cell::OnceCell;
 use std::vec::Vec;
 use strprintf::fmt;
 

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -1,12 +1,12 @@
 //! Keeps a record of what the program did.
 
 use chrono::{offset::Local, Datelike, Timelike};
-use once_cell::sync::OnceCell;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::sync::atomic::{AtomicIsize, Ordering};
 use std::sync::Mutex;
+use std::sync::OnceLock;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 /// "Importance levels" for log messages.
@@ -268,7 +268,7 @@ impl Default for Logger {
     }
 }
 
-static GLOBAL_LOGGER: OnceCell<Logger> = OnceCell::new();
+static GLOBAL_LOGGER: OnceLock<Logger> = OnceLock::new();
 
 /// Returns a global logger instance.
 ///


### PR DESCRIPTION
Rust 1.70 stabilized `OnceCell` and `OnceLock` in the standard library: https://github.com/rust-lang/rust/pull/105587/

This probably obsoletes https://github.com/newsboat/newsboat/pull/2610