### PR TITLE
Add utilities for detecting text encoding based on byte-order-mark and XML declaration

### DIFF
--- a/include/charencoding.h
+++ b/include/charencoding.h
@@ -1,0 +1,20 @@
+#ifndef NEWSBOAT_CHARENCODING_H_
+#define NEWSBOAT_CHARENCODING_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "3rd-party/optional.hpp"
+
+namespace newsboat {
+namespace charencoding {
+
+nonstd::optional<std::string> charset_from_bom(std::vector<std::uint8_t> content);
+nonstd::optional<std::string> charset_from_xml_declaration(std::vector<std::uint8_t>
+	content);
+
+} // namespace charencoding
+} // namespace newsboat
+
+#endif /* NEWSBOAT_CHARENCODING_H_ */

--- a/mk/libboat.deps
+++ b/mk/libboat.deps
@@ -1,3 +1,4 @@
+src/charencoding.cpp
 src/colormanager.cpp
 src/configcontainer.cpp
 src/configdata.cpp

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -10,6 +10,7 @@ fn add_cxxbridge(module: &str) {
 }
 
 fn main() {
+    add_cxxbridge("charencoding");
     add_cxxbridge("cliargsparser");
     add_cxxbridge("configpaths");
     add_cxxbridge("fmtstrformatter");

--- a/rust/libnewsboat-ffi/src/charencoding.rs
+++ b/rust/libnewsboat-ffi/src/charencoding.rs
@@ -1,0 +1,29 @@
+use libnewsboat::charencoding;
+
+#[cxx::bridge(namespace = "newsboat::charencoding::bridged")]
+mod bridged {
+    extern "Rust" {
+        fn charset_from_bom(content: &[u8], output: &mut String) -> bool;
+        fn charset_from_xml_declaration(content: &[u8], output: &mut String) -> bool;
+    }
+}
+
+fn charset_from_bom(content: &[u8], output: &mut String) -> bool {
+    match charencoding::charset_from_bom(content) {
+        Some(charset) => {
+            *output = charset.to_owned();
+            true
+        }
+        None => false,
+    }
+}
+
+fn charset_from_xml_declaration(content: &[u8], output: &mut String) -> bool {
+    match charencoding::charset_from_xml_declaration(content) {
+        Some(charset) => {
+            *output = charset.to_owned();
+            true
+        }
+        None => false,
+    }
+}

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -10,6 +10,7 @@ use std::ffi::CString;
 use std::panic::{catch_unwind, UnwindSafe};
 use std::process::abort;
 
+pub mod charencoding;
 pub mod cliargsparser;
 pub mod configpaths;
 pub mod fmtstrformatter;

--- a/rust/libnewsboat/src/charencoding.rs
+++ b/rust/libnewsboat/src/charencoding.rs
@@ -1,3 +1,13 @@
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::{alpha1, alphanumeric1, digit1, space0};
+use nom::combinator::recognize;
+use nom::multi::many0;
+use nom::sequence::pair;
+use nom::IResult;
+use std::str;
+
+/// Returns charset if it can be derived from the optional byte-order-mark
 pub fn charset_from_bom(content: &[u8]) -> Option<&'static str> {
     match content {
         [0x00, 0x00, 0xFE, 0xFF, ..] => Some("UTF-32BE"),
@@ -8,6 +18,49 @@ pub fn charset_from_bom(content: &[u8]) -> Option<&'static str> {
         [0x2B, 0x2F, 0x76, ..] => Some("UTF-7"),
         _ => None,
     }
+}
+
+/// Returns charset if the encoding is specified in an XML declaration
+///
+/// Example XML declaration: `<?xml version="1.0" encoding="UTF-8"?>`
+pub fn charset_from_xml_declaration(content: &[u8]) -> Option<String> {
+    fn parse_version_info(input: &[u8]) -> IResult<&[u8], ()> {
+        let (input, _) = space0(input)?;
+        let (input, _) = tag(b"version=")(input)?;
+        let (input, quote) = alt((tag(b"\""), tag(b"'")))(input)?;
+        let (input, _) = tag(b"1.")(input)?;
+        let (input, _) = digit1(input)?;
+        let (input, _) = tag(quote)(input)?;
+        Ok((input, ()))
+    }
+
+    fn parse_encoding_declaration(input: &[u8]) -> IResult<&[u8], &str> {
+        let (input, _) = space0(input)?;
+        let (input, _) = tag(b"encoding=")(input)?;
+        let (input, quote) = alt((tag(b"\""), tag(b"'")))(input)?;
+        let (input, encoding) = recognize(pair(
+            alpha1,
+            many0(alt((alphanumeric1, tag("_"), tag("-"), tag(".")))),
+        ))(input)?;
+        let (input, _) = tag(quote)(input)?;
+
+        // This unwrap should be safe because the encoding can only consists of ASCII characters
+        // a-z, A-Z, 0-9, '.', '_', and '-'. These ASCII characters are valid 1-byte UTF-8 sequences.
+        let encoding = str::from_utf8(encoding).unwrap();
+
+        Ok((input, encoding))
+    }
+
+    fn parse_xml_declaration(input: &[u8]) -> IResult<&[u8], String> {
+        let (input, _) = tag(b"<?xml")(input)?;
+        let (input, _) = parse_version_info(input)?;
+        let (input, encoding) = parse_encoding_declaration(input)?;
+        Ok((input, encoding.to_owned()))
+    }
+
+    parse_xml_declaration(content)
+        .ok()
+        .map(|(_, encoding)| encoding)
 }
 
 #[cfg(test)]
