### PR TITLE
adds simple wallabag bookmark plugin

### DIFF
--- a/contrib/wallabag/README.md
+++ b/contrib/wallabag/README.md
@@ -1,0 +1,13 @@
+# README
+
+A simple Wallabag plugin.
+
+1. `gem install httparty`
+2. Edit to reflect your Wallabag instance's base URL. (e.g. `https://wallabag.example.com/`)
+3. Get your Wallabag API tokens from `Settings > API clients management` in your Wallabag instance
+4. Either set the following environment variables with your tokens from step 3, or hardcode them in this script:
+   - `WALLABAG_CLIENT`
+   - `WALLABAG_SECRET`
+5. Set `WALLABAG_USER` and `WALLABAG_PASSWORD`, either as environment variables or hardcode them.
+5. Copy somewhere you can find it. (`~/bin`, `~/usr/local/bin`, etc.)
+6. Set `bookmark-cmd` to `~/bin/wallabag.rb` or wherever you put this.

--- a/contrib/wallabag/wallabag.rb
+++ b/contrib/wallabag/wallabag.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+require 'httparty' # gem install httparty
+require 'json'
+
+entry_url = ARGV[0]
+
+# Change to reflext your own Wallabag instance's base URL
+wallabag_url="https://wallabag.example.net"
+
+
+# Get your client_id and client_secret from Wallabag:
+# Settings -> API clients management
+# Either hardcode these values or put them into environment variables
+client_id = ENV['WALLABAG_CLIENT']
+client_secret = ENV['WALLABAG_SECRET']
+username = ENV['WALLABAG_USER']
+password = ENV['WALLABAG_PASSWORD']
+
+# Get an oauth token. Expires every 30 minutes
+token_params = {grant_type: "password", client_id: client_id, client_secret: client_secret, username: username, password: password}
+token_req = HTTParty.post("#{wallabag_url}/oauth/v2/token", body: token_params)
+access_token = token_req["access_token"]
+
+# Store the bookmark. Wallabag extracts from the page, so we're not sending title, desc, etc.
+headers = {'Content-Type' => "application/json", 'Authorization' => "Bearer #{access_token}"}
+params = {url: entry_url, starred: 0, archive: 0}
+resp = HTTParty.post("#{wallabag_url}/api/entries.json", body: params.to_json, headers: headers)


### PR DESCRIPTION
A super simple bookmark plugin for Wallabag. Could stand to be refactored to use Ruby's native net:http library to remove the dependency on httparty. This one only sends the URL since Wallabag does its own extraction of title and description. 

README has step-by-step on how to configure and deploy.