### PR TITLE
Update to chrono 0.4.35

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,7 +39,7 @@ task:
         - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
         - pkg update -f
         - pkg upgrade -y
-        - pkg install -y rust gmake rubygem-asciidoctor pkgconf stfl curl json-c ncurses openssl sqlite3 gettext-tools libxml2
+        - pkg install -y rust gmake rubygem-asciidoctor pkgconf stfl curl json-c ncurses openssl ca_root_nss sqlite3 gettext-tools libxml2
     setup_script:
         - pw groupadd testgroup
         - pw useradd testuser -g testgroup -w none -m

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/rust/libnewsboat/src/logger.rs
+++ b/rust/libnewsboat/src/logger.rs
@@ -302,7 +302,7 @@ macro_rules! log {
 mod tests {
     use super::*;
 
-    use chrono::{Duration, NaiveDateTime};
+    use chrono::{NaiveDateTime, TimeDelta};
     use std::io::{self, BufRead, BufReader};
     use std::path;
     use tempfile::TempDir;
@@ -499,7 +499,7 @@ mod tests {
                     // `start_time` and `end_time` may have millisecond precision or better,
                     // whereas `timestamp` is limited to seconds. Therefore, we account for
                     // a situation where `start_time` is slightly bigger than `timestamp`.
-                    assert!(timestamp - start_time > Duration::seconds(-1));
+                    assert!(timestamp - start_time > TimeDelta::try_seconds(-1).unwrap());
                     assert!(finish_time >= timestamp);
 
                     assert_eq!(message, expected);
@@ -830,7 +830,7 @@ mod tests {
                     // `start_time` and `end_time` may have millisecond precision or better,
                     // whereas `timestamp` is limited to seconds. Therefore, we account for
                     // a situation where `start_time` is slightly bigger than `timestamp`.
-                    assert!(timestamp - start_time > Duration::seconds(-1));
+                    assert!(timestamp - start_time > TimeDelta::try_seconds(-1).unwrap());
                     assert!(finish_time >= timestamp);
 
                     assert_eq!(message, expected);


### PR DESCRIPTION
Supersedes https://github.com/newsboat/newsboat/pull/2696 (this PR fixes warnings caused by the update)