### PR TITLE
Fix setup for old SSL library versions

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -27,13 +27,6 @@
 #include <unistd.h>
 #include <unordered_set>
 
-#include "config.h"
-#include "curldatareceiver.h"
-#include "curlhandle.h"
-#include "htmlrenderer.h"
-#include "logger.h"
-#include "strprintf.h"
-
 #if HAVE_GCRYPT
 #include <gnutls/gnutls.h>
 #if GNUTLS_VERSION_NUMBER < 0x020b00
@@ -50,6 +43,13 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 #include <openssl/crypto.h>
 #endif
 #endif
+
+#include "config.h"
+#include "curldatareceiver.h"
+#include "curlhandle.h"
+#include "htmlrenderer.h"
+#include "logger.h"
+#include "strprintf.h"
 
 using HTTPMethod = newsboat::utils::HTTPMethod;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -828,7 +828,6 @@ void utils::initialize_ssl_implementation(void)
 
 #if HAVE_GCRYPT && GNUTLS_VERSION_NUMBER < 0x020b00
 	gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
-	gnutls_global_init();
 #endif
 }
 


### PR DESCRIPTION
Currently the macro guard for manually setting up the OpenSSL library for multi-threaded use is confusing.
First, `openssl/opensslv.h` has to be included to use `OPENSSL_VERSION_NUMBER`. Otherwise `OPENSSL_VERSION_NUMBER` (= 0) < 0x01010000fL always holds. There is no bug here, this just creates unnecessary complexity imo.
Second, the correct unsigned long for version 1.1.0 is 0x10100000L, not 0x(0)1010000fL. The format is 0xMNN00PP0L where M := major, N := minor and P := patch version.

I also added a macro guard for manually setting up locking procedures for GnuTLS. This has been discouraged since version 2.11.0 and deprecated since 3.7.3.
See changelog: https://gitlab.com/gnutls/gnutls/-/blob/master/NEWS?ref_type=heads#L4521
and commit: https://gitlab.com/gnutls/gnutls/-/commit/fe1b3846c8c34a103da138e375f435f72fa042a6
and deprecation: https://gnutls.org/reference/gnutls-gnutls.html#gnutls-global-set-mutex

Finally, I removed the call to initialize GnuTLS since curl handles it ever since [version 7.32.0](https://github.com/curl/curl/blob/70812c2f32fc5734bcbbe572b9f61c380433ad6a/lib/gtls.c#L163-L167), if the `CURL_GLOBAL_SSL` flag is set upon initialization (which it is).