### PR TITLE
Update overview of title formats

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1119,9 +1119,9 @@ title text may vary unless you customize it.
 [frame="all", grid="all", format="dsv", options="header", cols="20,30,50l"]
 |==========================================================================
 Dialog:Configuration Variable:Default Value
-Feed List:<<feedlist-title-format,+feedlist-title-format+>>:%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter `%F'&?%?T? - tag `%T'&?
-Article List:<<articlelist-title-format,+articlelist-title-format+>>:%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter `%F'&? - %U
-Search Result:<<searchresult-title-format,+searchresult-title-format+>>:%N %V - Search results for '%s' (%u unread, %t total)%?F? matching filter `%F'&?
+Feed List:<<feedlist-title-format,+feedlist-title-format+>>:%N %V - %?F?Feeds&Your feeds? (%u unread, %t total)%?F? matching filter '%F'&?%?T? - tag '%T'&?
+Article List:<<articlelist-title-format,+articlelist-title-format+>>:%N %V - Articles in feed '%T' (%u unread, %t total)%?F? matching filter '%F'&? - %U
+Search Result:<<searchresult-title-format,+searchresult-title-format+>>:%N %V - Search results for '%s' (%u unread, %t total)%?F? matching filter '%F'&?
 File Browser:<<filebrowser-title-format,+filebrowser-title-format+>>:%N %V - %?O?Open File&Save File? - %f
 Directory Browser:<<dirbrowser-title-format,+dirbrowser-title-format+>>:%N %V - %?O?Open Directory&Save File? - %f
 Help:<<help-title-format,+help-title-format+>>:%N %V - Help


### PR DESCRIPTION
The documentation specifies the title format defaults in two different locations.
One of those locations was missed when removing backticks from those formats in https://github.com/newsboat/newsboat/pull/1572.
Resolves https://github.com/newsboat/newsboat/issues/2625