### PR TITLE
Use PathBuf on FFI (replacing `&str` and `String`)

### DIFF
--- a/include/cliargsparser.h
+++ b/include/cliargsparser.h
@@ -72,11 +72,11 @@ public:
 
 	nonstd::optional<Filepath> config_file() const;
 
-	nonstd::optional<std::string> queue_file() const;
+	nonstd::optional<Filepath> queue_file() const;
 
-	nonstd::optional<std::string> search_history_file() const;
+	nonstd::optional<Filepath> search_history_file() const;
 
-	nonstd::optional<std::string> cmdline_history_file() const;
+	nonstd::optional<Filepath> cmdline_history_file() const;
 
 	/// If non-empty, Newsboat should execute these commands and then quit.
 	///

--- a/include/configpaths.h
+++ b/include/configpaths.h
@@ -49,7 +49,7 @@ public:
 	// FIXME: this is actually a kludge that lets Controller change the path
 	// midway. That logic should be moved into ConfigPaths, and this method
 	// removed.
-	void set_cache_file(const std::string&);
+	void set_cache_file(const Filepath&);
 
 	/// Path to the config file.
 	Filepath config_file() const;

--- a/include/filepath.h
+++ b/include/filepath.h
@@ -36,7 +36,7 @@ public:
 	{
 	}
 
-	Filepath(rust::Box<filepath::bridged::PathBuf> rs_object)
+	Filepath(rust::Box<filepath::bridged::PathBuf>&& rs_object)
 		: rs_object(std::move(rs_object))
 	{
 	}

--- a/include/fslock.h
+++ b/include/fslock.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <sys/types.h>
 
+#include "filepath.h"
+
 namespace newsboat {
 
 class FsLock {
@@ -13,7 +15,7 @@ public:
 	FsLock();
 	~FsLock() = default;
 
-	bool try_lock(const std::string& lock_file, pid_t& pid,
+	bool try_lock(const Filepath& lock_file, pid_t& pid,
 		std::string& error_message);
 
 private:

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -10,9 +10,9 @@ fn add_cxxbridge(module: &str) {
 }
 
 fn main() {
+    add_cxxbridge("filepath");
     add_cxxbridge("cliargsparser");
     add_cxxbridge("configpaths");
-    add_cxxbridge("filepath");
     add_cxxbridge("fmtstrformatter");
     add_cxxbridge("fslock");
     add_cxxbridge("history");

--- a/rust/libnewsboat-ffi/src/cliargsparser.rs
+++ b/rust/libnewsboat-ffi/src/cliargsparser.rs
@@ -1,8 +1,10 @@
 use cxx::{type_id, ExternType};
 
+use crate::filepath::PathBuf;
 use libnewsboat::cliargsparser;
 use std::ffi::OsString;
 use std::os::unix::ffi::OsStringExt;
+use std::pin::Pin;
 
 // cxx doesn't allow to share types from other crates, so we have to wrap it
 // cf. https://github.com/dtolnay/cxx/issues/496
@@ -15,6 +17,13 @@ unsafe impl ExternType for CliArgsParser {
 
 #[cxx::bridge(namespace = "newsboat::cliargsparser::bridged")]
 mod bridged {
+    #[namespace = "newsboat::filepath::bridged"]
+    extern "C++" {
+        include!("libnewsboat-ffi/src/filepath.rs.h");
+
+        type PathBuf = crate::filepath::PathBuf;
+    }
+
     /// Shared data structure between C++/Rust. We need to do this, because
     /// Vec<Vec<T>> is an unsupported CXX type.
     struct BytesVec {
@@ -37,22 +46,25 @@ mod bridged {
         fn should_print_usage(cliargsparser: &CliArgsParser) -> bool;
         fn refresh_on_start(cliargsparser: &CliArgsParser) -> bool;
 
-        fn importfile(cliargsparser: &CliArgsParser) -> String;
+        fn importfile(cliargsparser: &CliArgsParser, mut file: Pin<&mut PathBuf>);
         fn program_name(cliargsparser: &CliArgsParser) -> String;
         fn display_msg(cliargsparser: &CliArgsParser) -> String;
 
         fn return_code(cliargsparser: &CliArgsParser, value: &mut isize) -> bool;
 
-        fn readinfo_import_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
-        fn readinfo_export_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
-        fn url_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
-        fn lock_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
-        fn cache_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
-        fn config_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
-        fn queue_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
-        fn search_history_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
-        fn cmdline_history_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
-        fn log_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool;
+        fn readinfo_import_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>)
+            -> bool;
+        fn readinfo_export_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>)
+            -> bool;
+        fn url_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool;
+        fn lock_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool;
+        fn cache_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool;
+        fn config_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool;
+        fn queue_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool;
+        fn search_history_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool;
+        fn cmdline_history_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>)
+            -> bool;
+        fn log_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool;
 
         fn cmds_to_execute(cliargsparser: &CliArgsParser) -> Vec<String>;
 
@@ -119,10 +131,10 @@ fn refresh_on_start(cliargsparser: &CliArgsParser) -> bool {
     cliargsparser.0.refresh_on_start
 }
 
-fn importfile(cliargsparser: &CliArgsParser) -> String {
+fn importfile(cliargsparser: &CliArgsParser, mut output: Pin<&mut PathBuf>) {
     match &cliargsparser.0.importfile {
-        Some(path) => path.to_string_lossy().to_string(),
-        None => String::new(),
+        Some(path) => output.0 = path.to_owned(),
+        None => output.0.clear(),
     }
 }
 
@@ -144,100 +156,100 @@ fn return_code(cliargsparser: &CliArgsParser, value: &mut isize) -> bool {
     }
 }
 
-fn readinfo_import_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn readinfo_import_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.readinfo_import_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,
     }
 }
 
-fn readinfo_export_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn readinfo_export_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.readinfo_export_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,
     }
 }
 
-fn url_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn url_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.url_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,
     }
 }
 