@@ -46,5 +99,45 @@ mod tests {
         }
         assert_eq!(charset_from_bom(&utf16_bytes_le), Some("UTF-16LE"));
         assert_eq!(charset_from_bom(&utf16_bytes_be), Some("UTF-16BE"));
+    }
+
+    #[test]
+    fn t_charset_from_xml_declaration_empty_slice_none() {
+        assert_eq!(charset_from_xml_declaration(&[]), None);
+    }
+
+    #[test]
+    fn t_charset_from_xml_declaration_no_declaration_none() {
+        assert_eq!(
+            charset_from_xml_declaration(b"not an xml declaration"),
+            None
+        );
+    }
+
+    #[test]
+    fn t_charset_from_xml_declaration_valid_encoding_extracted() {
+        let input = br#"<?xml version="1.0" encoding="koi8-r"?>"#;
+        assert_eq!(
+            charset_from_xml_declaration(input),
+            Some("koi8-r".to_owned())
+        );
+    }
+
+    #[test]
+    fn t_charset_from_xml_declaration_no_encoding_none() {
+        let input = br#"<?xml version="1.0" ?>"#;
+        assert_eq!(charset_from_xml_declaration(input), None);
+    }
+
+    #[test]
+    fn t_charset_from_xml_declaration_invalid_encoding() {
+        let input = br#"<?xml version="1.0" encoding="no spaces allowed in encoding" ?>"#;
+        assert_eq!(charset_from_xml_declaration(input), None);
+    }
+
+    #[test]
+    fn t_charset_from_xml_declaration_leading_space_fails_parsing() {
+        let input = br#" <?xml version="1.0" encoding="koi8-r"?>"#;
+        assert_eq!(charset_from_xml_declaration(input), None);
     }
 }

