### PR TITLE
Fix -Wpedantic warnings

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -142,7 +142,7 @@ task:
                 cc: gcc-13
                 cxx: g++-13
           env: &extra_warnings_and_checks_env
-            CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-all -Wstack-protector -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3 -Wpedantic"
+            CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-all -Wstack-protector -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
         - name: Clang 17, more warnings and checks (Ubuntu 23.10)
           container:
             greedy: true

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -142,7 +142,7 @@ task:
                 cc: gcc-13
                 cxx: g++-13
           env: &extra_warnings_and_checks_env
-            CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-all -Wstack-protector -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
+            CXXFLAGS: "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-all -Wstack-protector -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3 -Wpedantic"
         - name: Clang 17, more warnings and checks (Ubuntu 23.10)
           container:
             greedy: true

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -42,6 +42,11 @@ enum class BindingType {
 struct Command {
 	CommandType type;
 	std::vector<std::string> args;
+
+	Command(CommandType type, std::vector<std::string> args = {})
+		: type(type)
+		, args(args)
+	{}
 };
 
 class FormAction {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -609,29 +609,29 @@ Command FormAction::parse_command(const std::string& input,
 {
 	auto tokens = utils::tokenize_quoted(input, delimiters);
 	if (tokens.empty()) {
-		return Command { .type = CommandType::INVALID, .args = {} };
+		return Command(CommandType::INVALID);
 	} else {
 		auto cmd_name = tokens.front();
 		tokens.erase(tokens.begin());
 		if (cmd_name == "set") {
-			return Command { .type = CommandType::SET, .args = std::move(tokens) };
+			return Command(CommandType::SET, std::move(tokens));
 		} else if (cmd_name == "q" || cmd_name == "quit") {
-			return Command { .type = CommandType::QUIT, .args = std::move(tokens) };
+			return Command(CommandType::QUIT, std::move(tokens));
 		} else if (cmd_name == "source") {
-			return Command { .type = CommandType::SOURCE, .args = std::move(tokens) };
+			return Command(CommandType::SOURCE, std::move(tokens));
 		} else if (cmd_name == "dumpconfig") {
-			return Command { .type = CommandType::DUMPCONFIG, .args = std::move(tokens) };
+			return Command(CommandType::DUMPCONFIG, std::move(tokens));
 		} else if (cmd_name == "exec") {
-			return Command { .type = CommandType::EXEC, .args = std::move(tokens) };
+			return Command(CommandType::EXEC, std::move(tokens));
 		} else if (cmd_name == "tag") {
-			return Command { .type = CommandType::TAG, .args = std::move(tokens) };
+			return Command(CommandType::TAG, std::move(tokens));
 		} else if (cmd_name == "goto") {
-			return Command { .type = CommandType::GOTO, .args = std::move(tokens) };
+			return Command(CommandType::GOTO, std::move(tokens));
 		} else if (cmd_name == "save") {
-			return Command { .type = CommandType::SAVE, .args = std::move(tokens) };
+			return Command(CommandType::SAVE, std::move(tokens));
 		} else {
 			tokens.insert(tokens.begin(), std::move(cmd_name));
-			return Command { .type = CommandType::UNKNOWN, .args = std::move(tokens) };
+			return Command(CommandType::UNKNOWN, std::move(tokens));
 		}
 	}
 }

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -51,9 +51,7 @@ void prepare_header(
 {
 	const auto add_line =
 		[&lines]
-		(const std::string& value,
-			const std::string& name,
-	LineType lineType = LineType::wrappable) {
+	(const std::string& value, const std::string& name, LineType lineType) {
 		if (!value.empty()) {
 			const auto line = strprintf::fmt("%s%s", name, value);
 			lines.push_back(std::make_pair(lineType, line));
@@ -71,14 +69,14 @@ void prepare_header(
 	};
 
 	const std::string feedtitle = item_renderer::get_feedtitle(item);
-	add_line(stfl_quote_if_needed(feedtitle), _("Feed: "));
+	add_line(stfl_quote_if_needed(feedtitle), _("Feed: "), LineType::wrappable);
 	add_line(stfl_quote_if_needed(utils::utf8_to_locale(item->title())),
-		_("Title: "));
+		_("Title: "), LineType::wrappable);
 	add_line(stfl_quote_if_needed(utils::utf8_to_locale(item->author())),
-		_("Author: "));
-	add_line(item->pubDate(), _("Date: "));
+		_("Author: "), LineType::wrappable);
+	add_line(item->pubDate(), _("Date: "), LineType::wrappable);
 	add_line(item->link(), _("Link: "), LineType::softwrappable);
-	add_line(item->flags(), _("Flags: "));
+	add_line(item->flags(), _("Flags: "), LineType::wrappable);
 
 	const bool could_be_podcast = item->enclosure_type().empty()
 		|| utils::is_valid_podcast_type(item->enclosure_type());

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -1039,10 +1039,10 @@ ParsedOperations KeyMap::parse_operation_sequence(const std::string& line,
 		cmds.push_back(cmd);
 	}
 
-	return ParsedOperations{
-		.operations = cmds,
-		.description = std::string(description)
-	};
+	ParsedOperations result;
+	result.operations = cmds;
+	result.description = std::string(description);
+	return result;
 }
 
 std::vector<MacroCmd> KeyMap::get_startup_operation_sequence()

--- a/test/rssparser.cpp
+++ b/test/rssparser.cpp
@@ -174,24 +174,38 @@ TEST_CASE("parse() extracts best enclosure", "[RssParser]")
 	upstream_feed.items.push_back({});
 	rsspp::Item& upstream_item = upstream_feed.items[0];
 
-	rsspp::Enclosure image_enclosure1 = {
-		.url = "http://example.com/enclosure1",
-		.type = "image/png",
-		.description = "description1",
-		.description_mime_type = "text/plain",
+	const auto make_enclosure = [](
+			const std::string& url,
+			const std::string& type,
+			const std::string& description,
+			const std::string& mime
+	) -> rsspp::Enclosure {
+		rsspp::Enclosure result;
+		result.url = url;
+		result.type = type;
+		result.description = description;
+		result.description_mime_type = mime;
+		return result;
 	};
-	rsspp::Enclosure image_enclosure2 = {
-		.url = "http://example.com/enclosure2",
-		.type = "image/jpg",
-		.description = "description2",
-		.description_mime_type = "text/plain",
-	};
-	rsspp::Enclosure audio_enclosure = {
-		.url = "http://example.com/enclosure3",
-		.type = "audio/ogg",
-		.description = "description3",
-		.description_mime_type = "text/plain",
-	};
+
+	const auto image_enclosure1 = make_enclosure(
+			"http://example.com/enclosure1",
+			"image/png",
+			"description1",
+			"text/plain"
+		);
+	const auto image_enclosure2 = make_enclosure(
+			"http://example.com/enclosure2",
+			"image/jpg",
+			"description2",
+			"text/plain"
+		);
+	const auto audio_enclosure = make_enclosure(
+			"http://example.com/enclosure3",
+			"audio/ogg",
+			"description3",
+			"text/plain"
+		);
 
 	SECTION("podcast preferred over non-podcast enclosure") {
 		const auto run_validation = [&]() {


### PR DESCRIPTION
This is yet another follow-up to https://github.com/newsboat/newsboat/pull/2654. The idea is: since we declare that C++11 compiler is enough for us, we should check that. We already checked by compiling with old compilers that didn't support newer standards, but that still left some room for error: e.g. GCC and Clang are fine with using designated initializers for structures even though they only appeared in C++20.