-fn lock_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn lock_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.lock_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,
     }
 }
 
-fn cache_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn cache_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.cache_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,
     }
 }
 
-fn config_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn config_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.config_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,
     }
 }
 
-fn queue_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn queue_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.queue_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,
     }
 }
 
-fn search_history_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn search_history_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.search_history_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,
     }
 }
 
-fn cmdline_history_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn cmdline_history_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.cmdline_history_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,
     }
 }
 
-fn log_file(cliargsparser: &CliArgsParser, path: &mut String) -> bool {
+fn log_file(cliargsparser: &CliArgsParser, mut path: Pin<&mut PathBuf>) -> bool {
     match &cliargsparser.0.log_file {
         Some(p) => {
-            *path = p.to_string_lossy().to_string();
+            path.0 = p.to_owned();
             true
         }
         None => false,

--- a/rust/libnewsboat-ffi/src/configpaths.rs
+++ b/rust/libnewsboat-ffi/src/configpaths.rs
@@ -1,6 +1,7 @@
 use crate::cliargsparser::CliArgsParser;
+use crate::filepath::PathBuf;
 use libnewsboat::configpaths;
-use std::path::Path;
+use std::pin::Pin;
 
 // cxx doesn't allow to share types from other crates, so we have to wrap it
 // cf. https://github.com/dtolnay/cxx/issues/496
@@ -12,6 +13,11 @@ mod bridged {
     extern "C++" {
         include!("libnewsboat-ffi/src/cliargsparser.rs.h");
         type CliArgsParser = crate::cliargsparser::CliArgsParser;
+    }
+    #[namespace = "newsboat::filepath::bridged"]
+    extern "C++" {
+        include!("libnewsboat-ffi/src/filepath.rs.h");
+        type PathBuf = crate::filepath::PathBuf;
     }
 
     extern "Rust" {
@@ -28,14 +34,14 @@ mod bridged {
 
         fn try_migrate_from_newsbeuter(configpaths: &mut ConfigPaths) -> bool;
 
-        fn url_file(configpaths: &ConfigPaths) -> String;
-        fn cache_file(configpaths: &ConfigPaths) -> String;
-        fn set_cache_file(configpaths: &mut ConfigPaths, path: &str);
-        fn config_file(configpaths: &ConfigPaths) -> String;
-        fn lock_file(configpaths: &ConfigPaths) -> String;
-        fn queue_file(configpaths: &ConfigPaths) -> String;
-        fn search_history_file(configpaths: &ConfigPaths) -> String;
-        fn cmdline_history_file(configpaths: &ConfigPaths) -> String;
+        fn url_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>);
+        fn cache_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>);
+        fn set_cache_file(configpaths: &mut ConfigPaths, path: &PathBuf);
+        fn config_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>);
+        fn lock_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>);
+        fn queue_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>);
+        fn search_history_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>);
+        fn cmdline_history_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>);
     }
 }
 
