### PR TITLE
Parse key sequences and store new bindings into map/tree

### DIFF
--- a/include/keycombination.h
+++ b/include/keycombination.h
@@ -2,6 +2,7 @@
 #define NEWSBOAT_KEYCOMBINATION_H_
 
 #include <string>
+#include <vector>
 
 namespace newsboat {
 
@@ -28,7 +29,9 @@ public:
 		AltState alt = AltState::NoAlt);
 
 	static KeyCombination from_bindkey(const std::string& input);
+	static std::vector<KeyCombination> from_bind(const std::string& input);
 	std::string to_bindkey_string() const;
+	std::string to_bind_string() const;
 
 	bool operator==(const KeyCombination& other) const;
 	bool operator<(const KeyCombination& rhs) const;

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -2,6 +2,7 @@
 #define NEWSBOAT_KEYMAP_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -185,6 +186,12 @@ struct KeyMapHintEntry {
 	std::string text;
 };
 
+struct Mapping {
+	bool is_leaf_node = false;
+	std::map<KeyCombination, Mapping> continuations = {};
+	MacroBinding action = {};
+};
+
 class KeyMap : public ConfigActionHandler {
 public:
 	explicit KeyMap(unsigned int flags);
@@ -194,7 +201,7 @@ public:
 		const std::string& context);
 	void unset_key(const KeyCombination& key, const std::string& context);
 	void unset_all_keys(const std::string& context);
-	Operation get_opcode(const std::string& opstr);
+	static Operation get_opcode(const std::string& opstr);
 	Operation get_operation(const KeyCombination& key_combination,
 		const std::string& context);
 	std::vector<MacroCmd> get_macro(const KeyCombination& key_combination);
@@ -214,11 +221,14 @@ public:
 		const std::string& context);
 
 private:
+	void apply_bind(Mapping& target, const std::vector<KeyCombination> key_sequence,
+		const std::vector<MacroCmd>& cmds, const std::string& description);
 	bool is_valid_context(const std::string& context);
 	unsigned short get_flag_from_context(const std::string& context);
 	std::map<KeyCombination, Operation> get_internal_operations() const;
 	std::string getopname(Operation op) const;
 	std::map<std::string, std::map<KeyCombination, Operation>> keymap_;
+	std::map<std::string, Mapping> context_keymaps;
 	std::map<KeyCombination, MacroBinding> macros_;
 	std::vector<MacroCmd> startup_operations_sequence;
 };

