### PR TITLE
Adds a bookmark plugin for Linkding

### DIFF
--- a/contrib/linkding/README.md
+++ b/contrib/linkding/README.md
@@ -1,0 +1,10 @@
+# README
+
+A simple Linkding plugin. 
+
+1. `gem install httparty`
+2. Edit to reflect your Linkding instance's API endpoint. (e.g. `http://example.com/api/bookmarks`)
+3. Get your Linkding API key from `Settings > Integrations` in your Linkding instance 
+4. Either set the environment variable `LINKDING_TOKEN` with your API key from step 3, or hardcode your API key in this script by setting the `token` variable on line 10.
+5. Copy somewhere you can find it. (`~/bin`, `~/usr/local/bin`, etc.)
+5. Set `bookmark-cmd` to `~/bin/linkding.rb` or wherever you put this.  

--- a/contrib/linkding/README.md
+++ b/contrib/linkding/README.md
@@ -1,10 +1,10 @@
 # README
 
-A simple Linkding plugin. 
+A simple Linkding plugin.
 
 1. `gem install httparty`
 2. Edit to reflect your Linkding instance's API endpoint. (e.g. `http://example.com/api/bookmarks`)
-3. Get your Linkding API key from `Settings > Integrations` in your Linkding instance 
+3. Get your Linkding API key from `Settings > Integrations` in your Linkding instance
 4. Either set the environment variable `LINKDING_TOKEN` with your API key from step 3, or hardcode your API key in this script by setting the `token` variable on line 10.
 5. Copy somewhere you can find it. (`~/bin`, `~/usr/local/bin`, etc.)
-5. Set `bookmark-cmd` to `~/bin/linkding.rb` or wherever you put this.  
+6. Set `bookmark-cmd` to `~/bin/linkding.rb` or wherever you put this.

--- a/contrib/linkding/linkding.rb
+++ b/contrib/linkding/linkding.rb
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+require 'httparty' # gem install httparty
+require 'json'
+
+# Set this to your own instance's API URL:
+linkding_uri = "http://example.linkding.com/api/bookmarks"
+
+# Get your Linkding API key from Settings > Integrations
+# Set the LINKDING_TOKEN env variable with you Linkding key, or just hardcode it here.
+token = ENV['LINKDING_TOKEN']
+
+link_url = ARGV[0]
+link_title = ARGV[1]
+description = ARGV[2]
+website_title = ARGV[3]
+
+params = {url: URI(link_url), title: link_title, website_title: website_title, unread: true}
+headers = {'Content-Type' => "application/json", 'Authorization' => "Token #{token}"}
+
+resp = HTTParty.post(linkding_uri, body: params.to_json, headers: headers)


### PR DESCRIPTION
Super simple plugin for Linkding. Could stand to be refactored to use Ruby's native `net:http` library to remove the dependency on `httparty`. 

README has step-by-step on how to configure and deploy. 