@@ -63,42 +69,34 @@ fn try_migrate_from_newsbeuter(configpaths: &mut ConfigPaths) -> bool {
     configpaths.0.try_migrate_from_newsbeuter()
 }
 
-fn url_file(configpaths: &ConfigPaths) -> String {
-    configpaths.0.url_file().to_string_lossy().into_owned()
+fn url_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>) {
+    path.0 = configpaths.0.url_file().to_owned();
 }
 
-fn cache_file(configpaths: &ConfigPaths) -> String {
-    configpaths.0.cache_file().to_string_lossy().into_owned()
+fn cache_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>) {
+    path.0 = configpaths.0.cache_file().to_owned();
 }
 
-fn set_cache_file(configpaths: &mut ConfigPaths, path: &str) {
-    configpaths.0.set_cache_file(Path::new(path).to_owned());
+fn set_cache_file(configpaths: &mut ConfigPaths, path: &PathBuf) {
+    configpaths.0.set_cache_file(path.0.to_owned());
 }
 
-fn config_file(configpaths: &ConfigPaths) -> String {
-    configpaths.0.config_file().to_string_lossy().into_owned()
+fn config_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>) {
+    path.0 = configpaths.0.config_file().to_owned();
 }
 
-fn lock_file(configpaths: &ConfigPaths) -> String {
-    configpaths.0.lock_file().to_string_lossy().into_owned()
+fn lock_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>) {
+    path.0 = configpaths.0.lock_file().to_owned();
 }
 
-fn queue_file(configpaths: &ConfigPaths) -> String {
-    configpaths.0.queue_file().to_string_lossy().into_owned()
+fn queue_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>) {
+    path.0 = configpaths.0.queue_file().to_owned();
 }
 
-fn search_history_file(configpaths: &ConfigPaths) -> String {
-    configpaths
-        .0
-        .search_history_file()
-        .to_string_lossy()
-        .into_owned()
+fn search_history_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>) {
+    path.0 = configpaths.0.search_history_file().to_owned();
 }
 
-fn cmdline_history_file(configpaths: &ConfigPaths) -> String {
-    configpaths
-        .0
-        .cmdline_history_file()
-        .to_string_lossy()
-        .into_owned()
+fn cmdline_history_file(configpaths: &ConfigPaths, mut path: Pin<&mut PathBuf>) {
+    path.0 = configpaths.0.cmdline_history_file().to_owned();
 }

--- a/rust/libnewsboat-ffi/src/logger.rs
+++ b/rust/libnewsboat-ffi/src/logger.rs
@@ -1,8 +1,16 @@
-use cxx::CxxString;
 use libnewsboat::logger;
+
+use crate::filepath::PathBuf;
+use cxx::CxxString;
 
 #[cxx::bridge(namespace = "newsboat::logger")]
 mod ffi {
+    #[namespace = "newsboat::filepath::bridged"]
+    extern "C++" {
+        include!("libnewsboat-ffi/src/filepath.rs.h");
+        type PathBuf = crate::filepath::PathBuf;
+    }
+
     // This has to be in sync with logger::Level in rust/libnewsboat/src/logger.rs
     enum Level {
         USERERROR = 1,
@@ -15,11 +23,11 @@ mod ffi {
 
     extern "Rust" {
         fn unset_loglevel();
-        fn set_logfile(logfile: &str);
+        fn set_logfile(logfile: &PathBuf);
         fn get_loglevel() -> i64;
         fn set_loglevel(level: Level);
         fn log_internal(level: Level, message: &CxxString);
-        fn set_user_error_logfile(user_error_logfile: &str);
+        fn set_user_error_logfile(user_error_logfile: &PathBuf);
     }
 }
 
@@ -39,8 +47,8 @@ fn unset_loglevel() {
     logger::get_instance().unset_loglevel();
 }
 
-fn set_logfile(logfile: &str) {
-    logger::get_instance().set_logfile(logfile);
+fn set_logfile(logfile: &PathBuf) {
+    logger::get_instance().set_logfile(&logfile.0);
 }
 
 fn get_loglevel() -> i64 {
@@ -57,6 +65,6 @@ fn log_internal(level: ffi::Level, message: &CxxString) {
     logger::get_instance().log_raw(level, message.as_bytes());
 }
 
-fn set_user_error_logfile(user_error_logfile: &str) {
-    logger::get_instance().set_user_error_logfile(user_error_logfile);
+fn set_user_error_logfile(user_error_logfile: &PathBuf) {
+    logger::get_instance().set_user_error_logfile(&user_error_logfile.0);
 }

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -52,23 +52,25 @@ bool CliArgsParser::do_cleanup() const
 
 Filepath CliArgsParser::importfile() const
 {
-	return std::string(newsboat::cliargsparser::bridged::importfile(*rs_object));
+	auto output = filepath::bridged::create_empty();
+	newsboat::cliargsparser::bridged::importfile(*rs_object, *output);
+	return output;
 }
 
 nonstd::optional<Filepath> CliArgsParser::readinfo_import_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::readinfo_import_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::readinfo_import_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }
 
 nonstd::optional<Filepath> CliArgsParser::readinfo_export_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::readinfo_export_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::readinfo_export_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }
@@ -119,63 +121,63 @@ bool CliArgsParser::refresh_on_start() const
 
 nonstd::optional<Filepath> CliArgsParser::url_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::url_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::url_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }
 
 nonstd::optional<Filepath> CliArgsParser::lock_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::lock_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::lock_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }
 
 nonstd::optional<Filepath> CliArgsParser::cache_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::cache_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::cache_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }
 
 nonstd::optional<Filepath> CliArgsParser::config_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::config_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::config_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }
 
-nonstd::optional<std::string> CliArgsParser::queue_file() const
+nonstd::optional<Filepath> CliArgsParser::queue_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::queue_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::queue_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }
 