--- a/rust/libnewsboat-ffi/src/keycombination.rs
+++ b/rust/libnewsboat-ffi/src/keycombination.rs
@@ -10,6 +10,7 @@ mod ffi {
         type KeyCombination;
 
         fn from_bindkey(input: &str) -> Box<KeyCombination>;
+        fn from_bind(input: &str) -> Vec<KeyCombination>;
 
         fn get_key(key_combination: &KeyCombination) -> &str;
         fn has_shift(key_combination: &KeyCombination) -> bool;
@@ -20,6 +21,13 @@ mod ffi {
 
 fn from_bindkey(input: &str) -> Box<KeyCombination> {
     Box::new(KeyCombination(keycombination::bindkey(input)))
+}
+
+fn from_bind(input: &str) -> Vec<KeyCombination> {
+    keycombination::bind(input)
+        .into_iter()
+        .map(KeyCombination)
+        .collect()
 }
 
 fn get_key(key_combination: &KeyCombination) -> &str {

--- a/rust/libnewsboat/src/keycombination.rs
+++ b/rust/libnewsboat/src/keycombination.rs
@@ -1,8 +1,13 @@
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    character::{complete::anychar, is_alphabetic},
-    combinator::{eof, verify},
+    character::{
+        complete::{anychar, none_of},
+        is_alphabetic,
+    },
+    combinator::{eof, recognize, verify},
+    multi::{many0, many1},
+    sequence::terminated,
     IResult,
 };
 
@@ -106,10 +111,88 @@ pub fn bindkey(input: &str) -> KeyCombination {
     key_combination
 }
 
+fn control_key_bind(input: &str) -> IResult<&str, KeyCombination> {
+    let (input, _) = tag("^")(input)?;
+    let (input, key) = alphabetic(input)?;
+
+    let key_combination = KeyCombination::new(key.to_lowercase().to_string()).with_control();
+    Ok((input, key_combination))
+}
+
+fn shift_key_bind(input: &str) -> IResult<&str, KeyCombination> {
+    let (input, key) = verify(alphabetic, |c: &char| c.is_uppercase())(input)?;
+
+    let key_combination = KeyCombination::new(key.to_lowercase().to_string()).with_shift();
+    Ok((input, key_combination))
+}
+
+fn combination_key_bind(input: &str) -> IResult<&str, KeyCombination> {
+    let (input, _) = tag("<")(input)?;
+    let (input, modifiers) = many0(alt((tag("C-"), tag("S-"), tag("M-"))))(input)?;
+    let (input, key) = recognize(many1(none_of(">")))(input)?;
+    let (input, _) = tag(">")(input)?;
+
+    let mut key_combination = KeyCombination::new(key.to_owned());
+
+    for modifier in modifiers {
+        match modifier {
+            "C-" => key_combination = key_combination.with_control(),
+            "S-" => key_combination = key_combination.with_shift(),
+            "M-" => key_combination = key_combination.with_alt(),
+            _ => (),
+        }
+    }
+
+    Ok((input, key_combination))
+}
+
+fn single_key_bind(input: &str) -> IResult<&str, KeyCombination> {
+    let (input, key) = anychar(input)?;
+    let mut key_combination = KeyCombination::new(key.to_string());
+
+    key_combination.key = match key_combination.key.as_str() {
+        "<" => String::from("LT"),
+        ">" => String::from("GT"),
+        _ => key_combination.key,
+    };
+
+    Ok((input, key_combination))
+}
+
+pub fn bind(input: &str) -> Vec<KeyCombination> {
+    let result = terminated(
+        many0(alt((
+            control_key_bind,
+            shift_key_bind,
+            combination_key_bind,
+            single_key_bind,
+        ))),
+        eof,
+    )(input);
+    // Should be save to unwrap because `single_key_bind` accepts any input
+    let (_, key_combinations) = result.unwrap();
+
+    key_combinations
+}
+
 #[cfg(test)]
 mod tests {
+    use super::bind;
     use super::bindkey;
     use super::KeyCombination;
+
+    proptest::proptest! {
+        #[test]
+        fn t_bindkey_does_not_crash_on_any_input(ref input in "\\PC*") {
+            // Result explicitly ignored because we just want to make sure this call doesn't panic.
+            let _ = bindkey(input);
+        }
+        #[test]
+        fn t_bind_does_not_crash_on_any_input(ref input in "\\PC*") {
+            // Result explicitly ignored because we just want to make sure this call doesn't panic.
+            let _ = bind(input);
+        }
+    }
 
     #[test]
     fn t_bindkey_no_modifiers() {
@@ -150,6 +233,122 @@ mod tests {
         assert_eq!(
             bindkey("^z"),
             KeyCombination::new("z".to_owned()).with_control()
+        );
+    }
+
+    #[test]
+    fn t_bind_single_regular_key() {
+        assert_eq!(bind("a"), vec![KeyCombination::new("a".to_owned())]);
+        assert_eq!(
+            bind("A"),
+            vec![KeyCombination::new("a".to_owned()).with_shift()]
+        );
+        assert_eq!(
+            bind("^A"),
+            vec![KeyCombination::new("a".to_owned()).with_control()]
+        );
+        assert_eq!(
+            bind("^a"),
+            vec![KeyCombination::new("a".to_owned()).with_control()]
+        );
+    }
+
+    #[test]
+    fn t_bind_single_special_key() {
+        assert_eq!(bind("="), vec![KeyCombination::new("=".to_owned())]);
+        assert_eq!(bind("<"), vec![KeyCombination::new("LT".to_owned())]);
+        assert_eq!(bind(">"), vec![KeyCombination::new("GT".to_owned())]);
+        assert_eq!(bind("-"), vec![KeyCombination::new("-".to_owned())]);
+    }
+
+    #[test]
+    fn t_bind_single_key_with_modifiers() {
+        assert_eq!(
+            bind("<SPACE>"),
+            vec![KeyCombination::new("SPACE".to_owned())]
+        );
+        assert_eq!(
+            bind("<M-SPACE>"),
+            vec![KeyCombination::new("SPACE".to_owned()).with_alt()]
+        );
+        assert_eq!(
+            bind("<S-SPACE>"),
+            vec![KeyCombination::new("SPACE".to_owned()).with_shift()]
+        );
+        assert_eq!(
+            bind("<S-M-SPACE>"),
+            vec![KeyCombination::new("SPACE".to_owned())
+                .with_shift()
+                .with_alt()]
+        );
+        assert_eq!(
+            bind("<C-SPACE>"),
+            vec![KeyCombination::new("SPACE".to_owned()).with_control()]
+        );
+        assert_eq!(
+            bind("<C-M-SPACE>"),
+            vec![KeyCombination::new("SPACE".to_owned())
+                .with_control()
+                .with_alt()]
+        );
+        assert_eq!(
+            bind("<C-S-SPACE>"),
+            vec![KeyCombination::new("SPACE".to_owned())
+                .with_control()
+                .with_shift()]
+        );
+        assert_eq!(
+            bind("<C-S-M-SPACE>"),
+            vec![KeyCombination::new("SPACE".to_owned())
+                .with_control()
+                .with_shift()
+                .with_alt()]
+        );
+    }
+
+    #[test]
+    fn t_bind_single_key_with_modifiers_in_nonstandard_order() {
+        assert_eq!(
+            bind("<M-S-C-SPACE>"),
+            vec![KeyCombination::new("SPACE".to_owned())
+                .with_control()
+                .with_shift()
+                .with_alt()]
+        );
+    }
+
+    #[test]
+    fn t_bind_multiple_regular_keys() {
+        assert_eq!(
+            bind("abc"),
+            vec![
+                KeyCombination::new("a".to_owned()),
+                KeyCombination::new("b".to_owned()),
+                KeyCombination::new("c".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn t_bind_multiple_special_keys() {
+        assert_eq!(
+            bind("<F1><S-ENTER>"),
+            vec![
+                KeyCombination::new("F1".to_owned()),
+                KeyCombination::new("ENTER".to_owned()).with_shift(),
+            ]
+        );
+    }
+
+    #[test]
+    fn t_bind_multiple_mixed_keys() {
+        assert_eq!(
+            bind("^G<ENTER>p"),
+            vec![
+                KeyCombination::new("g".to_owned()).with_control(),
+                KeyCombination::new("ENTER".to_owned()),
+                KeyCombination::new("p".to_owned()),
+            ]
         );
     }
 }


### PR DESCRIPTION
I'm not yet sure if we need to provide any escape characters (to allow for special keys `<`, `>`, `-`).
As far as I know, this PR supports these keys if they are used on their own but might have some issues if they are used in a sequence of keys or in combination with control/alt.

- [x] It might be worth directly porting this to Rust (nom), I might do that later today.