### PR TITLE
Add clang-tidy to the Makefile and CI, fix warnings it produces

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -456,3 +456,25 @@ task:
       # We need parentheses to prevent YAML parser from eating up the
       # exclamation mark.
       - ( ! grep -Ern '\<dbg!' * )
+
+task:
+    name: clang-tidy (Clang 17, Ubuntu 23.10)
+    skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
+
+    container:
+      greedy: true
+      dockerfile: docker/ubuntu_23.10-build-tools.dockerfile
+      docker_arguments:
+          cxx_package: "clang-tidy-17"
+          cc: clang-17
+          cxx: clang++-17
+
+    env:
+      CLANG_TIDY: "clang-tidy-17"
+      JOBS: 2
+
+    cargo_cache: *cargo_cache
+
+    after_cache_script: *after_cache_script
+    test_script: make -j${JOBS} --keep-going clang-tidy
+    before_cache_script: *before_cache_script

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,45 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: '*'
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+CheckOptions:
+  - key:             llvm-else-after-return.WarnOnConditionVariables
+    value:           'false'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             cert-str34-c.DiagnoseSignedUnsignedCharComparisons
+    value:           'false'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             cert-err33-c.CheckedFunctions
+    value:           '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s;'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           'false'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           'true'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             llvm-qualified-auto.AddConstToQualified
+    value:           'false'
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             llvm-else-after-return.WarnOnUnfixable
+    value:           'false'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ doc/podboat-cmds-linked.asciidoc
 /cppcheck.log
 *.dSYM
 /.deps/
+/compile_flags.txt

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -529,11 +529,8 @@ void HtmlRenderer::render(std::istream& input,
 				// have a closing tag
 				if (inside_video || inside_audio) {
 					source_count = 0;
-					inside_video = false;
 					inside_audio = false;
-					LOG(Level::WARN,
-						"HtmlRenderer::render: "
-						"media element left unclosed");
+					LOG(Level::WARN, "HtmlRenderer::render: media element left unclosed");
 				}
 				inside_video = true;
 
@@ -580,10 +577,7 @@ void HtmlRenderer::render(std::istream& input,
 				if (inside_video || inside_audio) {
 					source_count = 0;
 					inside_video = false;
-					inside_audio = false;
-					LOG(Level::WARN,
-						"HtmlRenderer::render: "
-						"media element left unclosed");
+					LOG(Level::WARN, "HtmlRenderer::render: media element left unclosed");
 				}
 				inside_audio = true;
 

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -8,9 +8,10 @@
 #include <functional>
 #include <iostream>
 #include <langinfo.h>
+#include <random>
 #include <sstream>
-#include <sys/utsname.h>
 #include <string.h>
+#include <sys/utsname.h>
 #include <time.h>
 
 #include "cache.h"
@@ -335,7 +336,9 @@ void RssFeed::sort_unlocked(const ArticleSortStrategy& sort_strategy)
 		});
 		break;
 	case ArtSortMethod::RANDOM:
-		std::random_shuffle(items_.begin(), items_.end());
+		std::random_device rd;
+		std::default_random_engine rng(rd());
+		std::shuffle(items_.begin(), items_.end(), rng);
 		break;
 	}
 }


### PR DESCRIPTION
I'm a sucker for static analysis, so even though I initially agreed with https://github.com/newsboat/newsboat/pull/2654#issuecomment-1937004529, I still feel like we should have clang-tidy in CI. So here goes. My expectation is that we'll gradually expand .clang-tidy with more stringent checks.