### PR TITLE
Split key bindings and events into a base key with some modifiers (shift, control, alt)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,8 @@ doc/example-config: doc/gen-example-config doc/configcommands.dsv
 fmt:
 	astyle --project \
 		*.cpp doc/*.cpp include/*.h rss/*.h rss/*.cpp src/*.cpp \
-		test/*.cpp test/test_helpers/*.h test/test_helpers/*.cpp
+		test/*.cpp test/test_helpers/*.h test/test_helpers/*.cpp \
+		test/test_helpers/stringmaker/*.h
 	$(CARGO) fmt
 	# We reset the locale to make the sorting reproducible.
 	LC_ALL=C sort -t '|' -k 1,1 -o doc/configcommands.dsv doc/configcommands.dsv

--- a/include/keycombination.h
+++ b/include/keycombination.h
@@ -1,0 +1,33 @@
+#ifndef NEWSBOAT_KEYCOMBINATION_H_
+#define NEWSBOAT_KEYCOMBINATION_H_
+
+#include <ostream>
+#include <string>
+
+namespace newsboat {
+
+class KeyCombination {
+public:
+	KeyCombination(const std::string& key, bool shift, bool control, bool alt);
+
+	static KeyCombination from_bindkey(const std::string& input);
+	std::string to_bindkey_string() const;
+
+	bool operator==(const KeyCombination& other) const;
+	bool operator<(const KeyCombination& rhs) const;
+
+	std::string get_key() const;
+	bool has_shift() const;
+	bool has_control() const;
+	bool has_alt() const;
+
+private:
+	std::string key;
+	bool shift;
+	bool control;
+	bool alt;
+};
+
+} // namespace newsboat
+
+#endif /* NEWSBOAT_KEYCOMBINATION_H_ */

--- a/include/keycombination.h
+++ b/include/keycombination.h
@@ -6,10 +6,27 @@
 
 namespace newsboat {
 
+enum class ShiftState {
+	Shift,
+	NoShift,
+};
+
+enum class ControlState {
+	Control,
+	NoControl,
+};
+
+enum class AltState {
+	Alt,
+	NoAlt,
+};
+
 class KeyCombination {
 public:
-	explicit KeyCombination(const std::string& key, bool shift = false, bool control = false,
-		bool alt = false);
+	explicit KeyCombination(const std::string& key,
+		ShiftState shift = ShiftState::NoShift,
+		ControlState control = ControlState::NoControl,
+		AltState alt = AltState::NoAlt);
 
 	static KeyCombination from_bindkey(const std::string& input);
 	std::string to_bindkey_string() const;
@@ -24,9 +41,9 @@ public:
 
 private:
 	std::string key;
-	bool shift;
-	bool control;
-	bool alt;
+	ShiftState shift;
+	ControlState control;
+	AltState alt;
 };
 
 } // namespace newsboat

--- a/include/keycombination.h
+++ b/include/keycombination.h
@@ -8,7 +8,8 @@ namespace newsboat {
 
 class KeyCombination {
 public:
-	KeyCombination(const std::string& key, bool shift, bool control, bool alt);
+	explicit KeyCombination(const std::string& key, bool shift = false, bool control = false,
+		bool alt = false);
 
 	static KeyCombination from_bindkey(const std::string& input);
 	std::string to_bindkey_string() const;

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "configactionhandler.h"
+#include "keycombination.h"
 
 // in configuration: bind-key <key> <operation>
 
@@ -204,7 +205,7 @@ public:
 		const std::string& params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;
 	std::vector<KeyMapDesc> get_keymap_descriptions(std::string context);
-	const std::map<std::string, MacroBinding>& get_macro_descriptions();
+	const std::map<KeyCombination, MacroBinding>& get_macro_descriptions();
 
 	ParsedOperations parse_operation_sequence(const std::string& line,
 		const std::string& command_name, bool allow_description = true);
@@ -219,7 +220,7 @@ private:
 	std::map<std::string, Operation> get_internal_operations() const;
 	std::string getopname(Operation op) const;
 	std::map<std::string, std::map<std::string, Operation>> keymap_;
-	std::map<std::string, MacroBinding> macros_;
+	std::map<KeyCombination, MacroBinding> macros_;
 	std::vector<MacroCmd> startup_operations_sequence;
 };
 

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -217,9 +217,9 @@ public:
 private:
 	bool is_valid_context(const std::string& context);
 	unsigned short get_flag_from_context(const std::string& context);
-	std::map<std::string, Operation> get_internal_operations() const;
+	std::map<KeyCombination, Operation> get_internal_operations() const;
 	std::string getopname(Operation op) const;
-	std::map<std::string, std::map<std::string, Operation>> keymap_;
+	std::map<std::string, std::map<KeyCombination, Operation>> keymap_;
 	std::map<KeyCombination, MacroBinding> macros_;
 	std::vector<MacroCmd> startup_operations_sequence;
 };

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -198,7 +198,7 @@ public:
 	Operation get_opcode(const std::string& opstr);
 	Operation get_operation(const KeyCombination& key_combination,
 		const std::string& context);
