### PR TITLE
Compile in C++14 mode, migrate to `std::make_unique()` where possible

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-make-unique'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ DEFINES=-DLOCALEDIR='"$(localedir)"'
 
 WARNFLAGS=-Werror -Wall -Wextra -Wunreachable-code
 INCLUDES=-Iinclude -Istfl -Ifilter -I. -Irss -I$(CARGO_TARGET_DIR)/cxxbridge/
-BARE_CXXFLAGS=-std=c++11 -O2 -ggdb $(INCLUDES)
+BARE_CXXFLAGS=-std=c++14 -O2 -ggdb $(INCLUDES)
 LDFLAGS+=-L.
 
 # Constants

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -15,6 +15,7 @@
 #include <libxml/tree.h>
 #include <libxml/xmlsave.h>
 #include <libxml/xmlversion.h>
+#include <memory>
 #include <mutex>
 #include <pwd.h>
 #include <signal.h>
@@ -250,8 +251,7 @@ int Controller::run(const CliArgsParser& args)
 		std::cout << _("done.") << std::endl;
 	}
 
-	reloader =
-		std::unique_ptr<Reloader>(new Reloader(this, rsscache, cfg));
+	reloader = std::make_unique<Reloader>(this, rsscache, cfg);
 
 	std::string type = cfg.get_configvalue("urls-source");
 	if (type == "local") {

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -11,6 +11,7 @@
 #include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <memory>
 #include <thread>
 #include <unistd.h>
 
@@ -253,7 +254,7 @@ void PbController::initialize(int argc, char* argv[])
 			_("Starting %s %s..."), "Podboat", utils::program_version())
 		<< std::endl;
 
-	fslock = std::unique_ptr<FsLock>(new FsLock());
+	fslock = std::make_unique<FsLock>();
 	pid_t pid;
 	std::string error_message;
 	if (!fslock->try_lock(lock_file, pid, error_message)) {
@@ -308,9 +309,9 @@ int PbController::run(PbView& v)
 
 	std::cout << _("done.") << std::endl;
 
-	ql.reset(new QueueLoader(queue_file, cfg, [&]() {
+	ql = std::make_unique<QueueLoader>(queue_file, cfg, [&]() {
 		v.set_view_update_necessary();
-	}));
+	});
 	ql->reload(downloads_);
 
 	v.run(automatic_dl, cfg.get_configvalue_as_bool("wrap-scroll"));

--- a/test/remoteapi.cpp
+++ b/test/remoteapi.cpp
@@ -62,7 +62,7 @@ TEST_CASE("get_credentials() returns the users name and password",
 	ConfigParser cfgparser;
 	cfg.register_commands(cfgparser);
 	cfgparser.parse_file("data/test-config-credentials.txt");
-	std::unique_ptr<test_api> api(new test_api(cfg));
+	auto api = std::make_unique<test_api>(cfg);
 	REQUIRE(api->get_user("ttrss", "") == "ttrss-user");
 	REQUIRE(api->get_pass("ttrss", "") == "my-birthday");
 	REQUIRE(api->get_pass("ocnews", "") == "dadada");

--- a/test/test_helpers/opts.cpp
+++ b/test/test_helpers/opts.cpp
@@ -6,10 +6,8 @@ test_helpers::Opts::Opts(std::initializer_list<std::string> opts)
 	m_opts.reserve(m_argc);
 
 	for (const std::string& option : opts) {
-		// Copy string into separate char[], managed by
-		// unique_ptr.
-		auto ptr = std::unique_ptr<char[]>(
-				new char[option.size() + 1]);
+		// Copy string into separate char[], managed by unique_ptr.
+		auto ptr = std::make_unique<char[]>(option.size() + 1);
 		std::copy(option.cbegin(), option.cend(), ptr.get());
 		// C and C++ require argv to be NULL-terminated:
 		// https://stackoverflow.com/questions/18547114/why-do-we-need-argc-while-there-is-always-a-null-at-the-end-of-argv
@@ -21,7 +19,7 @@ test_helpers::Opts::Opts(std::initializer_list<std::string> opts)
 	}
 
 	// Copy out intermediate argv vector into its final storage.
-	m_data = std::unique_ptr<char* []>(new char* [m_argc + 1]);
+	m_data = std::make_unique<char* []>(m_argc + 1);
 	int i = 0;
 	for (const auto& ptr : m_opts) {
 		m_data.get()[i++] = ptr.get();


### PR DESCRIPTION
As noted in the first commit, this change doesn't affect our requirements for compilers, because our current requirements are already sufficient for C++14.

Inspired by @dennisschagt's comment: https://github.com/newsboat/newsboat/pull/2683#pullrequestreview-1887240317.