-nonstd::optional<std::string> CliArgsParser::search_history_file() const
+nonstd::optional<Filepath> CliArgsParser::search_history_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::search_history_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::search_history_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }
 
-nonstd::optional<std::string> CliArgsParser::cmdline_history_file() const
+nonstd::optional<Filepath> CliArgsParser::cmdline_history_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::cmdline_history_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::cmdline_history_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }
@@ -195,9 +197,9 @@ const
 
 nonstd::optional<Filepath> CliArgsParser::log_file() const
 {
-	rust::String path;
-	if (newsboat::cliargsparser::bridged::log_file(*rs_object, path)) {
-		return std::string(path);
+	auto path = filepath::bridged::create_empty();
+	if (newsboat::cliargsparser::bridged::log_file(*rs_object, *path)) {
+		return path;
 	}
 	return nonstd::nullopt;
 }

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -61,7 +61,7 @@ nonstd::optional<Filepath> CliArgsParser::readinfo_import_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::readinfo_import_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }
@@ -70,7 +70,7 @@ nonstd::optional<Filepath> CliArgsParser::readinfo_export_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::readinfo_export_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }
@@ -123,7 +123,7 @@ nonstd::optional<Filepath> CliArgsParser::url_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::url_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }
@@ -132,7 +132,7 @@ nonstd::optional<Filepath> CliArgsParser::lock_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::lock_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }
@@ -141,7 +141,7 @@ nonstd::optional<Filepath> CliArgsParser::cache_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::cache_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }
@@ -150,7 +150,7 @@ nonstd::optional<Filepath> CliArgsParser::config_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::config_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }
@@ -159,7 +159,7 @@ nonstd::optional<Filepath> CliArgsParser::queue_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::queue_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }
@@ -168,7 +168,7 @@ nonstd::optional<Filepath> CliArgsParser::search_history_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::search_history_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }
@@ -177,7 +177,7 @@ nonstd::optional<Filepath> CliArgsParser::cmdline_history_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::cmdline_history_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }
@@ -199,7 +199,7 @@ nonstd::optional<Filepath> CliArgsParser::log_file() const
 {
 	auto path = filepath::bridged::create_empty();
 	if (newsboat::cliargsparser::bridged::log_file(*rs_object, *path)) {
-		return path;
+		return Filepath(std::move(path));
 	}
 	return nonstd::nullopt;
 }