-	std::vector<MacroCmd> get_macro(const std::string& key);
+	std::vector<MacroCmd> get_macro(const KeyCombination& key_combination);
 	char get_key(const std::string& keycode);
 	std::vector<std::string> get_keys(Operation op, const std::string& context);
 	void handle_action(const std::string& action,

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -196,7 +196,7 @@ public:
 	void unset_key(const std::string& key, const std::string& context);
 	void unset_all_keys(const std::string& context);
 	Operation get_opcode(const std::string& opstr);
-	Operation get_operation(const std::string& keycode,
+	Operation get_operation(const KeyCombination& key_combination,
 		const std::string& context);
 	std::vector<MacroCmd> get_macro(const std::string& key);
 	char get_key(const std::string& keycode);

--- a/mk/libboat.deps
+++ b/mk/libboat.deps
@@ -8,6 +8,7 @@ src/exception.cpp
 src/fmtstrformatter.cpp
 src/fslock.cpp
 src/history.cpp
+src/keycombination.cpp
 src/keymap.cpp
 src/matcher.cpp
 src/matcherexception.cpp

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -160,7 +160,7 @@ void HelpFormAction::prepare()
 			listfmt.add_line("");
 
 			for (const auto& macro : macros) {
-				const std::string key = macro.first;
+				const std::string key = macro.first.to_bindkey_string();
 				const std::string description = macro.second.description;
 
 				// "macro-prefix" is not translated because it refers to an operation name

--- a/src/keycombination.cpp
+++ b/src/keycombination.cpp
@@ -1,0 +1,82 @@
+#include "keycombination.h"
+
+#include <locale>
+#include <tuple>
+
+namespace newsboat {
+
+KeyCombination::KeyCombination(const std::string& key, bool shift, bool control, bool alt)
+	: key(key)
+	, shift(shift)
+	, control(control)
+	, alt(alt)
+{
+}
+
+KeyCombination KeyCombination::from_bindkey(const std::string& input)
+{
+	std::string key = input;
+	bool shift = false;
+	bool control = false;
+	bool alt = false;
+
+	if (key.length() == 1 && std::isupper(key[0])) {
+		shift = true;
+		key = std::tolower(key[0]);
+	}
+	if (key.length() == 2 && key[0] == '^') {
+		control = true;
+		key = std::tolower(key[1]);
+	}
+	return KeyCombination(key, shift, control, alt);
+}
+
+std::string KeyCombination::to_bindkey_string() const
+{
+	std::string output = key;
+	if (control && output.length() == 1) {
+		output = std::string("^") + static_cast<char>(std::toupper(output[0]));
+	}
+	if (shift && output.length() == 1) {
+		output = std::toupper(output[0]);
+	}
+	return output;
+}
+
+bool KeyCombination::operator==(const KeyCombination& other) const
+{
+	return key == other.key
+		&& shift == other.shift
+		&& control == other.control
+		&& alt == other.alt;
+}
+
+bool KeyCombination::operator<(const KeyCombination& rhs) const
+{
+	return std::tie(key, shift, control, alt)
+		< std::tie(rhs.key, rhs.shift, rhs.control, rhs.alt);
+}
+
+std::string KeyCombination::get_key() const
+{
+	return key;
+}
+
+bool KeyCombination::has_shift() const
+{
+	return shift;
+}
+
+bool KeyCombination::has_control() const
+{
+	return control;
+}
+
+bool KeyCombination::has_alt() const
+{
+	return alt;
+}
+
+
+
+} // namespace newsboat

--- a/src/keycombination.cpp
+++ b/src/keycombination.cpp
@@ -5,7 +5,8 @@
 
 namespace newsboat {
 
-KeyCombination::KeyCombination(const std::string& key, bool shift, bool control, bool alt)
+KeyCombination::KeyCombination(const std::string& key, ShiftState shift,
+	ControlState control, AltState alt)
 	: key(key)
 	, shift(shift)
 	, control(control)
@@ -16,15 +17,15 @@ KeyCombination::KeyCombination(const std::string& key, bool shift, bool control,
 KeyCombination KeyCombination::from_bindkey(const std::string& input)
 {
 	std::string key = input;
-	bool shift = false;
-	bool control = false;
-	bool alt = false;
+	ShiftState shift = ShiftState::NoShift;
+	ControlState control = ControlState::NoControl;
+	AltState alt = AltState::NoAlt;
 
 	if (key.length() == 1 && std::isupper(key[0])) {
-		shift = true;
+		shift = ShiftState::Shift;
 		key = std::tolower(key[0]);
 	} else if (key.length() == 2 && key[0] == '^') {
-		control = true;
+		control = ControlState::Control;
 		key = std::tolower(key[1]);
 	}
 	return KeyCombination(key, shift, control, alt);
@@ -32,10 +33,9 @@ KeyCombination KeyCombination::from_bindkey(const std::string& input)
 
 std::string KeyCombination::to_bindkey_string() const
 {
-	if (control && key.length() == 1) {
+	if (control == ControlState::Control && key.length() == 1) {
 		return std::string("^") + static_cast<char>(std::toupper(key[0]));
-	}
-	else if (shift && key.length() == 1) {
+	} else if (shift == ShiftState::Shift && key.length() == 1) {
 		return std::string{static_cast<char>(std::toupper(key[0]))};
 	} else {
 		return key;
@@ -63,17 +63,17 @@ std::string KeyCombination::get_key() const
 
 bool KeyCombination::has_shift() const
 {
-	return shift;
+	return shift == ShiftState::Shift;
 }
 
 bool KeyCombination::has_control() const
 {
-	return control;
+	return control == ControlState::Control;
 }
 
 bool KeyCombination::has_alt() const
 {
-	return alt;
+	return alt == AltState::Alt;
 }
 
 } // namespace newsboat

--- a/src/keycombination.cpp
+++ b/src/keycombination.cpp
@@ -23,8 +23,7 @@ KeyCombination KeyCombination::from_bindkey(const std::string& input)
 	if (key.length() == 1 && std::isupper(key[0])) {
 		shift = true;
 		key = std::tolower(key[0]);
-	}
-	if (key.length() == 2 && key[0] == '^') {
+	} else if (key.length() == 2 && key[0] == '^') {
 		control = true;
 		key = std::tolower(key[1]);
 	}
@@ -33,14 +32,14 @@ KeyCombination KeyCombination::from_bindkey(const std::string& input)
 
 std::string KeyCombination::to_bindkey_string() const
 {
-	std::string output = key;
-	if (control && output.length() == 1) {
-		output = std::string("^") + static_cast<char>(std::toupper(output[0]));
+	if (control && key.length() == 1) {
+		return std::string("^") + static_cast<char>(std::toupper(key[0]));
 	}
-	if (shift && output.length() == 1) {
-		output = std::toupper(output[0]);
+	else if (shift && key.length() == 1) {
+		return std::string{static_cast<char>(std::toupper(key[0]))};
+	} else {
+		return key;
 	}
-	return output;
 }
 
 bool KeyCombination::operator==(const KeyCombination& other) const
@@ -76,7 +75,5 @@ bool KeyCombination::has_alt() const
 {
 	return alt;
 }
-
-
 
 } // namespace newsboat

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -550,7 +550,7 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 	return descs;
 }
 
-const std::map<std::string, MacroBinding>& KeyMap::get_macro_descriptions()
+const std::map<KeyCombination, MacroBinding>& KeyMap::get_macro_descriptions()
 {
 	return macros_;
 }
@@ -656,7 +656,7 @@ void KeyMap::dump_config(std::vector<std::string>& config_output) const
 	}
 	for (const auto& macro : macros_) {
 		std::string configline = "macro ";
-		configline.append(macro.first);
+		configline.append(macro.first.to_bindkey_string());
 		configline.append(" ");
 		for (unsigned int i = 0; i < macro.second.cmds.size(); ++i) {
 			const auto& cmd = macro.second.cmds[i];
@@ -750,7 +750,7 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 		if (!token.has_value() || cmds.empty()) {
 			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 		}
-		const std::string macrokey = token.value();
+		const auto macrokey = KeyCombination::from_bindkey(token.value());
 
 		macros_[macrokey] = {cmds, description};
 	} else if (action == "run-on-startup") {
@@ -820,8 +820,9 @@ std::vector<std::string> KeyMap::get_keys(Operation op,
 
 std::vector<MacroCmd> KeyMap::get_macro(const std::string& key)
 {
-	if (macros_.count(key) >= 1) {
-		return macros_.at(key).cmds;
+	const auto key_combination = KeyCombination::from_bindkey(key);
+	if (macros_.count(key_combination) >= 1) {
+		return macros_.at(key_combination).cmds;
 	}
 	return {};
 }

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -510,15 +510,16 @@ KeyMap::KeyMap(unsigned flags)
 			const std::string& context = ctx.first;
 			const std::uint32_t context_flag = ctx.second;
 			if ((op_desc.flags & (context_flag | KM_INTERNAL | KM_SYSKEYS))) {
-				keymap_[context][op_desc.default_key] = op_desc.op;
+				const auto key_combination = KeyCombination::from_bindkey(op_desc.default_key);
+				keymap_[context][key_combination] = op_desc.op;
 			}
 		}
 	}
 
-	keymap_["help"]["b"] = OP_SK_PGUP;
-	keymap_["help"]["SPACE"] = OP_SK_PGDOWN;
-	keymap_["article"]["b"] = OP_SK_PGUP;
-	keymap_["article"]["SPACE"] = OP_SK_PGDOWN;
+	keymap_["help"][KeyCombination::from_bindkey("b")] = OP_SK_PGUP;
+	keymap_["help"][KeyCombination::from_bindkey("SPACE")] = OP_SK_PGDOWN;
+	keymap_["article"][KeyCombination::from_bindkey("b")] = OP_SK_PGUP;
+	keymap_["article"][KeyCombination::from_bindkey("SPACE")] = OP_SK_PGDOWN;
 }
 
 std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
@@ -532,7 +533,7 @@ std::vector<KeyMapDesc> KeyMap::get_keymap_descriptions(std::string context)
 
 		bool bound_to_key = false;
 		for (const auto& keymap : keymap_[context]) {
-			const std::string& key = keymap.first;
+			const std::string& key = keymap.first.to_bindkey_string();
 			const Operation op = keymap.second;
 			if (opdesc.op == op) {
 				descs.push_back({key, opdesc.opstr, _(opdesc.help_text.c_str()), context, opdesc.flags});
@@ -562,24 +563,26 @@ void KeyMap::set_key(Operation op,
 	const std::string& context)
 {
 	LOG(Level::DEBUG, "KeyMap::set_key(%d,%s) called", op, key);
+	const auto key_combination = KeyCombination::from_bindkey(key);
 	if (context == "all") {
 		for (const auto& ctx : contexts) {
-			keymap_[ctx.first][key] = op;
+			keymap_[ctx.first][key_combination] = op;
 		}
 	} else {
-		keymap_[context][key] = op;
+		keymap_[context][key_combination] = op;
 	}
 }
 
 void KeyMap::unset_key(const std::string& key, const std::string& context)
 {
 	LOG(Level::DEBUG, "KeyMap::unset_key(%s) called", key);
+	const auto key_combination = KeyCombination::from_bindkey(key);
 	if (context == "all") {
 		for (const auto& ctx : contexts) {
-			keymap_[ctx.first][key] = OP_NIL;
+			keymap_[ctx.first][key_combination] = OP_NIL;
 		}
 	} else {
-		keymap_[context][key] = OP_NIL;
+		keymap_[context][key_combination] = OP_NIL;
 	}
 }
 
@@ -629,12 +632,13 @@ Operation KeyMap::get_operation(const std::string& keycode,
 		"KeyMap::get_operation: keycode = %s context = %s",
 		keycode,
 		context);
+	const auto key_combination = KeyCombination::from_bindkey(keycode);
 	if (keycode.length() > 0) {
 		key = keycode;
 	} else {
 		key = "NIL";
 	}
-	return keymap_[context][key];
+	return keymap_[context][key_combination];
 }
 
 void KeyMap::dump_config(std::vector<std::string>& config_output) const
@@ -645,7 +649,7 @@ void KeyMap::dump_config(std::vector<std::string>& config_output) const
 		for (const auto& keymap : x) {
 			if (keymap.second < OP_INT_MIN) {
 				std::string configline = "bind-key ";
-				configline.append(utils::quote(keymap.first));
+				configline.append(utils::quote(keymap.first.to_bindkey_string()));
 				configline.append(" ");
 				configline.append(getopname(keymap.second));
 				configline.append(" ");
@@ -812,7 +816,7 @@ std::vector<std::string> KeyMap::get_keys(Operation op,
 	std::vector<std::string> keys;
 	for (const auto& keymap : keymap_[context]) {
 		if (keymap.second == op) {
-			keys.push_back(keymap.first);
+			keys.push_back(keymap.first.to_bindkey_string());
 		}
 	}
 	return keys;
@@ -840,12 +844,13 @@ bool KeyMap::is_valid_context(const std::string& context)
 	return false;
 }
 
-std::map<std::string, Operation> KeyMap::get_internal_operations() const
+std::map<KeyCombination, Operation> KeyMap::get_internal_operations() const
 {
-	std::map<std::string, Operation> internal_ops;
+	std::map<KeyCombination, Operation> internal_ops;
 	for (const auto& opdesc : opdescs) {
 		if (opdesc.flags & KM_INTERNAL) {
-			internal_ops[opdesc.default_key] = opdesc.op;
+			const auto key_combination = KeyCombination::from_bindkey(opdesc.default_key);
+			internal_ops[key_combination] = opdesc.op;
 		}
 	}
 	return internal_ops;

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -624,20 +624,14 @@ char KeyMap::get_key(const std::string& keycode)
 	return 0;
 }
 
-Operation KeyMap::get_operation(const std::string& keycode,
+Operation KeyMap::get_operation(const KeyCombination& key_combination,
 	const std::string& context)
 {
 	std::string key;
 	LOG(Level::DEBUG,
 		"KeyMap::get_operation: keycode = %s context = %s",
-		keycode,
+		key_combination.to_bindkey_string(),
 		context);
-	const auto key_combination = KeyCombination::from_bindkey(keycode);
-	if (keycode.length() > 0) {
-		key = keycode;
-	} else {
-		key = "NIL";
-	}
 	return keymap_[context][key_combination];
 }
 

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -816,9 +816,8 @@ std::vector<std::string> KeyMap::get_keys(Operation op,
 	return keys;
 }
 
-std::vector<MacroCmd> KeyMap::get_macro(const std::string& key)
+std::vector<MacroCmd> KeyMap::get_macro(const KeyCombination& key_combination)
 {
-	const auto key_combination = KeyCombination::from_bindkey(key);
 	if (macros_.count(key_combination) >= 1) {
 		return macros_.at(key_combination).cmds;
 	}

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -125,7 +125,8 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			continue;
 		}
 
-		Operation op = keys.get_operation(event, "podboat");
+		const auto key_combination = KeyCombination::from_bindkey(event);
+		Operation op = keys.get_operation(key_combination, "podboat");
 
 		if (msg_line_dllist_form.get_text().length() > 0) {
 			msg_line_dllist_form.set_text("");
@@ -332,7 +333,8 @@ void PbView::run_help()
 			continue;
 		}
 
-		Operation op = keys.get_operation(event, "help");
+		const auto key_combination = KeyCombination::from_bindkey(event);
+		Operation op = keys.get_operation(key_combination, "help");
 
 		switch (op) {
 		case OP_SK_UP:

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -49,6 +49,7 @@ extern "C" {
 #include "itemlistformaction.h"
 #include "itemview.h"
 #include "itemviewformaction.h"
+#include "keycombination.h"
 #include "keymap.h"
 #include "logger.h"
 #include "matcherexception.h"
@@ -224,7 +225,8 @@ int View::run()
 				event);
 			run_commands(keys->get_macro(event));
 		} else {
-			const Operation op = keys->get_operation(event, fa->id());
+			const auto key_combination = KeyCombination::from_bindkey(event);
+			const Operation op = keys->get_operation(key_combination, fa->id());
 
 			LOG(Level::DEBUG,
 				"View::run: event = %s op = %u",
@@ -286,7 +288,8 @@ std::string View::run_modal(std::shared_ptr<FormAction> f,
 			continue;
 		}
 
-		Operation op = keys->get_operation(event, fa->id());
+		const auto key_combination = KeyCombination::from_bindkey(event);
+		Operation op = keys->get_operation(key_combination, fa->id());
 
 		if (OP_REDRAW == op) {
 			Stfl::reset();

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -217,15 +217,15 @@ int View::run()
 
 		LOG(Level::DEBUG, "View::run: event = %s", event);
 
+		const auto key_combination = KeyCombination::from_bindkey(event);
 		if (have_macroprefix) {
 			have_macroprefix = false;
 			status_line.show_message("");
 			LOG(Level::DEBUG,
 				"View::run: running macro `%s'",
 				event);
-			run_commands(keys->get_macro(event));
+			run_commands(keys->get_macro(key_combination));
 		} else {
-			const auto key_combination = KeyCombination::from_bindkey(event);
 			const Operation op = keys->get_operation(key_combination, fa->id());
 
 			LOG(Level::DEBUG,

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -255,14 +255,14 @@ TEST_CASE("Concatenates lines that end with a backslash", "[ConfigParser]")
 	KeyMap k(KM_NEWSBOAT);
 	cfgparser.register_handler("macro", k);
 	REQUIRE_NOTHROW(cfgparser.parse_file("data/config-multi-line"));
-	auto p_macro = k.get_macro("p");
+	auto p_macro = k.get_macro(KeyCombination("p"));
 	REQUIRE(!p_macro.empty());
 	REQUIRE(p_macro[0].op == newsboat::OP_OPEN);
 	REQUIRE(p_macro[1].op == newsboat::OP_RELOAD);
 	REQUIRE(p_macro[2].op == newsboat::OP_QUIT);
 	REQUIRE(p_macro[3].op == newsboat::OP_QUIT);
 
-	auto contrived = k.get_macro("j");
+	auto contrived = k.get_macro(KeyCombination("j"));
 	REQUIRE(!contrived.empty());
 	REQUIRE(contrived[0].op == newsboat::OP_QUIT);
 	REQUIRE(contrived[1].op == newsboat::OP_QUIT);

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -7,6 +7,7 @@
 #include "3rd-party/catch.hpp"
 
 #include "configexception.h"
+#include "keycombination.h"
 #include "keymap.h"
 #include "test_helpers/envvar.h"
 #include "test_helpers/tempfile.h"
@@ -182,7 +183,7 @@ TEST_CASE("evaluate_backticks replaces command in backticks with its output",
 		KeyMap keys(KM_NEWSBOAT);
 		cfgparser.register_handler("bind-key", keys);
 		REQUIRE_NOTHROW(cfgparser.parse_file("data/config-space-backticks"));
-		REQUIRE(keys.get_operation("s", "feedlist") == OP_SORT);
+		REQUIRE(keys.get_operation(KeyCombination("s"), "feedlist") == OP_SORT);
 	}
 
 	SECTION("Unbalanced backtick does *not* start a command") {

--- a/test/keycombination.cpp
+++ b/test/keycombination.cpp
@@ -1,0 +1,107 @@
+#include "keycombination.h"
+
+#include "3rd-party/catch.hpp"
+#include "test_helpers/stringmaker/keycombination.h"
+
+using namespace newsboat;
+
+TEST_CASE("KeyCombination parses bind-key key combinations", "[KeyCombination]")
+{
+	const auto check = [](const std::string& input, const std::string& key, bool shift,
+	bool control, bool alt) {
+		const auto key_combination = KeyCombination::from_bindkey(input);
+		REQUIRE(key_combination.get_key() == key);
+		REQUIRE(key_combination.has_shift() == shift);
+		REQUIRE(key_combination.has_control() == control);
+		REQUIRE(key_combination.has_alt() == alt);
+	};
+
+	check("a", "a", false, false, false);
+	check("A", "a", true, false, false);
+	check("^a", "a", false, true, false);
+	check("^A", "a", false, true, false);
+
+	check("<", "<", false, false, false);
+	check(">", ">", false, false, false);
+	check("ENTER", "ENTER", false, false, false);
+}
+
+TEST_CASE("KeyCombination can output bind-key styled strings", "[KeyCombination]")
+{
+	const auto check = [](const std::string& expected, const std::string& key, bool shift,
+	bool control) {
+		REQUIRE(KeyCombination(key, shift, control, false).to_bindkey_string() == expected);
+	};
+
+	check("a", "a", false, false);
+	check("A", "a", true, false);
+	check("^A", "a", false, true);
+	check("^A", "a", true, true);
+
+	check("ENTER", "ENTER", false, false);
+}
+
+TEST_CASE("KeyCombination equality operator", "[KeyCombination]")
+{
+	SECTION("KeyCombinations equal") {
+		REQUIRE(KeyCombination::from_bindkey("a")
+			== KeyCombination("a", false, false, false));
+		REQUIRE(KeyCombination("a", false, false, false)
+			== KeyCombination("a", false, false, false));
+		REQUIRE(KeyCombination("a", true, true, true)
+			== KeyCombination("a", true, true, true));
+	}
+
+	SECTION("KeyCombinations differ") {
+		REQUIRE_FALSE(KeyCombination::from_bindkey("a")
+			== KeyCombination("a", true, false, false));
+		REQUIRE_FALSE(KeyCombination::from_bindkey("a")
+			== KeyCombination("a", false, true, false));
+		REQUIRE_FALSE(KeyCombination::from_bindkey("a")
+			== KeyCombination("a", false, false, true));
+
+		REQUIRE_FALSE(KeyCombination::from_bindkey("^A")
+			== KeyCombination("a", true, true, false));
+		REQUIRE_FALSE(KeyCombination::from_bindkey("^A")
+			== KeyCombination("a", false, false, false));
+		REQUIRE_FALSE(KeyCombination::from_bindkey("^A")
+			== KeyCombination("a", false, true, true));
+
+		REQUIRE_FALSE(KeyCombination("a", false, false, false)
+			== KeyCombination("a", true, false, false));
+		REQUIRE_FALSE(KeyCombination("a", false, false, false)
+			== KeyCombination("a", false, true, false));
+		REQUIRE_FALSE(KeyCombination("a", false, false, false)
+			== KeyCombination("a", false, false, true));
+	}
+}
+
+TEST_CASE("KeyCombination less-than operator", "[KeyCombination]")
+{
+	SECTION("Consistent results") {
+		const auto check_smaller = [](const KeyCombination& lhs, const KeyCombination& rhs) {
+			REQUIRE(lhs < rhs);
+			REQUIRE_FALSE(rhs < lhs);
+		};
+
+		check_smaller(
+			KeyCombination("a", false, false, false),
+			KeyCombination("b", false, false, false));
+		check_smaller(
+			KeyCombination("a", false, false, false),
+			KeyCombination("a", true, false, false));
+		check_smaller(
+			KeyCombination("a", false, false, false),
+			KeyCombination("a", false, true, false));
+		check_smaller(
+			KeyCombination("a", false, false, false),
+			KeyCombination("a", false, false, true));
+	}
+
+	SECTION("Equal values") {
+		REQUIRE_FALSE(KeyCombination("a", false, false, false)
+			< KeyCombination("a", false, false, false));
+		REQUIRE_FALSE(KeyCombination("ENTER", true, true, true)
+			< KeyCombination("ENTER", true, true, true));
+	}
+}

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -20,7 +20,7 @@ TEST_CASE("get_operation()", "[KeyMap]")
 	KeyMap k(KM_NEWSBOAT);
 
 	REQUIRE(k.get_operation(KeyCombination("u"), "article") == OP_SHOWURLS);
-	REQUIRE(k.get_operation(KeyCombination("x", true), "feedlist") == OP_NIL);
+	REQUIRE(k.get_operation(KeyCombination("x", ShiftState::Shift), "feedlist") == OP_NIL);
 	REQUIRE(k.get_operation(KeyCombination(""), "feedlist") == OP_NIL);
 	REQUIRE(k.get_operation(KeyCombination("ENTER"), "feedlist") == OP_OPEN);
 

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -540,7 +540,7 @@ TEST_CASE("Regression test for https://github.com/newsboat/newsboat/issues/702",
 	SECTION("semicolon following quoted argument") {
 		k.handle_action("macro", R"(a set browser "firefox"; open-in-browser)");
 
-		const auto macros = k.get_macro("a");
+		const auto macros = k.get_macro(KeyCombination("a"));
 		REQUIRE(macros.size() == 2);
 		REQUIRE(macros[0].op == OP_INT_SET);
 		REQUIRE(macros[0].args == std::vector<std::string>({"browser", "firefox"}));
@@ -551,7 +551,7 @@ TEST_CASE("Regression test for https://github.com/newsboat/newsboat/issues/702",
 	SECTION("semicolon following unquoted argument") {
 		k.handle_action("macro", R"(b set browser firefox; open-in-browser)");
 
-		const auto macros = k.get_macro("b");
+		const auto macros = k.get_macro(KeyCombination("b"));
 		REQUIRE(macros.size() == 2);
 		REQUIRE(macros[0].op == OP_INT_SET);
 		REQUIRE(macros[0].args == std::vector<std::string>({"browser", "firefox"}));
@@ -562,7 +562,7 @@ TEST_CASE("Regression test for https://github.com/newsboat/newsboat/issues/702",
 	SECTION("semicolon following unquoted operation") {
 		k.handle_action("macro", R"(c open-in-browser; quit)");
 
-		const auto macros = k.get_macro("c");
+		const auto macros = k.get_macro(KeyCombination("c"));
 		REQUIRE(macros.size() == 2);
 		REQUIRE(macros[0].op == OP_OPENINBROWSER);
 		REQUIRE(macros[0].args == std::vector<std::string>({}));
@@ -576,7 +576,7 @@ TEST_CASE("Whitespace around semicolons in macros is optional", "[KeyMap]")
 	KeyMap k(KM_NEWSBOAT);
 
 	const auto check = [&k]() {
-		const auto macro = k.get_macro("x");
+		const auto macro = k.get_macro(KeyCombination("x"));
 
 		REQUIRE(macro.size() == 3);
 
@@ -630,7 +630,7 @@ TEST_CASE("It's not an error to have no operations before a semicolon in "
 		DYNAMIC_SECTION(op_list) {
 			k.handle_action("macro", "r " + op_list);
 
-			const auto macro = k.get_macro("r");
+			const auto macro = k.get_macro(KeyCombination("r"));
 			REQUIRE(macro.size() == 1);
 			REQUIRE(macro[0].op == OP_OPEN);
 			REQUIRE(macro[0].args == std::vector<std::string>({}));
@@ -648,7 +648,7 @@ TEST_CASE("Semicolons in operation's arguments don't break parsing of a macro",
 	k.handle_action("macro",
 		R"(x set browser "sleep 3; do-something ; echo hi"; open-in-browser)");
 
-	const auto macro = k.get_macro("x");
+	const auto macro = k.get_macro(KeyCombination("x"));
 	REQUIRE(macro.size() == 2);
 	REQUIRE(macro[0].op == OP_INT_SET);
 	REQUIRE(macro[0].args == std::vector<std::string>({"browser", "sleep 3; do-something ; echo hi"}));

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -6,6 +6,7 @@
 #include "3rd-party/catch.hpp"
 
 #include "confighandlerexception.h"
+#include "keycombination.h"
 
 using namespace newsboat;
 
@@ -18,14 +19,14 @@ TEST_CASE("get_operation()", "[KeyMap]")
 {
 	KeyMap k(KM_NEWSBOAT);
 
-	REQUIRE(k.get_operation("u", "article") == OP_SHOWURLS);
-	REQUIRE(k.get_operation("X", "feedlist") == OP_NIL);
-	REQUIRE(k.get_operation("", "feedlist") == OP_NIL);
-	REQUIRE(k.get_operation("ENTER", "feedlist") == OP_OPEN);
+	REQUIRE(k.get_operation(KeyCombination("u"), "article") == OP_SHOWURLS);
+	REQUIRE(k.get_operation(KeyCombination("x", true), "feedlist") == OP_NIL);
+	REQUIRE(k.get_operation(KeyCombination(""), "feedlist") == OP_NIL);
+	REQUIRE(k.get_operation(KeyCombination("ENTER"), "feedlist") == OP_OPEN);
 
 	SECTION("Returns OP_NIL after unset_key()") {
 		k.unset_key("ENTER", "all");
-		REQUIRE(k.get_operation("ENTER", "feedlist") == OP_NIL);
+		REQUIRE(k.get_operation(KeyCombination("ENTER"), "feedlist") == OP_NIL);
 	}
 }
 
@@ -33,16 +34,16 @@ TEST_CASE("unset_key() and set_key()", "[KeyMap]")
 {
 	KeyMap k(KM_NEWSBOAT);
 
-	REQUIRE(k.get_operation("ENTER", "feedlist") == OP_OPEN);
+	REQUIRE(k.get_operation(KeyCombination("ENTER"), "feedlist") == OP_OPEN);
 	REQUIRE(k.get_keys(OP_OPEN, "feedlist") == std::vector<std::string>({"ENTER"}));
 
 	SECTION("unset_key() removes the mapping") {
 		k.unset_key("ENTER", "all");
-		REQUIRE(k.get_operation("ENTER", "feedlist") == OP_NIL);
+		REQUIRE(k.get_operation(KeyCombination("ENTER"), "feedlist") == OP_NIL);
 
 		SECTION("set_key() sets the mapping") {
 			k.set_key(OP_OPEN, "ENTER", "all");
-			REQUIRE(k.get_operation("ENTER", "feedlist") == OP_OPEN);
+			REQUIRE(k.get_operation(KeyCombination("ENTER"), "feedlist") == OP_OPEN);
 			REQUIRE(k.get_keys(OP_OPEN, "feedlist") == std::vector<std::string>({"ENTER"}));
 		}
 	}

--- a/test/test_helpers/stringmaker/keycombination.h
+++ b/test/test_helpers/stringmaker/keycombination.h
@@ -1,0 +1,22 @@
+#ifndef NEWSBOAT_TEST_HELPERS_STRINGMAKER_KEYCOMBINATION_H_
+#define NEWSBOAT_TEST_HELPERS_STRINGMAKER_KEYCOMBINATION_H_
+
+#include "keycombination.h"
+#include "3rd-party/catch.hpp"
+
+namespace Catch {
+template<>
+struct StringMaker<newsboat::KeyCombination> {
+	static std::string convert(const newsboat::KeyCombination& key_combination)
+	{
+		return std::string("<")
+			+ (key_combination.has_control() ? "C-" : "")
+			+ (key_combination.has_shift() ? "S-" : "")
+			+ (key_combination.has_alt() ? "M-" : "")
+			+ key_combination.get_key()
+			+ ">";
+	}
+};
+}
+
+#endif /* NEWSBOAT_TEST_HELPERS_STRINGMAKER_KEYCOMBINATION_H_ */


### PR DESCRIPTION
STFL events currently are regular strings containing a key name, optionally prefixed with `^` (for the "control" modifier) or capitalized (for the "shift" modifier).
I expect a replacement for STFL might contain this information in a more structured way (a separate string for the key name and some flags to indicate active modifiers, e,g,: [Crossterm's `KeyEvent`](https://docs.rs/crossterm/latest/crossterm/event/struct.KeyEvent.html)).

I expect this PR makes it easier to move away from STFL and, at the time, easier to introduce the new `bind` option.