### PR TITLE
Switch all our crates to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = [
     "rust/strprintf",
     "rust/regex-rs",
 ]
+resolver = "2"

--- a/rust/libnewsboat-ffi/Cargo.toml
+++ b/rust/libnewsboat-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libnewsboat-ffi"
 version = "2.34.0"
 authors = ["Alexander Batischev <eual.jp@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libnewsboat = { path="../libnewsboat" }

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libnewsboat"
 version = "2.34.0"
 authors = ["Alexander Batischev <eual.jp@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 strprintf = { path="../strprintf" }

--- a/rust/regex-rs/Cargo.toml
+++ b/rust/regex-rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "regex-rs"
 version = "0.1.0"
 authors = ["Alexander Batischev <eual.jp@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust/strprintf/Cargo.toml
+++ b/rust/strprintf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "strprintf"
 version = "0.1.0"
 authors = ["Alexander Batischev <eual.jp@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
There are no changes to the code: `cargo fix --edition` and `cargo fix --edition-idioms` did nothing. I guess this is expected because I don't see anything that'd be particularly relevant to us in the edition guide[1].

1. https://doc.rust-lang.org/edition-guide/rust-2021/index.html