--- a/src/configpaths.cpp
+++ b/src/configpaths.cpp
@@ -32,44 +32,58 @@ bool ConfigPaths::create_dirs() const
 	return newsboat::configpaths::bridged::create_dirs(*rs_object);
 }
 
-void ConfigPaths::set_cache_file(const std::string& new_cachefile)
+void ConfigPaths::set_cache_file(const Filepath& new_cachefile)
 {
 	newsboat::configpaths::bridged::set_cache_file(*rs_object, new_cachefile);
 }
 
 Filepath ConfigPaths::url_file() const
 {
-	return std::string(newsboat::configpaths::bridged::url_file(*rs_object));
+	auto path = filepath::bridged::create_empty();
+	newsboat::configpaths::bridged::url_file(*rs_object, *path);
+	return path;
 }
 
 Filepath ConfigPaths::cache_file() const
 {
-	return std::string(newsboat::configpaths::bridged::cache_file(*rs_object));
+	auto path = filepath::bridged::create_empty();
+	newsboat::configpaths::bridged::cache_file(*rs_object, *path);
+	return path;
 }
 
 Filepath ConfigPaths::config_file() const
 {
-	return std::string(newsboat::configpaths::bridged::config_file(*rs_object));
+	auto path = filepath::bridged::create_empty();
+	newsboat::configpaths::bridged::config_file(*rs_object, *path);
+	return path;
 }
 
 Filepath ConfigPaths::lock_file() const
 {
-	return std::string(newsboat::configpaths::bridged::lock_file(*rs_object));
+	auto path = filepath::bridged::create_empty();
+	newsboat::configpaths::bridged::lock_file(*rs_object, *path);
+	return path;
 }
 
 Filepath ConfigPaths::queue_file() const
 {
-	return std::string(newsboat::configpaths::bridged::queue_file(*rs_object));
+	auto path = filepath::bridged::create_empty();
+	newsboat::configpaths::bridged::queue_file(*rs_object, *path);
+	return path;
 }
 
 Filepath ConfigPaths::search_history_file() const
 {
-	return std::string(newsboat::configpaths::bridged::search_history_file(*rs_object));
+	auto path = filepath::bridged::create_empty();
+	newsboat::configpaths::bridged::search_history_file(*rs_object, *path);
+	return path;
 }
 
 Filepath ConfigPaths::cmdline_history_file() const
 {
-	return std::string(newsboat::configpaths::bridged::cmdline_history_file(*rs_object));
+	auto path = filepath::bridged::create_empty();
+	newsboat::configpaths::bridged::cmdline_history_file(*rs_object, *path);
+	return path;
 }
 
 } // namespace newsboat

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -113,14 +113,15 @@ int Controller::run(const CliArgsParser& args)
 	}
 
 	if (args.log_file().has_value()) {
-		logger::set_logfile(args.log_file().value().to_locale_string());
+		logger::set_logfile(args.log_file().value());
 	}
 
 	if (!args.log_file().has_value() && args.log_level().has_value()) {
 		const std::string date_time_string = utils::mt_strf_localtime("%Y-%m-%d_%H.%M.%S",
 				std::time(nullptr));
 		const std::string filename = "newsboat_" + date_time_string + ".log";
-		logger::set_logfile(filename);
+		const auto filepath = Filepath::from_locale_string(filename);
+		logger::set_logfile(filepath);
 	}
 
 	if (!args.display_msg().empty()) {
@@ -992,7 +993,8 @@ void Controller::update_config()
 
 	if (cfg.get_configvalue("error-log").length() > 0) {
 		try {
-			logger::set_user_error_logfile(cfg.get_configvalue("error-log"));
+			const auto filepath = Filepath::from_locale_string(cfg.get_configvalue("error-log"));
+			logger::set_user_error_logfile(filepath);
 		} catch (const Exception& e) {
 			const std::string msg =
 				strprintf::fmt("Couldn't open %s: %s",

--- a/src/fslock.cpp
+++ b/src/fslock.cpp
@@ -15,7 +15,7 @@ FsLock::FsLock()
 {
 }
 
-bool FsLock::try_lock(const std::string& new_lock_filepath, pid_t& pid,
+bool FsLock::try_lock(const Filepath& new_lock_filepath, pid_t& pid,
 	std::string& error_message)
 {
 	std::int64_t p;

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -233,14 +233,16 @@ void PbController::initialize(int argc, char* argv[])
 	}
 
 	if (log_file.has_value()) {
-		logger::set_logfile(log_file.value());
+		const auto filepath = Filepath::from_locale_string(log_file.value());
+		logger::set_logfile(filepath);
 	}
 
 	if (!log_file.has_value() && log_level.has_value()) {
 		const std::string date_time_string = utils::mt_strf_localtime("%Y-%m-%d_%H.%M.%S",
 				std::time(nullptr));
 		const std::string filename = "podboat_" + date_time_string + ".log";
-		logger::set_logfile(filename);
+		const auto filepath = Filepath::from_locale_string(filename);
+		logger::set_logfile(filepath);
 	}
 
 	std::cout << strprintf::fmt(

--- a/test/scopemeasure.cpp
+++ b/test/scopemeasure.cpp
@@ -30,7 +30,8 @@ TEST_CASE("Destroying a ScopeMeasure object writes a line to the log",
 
 	{
 		test_helpers::LoggerResetter logReset;
-		logger::set_logfile(tmp.get_path());
+		const auto filepath = Filepath::from_locale_string(tmp.get_path());
+		logger::set_logfile(filepath);
 		logger::set_loglevel(Level::DEBUG);
 
 		ScopeMeasure sm("test");
@@ -50,7 +51,8 @@ TEST_CASE("stopover() adds an extra line to the log upon each call",
 
 	{
 		test_helpers::LoggerResetter logReset;
-		logger::set_logfile(tmp.get_path());
+		const auto filepath = Filepath::from_locale_string(tmp.get_path());
+		logger::set_logfile(filepath);
 		logger::set_loglevel(Level::DEBUG);
 
 		ScopeMeasure sm("test");

--- a/test/test_helpers/loggerresetter.cpp
+++ b/test/test_helpers/loggerresetter.cpp
@@ -6,8 +6,10 @@ namespace test_helpers {
 
 void reset_logger()
 {
-	::newsboat::logger::set_logfile("/dev/null");
-	::newsboat::logger::set_user_error_logfile("/dev/null");
+	const auto path = "/dev/null";
+	const auto filepath = ::newsboat::Filepath::from_locale_string(path);
+	::newsboat::logger::set_logfile(filepath);
+	::newsboat::logger::set_user_error_logfile(filepath);
 	::newsboat::logger::unset_loglevel();
 }
 


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2644

There are a few places where we now convert `Filepath` into `std::string` to then directly convert into a `Filepath` again.
I decided to postpone work on that given that we will find them already when working on https://github.com/newsboat/newsboat/issues/2326#issuecomment-1872314543