--- a/rust/libnewsboat/src/charencoding.rs
+++ b/rust/libnewsboat/src/charencoding.rs
@@ -1,0 +1,50 @@
+pub fn charset_from_bom(content: &[u8]) -> Option<&'static str> {
+    match content {
+        [0x00, 0x00, 0xFE, 0xFF, ..] => Some("UTF-32BE"),
+        [0xFF, 0xFE, 0x00, 0x00, ..] => Some("UTF-32LE"),
+        [0xFE, 0xFF, ..] => Some("UTF-16BE"),
+        [0xFF, 0xFE, ..] => Some("UTF-16LE"),
+        [0xEF, 0xBB, 0xBF, ..] => Some("UTF-8"),
+        [0x2B, 0x2F, 0x76, ..] => Some("UTF-7"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn t_charset_from_bom_on_empty_slice_none() {
+        assert_eq!(charset_from_bom(&[]), None);
+    }
+
+    #[test]
+    fn t_charset_from_bom_slice_without_bom_none() {
+        assert_eq!(charset_from_bom("regular string".as_bytes()), None);
+    }
+
+    #[test]
+    fn t_charset_from_bom_utf8_slice_with_bom_some() {
+        assert_eq!(
+            charset_from_bom("\u{feff}regular string".as_bytes()),
+            Some("UTF-8")
+        );
+    }
+
+    #[test]
+    fn t_charset_from_bom_utf16_slice_with_bom_some() {
+        let mut utf16_bytes_le = vec![];
+        let mut utf16_bytes_be = vec![];
+        for c in "\u{feff}regular string".encode_utf16() {
+            let low = c as u8;
+            let high = (c >> 8) as u8;
+            utf16_bytes_le.push(low);
+            utf16_bytes_le.push(high);
+            utf16_bytes_be.push(high);
+            utf16_bytes_be.push(low);
+        }
+        assert_eq!(charset_from_bom(&utf16_bytes_le), Some("UTF-16LE"));
+        assert_eq!(charset_from_bom(&utf16_bytes_be), Some("UTF-16BE"));
+    }
+}

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -9,6 +9,7 @@ pub mod logger;
 pub mod human_panic;
 pub mod utils;
 
+pub mod charencoding;
 pub mod cliargsparser;
 pub mod configpaths;
 pub mod filterparser;

--- a/src/charencoding.cpp
+++ b/src/charencoding.cpp
@@ -1,0 +1,30 @@
+#include "charencoding.h"
+
+#include "libnewsboat-ffi/src/charencoding.rs.h"
+
+namespace newsboat {
+namespace charencoding {
+
+nonstd::optional<std::string> charset_from_bom(std::vector<std::uint8_t> content)
+{
+	rust::String charset;
+	const auto input = rust::Slice<const std::uint8_t>(content.data(), content.size());
+	if (charencoding::bridged::charset_from_bom(input, charset)) {
+		return std::string(charset);
+	}
+	return {};
+}
+
+nonstd::optional<std::string> charset_from_xml_declaration(std::vector<std::uint8_t>
+	content)
+{
+	rust::String charset;
+	const auto input = rust::Slice<const std::uint8_t>(content.data(), content.size());
+	if (charencoding::bridged::charset_from_xml_declaration(input, charset)) {
+		return std::string(charset);
+	}
+	return {};
+}
+
+} // namespace charencoding
+} // namespace newsboat

--- a/test/charencoding.cpp
+++ b/test/charencoding.cpp
@@ -1,0 +1,54 @@
+#include "charencoding.h"
+
+#include <map>
+
+#include "3rd-party/catch.hpp"
+
+using namespace newsboat;
+
+TEST_CASE("charset_from_bom", "[charencoding]")
+{
+	const std::map<std::string, nonstd::optional<std::string>> test_cases {
+		{ "", nonstd::nullopt },
+		{ "text without BOM", nonstd::nullopt },
+		{ "\xEF\xBB\xBFtext with BOM", "UTF-8" },
+		{ "\xFE\xFFtext with BOM", "UTF-16BE" },
+		{ "\xFF\xFEtext with BOM", "UTF-16LE" },
+	};
+
+	for (const auto& test_case : test_cases) {
+		std::vector<std::uint8_t> input(test_case.first.begin(), test_case.first.end());
+
+		const auto actual = charencoding::charset_from_bom(input);
+		const auto expected = test_case.second;
+
+		INFO("actual: " << (actual.has_value() ? actual.value().c_str() : ""));
+		INFO("expected: " << (expected.has_value() ? expected.value().c_str() : ""));
+
+		REQUIRE(actual == expected);
+	}
+}
+
+TEST_CASE("charset_from_xml_declaration", "[charencoding]")
+{
+	const std::map<std::string, nonstd::optional<std::string>> test_cases {
+		{ "", nonstd::nullopt },
+		{ "not a declaration", nonstd::nullopt },
+		{ R"(<?xml version="1.0"?>No encoding specified)", nonstd::nullopt },
+		{ R"(<?xml version="1.0" encoding="UTF-8"?>Encoding specified)", "UTF-8" },
+		{ R"(<?xml version="1.0" encoding="utf-8"?>Encoding specified)", "utf-8" },
+		{ R"(<?xml version="1.0" encoding="fake.encoding"?>Encoding specified)", "fake.encoding" },
+	};
+
+	for (const auto& test_case : test_cases) {
+		std::vector<std::uint8_t> input(test_case.first.begin(), test_case.first.end());
+
+		const auto actual = charencoding::charset_from_xml_declaration(input);
+		const auto expected = test_case.second;
+
+		INFO("actual: " << (actual.has_value() ? actual.value().c_str() : ""));
+		INFO("expected: " << (expected.has_value() ? expected.value().c_str() : ""));
+
+		REQUIRE(actual == expected);
+	}
+}


### PR DESCRIPTION
These commits introduce a few utility functions for detecting the character encoding of text.
This can be used in a future PR to resolve several of our encoding issues (probably extending or obsoleting https://github.com/newsboat/newsboat/pull/2340).