### PR TITLE
Fix clang tidy warnings

### DIFF
--- a/include/dialogsformaction.h
+++ b/include/dialogsformaction.h
@@ -9,8 +9,8 @@ namespace newsboat {
 
 class DialogsFormAction : public ListFormAction {
 public:
-	DialogsFormAction(View*, std::string formstr, ConfigContainer* cfg, RegexManager& r);
-	~DialogsFormAction() override;
+	DialogsFormAction(View&, std::string formstr, ConfigContainer* cfg, RegexManager& r);
+	~DialogsFormAction() override = default;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -15,7 +15,7 @@ namespace newsboat {
 class DirBrowserFormAction : public FormAction {
 public:
 	DirBrowserFormAction(View*, std::string formstr, ConfigContainer* cfg);
-	~DirBrowserFormAction() override;
+	~DirBrowserFormAction() override = default;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
@@ -49,6 +49,8 @@ private:
 	std::string cwd;
 
 	ListWidget files_list;
+
+	View& view;
 };
 
 } // namespace newsboat

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -14,7 +14,7 @@ namespace newsboat {
 
 class DirBrowserFormAction : public FormAction {
 public:
-	DirBrowserFormAction(View*, std::string formstr, ConfigContainer* cfg);
+	DirBrowserFormAction(View&, std::string formstr, ConfigContainer* cfg);
 	~DirBrowserFormAction() override = default;
 	void prepare() override;
 	void init() override;

--- a/include/emptyformaction.h
+++ b/include/emptyformaction.h
@@ -7,7 +7,7 @@ namespace newsboat {
 
 class EmptyFormAction : public FormAction {
 public:
-	EmptyFormAction(View* v, const std::string& formstr, ConfigContainer* cfg);
+	EmptyFormAction(View& v, const std::string& formstr, ConfigContainer* cfg);
 	virtual ~EmptyFormAction() = default;
 
 	std::string id() const override;

--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -16,13 +16,13 @@ typedef std::pair<std::shared_ptr<RssFeed>, unsigned int> FeedPtrPosPair;
 
 class FeedListFormAction : public ListFormAction {
 public:
-	FeedListFormAction(View*,
+	FeedListFormAction(View&,
 		std::string formstr,
 		Cache* cc,
 		FilterContainer& f,
 		ConfigContainer* cfg,
 		RegexManager& r);
-	~FeedListFormAction() override;
+	~FeedListFormAction() override = default;
 	void prepare() override;
 	void init() override;
 	void set_feedlist(std::vector<std::shared_ptr<RssFeed>>& feeds);

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -14,7 +14,7 @@ namespace newsboat {
 
 class FileBrowserFormAction : public FormAction {
 public:
-	FileBrowserFormAction(View*, std::string formstr, ConfigContainer* cfg);
+	FileBrowserFormAction(View&, std::string formstr, ConfigContainer* cfg);
 	~FileBrowserFormAction() override = default;
 	void prepare() override;
 	void init() override;

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -15,7 +15,7 @@ namespace newsboat {
 class FileBrowserFormAction : public FormAction {
 public:
 	FileBrowserFormAction(View*, std::string formstr, ConfigContainer* cfg);
-	~FileBrowserFormAction() override;
+	~FileBrowserFormAction() override = default;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
@@ -57,6 +57,8 @@ private:
 	std::string default_filename;
 
 	ListWidget files_list;
+
+	View& view;
 };
 
 } // namespace newsboat

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -46,8 +46,8 @@ struct Command {
 
 class FormAction {
 public:
-	FormAction(View*, std::string formstr, ConfigContainer* cfg);
-	virtual ~FormAction();
+	FormAction(View&, std::string formstr, ConfigContainer* cfg);
+	virtual ~FormAction() = default;
 	virtual void prepare() = 0;
 	virtual void init() = 0;
 	virtual void set_redraw(bool b)
@@ -134,7 +134,7 @@ protected:
 	bool handle_list_operations(ListWidget& list, Operation op);
 	bool handle_textview_operations(TextviewWidget& textview, Operation op);
 
-	View* v;
+	View& v;
 	ConfigContainer* cfg;
 	Stfl::Form f;
 	bool do_redraw;

--- a/include/helpformaction.h
+++ b/include/helpformaction.h
@@ -8,9 +8,9 @@ namespace newsboat {
 
 class HelpFormAction : public FormAction {
 public:
-	HelpFormAction(View*, std::string formstr, ConfigContainer* cfg,
+	HelpFormAction(View&, std::string formstr, ConfigContainer* cfg,
 		const std::string& ctx);
-	~HelpFormAction() override;
+	~HelpFormAction() override = default;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -23,13 +23,13 @@ enum class InvalidationMode { NONE, PARTIAL, COMPLETE };
 
 class ItemListFormAction : public ListFormAction {
 public:
-	ItemListFormAction(View*,
+	ItemListFormAction(View&,
 		std::string formstr,
 		Cache* cc,
 		FilterContainer& f,
 		ConfigContainer* cfg,
 		RegexManager& r);
-	~ItemListFormAction() override;
+	~ItemListFormAction() override = default;
 	void prepare() override;
 	void init() override;
 

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -15,13 +15,13 @@ class RssItem;
 
 class ItemViewFormAction : public FormAction {
 public:
-	ItemViewFormAction(View*,
+	ItemViewFormAction(View&,
 		std::shared_ptr<ItemListFormAction> il,
 		std::string formstr,
 		Cache* cc,
 		ConfigContainer* cfg,
 		RegexManager& r);
-	~ItemViewFormAction() override;
+	~ItemViewFormAction() override = default;
 	void prepare() override;
 	void init() override;
 	void set_guid(const std::string& guid_)

--- a/include/listformaction.h
+++ b/include/listformaction.h
@@ -13,9 +13,10 @@ namespace newsboat {
 
 class ListFormAction : public FormAction {
 public:
-	ListFormAction(View* v, const std::string& context, std::string formstr,
+	ListFormAction(View& v, const std::string& context, std::string formstr,
 		std::string list_name,
 		ConfigContainer* cfg, RegexManager& r);
+	~ListFormAction() override = default;
 
 protected:
 	bool process_operation(Operation op,

--- a/include/searchresultslistformaction.h
+++ b/include/searchresultslistformaction.h
@@ -20,12 +20,13 @@ struct SearchResult {
 
 class SearchResultsListFormAction : public ItemListFormAction {
 public:
-	SearchResultsListFormAction(View* vv,
+	SearchResultsListFormAction(View& vv,
 		std::string formstr,
 		Cache* cc,
 		FilterContainer& f,
 		ConfigContainer* cfg,
 		RegexManager& r);
+	~SearchResultsListFormAction() override = default;
 
 	std::string id() const override
 	{

--- a/include/selectformaction.h
+++ b/include/selectformaction.h
@@ -11,8 +11,8 @@ class SelectFormAction : public FormAction {
 public:
 	enum class SelectionType { TAG, FILTER };
 
-	SelectFormAction(View*, std::string formstr, ConfigContainer* cfg);
-	~SelectFormAction() override;
+	SelectFormAction(View&, std::string formstr, ConfigContainer* cfg);
+	~SelectFormAction() override = default;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;

--- a/include/urlviewformaction.h
+++ b/include/urlviewformaction.h
@@ -9,11 +9,11 @@ namespace newsboat {
 
 class UrlViewFormAction : public FormAction {
 public:
-	UrlViewFormAction(View*,
+	UrlViewFormAction(View&,
 		std::shared_ptr<RssFeed>& feed,
 		std::string formstr,
 		ConfigContainer* cfg);
-	~UrlViewFormAction() override;
+	~UrlViewFormAction() override = default;
 	void prepare() override;
 	void init() override;
 	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -12,14 +12,12 @@
 
 namespace newsboat {
 
-DialogsFormAction::DialogsFormAction(View* vv,
+DialogsFormAction::DialogsFormAction(View& vv,
 	std::string formstr,
 	ConfigContainer* cfg, RegexManager& r)
 	: ListFormAction(vv, "dialoglist", formstr, "dialogs", cfg, r)
 {
 }
-
-DialogsFormAction::~DialogsFormAction() {}
 
 void DialogsFormAction::init()
 {
@@ -35,10 +33,10 @@ void DialogsFormAction::prepare()
 
 		auto render_line = [this](std::uint32_t line, std::uint32_t width) -> std::string {
 			(void)width;
-			const auto formaction_names = v->get_formaction_names();
+			const auto formaction_names = v.get_formaction_names();
 			const auto& fa = formaction_names[line];
 			const bool is_current_formaction =
-			v->get_formaction(fa.first) == get_parent_formaction();
+			v.get_formaction(fa.first) == get_parent_formaction();
 			return utils::quote_for_stfl(
 				strprintf::fmt("%4u %s %s",
 					line + 1,
@@ -46,7 +44,7 @@ void DialogsFormAction::prepare()
 					fa.second));
 		};
 
-		list.invalidate_list_content(v->get_formaction_names().size(), render_line);
+		list.invalidate_list_content(v.get_formaction_names().size(), render_line);
 
 		do_redraw = false;
 	}
@@ -79,16 +77,16 @@ bool DialogsFormAction::process_operation(Operation op,
 	switch (op) {
 	case OP_OPEN: {
 		const unsigned int pos = list.get_position();
-		v->set_current_formaction(pos);
+		v.set_current_formaction(pos);
 	}
 	break;
 	case OP_CLOSEDIALOG: {
 		const unsigned int pos = list.get_position();
 		if (pos != 0) {
-			v->remove_formaction(pos);
+			v.remove_formaction(pos);
 			do_redraw = true;
 		} else {
-			v->get_statusline().show_error(
+			v.get_statusline().show_error(
 				_("Error: you can't remove the feed list!"));
 		}
 	}
@@ -100,7 +98,7 @@ bool DialogsFormAction::process_operation(Operation op,
 		list.move_down(cfg->get_configvalue_as_bool("wrap-scroll"));
 		break;
 	case OP_QUIT:
-		v->pop_current_formaction();
+		v.pop_current_formaction();
 		break;
 	default:
 		ListFormAction::process_operation(op, args, bindingType);
@@ -118,10 +116,10 @@ void DialogsFormAction::handle_cmdline(const std::string& cmd)
 {
 	unsigned int idx = 0;
 	if (1 == sscanf(cmd.c_str(), "%u", &idx)) {
-		if (idx >= 1 && idx <= v->formaction_stack_size()) {
+		if (idx >= 1 && idx <= v.formaction_stack_size()) {
 			list.set_position(idx - 1);
 		} else {
-			v->get_statusline().show_error(_("Invalid position!"));
+			v.get_statusline().show_error(_("Invalid position!"));
 		}
 	} else {
 		FormAction::handle_cmdline(cmd);

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -30,17 +30,9 @@ DirBrowserFormAction::DirBrowserFormAction(View* vv,
 	: FormAction(vv, formstr, cfg)
 	, file_prompt_line(f, "fileprompt")
 	, files_list("files", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
+	, view(*vv)
 {
-	// In dirbrowser, keyboard focus is at the input field, so user will be
-	// unable to use alphanumeric keys to confirm or quit the dialog (e.g. they
-	// can't quit with the default `q` bind).
-	KeyMap* keys = vv->get_keymap();
-	keys->set_key(OP_OPEN, "ENTER", id());
-	keys->set_key(OP_QUIT, "ESC", id());
-	vv->set_keymap(keys);
 }
-
-DirBrowserFormAction::~DirBrowserFormAction() {}
 
 bool DirBrowserFormAction::process_operation(Operation op,
 	const std::vector<std::string>& /* args */,
@@ -274,6 +266,14 @@ void DirBrowserFormAction::prepare()
 
 void DirBrowserFormAction::init()
 {
+	// In dirbrowser, keyboard focus is at the input field, so user will be
+	// unable to use alphanumeric keys to confirm or quit the dialog (e.g. they
+	// can't quit with the default `q` bind).
+	KeyMap* keys = view.get_keymap();
+	keys->set_key(OP_OPEN, "ENTER", id());
+	keys->set_key(OP_QUIT, "ESC", id());
+	view.set_keymap(keys);
+
 	set_keymap_hints();
 
 	file_prompt_line.set_text(_("Directory: "));

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -24,13 +24,13 @@
 
 namespace newsboat {
 
-DirBrowserFormAction::DirBrowserFormAction(View* vv,
+DirBrowserFormAction::DirBrowserFormAction(View& vv,
 	std::string formstr,
 	ConfigContainer* cfg)
 	: FormAction(vv, formstr, cfg)
 	, file_prompt_line(f, "fileprompt")
 	, files_list("files", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
-	, view(*vv)
+	, view(vv)
 {
 }
 
@@ -89,7 +89,7 @@ bool DirBrowserFormAction::process_operation(Operation op,
 				}
 			} else {
 				curs_set(0);
-				v->pop_current_formaction();
+				v.pop_current_formaction();
 			}
 		}
 	}
@@ -161,13 +161,13 @@ bool DirBrowserFormAction::process_operation(Operation op,
 	case OP_QUIT:
 		LOG(Level::DEBUG, "view::dirbrowser: quitting");
 		curs_set(0);
-		v->pop_current_formaction();
+		v.pop_current_formaction();
 		set_value("filenametext", "");
 		break;
 	case OP_HARDQUIT:
 		LOG(Level::DEBUG, "view::dirbrowser: hard quitting");
-		while (v->formaction_stack_size() > 0) {
-			v->pop_current_formaction();
+		while (v.formaction_stack_size() > 0) {
+			v.pop_current_formaction();
 		}
 		set_value("filenametext", "");
 		break;

--- a/src/emptyformaction.cpp
+++ b/src/emptyformaction.cpp
@@ -2,7 +2,7 @@
 
 namespace newsboat {
 
-EmptyFormAction::EmptyFormAction(View* v, const std::string& formstr,
+EmptyFormAction::EmptyFormAction(View& v, const std::string& formstr,
 	ConfigContainer* cfg)
 	: FormAction(v, formstr, cfg)
 {

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -32,17 +32,9 @@ FileBrowserFormAction::FileBrowserFormAction(View* vv,
 	, file_prompt_line(f, "fileprompt")
 	, quit(false)
 	, files_list("files", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
+	, view(*vv)
 {
-	// In filebrowser, keyboard focus is at the input field, so user will be
-	// unable to use alphanumeric keys to confirm or quit the dialog (e.g. they
-	// can't quit with the default `q` bind).
-	KeyMap* keys = vv->get_keymap();
-	keys->set_key(OP_OPEN, "ENTER", id());
-	keys->set_key(OP_QUIT, "ESC", id());
-	vv->set_keymap(keys);
 }
-
-FileBrowserFormAction::~FileBrowserFormAction() {}
 
 bool FileBrowserFormAction::process_operation(Operation op,
 	const std::vector<std::string>& /* args */,
@@ -300,6 +292,14 @@ void FileBrowserFormAction::prepare()
 
 void FileBrowserFormAction::init()
 {
+	// In filebrowser, keyboard focus is at the input field, so user will be
+	// unable to use alphanumeric keys to confirm or quit the dialog (e.g. they
+	// can't quit with the default `q` bind).
+	KeyMap* keys = view.get_keymap();
+	keys->set_key(OP_OPEN, "ENTER", id());
+	keys->set_key(OP_QUIT, "ESC", id());
+	view.set_keymap(keys);
+
 	set_keymap_hints();
 
 	file_prompt_line.set_text(_("File: "));

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -25,14 +25,14 @@
 
 namespace newsboat {
 
-FileBrowserFormAction::FileBrowserFormAction(View* vv,
+FileBrowserFormAction::FileBrowserFormAction(View& vv,
 	std::string formstr,
 	ConfigContainer* cfg)
 	: FormAction(vv, formstr, cfg)
 	, file_prompt_line(f, "fileprompt")
 	, quit(false)
 	, files_list("files", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
-	, view(*vv)
+	, view(vv)
 {
 }
 
@@ -111,7 +111,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 				 */
 				if (::stat(fn.c_str(), &sbuf) != -1) {
 					f.set_focus("files");
-					if (v->confirm(
+					if (v.confirm(
 							strprintf::fmt(
 								_("Do you really want to overwrite `%s' "
 									"(y:Yes n:No)? "),
@@ -123,7 +123,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 				}
 				if (do_pop) {
 					curs_set(0);
-					v->pop_current_formaction();
+					v.pop_current_formaction();
 				}
 			}
 		}
@@ -196,13 +196,13 @@ bool FileBrowserFormAction::process_operation(Operation op,
 	case OP_QUIT:
 		LOG(Level::DEBUG, "view::filebrowser: quitting");
 		curs_set(0);
-		v->pop_current_formaction();
+		v.pop_current_formaction();
 		set_value("filenametext", "");
 		break;
 	case OP_HARDQUIT:
 		LOG(Level::DEBUG, "view::filebrowser: hard quitting");
-		while (v->formaction_stack_size() > 0) {
-			v->pop_current_formaction();
+		while (v.formaction_stack_size() > 0) {
+			v.pop_current_formaction();
 		}
 		set_value("filenametext", "");
 		break;

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -14,7 +14,7 @@
 
 namespace newsboat {
 
-HelpFormAction::HelpFormAction(View* vv,
+HelpFormAction::HelpFormAction(View& vv,
 	std::string formstr,
 	ConfigContainer* cfg,
 	const std::string& ctx)
@@ -25,8 +25,6 @@ HelpFormAction::HelpFormAction(View* vv,
 	, textview("helptext", FormAction::f)
 {
 }
-
-HelpFormAction::~HelpFormAction() {}
 
 bool HelpFormAction::process_operation(Operation op,
 	const std::vector<std::string>& /* args */,
@@ -57,11 +55,11 @@ bool HelpFormAction::process_operation(Operation op,
 		break;
 	}
 	if (hardquit) {
-		while (v->formaction_stack_size() > 0) {
-			v->pop_current_formaction();
+		while (v.formaction_stack_size() > 0) {
+			v.pop_current_formaction();
 		}
 	} else if (quit) {
-		v->pop_current_formaction();
+		v.pop_current_formaction();
 	}
 	return true;
 }
@@ -78,7 +76,7 @@ void HelpFormAction::prepare()
 		fmt.register_fmt('V', utils::program_version());
 		set_title(fmt.do_format(cfg->get_configvalue("help-title-format"), width));
 
-		const auto descs = v->get_keymap()->get_keymap_descriptions(context);
+		const auto descs = v.get_keymap()->get_keymap_descriptions(context);
 
 		std::vector<std::string> colors = utils::tokenize(
 				cfg->get_configvalue("search-highlight-colors"), " ");
@@ -153,7 +151,7 @@ void HelpFormAction::prepare()
 			}
 		}
 
-		const auto macros = v->get_keymap()->get_macro_descriptions();
+		const auto macros = v.get_keymap()->get_macro_descriptions();
 		if (!macros.empty()) {
 			listfmt.add_line("");
 			listfmt.add_line(_("Macros:"));
@@ -194,7 +192,7 @@ const std::vector<KeyMapHintEntry>& HelpFormAction::get_keymap_hint() const
 
 void HelpFormAction::finished_qna(Operation op)
 {
-	v->inside_qna(false);
+	v.inside_qna(false);
 	switch (op) {
 	case OP_INT_START_SEARCH:
 		searchphrase = qna_responses[0];

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -27,7 +27,7 @@
 
 namespace newsboat {
 
-ItemListFormAction::ItemListFormAction(View* vv,
+ItemListFormAction::ItemListFormAction(View& vv,
 	std::string formstr,
 	Cache* cc,
 	FilterContainer& f,
@@ -48,8 +48,6 @@ ItemListFormAction::ItemListFormAction(View* vv,
 {
 	register_format_styles();
 }
-
-ItemListFormAction::~ItemListFormAction() {}
 
 bool ItemListFormAction::process_operation(Operation op,
 	const std::vector<std::string>& args,
@@ -73,11 +71,11 @@ bool ItemListFormAction::process_operation(Operation op,
 			// no need to mark item as read, the itemview already do
 			// that
 			old_itempos = itempos;
-			v->push_itemview(feed,
+			v.push_itemview(feed,
 				visible_items[itempos].first->guid());
 			invalidate(itempos);
 		} else {
-			v->get_statusline().show_error(
+			v.get_statusline().show_error(
 				_("No item selected!")); // should not happen
 		}
 	}
@@ -86,7 +84,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		ScopeMeasure m1("OP_DELETE");
 		if (!visible_items.empty()) {
 			// mark as read
-			v->get_ctrl()->mark_article_read(
+			v.get_ctrl()->mark_article_read(
 				visible_items[itempos].first->guid(), true);
 			visible_items[itempos].first->set_unread(false);
 			// mark as deleted
@@ -100,14 +98,14 @@ bool ItemListFormAction::process_operation(Operation op,
 			}
 			invalidate(itempos);
 		} else {
-			v->get_statusline().show_error(
+			v.get_statusline().show_error(
 				_("No item selected!")); // should not happen
 		}
 	}
 	break;
 	case OP_DELETE_ALL: {
 		if (!cfg->get_configvalue_as_bool("confirm-delete-all-articles") ||
-			v->confirm(_("Do you really want to delete all articles (y:Yes n:No)? "),
+			v.confirm(_("Do you really want to delete all articles (y:Yes n:No)? "),
 				_("yn")) == *_("y")) {
 			ScopeMeasure m1("OP_DELETE_ALL");
 
@@ -116,7 +114,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				const auto item = pair.first;
 				item_guids.push_back(item->guid());
 			}
-			v->get_ctrl()->mark_all_read(item_guids);
+			v.get_ctrl()->mark_all_read(item_guids);
 
 			for (const auto& pair : visible_items) {
 				const auto item = pair.first;
@@ -146,7 +144,7 @@ bool ItemListFormAction::process_operation(Operation op,
 
 		auto item = visible_items[itempos].first;
 		item->set_unread(false);
-		v->get_ctrl()->mark_article_read(item->guid(), true);
+		v.get_ctrl()->mark_article_read(item->guid(), true);
 		if (cfg->get_configvalue_as_bool("openbrowser-and-mark-jumps-to-next-unread")) {
 			std::vector<std::string> args;
 			process_operation(OP_NEXTUNREAD, args);
@@ -182,10 +180,10 @@ bool ItemListFormAction::process_operation(Operation op,
 			exit_code = open_unread_items_in_browser(feed, false);
 
 			if (!exit_code.has_value()) {
-				v->get_statusline().show_error(_("Failed to spawn browser"));
+				v.get_statusline().show_error(_("Failed to spawn browser"));
 				return false;
 			} else if (*exit_code != 0) {
-				v->get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
+				v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
 						*exit_code));
 				return false;
 			}
@@ -205,10 +203,10 @@ bool ItemListFormAction::process_operation(Operation op,
 			exit_code = open_unread_items_in_browser(feed, true);
 
 			if (!exit_code.has_value()) {
-				v->get_statusline().show_error(_("Failed to spawn browser"));
+				v.get_statusline().show_error(_("Failed to spawn browser"));
 				return false;
 			} else if (*exit_code != 0) {
-				v->get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
+				v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
 						*exit_code));
 				return false;
 			}
@@ -220,14 +218,14 @@ bool ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO, "ItemListFormAction: toggling item read at pos `%u'", itempos);
 		if (!visible_items.empty()) {
 			try {
-				const auto message_lifetime = v->get_statusline().show_message_until_finished(
+				const auto message_lifetime = v.get_statusline().show_message_until_finished(
 						_("Toggling read flag for article..."));
 				if (args.size() > 0) {
 					if (args.front() == "read") {
 						visible_items[itempos]
 						.first->set_unread(
 							false);
-						v->get_ctrl()->mark_article_read(
+						v.get_ctrl()->mark_article_read(
 							visible_items[itempos]
 							.first->guid(),
 							true);
@@ -235,7 +233,7 @@ bool ItemListFormAction::process_operation(Operation op,
 						visible_items[itempos]
 						.first->set_unread(
 							true);
-						v->get_ctrl()->mark_article_read(
+						v.get_ctrl()->mark_article_read(
 							visible_items[itempos]
 							.first->guid(),
 							false);
@@ -253,13 +251,13 @@ bool ItemListFormAction::process_operation(Operation op,
 						.first->unread();
 					visible_items[itempos]
 					.first->set_unread(!unread);
-					v->get_ctrl()->mark_article_read(
+					v.get_ctrl()->mark_article_read(
 						visible_items[itempos]
 						.first->guid(),
 						unread);
 				}
 			} catch (const DbException& e) {
-				v->get_statusline().show_error(strprintf::fmt(
+				v.get_statusline().show_error(strprintf::fmt(
 						_("Error while toggling read flag: %s"),
 						e.what()));
 			}
@@ -302,9 +300,9 @@ bool ItemListFormAction::process_operation(Operation op,
 						links,
 						baseurl);
 					if (!links.empty()) {
-						v->push_urlview(links, feed);
+						v.push_urlview(links, feed);
 					} else {
-						v->get_statusline().show_error(
+						v.get_statusline().show_error(
 							_("URL list empty."));
 					}
 				} else {
@@ -314,7 +312,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				}
 			}
 		} else {
-			v->get_statusline().show_error(
+			v.get_statusline().show_error(
 				_("No item selected!")); // should not happen
 		}
 		break;
@@ -361,7 +359,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				}
 			}
 		} else {
-			v->get_statusline().show_error(
+			v.get_statusline().show_error(
 				_("No item selected!")); // should not happen
 		}
 	}
@@ -399,7 +397,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				}
 			}
 		} else {
-			v->get_statusline().show_error(
+			v.get_statusline().show_error(
 				_("No item selected!")); // should not happen
 		}
 	}
@@ -413,8 +411,8 @@ bool ItemListFormAction::process_operation(Operation op,
 			case BindingType::Bind:
 				if (args.empty()) {
 					const auto title = utils::utf8_to_locale(item->title());
-					const auto suggestion = v->get_filename_suggestion(title);
-					filename = v->run_filebrowser(suggestion);
+					const auto suggestion = v.get_filename_suggestion(title);
+					filename = v.run_filebrowser(suggestion);
 				} else {
 					filename = args.front();
 				}
@@ -426,13 +424,13 @@ bool ItemListFormAction::process_operation(Operation op,
 				break;
 			case BindingType::BindKey:
 				const auto title = utils::utf8_to_locale(item->title());
-				const auto suggestion = v->get_filename_suggestion(title);
-				filename = v->run_filebrowser(suggestion);
+				const auto suggestion = v.get_filename_suggestion(title);
+				filename = v.run_filebrowser(suggestion);
 				break;
 			}
 			save_article(filename, item);
 		} else {
-			v->get_statusline().show_error(_("Error: no item selected!"));
+			v.get_statusline().show_error(_("Error: no item selected!"));
 		}
 	}
 	break;
@@ -440,23 +438,23 @@ bool ItemListFormAction::process_operation(Operation op,
 		handle_op_saveall();
 		break;
 	case OP_HELP:
-		v->push_help();
+		v.push_help();
 		break;
 	case OP_RELOAD:
 		LOG(Level::INFO, "ItemListFormAction: reloading current feed");
-		v->get_ctrl()->get_reloader()->reload(pos);
+		v.get_ctrl()->get_reloader()->reload(pos);
 		invalidate_list();
 		break;
 	case OP_QUIT:
 		LOG(Level::INFO, "ItemListFormAction: quitting");
-		v->feedlist_mark_pos_if_visible(pos);
+		v.feedlist_mark_pos_if_visible(pos);
 		feed->purge_deleted_items();
 		feed->unload();
 		quit = true;
 		break;
 	case OP_HARDQUIT:
 		LOG(Level::INFO, "ItemListFormAction: hard quitting");
-		v->feedlist_mark_pos_if_visible(pos);
+		v.feedlist_mark_pos_if_visible(pos);
 		feed->purge_deleted_items();
 		hardquit = true;
 		break;
@@ -464,8 +462,8 @@ bool ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO,
 			"ItemListFormAction: jumping to next unread item");
 		if (!jump_to_next_unread_item(false)) {
-			if (!v->get_next_unread(*this)) {
-				v->get_statusline().show_error(_("No unread items."));
+			if (!v.get_next_unread(*this)) {
+				v.get_statusline().show_error(_("No unread items."));
 			}
 		}
 		break;
@@ -473,16 +471,16 @@ bool ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO,
 			"ItemListFormAction: jumping to previous unread item");
 		if (!jump_to_previous_unread_item(false)) {
-			if (!v->get_previous_unread(*this)) {
-				v->get_statusline().show_error(_("No unread items."));
+			if (!v.get_previous_unread(*this)) {
+				v.get_statusline().show_error(_("No unread items."));
 			}
 		}
 		break;
 	case OP_NEXT:
 		LOG(Level::INFO, "ItemListFormAction: jumping to next item");
 		if (!jump_to_next_item(false)) {
-			if (!v->get_next(*this)) {
-				v->get_statusline().show_error(_("Already on last item."));
+			if (!v.get_next(*this)) {
+				v.get_statusline().show_error(_("Already on last item."));
 			}
 		}
 		break;
@@ -490,46 +488,46 @@ bool ItemListFormAction::process_operation(Operation op,
 		LOG(Level::INFO,
 			"ItemListFormAction: jumping to previous item");
 		if (!jump_to_previous_item(false)) {
-			if (!v->get_previous(*this)) {
-				v->get_statusline().show_error(_("Already on first item."));
+			if (!v.get_previous(*this)) {
+				v.get_statusline().show_error(_("Already on first item."));
 			}
 		}
 		break;
 	case OP_RANDOMUNREAD:
 		if (!jump_to_random_unread_item()) {
-			if (!v->get_random_unread(*this)) {
-				v->get_statusline().show_error(_("No unread items."));
+			if (!v.get_random_unread(*this)) {
+				v.get_statusline().show_error(_("No unread items."));
 			}
 		}
 		break;
 	case OP_NEXTUNREADFEED:
-		if (!v->get_next_unread_feed(*this)) {
-			v->get_statusline().show_error(_("No unread feeds."));
+		if (!v.get_next_unread_feed(*this)) {
+			v.get_statusline().show_error(_("No unread feeds."));
 		}
 		break;
 	case OP_PREVUNREADFEED:
-		if (!v->get_prev_unread_feed(*this)) {
-			v->get_statusline().show_error(_("No unread feeds."));
+		if (!v.get_prev_unread_feed(*this)) {
+			v.get_statusline().show_error(_("No unread feeds."));
 		}
 		break;
 	case OP_NEXTFEED:
-		if (!v->get_next_feed(*this)) {
-			v->get_statusline().show_error(_("Already on last feed."));
+		if (!v.get_next_feed(*this)) {
+			v.get_statusline().show_error(_("Already on last feed."));
 		}
 		break;
 	case OP_PREVFEED:
-		if (!v->get_prev_feed(*this)) {
-			v->get_statusline().show_error(_("Already on first feed."));
+		if (!v.get_prev_feed(*this)) {
+			v.get_statusline().show_error(_("Already on first feed."));
 		}
 		break;
 	case OP_MARKFEEDREAD:
 		if (!cfg->get_configvalue_as_bool(
 				"confirm-mark-feed-read") ||
-			v->confirm(_("Do you really want to mark this feed as read (y:Yes n:No)? "),
+			v.confirm(_("Do you really want to mark this feed as read (y:Yes n:No)? "),
 				_("yn")) == *_("y")) {
 			LOG(Level::INFO, "ItemListFormAction: marking feed read");
 			try {
-				const auto message_lifetime = v->get_statusline().show_message_until_finished(
+				const auto message_lifetime = v.get_statusline().show_message_until_finished(
 						_("Marking feed read..."));
 
 				std::vector<std::string> guids;
@@ -541,9 +539,9 @@ bool ItemListFormAction::process_operation(Operation op,
 
 				if (filter_active) {
 					// We're only viewing a subset of items, so mark them off one by one.
-					v->get_ctrl()->mark_all_read(guids);
+					v.get_ctrl()->mark_all_read(guids);
 				} else {
-					v->get_ctrl()->mark_all_read(pos);
+					v.get_ctrl()->mark_all_read(pos);
 				}
 
 				if (visible_items.size() > 0) {
@@ -575,7 +573,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				}
 				invalidate_list();
 			} catch (const DbException& e) {
-				v->get_statusline().show_error(strprintf::fmt(
+				v.get_statusline().show_error(strprintf::fmt(
 						_("Error: couldn't mark feed read: %s"),
 						e.what()));
 			}
@@ -584,14 +582,14 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_MARKALLABOVEASREAD: {
 		LOG(Level::INFO,
 			"ItemListFormAction: marking all above as read");
-		const auto message_lifetime = v->get_statusline().show_message_until_finished(
+		const auto message_lifetime = v.get_statusline().show_message_until_finished(
 				_("Marking all above as read..."));
 		if (itempos < visible_items.size()) {
 			for (unsigned int i = 0; i < itempos; ++i) {
 				if (visible_items[i].first->unread()) {
 					visible_items[i].first->set_unread(
 						false);
-					v->get_ctrl()->mark_article_read(
+					v.get_ctrl()->mark_article_read(
 						visible_items[i].first->guid(),
 						true);
 				}
@@ -643,7 +641,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				break;
 			}
 		} else {
-			v->get_statusline().show_error(_("No item selected!"));
+			v.get_statusline().show_error(_("No item selected!"));
 		}
 		break;
 	case OP_SEARCH: {
@@ -700,7 +698,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		}
 		break;
 	case OP_EDIT_URLS:
-		v->get_ctrl()->edit_urls_file();
+		v.get_ctrl()->edit_urls_file();
 		break;
 	case OP_SELECTFILTER:
 		if (filter_container.size() > 0) {
@@ -712,15 +710,15 @@ bool ItemListFormAction::process_operation(Operation op,
 				if (filter.has_value()) {
 					apply_filter(filter.value());
 				} else {
-					v->get_statusline().show_error(strprintf::fmt(_("No filter found with name `%s'."),
+					v.get_statusline().show_error(strprintf::fmt(_("No filter found with name `%s'."),
 							filter_name));
 				}
 			} else {
-				const std::string filter_text = v->select_filter(filter_container.get_filters());
+				const std::string filter_text = v.select_filter(filter_container.get_filters());
 				apply_filter(filter_text);
 			}
 		} else {
-			v->get_statusline().show_error(_("No filters defined."));
+			v.get_statusline().show_error(_("No filters defined."));
 		}
 
 		break;
@@ -762,7 +760,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		// "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 		// messages
 		std::string input_options = _("dtfalgr");
-		char c = v->confirm(
+		char c = v.confirm(
 				_("Sort by "
 					"(d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"),
 				input_options);
@@ -800,7 +798,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	break;
 	case OP_REVSORT: {
 		std::string input_options = _("dtfalgr");
-		char c = v->confirm(
+		char c = v.confirm(
 				_("Reverse Sort by "
 					"(d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"),
 				input_options);
@@ -841,14 +839,14 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_ENQUEUE:
 		if (!visible_items.empty() && itempos < visible_items.size()) {
 			const auto item = visible_items[itempos].first;
-			return enqueue_item_enclosure(item, feed, *v, *rsscache);
+			return enqueue_item_enclosure(item, feed, v, *rsscache);
 		} else {
-			v->get_statusline().show_error(_("No item selected!"));
+			v.get_statusline().show_error(_("No item selected!"));
 			return false;
 		}
 		break;
 	case OP_ARTICLEFEED: {
-		auto feeds = v->get_ctrl()->get_feedcontainer()->get_all_feeds();
+		auto feeds = v.get_ctrl()->get_feedcontainer()->get_all_feeds();
 		size_t pos;
 		auto article_feed = visible_items[itempos].first->get_feedptr();
 		for (pos = 0; pos < feeds.size(); pos++) {
@@ -857,7 +855,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			}
 		}
 		if (pos != feeds.size()) {
-			v->push_itemlist(pos);
+			v.push_itemlist(pos);
 		}
 	}
 	break;
@@ -866,11 +864,11 @@ bool ItemListFormAction::process_operation(Operation op,
 		break;
 	}
 	if (hardquit) {
-		while (v->formaction_stack_size() > 0) {
-			v->pop_current_formaction();
+		while (v.formaction_stack_size() > 0) {
+			v.pop_current_formaction();
 		}
 	} else if (quit) {
-		v->pop_current_formaction();
+		v.pop_current_formaction();
 	}
 	return true;
 }
@@ -886,19 +884,19 @@ bool ItemListFormAction::open_position_in_browser(
 		const auto item = visible_items[pos].first;
 		const auto link = item->link();
 		const auto feedurl = item->feedurl();
-		const auto exit_code = v->open_in_browser(link, feedurl, "article", item->title(),
+		const auto exit_code = v.open_in_browser(link, feedurl, "article", item->title(),
 				interactive);
 		if (!exit_code.has_value()) {
-			v->get_statusline().show_error(_("Failed to spawn browser"));
+			v.get_statusline().show_error(_("Failed to spawn browser"));
 			return false;
 		} else if (*exit_code != 0) {
-			v->get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
+			v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
 					*exit_code));
 			return false;
 		}
 		return true;
 	} else {
-		v->get_statusline().show_error(_("No item selected!"));
+		v.get_statusline().show_error(_("No item selected!"));
 		return false;
 	}
 }
@@ -929,9 +927,9 @@ void ItemListFormAction::finished_qna(Operation op)
 			unsigned int itempos = list.get_position();
 			std::string cmd = qna_responses[0];
 			std::ostringstream ostr;
-			v->get_ctrl()->write_item(
+			v.get_ctrl()->write_item(
 				visible_items[itempos].first, ostr);
-			v->push_empty_formaction();
+			v.push_empty_formaction();
 			Stfl::reset();
 			FILE* f = popen(cmd.c_str(), "w");
 			if (f) {
@@ -939,8 +937,8 @@ void ItemListFormAction::finished_qna(Operation op)
 				fwrite(data.c_str(), data.length(), 1, f);
 				pclose(f);
 			}
-			v->drop_queued_input();
-			v->pop_current_formaction();
+			v.drop_queued_input();
+			v.pop_current_formaction();
 		}
 	}
 	break;
@@ -959,15 +957,15 @@ void ItemListFormAction::qna_end_setfilter()
 void ItemListFormAction::qna_end_editflags()
 {
 	if (visible_items.empty()) {
-		v->get_statusline().show_error(_("No item selected!")); // should not happen
+		v.get_statusline().show_error(_("No item selected!")); // should not happen
 		return;
 	}
 
 	const unsigned int itempos = list.get_position();
 	if (itempos < visible_items.size()) {
 		visible_items[itempos].first->set_flags(qna_responses[0]);
-		v->get_ctrl()->update_flags(visible_items[itempos].first);
-		v->get_statusline().show_message(_("Flags updated."));
+		v.get_ctrl()->update_flags(visible_items[itempos].first);
+		v.get_statusline().show_message(_("Flags updated."));
 		LOG(Level::DEBUG,
 			"ItemListFormAction::finished_qna: updated flags");
 		invalidate(itempos);
@@ -984,13 +982,13 @@ void ItemListFormAction::qna_start_search()
 	searchhistory.add_line(searchphrase);
 	std::vector<std::shared_ptr<RssItem>> items;
 	try {
-		const auto message_lifetime = v->get_statusline().show_message_until_finished(
+		const auto message_lifetime = v.get_statusline().show_message_until_finished(
 				_("Searching..."));
 		const auto utf8searchphrase = utils::locale_to_utf8(searchphrase);
-		items = v->get_ctrl()->search_for_items(
+		items = v.get_ctrl()->search_for_items(
 				utf8searchphrase, feed);
 	} catch (const DbException& e) {
-		v->get_statusline().show_error(
+		v.get_statusline().show_error(
 			strprintf::fmt(_("Error while searching for `%s': %s"),
 				searchphrase,
 				e.what()));
@@ -998,14 +996,14 @@ void ItemListFormAction::qna_start_search()
 	}
 
 	if (items.empty()) {
-		v->get_statusline().show_error(_("No results."));
+		v.get_statusline().show_error(_("No results."));
 		return;
 	}
 
 	std::shared_ptr<RssFeed> search_dummy_feed(new RssFeed(rsscache, ""));
 	search_dummy_feed->set_search_feed(true);
 	search_dummy_feed->add_items(items);
-	v->push_searchresult(search_dummy_feed, searchphrase);
+	v.push_searchresult(search_dummy_feed, searchphrase);
 }
 
 void ItemListFormAction::do_update_visible_items()
@@ -1102,7 +1100,7 @@ void ItemListFormAction::prepare()
 	try {
 		do_update_visible_items();
 	} catch (MatcherException& e) {
-		v->get_statusline().show_error(strprintf::fmt(
+		v.get_statusline().show_error(strprintf::fmt(
 				_("Error: applying the filter failed: %s"), e.what()));
 		return;
 	}
@@ -1112,7 +1110,7 @@ void ItemListFormAction::prepare()
 			const unsigned int itempos = list.get_position();
 			if (visible_items[itempos].first->unread()) {
 				visible_items[itempos].first->set_unread(false);
-				v->get_ctrl()->mark_article_read(
+				v.get_ctrl()->mark_article_read(
 					visible_items[itempos].first->guid(),
 					true);
 				invalidate(itempos);
@@ -1412,12 +1410,12 @@ void ItemListFormAction::handle_cmdline_num(unsigned int idx)
 		idx <= visible_items[visible_items.size() - 1].second + 1) {
 		int i = get_pos(idx - 1);
 		if (i == -1) {
-			v->get_statusline().show_error(_("Position not visible!"));
+			v.get_statusline().show_error(_("Position not visible!"));
 		} else {
 			list.set_position(i);
 		}
 	} else {
-		v->get_statusline().show_error(_("Invalid position!"));
+		v.get_statusline().show_error(_("Invalid position!"));
 	}
 }
 
@@ -1471,14 +1469,14 @@ void ItemListFormAction::save_article(const nonstd::optional<std::string>& filen
 	std::shared_ptr<RssItem> item)
 {
 	if (!filename.has_value()) {
-		v->get_statusline().show_error(_("Aborted saving."));
+		v.get_statusline().show_error(_("Aborted saving."));
 	} else {
 		try {
-			v->get_ctrl()->write_item(item, filename.value());
-			v->get_statusline().show_message(strprintf::fmt(
+			v.get_ctrl()->write_item(item, filename.value());
+			v.get_statusline().show_message(strprintf::fmt(
 					_("Saved article to %s"), filename.value()));
 		} catch (...) {
-			v->get_statusline().show_error(strprintf::fmt(
+			v.get_statusline().show_error(strprintf::fmt(
 					_("Error: couldn't save article to %s"),
 					filename.value()));
 		}
@@ -1488,11 +1486,11 @@ void ItemListFormAction::save_article(const nonstd::optional<std::string>& filen
 void ItemListFormAction::handle_save(const std::vector<std::string>& cmd_args)
 {
 	if (cmd_args.size() < 1) {
-		v->get_statusline().show_error(_("Error: no filename provided"));
+		v.get_statusline().show_error(_("Error: no filename provided"));
 		return;
 	}
 	if (visible_items.empty()) {
-		v->get_statusline().show_error(_("Error: no item selected!"));
+		v.get_statusline().show_error(_("Error: no item selected!"));
 		return;
 	}
 	const std::string filename = utils::resolve_tilde(cmd_args.front());
@@ -1593,7 +1591,7 @@ void ItemListFormAction::handle_op_saveall()
 		return;
 	}
 
-	nonstd::optional<std::string> directory = v->run_dirbrowser();
+	nonstd::optional<std::string> directory = v.run_dirbrowser();
 
 	if (!directory.has_value()) {
 		return;
@@ -1605,7 +1603,7 @@ void ItemListFormAction::handle_op_saveall()
 
 	std::vector<std::string> filenames;
 	for (const auto& item : visible_items) {
-		filenames.emplace_back( utils::utf8_to_locale(v->get_filename_suggestion(
+		filenames.emplace_back( utils::utf8_to_locale(v.get_filename_suggestion(
 					item.first->title())));
 	}
 
@@ -1648,14 +1646,14 @@ void ItemListFormAction::handle_op_saveall()
 
 			char c;
 			if (nfiles_exist > 1) {
-				c = v->confirm(strprintf::fmt(
+				c = v.confirm(strprintf::fmt(
 							_("Overwrite `%s' in `%s'? "
 								"There are %d more conflicts like this "
 								"(y:Yes a:Yes to all n:No q:No to all)"),
 							filename, directory.value(), --nfiles_exist),
 						input_options);
 			} else {
-				c = v->confirm(strprintf::fmt(
+				c = v.confirm(strprintf::fmt(
 							_("Overwrite `%s' in `%s'? "
 								"(y:Yes n:No)"),
 							filename, directory.value()),
@@ -1690,7 +1688,7 @@ void ItemListFormAction::apply_filter(const std::string& filtertext)
 
 	filterhistory.add_line(filtertext);
 	if (!matcher.parse(filtertext)) {
-		v->get_statusline().show_error(strprintf::fmt(
+		v.get_statusline().show_error(strprintf::fmt(
 				_("Error: couldn't parse filter expression `%s': %s"),
 				filtertext,
 				matcher.get_parse_error()));

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -23,7 +23,7 @@
 
 namespace newsboat {
 
-ItemViewFormAction::ItemViewFormAction(View* vv,
+ItemViewFormAction::ItemViewFormAction(View& vv,
 	std::shared_ptr<ItemListFormAction> il,
 	std::string formstr,
 	Cache* cc,
@@ -42,8 +42,6 @@ ItemViewFormAction::ItemViewFormAction(View* vv,
 	std::sort(valid_cmds.begin(), valid_cmds.end());
 	register_format_styles();
 }
-
-ItemViewFormAction::~ItemViewFormAction() {}
 
 void ItemViewFormAction::init()
 {
@@ -173,10 +171,10 @@ bool ItemViewFormAction::process_operation(Operation op,
 		bool old_unread = item->unread();
 		item->set_unread(false);
 		if (old_unread) {
-			v->get_ctrl()->mark_article_read(item->guid(), true);
+			v.get_ctrl()->mark_article_read(item->guid(), true);
 		}
 	} catch (const DbException& e) {
-		v->get_statusline().show_error(strprintf::fmt(
+		v.get_statusline().show_error(strprintf::fmt(
 				_("Error while marking article as read: %s"),
 				e.what()));
 	}
@@ -189,14 +187,14 @@ bool ItemViewFormAction::process_operation(Operation op,
 		textview.set_scroll_offset(0);
 		break;
 	case OP_ENQUEUE:
-		return enqueue_item_enclosure(item, feed, *v, *rsscache);
+		return enqueue_item_enclosure(item, feed, v, *rsscache);
 	case OP_SAVE: {
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: saving article");
 		nonstd::optional<std::string> filename;
 		switch (bindingType) {
 		case BindingType::Bind:
 			if (args.empty()) {
-				filename = v->run_filebrowser( utils::utf8_to_locale(v->get_filename_suggestion(
+				filename = v.run_filebrowser( utils::utf8_to_locale(v.get_filename_suggestion(
 								item->title())));
 			} else {
 				filename = args.front();
@@ -208,19 +206,19 @@ bool ItemViewFormAction::process_operation(Operation op,
 			}
 			break;
 		case BindingType::BindKey:
-			filename = v->run_filebrowser( utils::utf8_to_locale(v->get_filename_suggestion(
+			filename = v.run_filebrowser( utils::utf8_to_locale(v.get_filename_suggestion(
 							item->title())));
 			break;
 		}
 		if (!filename.has_value()) {
-			v->get_statusline().show_error(_("Aborted saving."));
+			v.get_statusline().show_error(_("Aborted saving."));
 		} else {
 			try {
-				v->get_ctrl()->write_item(item, filename.value());
-				v->get_statusline().show_message(strprintf::fmt(
+				v.get_ctrl()->write_item(item, filename.value());
+				v.get_statusline().show_message(strprintf::fmt(
 						_("Saved article to %s."), filename.value()));
 			} catch (...) {
-				v->get_statusline().show_error(strprintf::fmt(
+				v.get_statusline().show_error(strprintf::fmt(
 						_("Error: couldn't write article to "
 							"file %s"),
 						filename.value()));
@@ -362,9 +360,9 @@ bool ItemViewFormAction::process_operation(Operation op,
 		LOG(Level::DEBUG, "ItemViewFormAction::process_operation: showing URLs");
 		if (urlviewer == "") {
 			if (links.size() > 0) {
-				v->push_urlview(links, feed);
+				v.push_urlview(links, feed);
 			} else {
-				v->get_statusline().show_error(_("URL list empty."));
+				v.get_statusline().show_error(_("URL list empty."));
 			}
 		} else {
 			qna_responses.clear();
@@ -382,79 +380,79 @@ bool ItemViewFormAction::process_operation(Operation op,
 	case OP_NEXTUNREAD:
 		LOG(Level::INFO,
 			"ItemViewFormAction::process_operation: jumping to next unread article");
-		if (v->get_next_unread(*itemlist, this)) {
+		if (v.get_next_unread(*itemlist, this)) {
 			do_redraw = true;
 			textview.set_scroll_offset(0);
 		} else {
-			v->pop_current_formaction();
-			v->get_statusline().show_error(_("No unread items."));
+			v.pop_current_formaction();
+			v.get_statusline().show_error(_("No unread items."));
 		}
 		break;
 	case OP_PREVUNREAD:
 		LOG(Level::INFO,
 			"ItemViewFormAction::process_operation: jumping to previous unread "
 			"article");
-		if (v->get_previous_unread(*itemlist, this)) {
+		if (v.get_previous_unread(*itemlist, this)) {
 			do_redraw = true;
 			textview.set_scroll_offset(0);
 		} else {
-			v->pop_current_formaction();
-			v->get_statusline().show_error(_("No unread items."));
+			v.pop_current_formaction();
+			v.get_statusline().show_error(_("No unread items."));
 		}
 		break;
 	case OP_NEXT:
 		LOG(Level::INFO,
 			"ItemViewFormAction::process_operation: jumping to next article");
-		if (v->get_next(*itemlist, this)) {
+		if (v.get_next(*itemlist, this)) {
 			do_redraw = true;
 			textview.set_scroll_offset(0);
 		} else {
-			v->pop_current_formaction();
-			v->get_statusline().show_error(_("Already on last item."));
+			v.pop_current_formaction();
+			v.get_statusline().show_error(_("Already on last item."));
 		}
 		break;
 	case OP_PREV:
 		LOG(Level::INFO,
 			"ItemViewFormAction::process_operation: jumping to previous article");
-		if (v->get_previous(*itemlist, this)) {
+		if (v.get_previous(*itemlist, this)) {
 			do_redraw = true;
 			textview.set_scroll_offset(0);
 		} else {
-			v->pop_current_formaction();
-			v->get_statusline().show_error(_("Already on first item."));
+			v.pop_current_formaction();
+			v.get_statusline().show_error(_("Already on first item."));
 		}
 		break;
 	case OP_RANDOMUNREAD:
 		LOG(Level::INFO,
 			"ItemViewFormAction::process_operation: jumping to random unread article");
-		if (v->get_random_unread(*itemlist, this)) {
+		if (v.get_random_unread(*itemlist, this)) {
 			do_redraw = true;
 			textview.set_scroll_offset(0);
 		} else {
-			v->pop_current_formaction();
-			v->get_statusline().show_error(_("No unread items."));
+			v.pop_current_formaction();
+			v.get_statusline().show_error(_("No unread items."));
 		}
 		break;
 	case OP_TOGGLEITEMREAD: {
 		LOG(Level::INFO,
 			"ItemViewFormAction::process_operation: setting unread and quitting");
-		const auto message_lifetime = v->get_statusline().show_message_until_finished(
+		const auto message_lifetime = v.get_statusline().show_message_until_finished(
 				_("Toggling read flag for article..."));
 		try {
 			if (args.size() > 0) {
 				if (args.front() == "read") {
 					item->set_unread(false);
-					v->get_ctrl()->mark_article_read(item->guid(), true);
+					v.get_ctrl()->mark_article_read(item->guid(), true);
 				} else if (args.front() == "unread") {
 					item->set_unread(true);
-					v->get_ctrl()->mark_article_read(item->guid(), false);
+					v.get_ctrl()->mark_article_read(item->guid(), false);
 				}
 			} else {
 				item->set_unread(true);
-				v->get_ctrl()->mark_article_read(item->guid(), false);
+				v.get_ctrl()->mark_article_read(item->guid(), false);
 			}
 		} catch (const DbException& e) {
-			v->get_statusline().show_error(strprintf::fmt(
+			v.get_statusline().show_error(strprintf::fmt(
 					_("Error while marking article as unread: %s"),
 					e.what()));
 		}
@@ -470,7 +468,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 		hardquit = true;
 		break;
 	case OP_HELP:
-		v->push_help();
+		v.push_help();
 		break;
 	case OP_OPEN_URL_1:
 	case OP_OPEN_URL_2:
@@ -522,7 +520,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 	break;
 	case OP_ARTICLEFEED: {
-		auto feeds = v->get_ctrl()->get_feedcontainer()->get_all_feeds();
+		auto feeds = v.get_ctrl()->get_feedcontainer()->get_all_feeds();
 		size_t pos;
 		auto article_feed = item->get_feedptr();
 		for (pos = 0; pos < feeds.size(); pos++) {
@@ -531,7 +529,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 			}
 		}
 		if (pos != feeds.size()) {
-			v->push_itemlist(pos);
+			v.push_itemlist(pos);
 		}
 	}
 	break;
@@ -543,11 +541,11 @@ bool ItemViewFormAction::process_operation(Operation op,
 	}
 
 	if (hardquit) {
-		while (v->formaction_stack_size() > 0) {
-			v->pop_current_formaction();
+		while (v.formaction_stack_size() > 0) {
+			v.pop_current_formaction();
 		}
 	} else if (quit) {
-		v->pop_current_formaction();
+		v.pop_current_formaction();
 
 		auto parent_itemlist = std::dynamic_pointer_cast<ItemListFormAction>
 			(get_parent_formaction());
@@ -566,12 +564,12 @@ bool ItemViewFormAction::open_link_in_browser(const std::string& link,
 	const std::string& type, const std::string& title, bool interactive) const
 {
 	const std::string feedurl = item->feedurl();
-	const auto exit_code = v->open_in_browser(link, feedurl, type, title, interactive);
+	const auto exit_code = v.open_in_browser(link, feedurl, type, title, interactive);
 	if (!exit_code.has_value()) {
-		v->get_statusline().show_error(_("Failed to spawn browser"));
+		v.get_statusline().show_error(_("Failed to spawn browser"));
 		return false;
 	} else if (*exit_code != 0) {
-		v->get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
+		v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
 				*exit_code));
 		return false;
 	}
@@ -633,16 +631,16 @@ void ItemViewFormAction::handle_save(const std::string& filename_param)
 {
 	std::string filename = utils::resolve_tilde(filename_param);
 	if (filename == "") {
-		v->get_statusline().show_error(_("Aborted saving."));
+		v.get_statusline().show_error(_("Aborted saving."));
 	} else {
 		try {
-			v->get_ctrl()->write_item(
+			v.get_ctrl()->write_item(
 				item, filename);
-			v->get_statusline().show_message(strprintf::fmt(
+			v.get_statusline().show_message(strprintf::fmt(
 					_("Saved article to %s"),
 					filename));
 		} catch (...) {
-			v->get_statusline().show_error(strprintf::fmt(
+			v.get_statusline().show_error(strprintf::fmt(
 					_("Error: couldn't save "
 						"article to %s"),
 					filename));
@@ -657,8 +655,8 @@ void ItemViewFormAction::finished_qna(Operation op)
 	switch (op) {
 	case OP_INT_EDITFLAGS_END:
 		item->set_flags(qna_responses[0]);
-		v->get_ctrl()->update_flags(item);
-		v->get_statusline().show_message(_("Flags updated."));
+		v.get_ctrl()->update_flags(item);
+		v.get_statusline().show_message(_("Flags updated."));
 		do_redraw = true;
 		break;
 	case OP_INT_START_SEARCH:
@@ -667,8 +665,8 @@ void ItemViewFormAction::finished_qna(Operation op)
 	case OP_PIPE_TO: {
 		std::string cmd = qna_responses[0];
 		std::ostringstream ostr;
-		v->get_ctrl()->write_item(feed->get_item_by_guid(guid), ostr);
-		v->push_empty_formaction();
+		v.get_ctrl()->write_item(feed->get_item_by_guid(guid), ostr);
+		v.push_empty_formaction();
 		Stfl::reset();
 		FILE* f = popen(cmd.c_str(), "w");
 		if (f) {
@@ -676,8 +674,8 @@ void ItemViewFormAction::finished_qna(Operation op)
 			fwrite(data.c_str(), data.length(), 1, f);
 			pclose(f);
 		}
-		v->drop_queued_input();
-		v->pop_current_formaction();
+		v.drop_queued_input();
+		v.pop_current_formaction();
 	}
 	break;
 	case OP_INT_GOTO_URL: {
@@ -794,7 +792,7 @@ void ItemViewFormAction::highlight_text(const std::string& searchphrase)
 			"ItemViewFormAction::highlight_text: handle_action "
 			"failed, error = %s",
 			e.what());
-		v->get_statusline().show_error(_("Error: invalid regular expression!"));
+		v.get_statusline().show_error(_("Error: invalid regular expression!"));
 	}
 }
 

--- a/src/listformaction.cpp
+++ b/src/listformaction.cpp
@@ -6,7 +6,7 @@
 
 namespace newsboat {
 
-ListFormAction::ListFormAction(View* v,
+ListFormAction::ListFormAction(View& v,
 	const std::string& context,
 	std::string formstr,
 	std::string list_name,
@@ -70,7 +70,7 @@ nonstd::optional<std::uint8_t> ListFormAction::open_unread_items_in_browser(
 			cfg->get_configvalue_as_int("max-browser-tabs")) {
 			if (item->unread()) {
 				const bool interactive = true;
-				const auto exit_code = v->open_in_browser(item->link(), item->feedurl(),
+				const auto exit_code = v.open_in_browser(item->link(), item->feedurl(),
 						"article", item->title(), interactive);
 				if (!exit_code.has_value() || *exit_code != 0) {
 					return_value = exit_code;
@@ -89,7 +89,7 @@ nonstd::optional<std::uint8_t> ListFormAction::open_unread_items_in_browser(
 	}
 
 	if (guids_of_read_articles.size() > 0) {
-		v->get_ctrl()->mark_all_read(guids_of_read_articles);
+		v.get_ctrl()->mark_all_read(guids_of_read_articles);
 	}
 
 	return return_value;

--- a/src/searchresultslistformaction.cpp
+++ b/src/searchresultslistformaction.cpp
@@ -2,7 +2,7 @@
 #include "keymap.h"
 
 namespace newsboat {
-SearchResultsListFormAction::SearchResultsListFormAction(View* vv,
+SearchResultsListFormAction::SearchResultsListFormAction(View& vv,
 	std::string formstr,
 	Cache* cc,
 	FilterContainer& f,
@@ -46,11 +46,11 @@ bool SearchResultsListFormAction::process_operation(
 			// no need to mark item as read, the itemview already do
 			// that
 			old_itempos = itempos;
-			v->push_itemview(feed,
+			v.push_itemview(feed,
 				visible_items[itempos].first->guid(), search_phrase);
 			invalidate(itempos);
 		} else {
-			v->get_statusline().show_error(
+			v.get_statusline().show_error(
 				_("No item selected!")); // should not happen
 		}
 		break;
@@ -60,7 +60,7 @@ bool SearchResultsListFormAction::process_operation(
 			this->set_feed(search_results.top().search_result_feed);
 			this->set_searchphrase(search_results.top().search_phrase);
 		} else {
-			v->get_statusline().show_message(_("Already in first search result."));
+			v.get_statusline().show_message(_("Already in first search result."));
 		}
 		break;
 	default:

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -22,7 +22,7 @@ namespace newsboat {
  * a few places.
  */
 
-SelectFormAction::SelectFormAction(View* vv,
+SelectFormAction::SelectFormAction(View& vv,
 	std::string formstr,
 	ConfigContainer* cfg)
 	: FormAction(vv, formstr, cfg)
@@ -33,8 +33,6 @@ SelectFormAction::SelectFormAction(View* vv,
 	, tags_list("taglist", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
 {
 }
-
-SelectFormAction::~SelectFormAction() {}
 
 void SelectFormAction::handle_cmdline(const std::string& cmd)
 {
@@ -129,11 +127,11 @@ bool SelectFormAction::process_operation(Operation op,
 	}
 
 	if (hardquit) {
-		while (v->formaction_stack_size() > 0) {
-			v->pop_current_formaction();
+		while (v.formaction_stack_size() > 0) {
+			v.pop_current_formaction();
 		}
 	} else if (quit) {
-		v->pop_current_formaction();
+		v.pop_current_formaction();
 	}
 	return true;
 }
@@ -208,7 +206,7 @@ std::string SelectFormAction::format_line(const std::string& selecttag_format,
 {
 	FmtStrFormatter fmt;
 
-	const auto feedcontainer = v->get_ctrl()->get_feedcontainer();
+	const auto feedcontainer = v.get_ctrl()->get_feedcontainer();
 
 	const auto total_feeds = feedcontainer->get_feed_count_per_tag(tag);
 	const auto unread_feeds =

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -19,7 +19,7 @@ namespace newsboat {
  * in a browser or to bookmark them.
  */
 
-UrlViewFormAction::UrlViewFormAction(View* vv,
+UrlViewFormAction::UrlViewFormAction(View& vv,
 	std::shared_ptr<RssFeed>& feed,
 	std::string formstr,
 	ConfigContainer* cfg)
@@ -29,8 +29,6 @@ UrlViewFormAction::UrlViewFormAction(View* vv,
 	, urls_list("urls", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
 {
 }
-
-UrlViewFormAction::~UrlViewFormAction() {}
 
 bool UrlViewFormAction::process_operation(Operation op,
 	const std::vector<std::string>& /* args */,
@@ -61,7 +59,7 @@ bool UrlViewFormAction::process_operation(Operation op,
 			const unsigned int pos = urls_list.get_position();
 			this->start_bookmark_qna("", links[pos].url, feed->title());
 		} else {
-			v->get_statusline().show_error(_("No links available!"));
+			v.get_statusline().show_error(_("No links available!"));
 		}
 	}
 	break;
@@ -80,13 +78,13 @@ bool UrlViewFormAction::process_operation(Operation op,
 		if (idx < links.size()) {
 			const std::string feedurl = (feed != nullptr ?  feed->rssurl() : "");
 			const bool interactive = true;
-			v->open_in_browser(links[idx].url, feedurl, utils::link_type_str(links[idx].type),
+			v.open_in_browser(links[idx].url, feedurl, utils::link_type_str(links[idx].type),
 				feed->title(), interactive);
 		}
 	}
 	break;
 	case OP_HELP:
-		v->push_help();
+		v.push_help();
 		break;
 	case OP_QUIT:
 		quit = true;
@@ -101,11 +99,11 @@ bool UrlViewFormAction::process_operation(Operation op,
 		break;
 	}
 	if (hardquit) {
-		while (v->formaction_stack_size() > 0) {
-			v->pop_current_formaction();
+		while (v.formaction_stack_size() > 0) {
+			v.pop_current_formaction();
 		}
 	} else if (quit) {
-		v->pop_current_formaction();
+		v.pop_current_formaction();
 	}
 	return true;
 }
@@ -115,10 +113,10 @@ void UrlViewFormAction::open_current_position_in_browser(bool interactive)
 	if (!links.empty()) {
 		const unsigned int pos = urls_list.get_position();
 		const std::string feedurl = (feed != nullptr ?  feed->rssurl() : "");
-		v->open_in_browser(links[pos].url, feedurl, utils::link_type_str(links[pos].type),
+		v.open_in_browser(links[pos].url, feedurl, utils::link_type_str(links[pos].type),
 			feed->title(), interactive);
 	} else {
-		v->get_statusline().show_error(_("No links available!"));
+		v.get_statusline().show_error(_("No links available!"));
 	}
 }
 
@@ -172,7 +170,7 @@ void UrlViewFormAction::handle_cmdline(const std::string& cmd)
 	unsigned int idx = 0;
 	if (1 == sscanf(cmd.c_str(), "%u", &idx)) {
 		if (idx < 1 || idx > links.size()) {
-			v->get_statusline().show_error(_("Invalid position!"));
+			v.get_statusline().show_error(_("Invalid position!"));
 		} else {
 			urls_list.set_position(idx - 1);
 		}

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -157,7 +157,7 @@ int View::run()
 	bool have_macroprefix = false;
 
 	feedlist_form = std::make_shared<FeedListFormAction>(
-			this, feedlist_str, rsscache, filters, cfg, rxman);
+			*this, feedlist_str, rsscache, filters, cfg, rxman);
 	apply_colors(feedlist_form);
 	formaction_stack.push_back(feedlist_form);
 	current_formaction = formaction_stack_size() - 1;
@@ -465,7 +465,7 @@ void View::push_searchresult(std::shared_ptr<RssFeed> feed,
 	if (feed->total_item_count() > 0) {
 		if (this->get_current_formaction()->id() != "searchresultslist") {
 			auto searchresult = std::make_shared<SearchResultsListFormAction>(
-					this, itemlist_str, rsscache, filters, cfg, rxman);
+					*this, itemlist_str, rsscache, filters, cfg, rxman);
 			apply_colors(searchresult);
 			searchresult->set_parent_formaction(get_current_formaction());
 			searchresult->add_to_history(feed, phrase);
@@ -495,7 +495,7 @@ std::shared_ptr<ItemListFormAction> View::push_itemlist(
 
 	if (feed->total_item_count() > 0) {
 		auto itemlist = std::make_shared<ItemListFormAction>(
-				this, itemlist_str, rsscache, filters, cfg, rxman);
+				*this, itemlist_str, rsscache, filters, cfg, rxman);
 		itemlist->set_feed(feed);
 		apply_colors(itemlist);
 		itemlist->set_parent_formaction(get_current_formaction());
@@ -534,7 +534,7 @@ void View::push_itemview(std::shared_ptr<RssFeed> f,
 			FormAction>(fa);
 		assert(itemlist != nullptr);
 		auto itemview = std::make_shared<ItemViewFormAction>(
-				this, itemlist, itemview_str, rsscache, cfg, rxman);
+				*this, itemlist, itemview_str, rsscache, cfg, rxman);
 		itemview->set_feed(f);
 		itemview->set_guid(guid);
 		itemview->set_parent_formaction(fa);
@@ -570,7 +570,7 @@ void View::view_dialogs()
 	auto fa = get_current_formaction();
 	if (fa != nullptr && fa->id() != "dialogs") {
 		auto dialogs = std::make_shared<DialogsFormAction>(
-				this, dialogs_str, cfg, rxman);
+				*this, dialogs_str, cfg, rxman);
 		dialogs->set_parent_formaction(fa);
 		apply_colors(dialogs);
 		dialogs->init();
@@ -584,7 +584,7 @@ void View::push_empty_formaction()
 	auto fa = get_current_formaction();
 
 	auto empty_view = std::make_shared<EmptyFormAction>(
-			this, empty_str, cfg);
+			*this, empty_str, cfg);
 	empty_view->set_parent_formaction(fa);
 	empty_view->init();
 	formaction_stack.push_back(empty_view);
@@ -596,7 +596,7 @@ void View::push_help()
 	auto fa = get_current_formaction();
 
 	auto helpview = std::make_shared<HelpFormAction>(
-			this, help_str, cfg, fa->id());
+			*this, help_str, cfg, fa->id());
 	apply_colors(helpview);
 	helpview->set_parent_formaction(fa);
 	helpview->init();
@@ -608,7 +608,7 @@ void View::push_urlview(const Links& links,
 	std::shared_ptr<RssFeed>& feed)
 {
 	auto urlview = std::make_shared<UrlViewFormAction>(
-			this, feed, urlview_str, cfg);
+			*this, feed, urlview_str, cfg);
 	apply_colors(urlview);
 	urlview->set_parent_formaction(get_current_formaction());
 	urlview->init();
@@ -620,7 +620,7 @@ void View::push_urlview(const Links& links,
 nonstd::optional<std::string> View::run_filebrowser(const std::string& default_filename)
 {
 	auto filebrowser = std::make_shared<FileBrowserFormAction>(
-			this, filebrowser_str, cfg);
+			*this, filebrowser_str, cfg);
 	apply_colors(filebrowser);
 	filebrowser->set_default_filename(default_filename);
 	filebrowser->set_parent_formaction(get_current_formaction());
@@ -634,7 +634,7 @@ nonstd::optional<std::string> View::run_filebrowser(const std::string& default_f
 nonstd::optional<std::string> View::run_dirbrowser()
 {
 	auto dirbrowser = std::make_shared<DirBrowserFormAction>(
-			this, filebrowser_str, cfg);
+			*this, filebrowser_str, cfg);
 	apply_colors(dirbrowser);
 	dirbrowser->set_parent_formaction(get_current_formaction());
 	std::string res = run_modal(dirbrowser, "filenametext");
@@ -651,7 +651,7 @@ std::string View::select_tag(const std::string& current_tag)
 		return "";
 	}
 	auto selecttag = std::make_shared<SelectFormAction>(
-			this, selecttag_str, cfg);
+			*this, selecttag_str, cfg);
 	selecttag->set_type(SelectFormAction::SelectionType::TAG);
 	apply_colors(selecttag);
 	selecttag->set_parent_formaction(get_current_formaction());
@@ -664,7 +664,7 @@ std::string View::select_tag(const std::string& current_tag)
 std::string View::select_filter(const std::vector<FilterNameExprPair>& filters)
 {
 	auto selecttag = std::make_shared<SelectFormAction>(
-			this, selecttag_str, cfg);
+			*this, selecttag_str, cfg);
 	selecttag->set_type(SelectFormAction::SelectionType::FILTER);
 	apply_colors(selecttag);
 	selecttag->set_parent_formaction(get_current_formaction());

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -58,7 +58,7 @@ TEST_CASE("OP_OPEN displays article using an external pager",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	const std::vector<std::string> args;
@@ -89,7 +89,7 @@ TEST_CASE("OP_PURGE_DELETED purges previously deleted items",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	SECTION("No items to purge") {
@@ -134,7 +134,7 @@ TEST_CASE(
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 	const std::vector<std::string> args;
 	itemlist.process_op(OP_OPENBROWSER_AND_MARK, args);
@@ -172,7 +172,7 @@ TEST_CASE(
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 	const std::vector<std::string> args;
 	itemlist.process_op(OP_OPENBROWSER_AND_MARK, args);
@@ -205,7 +205,7 @@ TEST_CASE("OP_OPENINBROWSER passes the url to the browser",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 	const std::vector<std::string> args;
 	itemlist.process_op(OP_OPENINBROWSER, args);
@@ -240,7 +240,7 @@ TEST_CASE("OP_OPENINBROWSER_NONINTERACTIVE passes the url to the browser",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 	const std::vector<std::string> args;
 	itemlist.process_op(newsboat::OP_OPENINBROWSER_NONINTERACTIVE, args);
@@ -283,7 +283,7 @@ TEST_CASE("OP_OPENALLUNREADINBROWSER passes the url list to the browser",
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	SECTION("unread >= max-browser-tabs") {
@@ -369,7 +369,7 @@ TEST_CASE(
 	v.set_config_container(&cfg);
 	c.set_view(&v);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	SECTION("unread >= max-browser-tabs") {
@@ -455,7 +455,7 @@ TEST_CASE("OP_SHOWURLS shows the article's properties", "[ItemListFormAction]")
 	item->set_author(test_author);
 	item->set_description(test_description, "text/plain");
 	item->set_pubDate(test_pubDate);
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 
 	SECTION("with external-url-viewer") {
 		feed->add_item(item);
@@ -517,7 +517,7 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 	item->set_link(test_url);
 	item->set_title(test_title);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 
 	feed->add_item(item);
 	itemlist.set_feed(feed);
@@ -569,7 +569,7 @@ TEST_CASE("OP_EDITFLAGS arguments are added to an item's flags",
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 	std::shared_ptr<RssItem> item = std::make_shared<RssItem>(&rsscache);
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 
 	feed->add_item(item);
 	itemlist.set_feed(feed);
@@ -646,7 +646,7 @@ TEST_CASE("OP_SAVE writes an article's attributes to the specified file",
 	item->set_pubDate(test_pubDate);
 	item->set_description(test_description, "text/plain");
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 
 	feed->add_item(item);
 	itemlist.set_feed(feed);
@@ -715,7 +715,7 @@ TEST_CASE("OP_HARDQUIT command is processed", "[ItemListFormAction]")
 
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, "");
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 	itemlist.set_feed(feed);
 
 	const std::vector<std::string> args;
@@ -852,7 +852,7 @@ TEST_CASE("OP_PIPE_TO pipes an article's content to an external command",
 	item->set_pubDate(test_pubDate);
 	item->set_description(test_description, "text/plain");
 
-	ItemListFormAction itemlist(&v, itemlist_str, &rsscache, filters, &cfg, rxman);
+	ItemListFormAction itemlist(v, itemlist_str, &rsscache, filters, &cfg, rxman);
 
 	feed->add_item(item);
 	itemlist.set_feed(feed);


### PR DESCRIPTION
I recently heard about clang-tidy from a colleague.
With the default list of clang-tidy checks, there are a bunch of warnings.
Most of them in `filter/` which I'm going to ignore (generated code?).
A few in `src/htmlrenderer.cpp` which I don't think are useful to change on their own:
```
src/htmlrenderer.cpp:532:6: warning: Value stored to 'inside_video' is never read [clang-analyzer-deadcode.DeadStores]
                                        inside_video = false;
                                        ^              ~~~~~
src/htmlrenderer.cpp:583:6: warning: Value stored to 'inside_audio' is never read [clang-analyzer-deadcode.DeadStores]
                                        inside_audio = false;
                                        ^              ~~~~~
```

And a few in `src/filebrowserformaction.cpp` and `src/dirbrowserformaction.cpp` which I'm resolving in this PR:
```
src/dirbrowserformaction.cpp:38:34: warning: Call to virtual method 'DirBrowserFormAction::id' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
        keys->set_key(OP_OPEN, "ENTER", id());
                                        ^~~~
src/dirbrowserformaction.cpp:39:32: warning: Call to virtual method 'DirBrowserFormAction::id' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
        keys->set_key(OP_QUIT, "ESC", id());
                                      ^~~~
src/filebrowserformaction.cpp:40:34: warning: Call to virtual method 'FileBrowserFormAction::id' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
        keys->set_key(OP_OPEN, "ENTER", id());
                                        ^~~~
src/filebrowserformaction.cpp:41:32: warning: Call to virtual method 'FileBrowserFormAction::id' during construction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
        keys->set_key(OP_QUIT, "ESC", id());
                                      ^~~~
```