### PR TITLE
CI: update to Rust 1.75.0

### DIFF
--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.74.1 by default.
+# and Rust 1.75.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-8
-# - rust_version -- Rust version to install. Default: 1.74.1
+# - rust_version -- Rust version to install. Default: 1.75.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-8
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.74.1
+ARG rust_version=1.75.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -82,7 +82,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain 1.74.1 \
+        --default-toolchain 1.75.0 \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 9 and Rust 1.74.1 by default.
+# compilers. Contains GCC 9 and Rust 1.75.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.74.1
+# - rust_version -- Rust version to install. Default: 1.75.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -91,7 +91,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.74.1
+ARG rust_version=1.75.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_22.04-build-tools.dockerfile
+++ b/docker/ubuntu_22.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 12 and Rust 1.74.1 by default.
+# compilers. Contains GCC 12 and Rust 1.75.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-12
-# - rust_version -- Rust version to install. Default: 1.74.1
+# - rust_version -- Rust version to install. Default: 1.75.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-12
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -92,7 +92,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.74.1
+ARG rust_version=1.75.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_23.10-build-tools.dockerfile
+++ b/docker/ubuntu_23.10-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 13 and Rust 1.74.1 by default.
+# compilers. Contains GCC 13 and Rust 1.75.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-13
-# - rust_version -- Rust version to install. Default: 1.74.1
+# - rust_version -- Rust version to install. Default: 1.75.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-13
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -49,7 +49,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.74.1
+ARG rust_version=1.75.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/rust/libnewsboat/src/cliargsparser.rs
+++ b/rust/libnewsboat/src/cliargsparser.rs
@@ -260,7 +260,7 @@ impl CliArgsParser {
         let mut args = CliArgsParser::default();
 
         if let Some(program_name) = opts
-            .get(0)
+            .first()
             .map(|program_name| program_name.to_string_lossy().into_owned())
         {
             args.program_name = program_name;


### PR DESCRIPTION
This only required a small fix for
https://rust-lang.github.io/rust-clippy/master/index.html#/get_first