### PR TITLE
optimize RssIgnores::matches function

### DIFF
--- a/include/rssignores.h
+++ b/include/rssignores.h
@@ -30,7 +30,6 @@ private:
 	std::vector<std::string> resetflag;
 
 	static const std::string REGEX_PREFIX;
-
 };
 
 } // namespace newsboat

--- a/include/rssignores.h
+++ b/include/rssignores.h
@@ -2,6 +2,7 @@
 #define NEWSBOAT_RSSIGNORES_H_
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "configactionhandler.h"
@@ -9,8 +10,6 @@
 #include "rssitem.h"
 
 namespace newsboat {
-
-typedef std::pair<std::string, std::shared_ptr<Matcher>> FeedUrlExprPair;
 
 class RssIgnores : public ConfigActionHandler {
 public:
@@ -24,11 +23,14 @@ public:
 	bool matches_resetunread(const std::string& url);
 
 private:
-	std::vector<FeedUrlExprPair> ignores;
+	bool matches_expr(std::shared_ptr<Matcher> expr, RssItem* item);
+
+	std::unordered_multimap<std::string, std::shared_ptr<Matcher>> ignores;
 	std::vector<std::string> ignores_lastmodified;
 	std::vector<std::string> resetflag;
 
 	static const std::string REGEX_PREFIX;
+
 };
 
 } // namespace newsboat

--- a/include/rssignores.h
+++ b/include/rssignores.h
@@ -11,6 +11,8 @@
 
 namespace newsboat {
 
+typedef std::pair<std::string, std::shared_ptr<Matcher>> FeedUrlExprPair;
+
 class RssIgnores : public ConfigActionHandler {
 public:
 	RssIgnores() {}
@@ -25,7 +27,8 @@ public:
 private:
 	bool matches_expr(std::shared_ptr<Matcher> expr, RssItem* item);
 
-	std::unordered_multimap<std::string, std::shared_ptr<Matcher>> ignores;
+	std::vector<FeedUrlExprPair> regex_ignores;
+	std::unordered_multimap<std::string, std::shared_ptr<Matcher>> non_regex_ignores;
 	std::vector<std::string> ignores_lastmodified;
 	std::vector<std::string> resetflag;
 

--- a/include/rssignores.h
+++ b/include/rssignores.h
@@ -13,23 +13,23 @@ namespace newsboat {
 
 class RssIgnores : public ConfigActionHandler {
 public:
-	RssIgnores() {}
-	~RssIgnores() override {}
-	void handle_action(const std::string& action,
-		const std::vector<std::string>& params) override;
-	void dump_config(std::vector<std::string>& config_output) const override;
-	bool matches(RssItem* item);
-	bool matches_lastmodified(const std::string& url);
-	bool matches_resetunread(const std::string& url);
+    RssIgnores() {}
+    ~RssIgnores() override {}
+    void handle_action(const std::string& action,
+                       const std::vector<std::string>& params) override;
+    void dump_config(std::vector<std::string>& config_output) const override;
+    bool matches(RssItem* item);
+    bool matches_lastmodified(const std::string& url);
+    bool matches_resetunread(const std::string& url);
 
 private:
-	bool matches_expr(std::shared_ptr<Matcher> expr, RssItem* item);
+    bool matches_expr(std::shared_ptr<Matcher> expr, RssItem* item);
 
-	std::unordered_multimap<std::string, std::shared_ptr<Matcher>> ignores;
-	std::vector<std::string> ignores_lastmodified;
-	std::vector<std::string> resetflag;
+    std::unordered_multimap<std::string, std::shared_ptr<Matcher>> ignores;
+    std::vector<std::string> ignores_lastmodified;
+    std::vector<std::string> resetflag;
 
-	static const std::string REGEX_PREFIX;
+    static const std::string REGEX_PREFIX;
 };
 
 } // namespace newsboat

--- a/include/rssignores.h
+++ b/include/rssignores.h
@@ -13,23 +13,23 @@ namespace newsboat {
 
 class RssIgnores : public ConfigActionHandler {
 public:
-    RssIgnores() {}
-    ~RssIgnores() override {}
-    void handle_action(const std::string& action,
-                       const std::vector<std::string>& params) override;
-    void dump_config(std::vector<std::string>& config_output) const override;
-    bool matches(RssItem* item);
-    bool matches_lastmodified(const std::string& url);
-    bool matches_resetunread(const std::string& url);
+	RssIgnores() {}
+	~RssIgnores() override {}
+	void handle_action(const std::string& action,
+		const std::vector<std::string>& params) override;
+	void dump_config(std::vector<std::string>& config_output) const override;
+	bool matches(RssItem* item);
+	bool matches_lastmodified(const std::string& url);
+	bool matches_resetunread(const std::string& url);
 
 private:
-    bool matches_expr(std::shared_ptr<Matcher> expr, RssItem* item);
+	bool matches_expr(std::shared_ptr<Matcher> expr, RssItem* item);
 
-    std::unordered_multimap<std::string, std::shared_ptr<Matcher>> ignores;
-    std::vector<std::string> ignores_lastmodified;
-    std::vector<std::string> resetflag;
+	std::unordered_multimap<std::string, std::shared_ptr<Matcher>> ignores;
+	std::vector<std::string> ignores_lastmodified;
+	std::vector<std::string> resetflag;
 
-    static const std::string REGEX_PREFIX;
+	static const std::string REGEX_PREFIX;
 };
 
 } // namespace newsboat

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -18,232 +18,232 @@ namespace newsboat {
 Matcher::Matcher() {}
 
 Matcher::Matcher(const std::string& expr)
-    : exp(expr)
+	: exp(expr)
 {
-    parse(expr);
+	parse(expr);
 }
 
 std::string Matcher::get_expression()
 {
-    return exp;
+	return exp;
 }
 
 bool Matcher::parse(const std::string& expr)
 {
-    ScopeMeasure measurer("Matcher::parse");
+	ScopeMeasure measurer("Matcher::parse");
 
-    errmsg = "";
+	errmsg = "";
 
-    bool b = p.parse_string(expr);
+	bool b = p.parse_string(expr);
 
-    if (b) {
-        exp = expr;
-    } else {
-        errmsg = utils::wstr2str(p.get_error());
-    }
+	if (b) {
+		exp = expr;
+	} else {
+		errmsg = utils::wstr2str(p.get_error());
+	}
 
-    LOG(Level::DEBUG,
-        "Matcher::parse: parsing `%s' succeeded: %d",
-        expr,
-        b ? 1 : 0);
+	LOG(Level::DEBUG,
+		"Matcher::parse: parsing `%s' succeeded: %d",
+		expr,
+		b ? 1 : 0);
 
-    return b;
+	return b;
 }
 
 bool Matcher::matches(Matchable* item)
 {
-    /*
-     * with this method, every class that is derived from Matchable can be
-     * matched against a filter expression that was previously passed to the
-     * class with the parse() method.
-     *
-     * This makes it easy to use the Matcher virtually everywhere, since C++
-     * allows multiple inheritance (i.e. deriving from Matchable can even be
-     * used in class hierarchies), and deriving from Matchable means that
-     * you only have to implement the method attribute_value().
-     *
-     * The whole matching code is speed-critical, as the matching happens on
-     * a lot of different occasions, and slow matching can be easily
-     * measured (and felt by the user) on slow computers with a lot of items
-     * to match.
-     */
-    bool retval = false;
-    if (item) {
-        ScopeMeasure m1("Matcher::matches");
-        retval = matches_r(p.get_root(), item);
-    }
-    return retval;
+	/*
+	 * with this method, every class that is derived from Matchable can be
+	 * matched against a filter expression that was previously passed to the
+	 * class with the parse() method.
+	 *
+	 * This makes it easy to use the Matcher virtually everywhere, since C++
+	 * allows multiple inheritance (i.e. deriving from Matchable can even be
+	 * used in class hierarchies), and deriving from Matchable means that
+	 * you only have to implement the method attribute_value().
+	 *
+	 * The whole matching code is speed-critical, as the matching happens on
+	 * a lot of different occasions, and slow matching can be easily
+	 * measured (and felt by the user) on slow computers with a lot of items
+	 * to match.
+	 */
+	bool retval = false;
+	if (item) {
+		ScopeMeasure m1("Matcher::matches");
+		retval = matches_r(p.get_root(), item);
+	}
+	return retval;
 }
 
 std::string get_attr_or_throw(Matchable* item, const std::string& attr_name)
 {
-    const auto attr = item->attribute_value(attr_name);
+	const auto attr = item->attribute_value(attr_name);
 
-    if (!attr.has_value()) {
-        LOG(Level::WARN,
-            "Matcher::matches: attribute %s is not available",
-            attr_name);
-        throw MatcherException(MatcherException::Type::ATTRIB_UNAVAIL, attr_name);
-    }
+	if (!attr.has_value()) {
+		LOG(Level::WARN,
+			"Matcher::matches: attribute %s is not available",
+			attr_name);
+		throw MatcherException(MatcherException::Type::ATTRIB_UNAVAIL, attr_name);
+	}
 
-    return attr.value();
+	return attr.value();
 }
 
 bool Matcher::matchop_lt(expression* e, Matchable* item)
 {
-    const int ilit = string_to_num(e->literal);
+	const int ilit = string_to_num(e->literal);
 
-    const auto attr = get_attr_or_throw(item, e->name);
-    const int iatt = string_to_num(attr);
+	const auto attr = get_attr_or_throw(item, e->name);
+	const int iatt = string_to_num(attr);
 
-    return iatt < ilit;
+	return iatt < ilit;
 }
 
 bool Matcher::matchop_between(expression* e, Matchable* item)
 {
-    const auto attr = get_attr_or_throw(item, e->name);
-    const int att = string_to_num(attr);
+	const auto attr = get_attr_or_throw(item, e->name);
+	const int att = string_to_num(attr);
 
-    const std::vector<std::string> lit = utils::tokenize(e->literal, ":");
-    if (lit.size() < 2) {
-        return false;
-    }
+	const std::vector<std::string> lit = utils::tokenize(e->literal, ":");
+	if (lit.size() < 2) {
+		return false;
+	}
 
-    int i1 = string_to_num(lit[0]);
-    int i2 = string_to_num(lit[1]);
-    if (i1 > i2) {
-        std::swap(i1, i2);
-    }
+	int i1 = string_to_num(lit[0]);
+	int i2 = string_to_num(lit[1]);
+	if (i1 > i2) {
+		std::swap(i1, i2);
+	}
 
-    return (att >= i1 && att <= i2);
+	return (att >= i1 && att <= i2);
 }
 
 bool Matcher::matchop_gt(expression* e, Matchable* item)
 {
-    const auto attr = get_attr_or_throw(item, e->name);
-    const int iatt = string_to_num(attr);
+	const auto attr = get_attr_or_throw(item, e->name);
+	const int iatt = string_to_num(attr);
 
-    const int ilit = string_to_num(e->literal);
+	const int ilit = string_to_num(e->literal);
 
-    return iatt > ilit;
+	return iatt > ilit;
 }
 
 bool Matcher::matchop_rxeq(expression* e, Matchable* item)
 {
-    const auto attr = get_attr_or_throw(item, e->name);
+	const auto attr = get_attr_or_throw(item, e->name);
 
-    if (!e->regex) {
-        e->regex = new regex_t;
-        int err;
-        if ((err = regcomp(e->regex,
-                           e->literal.c_str(),
-                           REG_EXTENDED | REG_ICASE | REG_NOSUB)) != 0) {
-            delete e->regex;
-            e->regex = nullptr;
-            char buf[1024];
-            regerror(err, e->regex, buf, sizeof(buf));
-            throw MatcherException(
-                MatcherException::Type::INVALID_REGEX,
-                e->literal,
-                buf);
-        }
-    }
-    if (regexec(e->regex,
-                attr.c_str(),
-                0,
-                nullptr,
-                0) == 0) {
-        return true;
-    }
-    return false;
+	if (!e->regex) {
+		e->regex = new regex_t;
+		int err;
+		if ((err = regcomp(e->regex,
+						e->literal.c_str(),
+						REG_EXTENDED | REG_ICASE | REG_NOSUB)) != 0) {
+			delete e->regex;
+			e->regex = nullptr;
+			char buf[1024];
+			regerror(err, e->regex, buf, sizeof(buf));
+			throw MatcherException(
+				MatcherException::Type::INVALID_REGEX,
+				e->literal,
+				buf);
+		}
+	}
+	if (regexec(e->regex,
+			attr.c_str(),
+			0,
+			nullptr,
+			0) == 0) {
+		return true;
+	}
+	return false;
 }
 
 bool Matcher::matchop_cont(expression* e, Matchable* item)
 {
-    const auto attr = get_attr_or_throw(item, e->name);
+	const auto attr = get_attr_or_throw(item, e->name);
 
-    const std::vector<std::string> elements = utils::tokenize(attr, " ");
-    const std::string literal = e->literal;
-    for (const auto& elem : elements) {
-        if (literal == elem) {
-            return true;
-        }
-    }
-    return false;
+	const std::vector<std::string> elements = utils::tokenize(attr, " ");
+	const std::string literal = e->literal;
+	for (const auto& elem : elements) {
+		if (literal == elem) {
+			return true;
+		}
+	}
+	return false;
 }
 
 bool Matcher::matchop_eq(expression* e, Matchable* item)
 {
-    const auto attr = get_attr_or_throw(item, e->name);
+	const auto attr = get_attr_or_throw(item, e->name);
 
-    return (attr == e->literal);
+	return (attr == e->literal);
 }
 
 bool Matcher::matches_r(expression* e, Matchable* item)
 {
-    if (e) {
-        switch (e->op) {
-        /* the operator "and" and "or" simply connect two different
-         * subexpressions */
-        case LOGOP_AND:
-            // short-circuit evaluation in C -> short circuit evaluation in the filter language
-            return matches_r(e->l, item) &&
-                   matches_r(e->r, item);
+	if (e) {
+		switch (e->op) {
+		/* the operator "and" and "or" simply connect two different
+		 * subexpressions */
+		case LOGOP_AND:
+			// short-circuit evaluation in C -> short circuit evaluation in the filter language
+			return matches_r(e->l, item) &&
+				matches_r(e->r, item);
 
-        case LOGOP_OR:
-            return matches_r(e->l, item) ||
-                   matches_r(e->r, item); // same here
+		case LOGOP_OR:
+			return matches_r(e->l, item) ||
+				matches_r(e->r, item); // same here
 
-        /* while the other operators connect an attribute with a value */
-        case MATCHOP_EQ:
-            return matchop_eq(e, item);
+		/* while the other operators connect an attribute with a value */
+		case MATCHOP_EQ:
+			return matchop_eq(e, item);
 
-        case MATCHOP_NE:
-            return !matchop_eq(e, item);
+		case MATCHOP_NE:
+			return !matchop_eq(e, item);
 
-        case MATCHOP_LT:
-            return matchop_lt(e, item);
+		case MATCHOP_LT:
+			return matchop_lt(e, item);
 
-        case MATCHOP_BETWEEN:
-            return matchop_between(e, item);
+		case MATCHOP_BETWEEN:
+			return matchop_between(e, item);
 
-        case MATCHOP_GT:
-            return matchop_gt(e, item);
+		case MATCHOP_GT:
+			return matchop_gt(e, item);
 
-        case MATCHOP_LE:
-            return !matchop_gt(e, item);
+		case MATCHOP_LE:
+			return !matchop_gt(e, item);
 
-        case MATCHOP_GE:
-            return !matchop_lt(e, item);
+		case MATCHOP_GE:
+			return !matchop_lt(e, item);
 
-        case MATCHOP_RXEQ:
-            return matchop_rxeq(e, item);
+		case MATCHOP_RXEQ:
+			return matchop_rxeq(e, item);
 
-        case MATCHOP_RXNE:
-            return !matchop_rxeq(e, item);
+		case MATCHOP_RXNE:
+			return !matchop_rxeq(e, item);
 
-        case MATCHOP_CONTAINS:
-            return matchop_cont(e, item);
+		case MATCHOP_CONTAINS:
+			return matchop_cont(e, item);
 
-        case MATCHOP_CONTAINSNOT:
-            return !matchop_cont(e, item);
-        }
-        return false;
-    } else {
-        return true; // shouldn't happen
-    }
+		case MATCHOP_CONTAINSNOT:
+			return !matchop_cont(e, item);
+		}
+		return false;
+	} else {
+		return true; // shouldn't happen
+	}
 }
 
 std::string Matcher::get_parse_error()
 {
-    return errmsg;
+	return errmsg;
 }
 
 int Matcher::string_to_num(const std::string& number)
 {
-    int result = 0;
-    std::istringstream(number) >> result;
-    return result;
+	int result = 0;
+	std::istringstream(number) >> result;
+	return result;
 }
 
 } // namespace newsboat

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -18,232 +18,232 @@ namespace newsboat {
 Matcher::Matcher() {}
 
 Matcher::Matcher(const std::string& expr)
-	: exp(expr)
+    : exp(expr)
 {
-	parse(expr);
+    parse(expr);
 }
 
 std::string Matcher::get_expression()
 {
-	return exp;
+    return exp;
 }
 
 bool Matcher::parse(const std::string& expr)
 {
-	ScopeMeasure measurer("Matcher::parse");
+    ScopeMeasure measurer("Matcher::parse");
 
-	errmsg = "";
+    errmsg = "";
 
-	bool b = p.parse_string(expr);
+    bool b = p.parse_string(expr);
 
-	if (b) {
-		exp = expr;
-	} else {
-		errmsg = utils::wstr2str(p.get_error());
-	}
+    if (b) {
+        exp = expr;
+    } else {
+        errmsg = utils::wstr2str(p.get_error());
+    }
 
-	LOG(Level::DEBUG,
-		"Matcher::parse: parsing `%s' succeeded: %d",
-		expr,
-		b ? 1 : 0);
+    LOG(Level::DEBUG,
+        "Matcher::parse: parsing `%s' succeeded: %d",
+        expr,
+        b ? 1 : 0);
 
-	return b;
+    return b;
 }
 
 bool Matcher::matches(Matchable* item)
 {
-	/*
-	 * with this method, every class that is derived from Matchable can be
-	 * matched against a filter expression that was previously passed to the
-	 * class with the parse() method.
-	 *
-	 * This makes it easy to use the Matcher virtually everywhere, since C++
-	 * allows multiple inheritance (i.e. deriving from Matchable can even be
-	 * used in class hierarchies), and deriving from Matchable means that
-	 * you only have to implement the method attribute_value().
-	 *
-	 * The whole matching code is speed-critical, as the matching happens on
-	 * a lot of different occasions, and slow matching can be easily
-	 * measured (and felt by the user) on slow computers with a lot of items
-	 * to match.
-	 */
-	bool retval = false;
-	if (item) {
-		ScopeMeasure m1("Matcher::matches");
-		retval = matches_r(p.get_root(), item);
-	}
-	return retval;
+    /*
+     * with this method, every class that is derived from Matchable can be
+     * matched against a filter expression that was previously passed to the
+     * class with the parse() method.
+     *
+     * This makes it easy to use the Matcher virtually everywhere, since C++
+     * allows multiple inheritance (i.e. deriving from Matchable can even be
+     * used in class hierarchies), and deriving from Matchable means that
+     * you only have to implement the method attribute_value().
+     *
+     * The whole matching code is speed-critical, as the matching happens on
+     * a lot of different occasions, and slow matching can be easily
+     * measured (and felt by the user) on slow computers with a lot of items
+     * to match.
+     */
+    bool retval = false;
+    if (item) {
+        ScopeMeasure m1("Matcher::matches");
+        retval = matches_r(p.get_root(), item);
+    }
+    return retval;
 }
 
 std::string get_attr_or_throw(Matchable* item, const std::string& attr_name)
 {
-	const auto attr = item->attribute_value(attr_name);
+    const auto attr = item->attribute_value(attr_name);
 
-	if (!attr.has_value()) {
-		LOG(Level::WARN,
-			"Matcher::matches: attribute %s is not available",
-			attr_name);
-		throw MatcherException(MatcherException::Type::ATTRIB_UNAVAIL, attr_name);
-	}
+    if (!attr.has_value()) {
+        LOG(Level::WARN,
+            "Matcher::matches: attribute %s is not available",
+            attr_name);
+        throw MatcherException(MatcherException::Type::ATTRIB_UNAVAIL, attr_name);
+    }
 
-	return attr.value();
+    return attr.value();
 }
 
 bool Matcher::matchop_lt(expression* e, Matchable* item)
 {
-	const int ilit = string_to_num(e->literal);
+    const int ilit = string_to_num(e->literal);
 
-	const auto attr = get_attr_or_throw(item, e->name);
-	const int iatt = string_to_num(attr);
+    const auto attr = get_attr_or_throw(item, e->name);
+    const int iatt = string_to_num(attr);
 
-	return iatt < ilit;
+    return iatt < ilit;
 }
 
 bool Matcher::matchop_between(expression* e, Matchable* item)
 {
-	const auto attr = get_attr_or_throw(item, e->name);
-	const int att = string_to_num(attr);
+    const auto attr = get_attr_or_throw(item, e->name);
+    const int att = string_to_num(attr);
 
-	const std::vector<std::string> lit = utils::tokenize(e->literal, ":");
-	if (lit.size() < 2) {
-		return false;
-	}
+    const std::vector<std::string> lit = utils::tokenize(e->literal, ":");
+    if (lit.size() < 2) {
+        return false;
+    }
 
-	int i1 = string_to_num(lit[0]);
-	int i2 = string_to_num(lit[1]);
-	if (i1 > i2) {
-		std::swap(i1, i2);
-	}
+    int i1 = string_to_num(lit[0]);
+    int i2 = string_to_num(lit[1]);
+    if (i1 > i2) {
+        std::swap(i1, i2);
+    }
 
-	return (att >= i1 && att <= i2);
+    return (att >= i1 && att <= i2);
 }
 
 bool Matcher::matchop_gt(expression* e, Matchable* item)
 {
-	const auto attr = get_attr_or_throw(item, e->name);
-	const int iatt = string_to_num(attr);
+    const auto attr = get_attr_or_throw(item, e->name);
+    const int iatt = string_to_num(attr);
 
-	const int ilit = string_to_num(e->literal);
+    const int ilit = string_to_num(e->literal);
 
-	return iatt > ilit;
+    return iatt > ilit;
 }
 
 bool Matcher::matchop_rxeq(expression* e, Matchable* item)
 {
-	const auto attr = get_attr_or_throw(item, e->name);
+    const auto attr = get_attr_or_throw(item, e->name);
 
-	if (!e->regex) {
-		e->regex = new regex_t;
-		int err;
-		if ((err = regcomp(e->regex,
-						e->literal.c_str(),
-						REG_EXTENDED | REG_ICASE | REG_NOSUB)) != 0) {
-			delete e->regex;
-			e->regex = nullptr;
-			char buf[1024];
-			regerror(err, e->regex, buf, sizeof(buf));
-			throw MatcherException(
-				MatcherException::Type::INVALID_REGEX,
-				e->literal,
-				buf);
-		}
-	}
-	if (regexec(e->regex,
-			attr.c_str(),
-			0,
-			nullptr,
-			0) == 0) {
-		return true;
-	}
-	return false;
+    if (!e->regex) {
+        e->regex = new regex_t;
+        int err;
+        if ((err = regcomp(e->regex,
+                           e->literal.c_str(),
+                           REG_EXTENDED | REG_ICASE | REG_NOSUB)) != 0) {
+            delete e->regex;
+            e->regex = nullptr;
+            char buf[1024];
+            regerror(err, e->regex, buf, sizeof(buf));
+            throw MatcherException(
+                MatcherException::Type::INVALID_REGEX,
+                e->literal,
+                buf);
+        }
+    }
+    if (regexec(e->regex,
+                attr.c_str(),
+                0,
+                nullptr,
+                0) == 0) {
+        return true;
+    }
+    return false;
 }
 
 bool Matcher::matchop_cont(expression* e, Matchable* item)
 {
-	const auto attr = get_attr_or_throw(item, e->name);
+    const auto attr = get_attr_or_throw(item, e->name);
 
-	const std::vector<std::string> elements = utils::tokenize(attr, " ");
-	const std::string literal = e->literal;
-	for (const auto& elem : elements) {
-		if (literal == elem) {
-			return true;
-		}
-	}
-	return false;
+    const std::vector<std::string> elements = utils::tokenize(attr, " ");
+    const std::string literal = e->literal;
+    for (const auto& elem : elements) {
+        if (literal == elem) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool Matcher::matchop_eq(expression* e, Matchable* item)
 {
-	const auto attr = get_attr_or_throw(item, e->name);
+    const auto attr = get_attr_or_throw(item, e->name);
 
-	return (attr == e->literal);
+    return (attr == e->literal);
 }
 
 bool Matcher::matches_r(expression* e, Matchable* item)
 {
-	if (e) {
-		switch (e->op) {
-		/* the operator "and" and "or" simply connect two different
-		 * subexpressions */
-		case LOGOP_AND:
-			// short-circuit evaluation in C -> short circuit evaluation in the filter language
-			return matches_r(e->l, item) &&
-				matches_r(e->r, item);
+    if (e) {
+        switch (e->op) {
+        /* the operator "and" and "or" simply connect two different
+         * subexpressions */
+        case LOGOP_AND:
+            // short-circuit evaluation in C -> short circuit evaluation in the filter language
+            return matches_r(e->l, item) &&
+                   matches_r(e->r, item);
 
-		case LOGOP_OR:
-			return matches_r(e->l, item) ||
-				matches_r(e->r, item); // same here
+        case LOGOP_OR:
+            return matches_r(e->l, item) ||
+                   matches_r(e->r, item); // same here
 
-		/* while the other operators connect an attribute with a value */
-		case MATCHOP_EQ:
-			return matchop_eq(e, item);
+        /* while the other operators connect an attribute with a value */
+        case MATCHOP_EQ:
+            return matchop_eq(e, item);
 
-		case MATCHOP_NE:
-			return !matchop_eq(e, item);
+        case MATCHOP_NE:
+            return !matchop_eq(e, item);
 
-		case MATCHOP_LT:
-			return matchop_lt(e, item);
+        case MATCHOP_LT:
+            return matchop_lt(e, item);
 
-		case MATCHOP_BETWEEN:
-			return matchop_between(e, item);
+        case MATCHOP_BETWEEN:
+            return matchop_between(e, item);
 
-		case MATCHOP_GT:
-			return matchop_gt(e, item);
+        case MATCHOP_GT:
+            return matchop_gt(e, item);
 
-		case MATCHOP_LE:
-			return !matchop_gt(e, item);
+        case MATCHOP_LE:
+            return !matchop_gt(e, item);
 
-		case MATCHOP_GE:
-			return !matchop_lt(e, item);
+        case MATCHOP_GE:
+            return !matchop_lt(e, item);
 
-		case MATCHOP_RXEQ:
-			return matchop_rxeq(e, item);
+        case MATCHOP_RXEQ:
+            return matchop_rxeq(e, item);
 
-		case MATCHOP_RXNE:
-			return !matchop_rxeq(e, item);
+        case MATCHOP_RXNE:
+            return !matchop_rxeq(e, item);
 
-		case MATCHOP_CONTAINS:
-			return matchop_cont(e, item);
+        case MATCHOP_CONTAINS:
+            return matchop_cont(e, item);
 
-		case MATCHOP_CONTAINSNOT:
-			return !matchop_cont(e, item);
-		}
-		return false;
-	} else {
-		return true; // shouldn't happen
-	}
+        case MATCHOP_CONTAINSNOT:
+            return !matchop_cont(e, item);
+        }
+        return false;
+    } else {
+        return true; // shouldn't happen
+    }
 }
 
 std::string Matcher::get_parse_error()
 {
-	return errmsg;
+    return errmsg;
 }
 
 int Matcher::string_to_num(const std::string& number)
 {
-	int result = 0;
-	std::istringstream(number) >> result;
-	return result;
+    int result = 0;
+    std::istringstream(number) >> result;
+    return result;
 }
 
 } // namespace newsboat

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -63,7 +63,7 @@ bool Matcher::matches(Matchable* item)
 	 * you only have to implement the method attribute_value().
 	 *
 	 * The whole matching code is speed-critical, as the matching happens on
-	 * a lot of different occassions, and slow matching can be easily
+	 * a lot of different occasions, and slow matching can be easily
 	 * measured (and felt by the user) on slow computers with a lot of items
 	 * to match.
 	 */
@@ -194,7 +194,7 @@ bool Matcher::matches_r(expression* e, Matchable* item)
 			return matches_r(e->l, item) ||
 				matches_r(e->r, item); // same here
 
-		/* while the other operator connect an attribute with a value */
+		/* while the other operators connect an attribute with a value */
 		case MATCHOP_EQ:
 			return matchop_eq(e, item);
 

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -31,143 +31,143 @@ namespace newsboat {
 const std::string RssIgnores::REGEX_PREFIX = "regex:";
 
 void RssIgnores::handle_action(const std::string& action,
-	const std::vector<std::string>& params)
+                               const std::vector<std::string>& params)
 {
-	if (action == "ignore-article") {
-		if (params.size() < 2) {
-			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
-		}
-		std::string ignore_rssurl = params[0];
-		std::string ignore_expr = params[1];
-		auto m = std::make_shared<Matcher>();
-		if (!m->parse(ignore_expr)) {
-			throw ConfigHandlerException(strprintf::fmt(
-					_("couldn't parse filter expression `%s': %s"),
-					ignore_expr,
-					m->get_parse_error()));
-		}
+    if (action == "ignore-article") {
+        if (params.size() < 2) {
+            throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+        }
+        std::string ignore_rssurl = params[0];
+        std::string ignore_expr = params[1];
+        auto m = std::make_shared<Matcher>();
+        if (!m->parse(ignore_expr)) {
+            throw ConfigHandlerException(strprintf::fmt(
+                                             _("couldn't parse filter expression `%s': %s"),
+                                             ignore_expr,
+                                             m->get_parse_error()));
+        }
 
-		const int prefix_len = REGEX_PREFIX.length();
-		if (!ignore_rssurl.compare(0, prefix_len, REGEX_PREFIX)) {
-			std::string errorMessage;
-			const std::string pattern = ignore_rssurl.substr(prefix_len,
-					ignore_rssurl.length() - prefix_len);
-			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
-			if (regex == nullptr) {
-				throw ConfigHandlerException(strprintf::fmt(
-						_("`%s' is not a valid regular expression: %s"),
-						pattern, errorMessage));
-			}
-		}
+        const int prefix_len = REGEX_PREFIX.length();
+        if (!ignore_rssurl.compare(0, prefix_len, REGEX_PREFIX)) {
+            std::string errorMessage;
+            const std::string pattern = ignore_rssurl.substr(prefix_len,
+                                        ignore_rssurl.length() - prefix_len);
+            const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
+            if (regex == nullptr) {
+                throw ConfigHandlerException(strprintf::fmt(
+                                                 _("`%s' is not a valid regular expression: %s"),
+                                                 pattern, errorMessage));
+            }
+        }
 
-		ignores.insert({ignore_rssurl, m});
-	} else if (action == "always-download") {
-		if (params.empty()) {
-			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
-		}
+        ignores.insert({ignore_rssurl, m});
+    } else if (action == "always-download") {
+        if (params.empty()) {
+            throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+        }
 
-		for (const auto& param : params) {
-			ignores_lastmodified.push_back(param);
-		}
-	} else if (action == "reset-unread-on-update") {
-		if (params.empty()) {
-			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
-		}
+        for (const auto& param : params) {
+            ignores_lastmodified.push_back(param);
+        }
+    } else if (action == "reset-unread-on-update") {
+        if (params.empty()) {
+            throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+        }
 
-		for (const auto& param : params) {
-			resetflag.push_back(param);
-		}
-	} else {
-		throw ConfigHandlerException(ActionHandlerStatus::INVALID_COMMAND);
-	}
+        for (const auto& param : params) {
+            resetflag.push_back(param);
+        }
+    } else {
+        throw ConfigHandlerException(ActionHandlerStatus::INVALID_COMMAND);
+    }
 }
 
 void RssIgnores::dump_config(std::vector<std::string>& config_output) const
 {
-	for (const auto& ign : ignores) {
-		std::string configline = "ignore-article ";
-		if (ign.first == "*") {
-			configline.append("*");
-		} else {
-			configline.append(utils::quote(ign.first));
-		}
-		configline.append(" ");
-		configline.append(utils::quote(ign.second->get_expression()));
-		config_output.push_back(configline);
-	}
-	for (const auto& ign_lm : ignores_lastmodified) {
-		config_output.push_back(strprintf::fmt(
-				"always-download %s", utils::quote(ign_lm)));
-	}
-	for (const auto& rf : resetflag) {
-		config_output.push_back(strprintf::fmt(
-				"reset-unread-on-update %s", utils::quote(rf)));
-	}
+    for (const auto& ign : ignores) {
+        std::string configline = "ignore-article ";
+        if (ign.first == "*") {
+            configline.append("*");
+        } else {
+            configline.append(utils::quote(ign.first));
+        }
+        configline.append(" ");
+        configline.append(utils::quote(ign.second->get_expression()));
+        config_output.push_back(configline);
+    }
+    for (const auto& ign_lm : ignores_lastmodified) {
+        config_output.push_back(strprintf::fmt(
+                                    "always-download %s", utils::quote(ign_lm)));
+    }
+    for (const auto& rf : resetflag) {
+        config_output.push_back(strprintf::fmt(
+                                    "reset-unread-on-update %s", utils::quote(rf)));
+    }
 }
 
 bool RssIgnores::matches_expr(std::shared_ptr<Matcher> expr, RssItem *item)
 {
-	if (expr->matches(item)) {
-		LOG(Level::DEBUG,
-			"RssIgnores::matches_expr: found match");
-		return true;
-	}
+    if (expr->matches(item)) {
+        LOG(Level::DEBUG,
+            "RssIgnores::matches_expr: found match");
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 bool RssIgnores::matches(RssItem* item)
 {
-	auto search = ignores.equal_range(item->feedurl());
-	for (auto itr = search.first; itr != search.second; itr++) {
-		if (matches_expr(itr->second, item))
-			return true;
-	}
+    auto search = ignores.equal_range(item->feedurl());
+    for (auto itr = search.first; itr != search.second; itr++) {
+        if (matches_expr(itr->second, item))
+            return true;
+    }
 
-	search = ignores.equal_range("*");
-	for (auto itr = search.first; itr != search.second; itr++) {
-		if (matches_expr(itr->second, item))
-			return true;
-	}
+    search = ignores.equal_range("*");
+    for (auto itr = search.first; itr != search.second; itr++) {
+        if (matches_expr(itr->second, item))
+            return true;
+    }
 
-	const int prefix_len = REGEX_PREFIX.length();
-	for (const auto& ign : ignores) {
-		LOG(Level::DEBUG,
-			"RssIgnores::matches: ign.first = `%s' item->feedurl = `%s'",
-			ign.first,
-			item->feedurl());
+    const int prefix_len = REGEX_PREFIX.length();
+    for (const auto& ign : ignores) {
+        LOG(Level::DEBUG,
+            "RssIgnores::matches: ign.first = `%s' item->feedurl = `%s'",
+            ign.first,
+            item->feedurl());
 
-		if (!ign.first.compare(0, prefix_len, REGEX_PREFIX)) {
-			const std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
-			std::string errorMessage;
-			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
-			const auto matches = regex->matches(item->feedurl(), 1, 0);
-			if (!matches.empty() && matches_expr(ign.second, item))
-				return true;
-		}
-	}
+        if (!ign.first.compare(0, prefix_len, REGEX_PREFIX)) {
+            const std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
+            std::string errorMessage;
+            const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
+            const auto matches = regex->matches(item->feedurl(), 1, 0);
+            if (!matches.empty() && matches_expr(ign.second, item))
+                return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
 bool RssIgnores::matches_lastmodified(const std::string& url)
 {
-	return std::find_if(ignores_lastmodified.begin(),
-			ignores_lastmodified.end(),
-	[&](const std::string& u) {
-		return u == url;
-	}) !=
-	ignores_lastmodified.end();
+    return std::find_if(ignores_lastmodified.begin(),
+                        ignores_lastmodified.end(),
+    [&](const std::string& u) {
+        return u == url;
+    }) !=
+    ignores_lastmodified.end();
 }
 
 bool RssIgnores::matches_resetunread(const std::string& url)
 {
-	return std::find_if(resetflag.begin(),
-			resetflag.end(),
-	[&](const std::string& u) {
-		return u == url;
-	}) !=
-	resetflag.end();
+    return std::find_if(resetflag.begin(),
+                        resetflag.end(),
+    [&](const std::string& u) {
+        return u == url;
+    }) !=
+    resetflag.end();
 }
 
 } // namespace newsboat

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -58,9 +58,11 @@ void RssIgnores::handle_action(const std::string& action,
 						_("`%s' is not a valid regular expression: %s"),
 						pattern, errorMessage));
 			}
-		}
 
-		ignores.insert({ignore_rssurl, m});
+			regex_ignores.push_back(FeedUrlExprPair(pattern, m));
+		} else {
+			non_regex_ignores.insert({ignore_rssurl, m});
+		}
 	} else if (action == "always-download") {
 		if (params.empty()) {
 			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
@@ -84,13 +86,20 @@ void RssIgnores::handle_action(const std::string& action,
 
 void RssIgnores::dump_config(std::vector<std::string>& config_output) const
 {
-	for (const auto& ign : ignores) {
+	for (const auto& ign : non_regex_ignores) {
 		std::string configline = "ignore-article ";
 		if (ign.first == "*") {
 			configline.append("*");
 		} else {
 			configline.append(utils::quote(ign.first));
 		}
+		configline.append(" ");
+		configline.append(utils::quote(ign.second->get_expression()));
+		config_output.push_back(configline);
+	}
+	for (const auto& ign : regex_ignores) {
+		std::string configline = "ignore-article ";
+		configline.append(utils::quote(REGEX_PREFIX + ign.first));
 		configline.append(" ");
 		configline.append(utils::quote(ign.second->get_expression()));
 		config_output.push_back(configline);
@@ -118,35 +127,33 @@ bool RssIgnores::matches_expr(std::shared_ptr<Matcher> expr, RssItem* item)
 
 bool RssIgnores::matches(RssItem* item)
 {
-	auto search = ignores.equal_range(item->feedurl());
+	auto search = non_regex_ignores.equal_range(item->feedurl());
 	for (auto itr = search.first; itr != search.second; itr++) {
 		if (matches_expr(itr->second, item)) {
 			return true;
 		}
 	}
 
-	search = ignores.equal_range("*");
+	search = non_regex_ignores.equal_range("*");
 	for (auto itr = search.first; itr != search.second; itr++) {
 		if (matches_expr(itr->second, item)) {
 			return true;
 		}
 	}
 
-	const int prefix_len = REGEX_PREFIX.length();
-	for (const auto& ign : ignores) {
+	for (const auto& ign : regex_ignores) {
+		const std::string pattern = ign.first;
+
 		LOG(Level::DEBUG,
 			"RssIgnores::matches: ign.first = `%s' item->feedurl = `%s'",
-			ign.first,
+			pattern,
 			item->feedurl());
 
-		if (!ign.first.compare(0, prefix_len, REGEX_PREFIX)) {
-			const std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
-			std::string errorMessage;
-			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
-			const auto matches = regex->matches(item->feedurl(), 1, 0);
-			if (!matches.empty() && matches_expr(ign.second, item)) {
-				return true;
-			}
+		std::string errorMessage;
+		const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
+		const auto matches = regex->matches(item->feedurl(), 1, 0);
+		if (!matches.empty() && matches_expr(ign.second, item)) {
+			return true;
 		}
 	}
 

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -31,143 +31,143 @@ namespace newsboat {
 const std::string RssIgnores::REGEX_PREFIX = "regex:";
 
 void RssIgnores::handle_action(const std::string& action,
-                               const std::vector<std::string>& params)
+	const std::vector<std::string>& params)
 {
-    if (action == "ignore-article") {
-        if (params.size() < 2) {
-            throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
-        }
-        std::string ignore_rssurl = params[0];
-        std::string ignore_expr = params[1];
-        auto m = std::make_shared<Matcher>();
-        if (!m->parse(ignore_expr)) {
-            throw ConfigHandlerException(strprintf::fmt(
-                                             _("couldn't parse filter expression `%s': %s"),
-                                             ignore_expr,
-                                             m->get_parse_error()));
-        }
+	if (action == "ignore-article") {
+		if (params.size() < 2) {
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
+		std::string ignore_rssurl = params[0];
+		std::string ignore_expr = params[1];
+		auto m = std::make_shared<Matcher>();
+		if (!m->parse(ignore_expr)) {
+			throw ConfigHandlerException(strprintf::fmt(
+					_("couldn't parse filter expression `%s': %s"),
+					ignore_expr,
+					m->get_parse_error()));
+		}
 
-        const int prefix_len = REGEX_PREFIX.length();
-        if (!ignore_rssurl.compare(0, prefix_len, REGEX_PREFIX)) {
-            std::string errorMessage;
-            const std::string pattern = ignore_rssurl.substr(prefix_len,
-                                        ignore_rssurl.length() - prefix_len);
-            const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
-            if (regex == nullptr) {
-                throw ConfigHandlerException(strprintf::fmt(
-                                                 _("`%s' is not a valid regular expression: %s"),
-                                                 pattern, errorMessage));
-            }
-        }
+		const int prefix_len = REGEX_PREFIX.length();
+		if (!ignore_rssurl.compare(0, prefix_len, REGEX_PREFIX)) {
+			std::string errorMessage;
+			const std::string pattern = ignore_rssurl.substr(prefix_len,
+					ignore_rssurl.length() - prefix_len);
+			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
+			if (regex == nullptr) {
+				throw ConfigHandlerException(strprintf::fmt(
+						_("`%s' is not a valid regular expression: %s"),
+						pattern, errorMessage));
+			}
+		}
 
-        ignores.insert({ignore_rssurl, m});
-    } else if (action == "always-download") {
-        if (params.empty()) {
-            throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
-        }
+		ignores.insert({ignore_rssurl, m});
+	} else if (action == "always-download") {
+		if (params.empty()) {
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
 
-        for (const auto& param : params) {
-            ignores_lastmodified.push_back(param);
-        }
-    } else if (action == "reset-unread-on-update") {
-        if (params.empty()) {
-            throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
-        }
+		for (const auto& param : params) {
+			ignores_lastmodified.push_back(param);
+		}
+	} else if (action == "reset-unread-on-update") {
+		if (params.empty()) {
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
 
-        for (const auto& param : params) {
-            resetflag.push_back(param);
-        }
-    } else {
-        throw ConfigHandlerException(ActionHandlerStatus::INVALID_COMMAND);
-    }
+		for (const auto& param : params) {
+			resetflag.push_back(param);
+		}
+	} else {
+		throw ConfigHandlerException(ActionHandlerStatus::INVALID_COMMAND);
+	}
 }
 
 void RssIgnores::dump_config(std::vector<std::string>& config_output) const
 {
-    for (const auto& ign : ignores) {
-        std::string configline = "ignore-article ";
-        if (ign.first == "*") {
-            configline.append("*");
-        } else {
-            configline.append(utils::quote(ign.first));
-        }
-        configline.append(" ");
-        configline.append(utils::quote(ign.second->get_expression()));
-        config_output.push_back(configline);
-    }
-    for (const auto& ign_lm : ignores_lastmodified) {
-        config_output.push_back(strprintf::fmt(
-                                    "always-download %s", utils::quote(ign_lm)));
-    }
-    for (const auto& rf : resetflag) {
-        config_output.push_back(strprintf::fmt(
-                                    "reset-unread-on-update %s", utils::quote(rf)));
-    }
+	for (const auto& ign : ignores) {
+		std::string configline = "ignore-article ";
+		if (ign.first == "*") {
+			configline.append("*");
+		} else {
+			configline.append(utils::quote(ign.first));
+		}
+		configline.append(" ");
+		configline.append(utils::quote(ign.second->get_expression()));
+		config_output.push_back(configline);
+	}
+	for (const auto& ign_lm : ignores_lastmodified) {
+		config_output.push_back(strprintf::fmt(
+				"always-download %s", utils::quote(ign_lm)));
+	}
+	for (const auto& rf : resetflag) {
+		config_output.push_back(strprintf::fmt(
+				"reset-unread-on-update %s", utils::quote(rf)));
+	}
 }
 
 bool RssIgnores::matches_expr(std::shared_ptr<Matcher> expr, RssItem *item)
 {
-    if (expr->matches(item)) {
-        LOG(Level::DEBUG,
-            "RssIgnores::matches_expr: found match");
-        return true;
-    }
+	if (expr->matches(item)) {
+		LOG(Level::DEBUG,
+			"RssIgnores::matches_expr: found match");
+		return true;
+	}
 
-    return false;
+	return false;
 }
 
 bool RssIgnores::matches(RssItem* item)
 {
-    auto search = ignores.equal_range(item->feedurl());
-    for (auto itr = search.first; itr != search.second; itr++) {
-        if (matches_expr(itr->second, item))
-            return true;
-    }
+	auto search = ignores.equal_range(item->feedurl());
+	for (auto itr = search.first; itr != search.second; itr++) {
+		if (matches_expr(itr->second, item))
+			return true;
+	}
 
-    search = ignores.equal_range("*");
-    for (auto itr = search.first; itr != search.second; itr++) {
-        if (matches_expr(itr->second, item))
-            return true;
-    }
+	search = ignores.equal_range("*");
+	for (auto itr = search.first; itr != search.second; itr++) {
+		if (matches_expr(itr->second, item))
+			return true;
+	}
 
-    const int prefix_len = REGEX_PREFIX.length();
-    for (const auto& ign : ignores) {
-        LOG(Level::DEBUG,
-            "RssIgnores::matches: ign.first = `%s' item->feedurl = `%s'",
-            ign.first,
-            item->feedurl());
+	const int prefix_len = REGEX_PREFIX.length();
+	for (const auto& ign : ignores) {
+		LOG(Level::DEBUG,
+			"RssIgnores::matches: ign.first = `%s' item->feedurl = `%s'",
+			ign.first,
+			item->feedurl());
 
-        if (!ign.first.compare(0, prefix_len, REGEX_PREFIX)) {
-            const std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
-            std::string errorMessage;
-            const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
-            const auto matches = regex->matches(item->feedurl(), 1, 0);
-            if (!matches.empty() && matches_expr(ign.second, item))
-                return true;
-        }
-    }
+		if (!ign.first.compare(0, prefix_len, REGEX_PREFIX)) {
+			const std::string pattern = ign.first.substr(prefix_len, ign.first.length() - prefix_len);
+			std::string errorMessage;
+			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
+			const auto matches = regex->matches(item->feedurl(), 1, 0);
+			if (!matches.empty() && matches_expr(ign.second, item))
+				return true;
+		}
+	}
 
-    return false;
+	return false;
 }
 
 bool RssIgnores::matches_lastmodified(const std::string& url)
 {
-    return std::find_if(ignores_lastmodified.begin(),
-                        ignores_lastmodified.end(),
-    [&](const std::string& u) {
-        return u == url;
-    }) !=
-    ignores_lastmodified.end();
+	return std::find_if(ignores_lastmodified.begin(),
+			ignores_lastmodified.end(),
+	[&](const std::string& u) {
+		return u == url;
+	}) !=
+	ignores_lastmodified.end();
 }
 
 bool RssIgnores::matches_resetunread(const std::string& url)
 {
-    return std::find_if(resetflag.begin(),
-                        resetflag.end(),
-    [&](const std::string& u) {
-        return u == url;
-    }) !=
-    resetflag.end();
+	return std::find_if(resetflag.begin(),
+			resetflag.end(),
+	[&](const std::string& u) {
+		return u == url;
+	}) !=
+	resetflag.end();
 }
 
 } // namespace newsboat

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -60,7 +60,6 @@ void RssIgnores::handle_action(const std::string& action,
 			}
 		}
 
-		// ignores.push_back(FeedUrlExprPair(ignore_rssurl, m));
 		ignores.insert({ignore_rssurl, m});
 	} else if (action == "always-download") {
 		if (params.empty()) {

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -105,7 +105,7 @@ void RssIgnores::dump_config(std::vector<std::string>& config_output) const
 	}
 }
 
-bool RssIgnores::matches_expr(std::shared_ptr<Matcher> expr, RssItem *item)
+bool RssIgnores::matches_expr(std::shared_ptr<Matcher> expr, RssItem* item)
 {
 	if (expr->matches(item)) {
 		LOG(Level::DEBUG,
@@ -120,14 +120,16 @@ bool RssIgnores::matches(RssItem* item)
 {
 	auto search = ignores.equal_range(item->feedurl());
 	for (auto itr = search.first; itr != search.second; itr++) {
-		if (matches_expr(itr->second, item))
+		if (matches_expr(itr->second, item)) {
 			return true;
+		}
 	}
 
 	search = ignores.equal_range("*");
 	for (auto itr = search.first; itr != search.second; itr++) {
-		if (matches_expr(itr->second, item))
+		if (matches_expr(itr->second, item)) {
 			return true;
+		}
 	}
 
 	const int prefix_len = REGEX_PREFIX.length();
@@ -142,8 +144,9 @@ bool RssIgnores::matches(RssItem* item)
 			std::string errorMessage;
 			const auto regex = Regex::compile(pattern, REG_EXTENDED | REG_ICASE, errorMessage);
 			const auto matches = regex->matches(item->feedurl(), 1, 0);
-			if (!matches.empty() && matches_expr(ign.second, item))
+			if (!matches.empty() && matches_expr(ign.second, item)) {
 				return true;
+			}
 		}
 	}
 

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -1,5 +1,6 @@
 #include "rssignores.h"
 
+#include <iostream>
 #include <set>
 
 #include "3rd-party/catch.hpp"
@@ -137,6 +138,7 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 		ignores.handle_action(action, {"https://example.com/feed.xml", "author =~ \"Joe\""});
 		ignores.handle_action(action, {"*", "title # \"interesting\""});
 		ignores.handle_action(action, {"https://blog.example.com/joe/posts.xml", "guid # 123"});
+		ignores.handle_action(action, {"regex:^https://.*", "author = \"John Doe\""});
 
 		std::vector<std::string> config;
 		const auto comment =
@@ -147,7 +149,7 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 
 		std::set<std::string> config_set(config.begin(), config.end());
 
-		REQUIRE(config.size() == 4); // three actions plus one comment
+		REQUIRE(config.size() == 5); // four actions plus one comment
 		REQUIRE(config_set.count(comment) == 1);
 		REQUIRE(config_set.count(
 				R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#") == 1);
@@ -155,6 +157,8 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 				R"#(ignore-article * "title # \"interesting\"")#") == 1);
 		REQUIRE(config_set.count(
 				R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
+		REQUIRE(config_set.count(
+				R"#(ignore-article "regex:^https://.*" "author = \"John Doe\"")#") == 1);
 	}
 
 	SECTION("`always-download`") {

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -1,5 +1,7 @@
 #include "rssignores.h"
 
+#include <set>
+
 #include "3rd-party/catch.hpp"
 
 #include "cache.h"
@@ -143,13 +145,16 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 
 		ignores.dump_config(config);
 
+		std::set<std::string> config_set(config.begin(), config.end());
+
 		REQUIRE(config.size() == 4); // three actions plus one comment
-		REQUIRE(config[0] == comment);
-		REQUIRE(config[1] ==
-			R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#");
-		REQUIRE(config[2] == R"#(ignore-article * "title # \"interesting\"")#");
-		REQUIRE(config[3] ==
-			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#");
+		REQUIRE(config_set.count(comment) == 1);
+		REQUIRE(config_set.count(
+			R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#") == 1);
+		REQUIRE(config_set.count(
+			R"#(ignore-article * "title # \"interesting\"")#") == 1);
+		REQUIRE(config_set.count(
+			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
 	}
 
 	SECTION("`always-download`") {
@@ -209,11 +214,14 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 
 		ignores.dump_config(config);
 
+		std::set<std::string> config_set(config.begin(), config.end());
+
 		REQUIRE(config.size() == 10);
 		REQUIRE(config[0] == comment);
-		REQUIRE(config[1] == R"#(ignore-article * "title # \"interesting\"")#");
-		REQUIRE(config[2] ==
-			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#");
+		REQUIRE(config_set.count(
+			R"#(ignore-article * "title # \"interesting\"")#") == 1);
+		REQUIRE(config_set.count(
+			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
 		REQUIRE(config[3] == R"#(always-download "url1")#");
 		REQUIRE(config[4] == R"#(always-download "url2")#");
 		REQUIRE(config[5] == R"#(always-download "url3")#");

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -11,287 +11,287 @@
 using namespace newsboat;
 
 TEST_CASE(
-    "RssIgnores::matches_lastmodified() returns true if given url "
-    "has to always be downloaded",
-    "[RssIgnores]")
+	"RssIgnores::matches_lastmodified() returns true if given url "
+	"has to always be downloaded",
+	"[RssIgnores]")
 {
-    RssIgnores ignores;
-    ignores.handle_action("always-download", {
-        "http://newsboat.org",
-        "www.cool-website.com",
-        "www.example.com"
-    });
+	RssIgnores ignores;
+	ignores.handle_action("always-download", {
+		"http://newsboat.org",
+		"www.cool-website.com",
+		"www.example.com"
+	});
 
-    REQUIRE(ignores.matches_lastmodified("www.example.com"));
-    REQUIRE(ignores.matches_lastmodified("http://newsboat.org"));
-    REQUIRE(ignores.matches_lastmodified("www.cool-website.com"));
-    REQUIRE_FALSE(ignores.matches_lastmodified("www.smth.com"));
+	REQUIRE(ignores.matches_lastmodified("www.example.com"));
+	REQUIRE(ignores.matches_lastmodified("http://newsboat.org"));
+	REQUIRE(ignores.matches_lastmodified("www.cool-website.com"));
+	REQUIRE_FALSE(ignores.matches_lastmodified("www.smth.com"));
 }
 
 TEST_CASE(
-    "RssIgnores::matches_resetunread() returns true if given url "
-    "will always have its unread flag reset on update",
-    "[RssIgnores]")
+	"RssIgnores::matches_resetunread() returns true if given url "
+	"will always have its unread flag reset on update",
+	"[RssIgnores]")
 {
-    RssIgnores ignores;
-    ignores.handle_action("reset-unread-on-update", {
-        "http://newsboat.org",
-        "www.cool-website.com",
-        "www.example.com"
-    });
+	RssIgnores ignores;
+	ignores.handle_action("reset-unread-on-update", {
+		"http://newsboat.org",
+		"www.cool-website.com",
+		"www.example.com"
+	});
 
-    REQUIRE(ignores.matches_resetunread("www.example.com"));
-    REQUIRE(ignores.matches_resetunread("http://newsboat.org"));
-    REQUIRE(ignores.matches_resetunread("www.cool-website.com"));
-    REQUIRE_FALSE(ignores.matches_resetunread("www.smth.com"));
+	REQUIRE(ignores.matches_resetunread("www.example.com"));
+	REQUIRE(ignores.matches_resetunread("http://newsboat.org"));
+	REQUIRE(ignores.matches_resetunread("www.cool-website.com"));
+	REQUIRE_FALSE(ignores.matches_resetunread("www.smth.com"));
 }
 
 TEST_CASE("RssIgnores::handle_action() handles `ignore-article`",
-          "[RssIgnores]")
+	"[RssIgnores]")
 {
-    RssIgnores ignores;
+	RssIgnores ignores;
 
-    const std::string action = "ignore-article";
+	const std::string action = "ignore-article";
 
-    SECTION("Throws ConfigHandlerException if less than 2 parameters") {
-        REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
-        REQUIRE_THROWS_AS(ignores.handle_action(action, {"param"}),
-                          ConfigHandlerException);
-    }
+	SECTION("Throws ConfigHandlerException if less than 2 parameters") {
+		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
+		REQUIRE_THROWS_AS(ignores.handle_action(action, {"param"}),
+			ConfigHandlerException);
+	}
 
-    SECTION("Throws ConfigHandlerException if second param can't be parsed as filter expression") {
-        REQUIRE_THROWS_AS(ignores.handle_action(action, {"url", "!?"}),
-                          ConfigHandlerException);
-    }
+	SECTION("Throws ConfigHandlerException if second param can't be parsed as filter expression") {
+		REQUIRE_THROWS_AS(ignores.handle_action(action, {"url", "!?"}),
+			ConfigHandlerException);
+	}
 
-    SECTION("Doesn't throw on two or more params") {
-        REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "more"}));
-        REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "way", "more different", "parameters"}));
-    }
+	SECTION("Doesn't throw on two or more params") {
+		REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "more"}));
+		REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "way", "more different", "parameters"}));
+	}
 
-    SECTION("Throws ConfigHandlerException if second param can't be parsed as a filter expression") {
-        REQUIRE_THROWS_AS(ignores.handle_action("ignore-article", {"regex:a{1z", "author = \"John Doe\""}),
-                          ConfigHandlerException);
-    }
+	SECTION("Throws ConfigHandlerException if second param can't be parsed as a filter expression") {
+		REQUIRE_THROWS_AS(ignores.handle_action("ignore-article", {"regex:a{1z", "author = \"John Doe\""}),
+			ConfigHandlerException);
+	}
 }
 
 TEST_CASE("RssIgnores::handle_action() handles `always-download`",
-          "[RssIgnores]")
+	"[RssIgnores]")
 {
-    RssIgnores ignores;
+	RssIgnores ignores;
 
-    const std::string action = "always-download";
+	const std::string action = "always-download";
 
-    SECTION("Throws ConfigHandlerException if given zero parameters") {
-        REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
-    }
+	SECTION("Throws ConfigHandlerException if given zero parameters") {
+		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
+	}
 
-    SECTION("Doesn't trow if given one or more parameters") {
-        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
-        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
-        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
-    }
+	SECTION("Doesn't trow if given one or more parameters") {
+		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
+		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
+		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
+	}
 }
 
 TEST_CASE("RssIgnores::handle_action() handles `reset-unread-on-update`",
-          "[RssIgnores]")
+	"[RssIgnores]")
 {
-    RssIgnores ignores;
+	RssIgnores ignores;
 
-    const std::string action = "reset-unread-on-update";
+	const std::string action = "reset-unread-on-update";
 
-    SECTION("Throws ConfigHandlerException if given zero parameters") {
-        REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
-    }
+	SECTION("Throws ConfigHandlerException if given zero parameters") {
+		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
+	}
 
-    SECTION("Doesn't throw if given one or more parameters") {
-        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
-        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
-        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
-    }
+	SECTION("Doesn't throw if given one or more parameters") {
+		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
+		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
+		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
+	}
 }
 
 TEST_CASE("RssIgnores::handle_action() throws ConfigHandlerException "
-          "on unknown command",
-          "[RssIgnores]")
+	"on unknown command",
+	"[RssIgnores]")
 {
-    RssIgnores ignores;
+	RssIgnores ignores;
 
-    REQUIRE_THROWS_AS(ignores.handle_action("bind-key", {"ESC", "quit"}),
-                      ConfigHandlerException);
-    REQUIRE_THROWS_AS(ignores.handle_action("auto-reload", {"yes"}),
-                      ConfigHandlerException);
-    REQUIRE_THROWS_AS(ignores.handle_action("color", {"listnormal", "blue", "black"}),
-                      ConfigHandlerException);
+	REQUIRE_THROWS_AS(ignores.handle_action("bind-key", {"ESC", "quit"}),
+		ConfigHandlerException);
+	REQUIRE_THROWS_AS(ignores.handle_action("auto-reload", {"yes"}),
+		ConfigHandlerException);
+	REQUIRE_THROWS_AS(ignores.handle_action("color", {"listnormal", "blue", "black"}),
+		ConfigHandlerException);
 }
 
 TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
-          "to the provided vector",
-          "[RssIgnores]")
+	"to the provided vector",
+	"[RssIgnores]")
 {
-    RssIgnores ignores;
+	RssIgnores ignores;
 
-    SECTION("`ignore-article`") {
-        const std::string action = "ignore-article";
+	SECTION("`ignore-article`") {
+		const std::string action = "ignore-article";
 
-        ignores.handle_action(action, {"https://example.com/feed.xml", "author =~ \"Joe\""});
-        ignores.handle_action(action, {"*", "title # \"interesting\""});
-        ignores.handle_action(action, {"https://blog.example.com/joe/posts.xml", "guid # 123"});
+		ignores.handle_action(action, {"https://example.com/feed.xml", "author =~ \"Joe\""});
+		ignores.handle_action(action, {"*", "title # \"interesting\""});
+		ignores.handle_action(action, {"https://blog.example.com/joe/posts.xml", "guid # 123"});
 
-        std::vector<std::string> config;
-        const auto comment =
-            "# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
-        config.push_back(comment);
+		std::vector<std::string> config;
+		const auto comment =
+			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
+		config.push_back(comment);
 
-        ignores.dump_config(config);
+		ignores.dump_config(config);
 
-        std::set<std::string> config_set(config.begin(), config.end());
+		std::set<std::string> config_set(config.begin(), config.end());
 
-        REQUIRE(config.size() == 4); // three actions plus one comment
-        REQUIRE(config_set.count(comment) == 1);
-        REQUIRE(config_set.count(
-                    R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#") == 1);
-                    REQUIRE(config_set.count(
-                                R"#(ignore-article * "title # \"interesting\"")#") == 1);
-                            REQUIRE(config_set.count(
-                                        R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
-    }
+		REQUIRE(config.size() == 4); // three actions plus one comment
+		REQUIRE(config_set.count(comment) == 1);
+		REQUIRE(config_set.count(
+			R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#") == 1);
+		REQUIRE(config_set.count(
+			R"#(ignore-article * "title # \"interesting\"")#") == 1);
+		REQUIRE(config_set.count(
+			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
+	}
 
-    SECTION("`always-download`") {
-        const std::string action = "always-download";
+	SECTION("`always-download`") {
+		const std::string action = "always-download";
 
-        ignores.handle_action(action, {"url1"});
-        ignores.handle_action(action, {"url2", "url3", "url4"});
+		ignores.handle_action(action, {"url1"});
+		ignores.handle_action(action, {"url2", "url3", "url4"});
 
-        std::vector<std::string> config;
-        const auto comment =
-            "# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
-        config.push_back(comment);
+		std::vector<std::string> config;
+		const auto comment =
+			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
+		config.push_back(comment);
 
-        ignores.dump_config(config);
+		ignores.dump_config(config);
 
-        REQUIRE(config.size() == 5); // four URLs plus one comment
-        REQUIRE(config[0] == comment);
-        REQUIRE(config[1] == R"#(always-download "url1")#");
-        REQUIRE(config[2] == R"#(always-download "url2")#");
-        REQUIRE(config[3] == R"#(always-download "url3")#");
-        REQUIRE(config[4] == R"#(always-download "url4")#");
-    }
+		REQUIRE(config.size() == 5); // four URLs plus one comment
+		REQUIRE(config[0] == comment);
+		REQUIRE(config[1] == R"#(always-download "url1")#");
+		REQUIRE(config[2] == R"#(always-download "url2")#");
+		REQUIRE(config[3] == R"#(always-download "url3")#");
+		REQUIRE(config[4] == R"#(always-download "url4")#");
+	}
 
-    SECTION("`reset-unread-on-update`") {
-        const std::string action = "reset-unread-on-update";
+	SECTION("`reset-unread-on-update`") {
+		const std::string action = "reset-unread-on-update";
 
-        ignores.handle_action(action, {"url1"});
-        ignores.handle_action(action, {"url2", "url3", "url4"});
+		ignores.handle_action(action, {"url1"});
+		ignores.handle_action(action, {"url2", "url3", "url4"});
 
-        std::vector<std::string> config;
-        const auto comment =
-            "# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
-        config.push_back(comment);
+		std::vector<std::string> config;
+		const auto comment =
+			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
+		config.push_back(comment);
 
-        ignores.dump_config(config);
+		ignores.dump_config(config);
 
-        REQUIRE(config.size() == 5); // four URLs plus one comment
-        REQUIRE(config[0] == comment);
-        REQUIRE(config[1] == R"#(reset-unread-on-update "url1")#");
-        REQUIRE(config[2] == R"#(reset-unread-on-update "url2")#");
-        REQUIRE(config[3] == R"#(reset-unread-on-update "url3")#");
-        REQUIRE(config[4] == R"#(reset-unread-on-update "url4")#");
-    }
+		REQUIRE(config.size() == 5); // four URLs plus one comment
+		REQUIRE(config[0] == comment);
+		REQUIRE(config[1] == R"#(reset-unread-on-update "url1")#");
+		REQUIRE(config[2] == R"#(reset-unread-on-update "url2")#");
+		REQUIRE(config[3] == R"#(reset-unread-on-update "url3")#");
+		REQUIRE(config[4] == R"#(reset-unread-on-update "url4")#");
+	}
 
-    SECTION("Mix of all supported commands") {
-        ignores.handle_action("reset-unread-on-update", {"url1"});
-        ignores.handle_action("ignore-article", {"*", "title # \"interesting\""});
-        ignores.handle_action("always-download", {"url1"});
-        ignores.handle_action("ignore-article", {"https://blog.example.com/joe/posts.xml", "guid # 123"});
-        ignores.handle_action("reset-unread-on-update", {"url2", "url3"});
-        ignores.handle_action("always-download", {"url2", "url3", "url4"});
+	SECTION("Mix of all supported commands") {
+		ignores.handle_action("reset-unread-on-update", {"url1"});
+		ignores.handle_action("ignore-article", {"*", "title # \"interesting\""});
+		ignores.handle_action("always-download", {"url1"});
+		ignores.handle_action("ignore-article", {"https://blog.example.com/joe/posts.xml", "guid # 123"});
+		ignores.handle_action("reset-unread-on-update", {"url2", "url3"});
+		ignores.handle_action("always-download", {"url2", "url3", "url4"});
 
-        std::vector<std::string> config;
-        const auto comment =
-            "# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
-        config.push_back(comment);
+		std::vector<std::string> config;
+		const auto comment =
+			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
+		config.push_back(comment);
 
-        ignores.dump_config(config);
+		ignores.dump_config(config);
 
-        std::set<std::string> config_set(config.begin(), config.end());
+		std::set<std::string> config_set(config.begin(), config.end());
 
-        REQUIRE(config.size() == 10);
-        REQUIRE(config[0] == comment);
-        REQUIRE(config_set.count(
-                    R"#(ignore-article * "title # \"interesting\"")#") == 1);
-                REQUIRE(config_set.count(
-                            R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
-                            REQUIRE(config[3] == R"#(always-download "url1")#");
-                            REQUIRE(config[4] == R"#(always-download "url2")#");
-                            REQUIRE(config[5] == R"#(always-download "url3")#");
-                            REQUIRE(config[6] == R"#(always-download "url4")#");
-                            REQUIRE(config[7] == R"#(reset-unread-on-update "url1")#");
-                            REQUIRE(config[8] == R"#(reset-unread-on-update "url2")#");
-                            REQUIRE(config[9] == R"#(reset-unread-on-update "url3")#");
-    }
+		REQUIRE(config.size() == 10);
+		REQUIRE(config[0] == comment);
+		REQUIRE(config_set.count(
+			R"#(ignore-article * "title # \"interesting\"")#") == 1);
+		REQUIRE(config_set.count(
+			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
+		REQUIRE(config[3] == R"#(always-download "url1")#");
+		REQUIRE(config[4] == R"#(always-download "url2")#");
+		REQUIRE(config[5] == R"#(always-download "url3")#");
+		REQUIRE(config[6] == R"#(always-download "url4")#");
+		REQUIRE(config[7] == R"#(reset-unread-on-update "url1")#");
+		REQUIRE(config[8] == R"#(reset-unread-on-update "url2")#");
+		REQUIRE(config[9] == R"#(reset-unread-on-update "url3")#");
+	}
 }
 
-        TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
-                  "of ignore-article rules, otherwise false",
-                  "[RssIgnores]")
+TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
+	"of ignore-article rules, otherwise false",
+	"[RssIgnores]")
 {
-    RssIgnores ignores;
+	RssIgnores ignores;
 
-    ConfigContainer cfg;
-    Cache rsscache(":memory:", &cfg);
-    RssItem item(&rsscache);
+	ConfigContainer cfg;
+	Cache rsscache(":memory:", &cfg);
+	RssItem item(&rsscache);
 
-    const auto feedurl = "https://example.com/feed.xml";
+	const auto feedurl = "https://example.com/feed.xml";
 
-    item.set_title("Updates");
-    item.set_author("John Doe");
-    item.set_feedurl(feedurl);
+	item.set_title("Updates");
+	item.set_author("John Doe");
+	item.set_feedurl(feedurl);
 
-    SECTION("Only rules associated with item's feed URL are applied") {
-        SECTION("No rules for this feed") {
-            ignores.handle_action("ignore-article", {"https://example.org/anotherfeed.xml", "title =~ \".*\""});
+	SECTION("Only rules associated with item's feed URL are applied") {
+		SECTION("No rules for this feed") {
+			ignores.handle_action("ignore-article", {"https://example.org/anotherfeed.xml", "title =~ \".*\""});
 
-            REQUIRE_FALSE(ignores.matches(&item));
-        }
+			REQUIRE_FALSE(ignores.matches(&item));
+		}
 
-        SECTION("One rule for feed, but doesn't match item") {
-            ignores.handle_action("ignore-article", {feedurl, "title = \"news\""});
+		SECTION("One rule for feed, but doesn't match item") {
+			ignores.handle_action("ignore-article", {feedurl, "title = \"news\""});
 
-            REQUIRE_FALSE(ignores.matches(&item));
-        }
+			REQUIRE_FALSE(ignores.matches(&item));
+		}
 
-        SECTION("A rule matches both the feed and the item") {
-            ignores.handle_action("ignore-article", {feedurl, "title = \"Updates\""});
+		SECTION("A rule matches both the feed and the item") {
+			ignores.handle_action("ignore-article", {feedurl, "title = \"Updates\""});
 
-            REQUIRE(ignores.matches(&item));
-        }
+			REQUIRE(ignores.matches(&item));
+		}
 
-        SECTION("Multiple rules that match both the feed and the item") {
-            ignores.handle_action("ignore-article", {feedurl, "title = \"Updates\""});
-            ignores.handle_action("ignore-article", {feedurl, "author = \"John Doe\""});
+		SECTION("Multiple rules that match both the feed and the item") {
+			ignores.handle_action("ignore-article", {feedurl, "title = \"Updates\""});
+			ignores.handle_action("ignore-article", {feedurl, "author = \"John Doe\""});
 
-            REQUIRE(ignores.matches(&item));
-        }
-    }
+			REQUIRE(ignores.matches(&item));
+		}
+	}
 
-    SECTION("Pattern matching rules prefixed with \"regex:\"") {
-        SECTION("Matching feeds starting with https://") {
-            ignores.handle_action("ignore-article", {"regex:^https://.*", "author = \"John Doe\""});
+	SECTION("Pattern matching rules prefixed with \"regex:\"") {
+		SECTION("Matching feeds starting with https://") {
+			ignores.handle_action("ignore-article", {"regex:^https://.*", "author = \"John Doe\""});
 
-            REQUIRE(ignores.matches(&item));
-        }
+			REQUIRE(ignores.matches(&item));
+		}
 
-        SECTION("Matching feeds containing example.com and ending with xml") {
-            ignores.handle_action("ignore-article", {"regex:.*example.com/.*\\.xml", "author = \"John Doe\""});
+		SECTION("Matching feeds containing example.com and ending with xml") {
+			ignores.handle_action("ignore-article", {"regex:.*example.com/.*\\.xml", "author = \"John Doe\""});
 
-            REQUIRE(ignores.matches(&item));
-        }
-    }
+			REQUIRE(ignores.matches(&item));
+		}
+	}
 
-    SECTION("Rules with URL of \"*\" match any feed") {
-        ignores.handle_action("ignore-article", {"*", "author = \"John Doe\""});
+	SECTION("Rules with URL of \"*\" match any feed") {
+		ignores.handle_action("ignore-article", {"*", "author = \"John Doe\""});
 
-        REQUIRE(ignores.matches(&item));
-    }
+		REQUIRE(ignores.matches(&item));
+	}
 }

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -11,287 +11,287 @@
 using namespace newsboat;
 
 TEST_CASE(
-	"RssIgnores::matches_lastmodified() returns true if given url "
-	"has to always be downloaded",
-	"[RssIgnores]")
+    "RssIgnores::matches_lastmodified() returns true if given url "
+    "has to always be downloaded",
+    "[RssIgnores]")
 {
-	RssIgnores ignores;
-	ignores.handle_action("always-download", {
-		"http://newsboat.org",
-		"www.cool-website.com",
-		"www.example.com"
-	});
+    RssIgnores ignores;
+    ignores.handle_action("always-download", {
+        "http://newsboat.org",
+        "www.cool-website.com",
+        "www.example.com"
+    });
 
-	REQUIRE(ignores.matches_lastmodified("www.example.com"));
-	REQUIRE(ignores.matches_lastmodified("http://newsboat.org"));
-	REQUIRE(ignores.matches_lastmodified("www.cool-website.com"));
-	REQUIRE_FALSE(ignores.matches_lastmodified("www.smth.com"));
+    REQUIRE(ignores.matches_lastmodified("www.example.com"));
+    REQUIRE(ignores.matches_lastmodified("http://newsboat.org"));
+    REQUIRE(ignores.matches_lastmodified("www.cool-website.com"));
+    REQUIRE_FALSE(ignores.matches_lastmodified("www.smth.com"));
 }
 
 TEST_CASE(
-	"RssIgnores::matches_resetunread() returns true if given url "
-	"will always have its unread flag reset on update",
-	"[RssIgnores]")
+    "RssIgnores::matches_resetunread() returns true if given url "
+    "will always have its unread flag reset on update",
+    "[RssIgnores]")
 {
-	RssIgnores ignores;
-	ignores.handle_action("reset-unread-on-update", {
-		"http://newsboat.org",
-		"www.cool-website.com",
-		"www.example.com"
-	});
+    RssIgnores ignores;
+    ignores.handle_action("reset-unread-on-update", {
+        "http://newsboat.org",
+        "www.cool-website.com",
+        "www.example.com"
+    });
 
-	REQUIRE(ignores.matches_resetunread("www.example.com"));
-	REQUIRE(ignores.matches_resetunread("http://newsboat.org"));
-	REQUIRE(ignores.matches_resetunread("www.cool-website.com"));
-	REQUIRE_FALSE(ignores.matches_resetunread("www.smth.com"));
+    REQUIRE(ignores.matches_resetunread("www.example.com"));
+    REQUIRE(ignores.matches_resetunread("http://newsboat.org"));
+    REQUIRE(ignores.matches_resetunread("www.cool-website.com"));
+    REQUIRE_FALSE(ignores.matches_resetunread("www.smth.com"));
 }
 
 TEST_CASE("RssIgnores::handle_action() handles `ignore-article`",
-	"[RssIgnores]")
+          "[RssIgnores]")
 {
-	RssIgnores ignores;
+    RssIgnores ignores;
 
-	const std::string action = "ignore-article";
+    const std::string action = "ignore-article";
 
-	SECTION("Throws ConfigHandlerException if less than 2 parameters") {
-		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
-		REQUIRE_THROWS_AS(ignores.handle_action(action, {"param"}),
-			ConfigHandlerException);
-	}
+    SECTION("Throws ConfigHandlerException if less than 2 parameters") {
+        REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
+        REQUIRE_THROWS_AS(ignores.handle_action(action, {"param"}),
+                          ConfigHandlerException);
+    }
 
-	SECTION("Throws ConfigHandlerException if second param can't be parsed as filter expression") {
-		REQUIRE_THROWS_AS(ignores.handle_action(action, {"url", "!?"}),
-			ConfigHandlerException);
-	}
+    SECTION("Throws ConfigHandlerException if second param can't be parsed as filter expression") {
+        REQUIRE_THROWS_AS(ignores.handle_action(action, {"url", "!?"}),
+                          ConfigHandlerException);
+    }
 
-	SECTION("Doesn't throw on two or more params") {
-		REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "more"}));
-		REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "way", "more different", "parameters"}));
-	}
+    SECTION("Doesn't throw on two or more params") {
+        REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "more"}));
+        REQUIRE_NOTHROW(ignores.handle_action(action, {"url", "expression = 1", "way", "more different", "parameters"}));
+    }
 
-	SECTION("Throws ConfigHandlerException if second param can't be parsed as a filter expression") {
-		REQUIRE_THROWS_AS(ignores.handle_action("ignore-article", {"regex:a{1z", "author = \"John Doe\""}),
-			ConfigHandlerException);
-	}
+    SECTION("Throws ConfigHandlerException if second param can't be parsed as a filter expression") {
+        REQUIRE_THROWS_AS(ignores.handle_action("ignore-article", {"regex:a{1z", "author = \"John Doe\""}),
+                          ConfigHandlerException);
+    }
 }
 
 TEST_CASE("RssIgnores::handle_action() handles `always-download`",
-	"[RssIgnores]")
+          "[RssIgnores]")
 {
-	RssIgnores ignores;
+    RssIgnores ignores;
 
-	const std::string action = "always-download";
+    const std::string action = "always-download";
 
-	SECTION("Throws ConfigHandlerException if given zero parameters") {
-		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
-	}
+    SECTION("Throws ConfigHandlerException if given zero parameters") {
+        REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
+    }
 
-	SECTION("Doesn't trow if given one or more parameters") {
-		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
-		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
-		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
-	}
+    SECTION("Doesn't trow if given one or more parameters") {
+        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
+        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
+        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
+    }
 }
 
 TEST_CASE("RssIgnores::handle_action() handles `reset-unread-on-update`",
-	"[RssIgnores]")
+          "[RssIgnores]")
 {
-	RssIgnores ignores;
+    RssIgnores ignores;
 
-	const std::string action = "reset-unread-on-update";
+    const std::string action = "reset-unread-on-update";
 
-	SECTION("Throws ConfigHandlerException if given zero parameters") {
-		REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
-	}
+    SECTION("Throws ConfigHandlerException if given zero parameters") {
+        REQUIRE_THROWS_AS(ignores.handle_action(action, {}), ConfigHandlerException);
+    }
 
-	SECTION("Doesn't throw if given one or more parameters") {
-		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
-		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
-		REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
-	}
+    SECTION("Doesn't throw if given one or more parameters") {
+        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1"}));
+        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2"}));
+        REQUIRE_NOTHROW(ignores.handle_action(action, {"url1", "url2", "url3", "url4", "url5"}));
+    }
 }
 
 TEST_CASE("RssIgnores::handle_action() throws ConfigHandlerException "
-	"on unknown command",
-	"[RssIgnores]")
+          "on unknown command",
+          "[RssIgnores]")
 {
-	RssIgnores ignores;
+    RssIgnores ignores;
 
-	REQUIRE_THROWS_AS(ignores.handle_action("bind-key", {"ESC", "quit"}),
-		ConfigHandlerException);
-	REQUIRE_THROWS_AS(ignores.handle_action("auto-reload", {"yes"}),
-		ConfigHandlerException);
-	REQUIRE_THROWS_AS(ignores.handle_action("color", {"listnormal", "blue", "black"}),
-		ConfigHandlerException);
+    REQUIRE_THROWS_AS(ignores.handle_action("bind-key", {"ESC", "quit"}),
+                      ConfigHandlerException);
+    REQUIRE_THROWS_AS(ignores.handle_action("auto-reload", {"yes"}),
+                      ConfigHandlerException);
+    REQUIRE_THROWS_AS(ignores.handle_action("color", {"listnormal", "blue", "black"}),
+                      ConfigHandlerException);
 }
 
 TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
-	"to the provided vector",
-	"[RssIgnores]")
+          "to the provided vector",
+          "[RssIgnores]")
 {
-	RssIgnores ignores;
+    RssIgnores ignores;
 
-	SECTION("`ignore-article`") {
-		const std::string action = "ignore-article";
+    SECTION("`ignore-article`") {
+        const std::string action = "ignore-article";
 
-		ignores.handle_action(action, {"https://example.com/feed.xml", "author =~ \"Joe\""});
-		ignores.handle_action(action, {"*", "title # \"interesting\""});
-		ignores.handle_action(action, {"https://blog.example.com/joe/posts.xml", "guid # 123"});
+        ignores.handle_action(action, {"https://example.com/feed.xml", "author =~ \"Joe\""});
+        ignores.handle_action(action, {"*", "title # \"interesting\""});
+        ignores.handle_action(action, {"https://blog.example.com/joe/posts.xml", "guid # 123"});
 
-		std::vector<std::string> config;
-		const auto comment =
-			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
-		config.push_back(comment);
+        std::vector<std::string> config;
+        const auto comment =
+            "# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
+        config.push_back(comment);
 
-		ignores.dump_config(config);
+        ignores.dump_config(config);
 
-		std::set<std::string> config_set(config.begin(), config.end());
+        std::set<std::string> config_set(config.begin(), config.end());
 
-		REQUIRE(config.size() == 4); // three actions plus one comment
-		REQUIRE(config_set.count(comment) == 1);
-		REQUIRE(config_set.count(
-			R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#") == 1);
-		REQUIRE(config_set.count(
-			R"#(ignore-article * "title # \"interesting\"")#") == 1);
-		REQUIRE(config_set.count(
-			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
-	}
+        REQUIRE(config.size() == 4); // three actions plus one comment
+        REQUIRE(config_set.count(comment) == 1);
+        REQUIRE(config_set.count(
+                    R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#") == 1);
+                    REQUIRE(config_set.count(
+                                R"#(ignore-article * "title # \"interesting\"")#") == 1);
+                            REQUIRE(config_set.count(
+                                        R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
+    }
 
-	SECTION("`always-download`") {
-		const std::string action = "always-download";
+    SECTION("`always-download`") {
+        const std::string action = "always-download";
 
-		ignores.handle_action(action, {"url1"});
-		ignores.handle_action(action, {"url2", "url3", "url4"});
+        ignores.handle_action(action, {"url1"});
+        ignores.handle_action(action, {"url2", "url3", "url4"});
 
-		std::vector<std::string> config;
-		const auto comment =
-			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
-		config.push_back(comment);
+        std::vector<std::string> config;
+        const auto comment =
+            "# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
+        config.push_back(comment);
 
-		ignores.dump_config(config);
+        ignores.dump_config(config);
 
-		REQUIRE(config.size() == 5); // four URLs plus one comment
-		REQUIRE(config[0] == comment);
-		REQUIRE(config[1] == R"#(always-download "url1")#");
-		REQUIRE(config[2] == R"#(always-download "url2")#");
-		REQUIRE(config[3] == R"#(always-download "url3")#");
-		REQUIRE(config[4] == R"#(always-download "url4")#");
-	}
+        REQUIRE(config.size() == 5); // four URLs plus one comment
+        REQUIRE(config[0] == comment);
+        REQUIRE(config[1] == R"#(always-download "url1")#");
+        REQUIRE(config[2] == R"#(always-download "url2")#");
+        REQUIRE(config[3] == R"#(always-download "url3")#");
+        REQUIRE(config[4] == R"#(always-download "url4")#");
+    }
 
-	SECTION("`reset-unread-on-update`") {
-		const std::string action = "reset-unread-on-update";
+    SECTION("`reset-unread-on-update`") {
+        const std::string action = "reset-unread-on-update";
 
-		ignores.handle_action(action, {"url1"});
-		ignores.handle_action(action, {"url2", "url3", "url4"});
+        ignores.handle_action(action, {"url1"});
+        ignores.handle_action(action, {"url2", "url3", "url4"});
 
-		std::vector<std::string> config;
-		const auto comment =
-			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
-		config.push_back(comment);
+        std::vector<std::string> config;
+        const auto comment =
+            "# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
+        config.push_back(comment);
 
-		ignores.dump_config(config);
+        ignores.dump_config(config);
 
-		REQUIRE(config.size() == 5); // four URLs plus one comment
-		REQUIRE(config[0] == comment);
-		REQUIRE(config[1] == R"#(reset-unread-on-update "url1")#");
-		REQUIRE(config[2] == R"#(reset-unread-on-update "url2")#");
-		REQUIRE(config[3] == R"#(reset-unread-on-update "url3")#");
-		REQUIRE(config[4] == R"#(reset-unread-on-update "url4")#");
-	}
+        REQUIRE(config.size() == 5); // four URLs plus one comment
+        REQUIRE(config[0] == comment);
+        REQUIRE(config[1] == R"#(reset-unread-on-update "url1")#");
+        REQUIRE(config[2] == R"#(reset-unread-on-update "url2")#");
+        REQUIRE(config[3] == R"#(reset-unread-on-update "url3")#");
+        REQUIRE(config[4] == R"#(reset-unread-on-update "url4")#");
+    }
 
-	SECTION("Mix of all supported commands") {
-		ignores.handle_action("reset-unread-on-update", {"url1"});
-		ignores.handle_action("ignore-article", {"*", "title # \"interesting\""});
-		ignores.handle_action("always-download", {"url1"});
-		ignores.handle_action("ignore-article", {"https://blog.example.com/joe/posts.xml", "guid # 123"});
-		ignores.handle_action("reset-unread-on-update", {"url2", "url3"});
-		ignores.handle_action("always-download", {"url2", "url3", "url4"});
+    SECTION("Mix of all supported commands") {
+        ignores.handle_action("reset-unread-on-update", {"url1"});
+        ignores.handle_action("ignore-article", {"*", "title # \"interesting\""});
+        ignores.handle_action("always-download", {"url1"});
+        ignores.handle_action("ignore-article", {"https://blog.example.com/joe/posts.xml", "guid # 123"});
+        ignores.handle_action("reset-unread-on-update", {"url2", "url3"});
+        ignores.handle_action("always-download", {"url2", "url3", "url4"});
 
-		std::vector<std::string> config;
-		const auto comment =
-			"# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
-		config.push_back(comment);
+        std::vector<std::string> config;
+        const auto comment =
+            "# Comment to check that RssIgnores::dump_config() doesn't clear the vector";
+        config.push_back(comment);
 
-		ignores.dump_config(config);
+        ignores.dump_config(config);
 
-		std::set<std::string> config_set(config.begin(), config.end());
+        std::set<std::string> config_set(config.begin(), config.end());
 
-		REQUIRE(config.size() == 10);
-		REQUIRE(config[0] == comment);
-		REQUIRE(config_set.count(
-			R"#(ignore-article * "title # \"interesting\"")#") == 1);
-		REQUIRE(config_set.count(
-			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
-		REQUIRE(config[3] == R"#(always-download "url1")#");
-		REQUIRE(config[4] == R"#(always-download "url2")#");
-		REQUIRE(config[5] == R"#(always-download "url3")#");
-		REQUIRE(config[6] == R"#(always-download "url4")#");
-		REQUIRE(config[7] == R"#(reset-unread-on-update "url1")#");
-		REQUIRE(config[8] == R"#(reset-unread-on-update "url2")#");
-		REQUIRE(config[9] == R"#(reset-unread-on-update "url3")#");
-	}
+        REQUIRE(config.size() == 10);
+        REQUIRE(config[0] == comment);
+        REQUIRE(config_set.count(
+                    R"#(ignore-article * "title # \"interesting\"")#") == 1);
+                REQUIRE(config_set.count(
+                            R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
+                            REQUIRE(config[3] == R"#(always-download "url1")#");
+                            REQUIRE(config[4] == R"#(always-download "url2")#");
+                            REQUIRE(config[5] == R"#(always-download "url3")#");
+                            REQUIRE(config[6] == R"#(always-download "url4")#");
+                            REQUIRE(config[7] == R"#(reset-unread-on-update "url1")#");
+                            REQUIRE(config[8] == R"#(reset-unread-on-update "url2")#");
+                            REQUIRE(config[9] == R"#(reset-unread-on-update "url3")#");
+    }
 }
 
-TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
-	"of ignore-article rules, otherwise false",
-	"[RssIgnores]")
+        TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
+                  "of ignore-article rules, otherwise false",
+                  "[RssIgnores]")
 {
-	RssIgnores ignores;
+    RssIgnores ignores;
 
-	ConfigContainer cfg;
-	Cache rsscache(":memory:", &cfg);
-	RssItem item(&rsscache);
+    ConfigContainer cfg;
+    Cache rsscache(":memory:", &cfg);
+    RssItem item(&rsscache);
 
-	const auto feedurl = "https://example.com/feed.xml";
+    const auto feedurl = "https://example.com/feed.xml";
 
-	item.set_title("Updates");
-	item.set_author("John Doe");
-	item.set_feedurl(feedurl);
+    item.set_title("Updates");
+    item.set_author("John Doe");
+    item.set_feedurl(feedurl);
 
-	SECTION("Only rules associated with item's feed URL are applied") {
-		SECTION("No rules for this feed") {
-			ignores.handle_action("ignore-article", {"https://example.org/anotherfeed.xml", "title =~ \".*\""});
+    SECTION("Only rules associated with item's feed URL are applied") {
+        SECTION("No rules for this feed") {
+            ignores.handle_action("ignore-article", {"https://example.org/anotherfeed.xml", "title =~ \".*\""});
 
-			REQUIRE_FALSE(ignores.matches(&item));
-		}
+            REQUIRE_FALSE(ignores.matches(&item));
+        }
 
-		SECTION("One rule for feed, but doesn't match item") {
-			ignores.handle_action("ignore-article", {feedurl, "title = \"news\""});
+        SECTION("One rule for feed, but doesn't match item") {
+            ignores.handle_action("ignore-article", {feedurl, "title = \"news\""});
 
-			REQUIRE_FALSE(ignores.matches(&item));
-		}
+            REQUIRE_FALSE(ignores.matches(&item));
+        }
 
-		SECTION("A rule matches both the feed and the item") {
-			ignores.handle_action("ignore-article", {feedurl, "title = \"Updates\""});
+        SECTION("A rule matches both the feed and the item") {
+            ignores.handle_action("ignore-article", {feedurl, "title = \"Updates\""});
 
-			REQUIRE(ignores.matches(&item));
-		}
+            REQUIRE(ignores.matches(&item));
+        }
 
-		SECTION("Multiple rules that match both the feed and the item") {
-			ignores.handle_action("ignore-article", {feedurl, "title = \"Updates\""});
-			ignores.handle_action("ignore-article", {feedurl, "author = \"John Doe\""});
+        SECTION("Multiple rules that match both the feed and the item") {
+            ignores.handle_action("ignore-article", {feedurl, "title = \"Updates\""});
+            ignores.handle_action("ignore-article", {feedurl, "author = \"John Doe\""});
 
-			REQUIRE(ignores.matches(&item));
-		}
-	}
+            REQUIRE(ignores.matches(&item));
+        }
+    }
 
-	SECTION("Pattern matching rules prefixed with \"regex:\"") {
-		SECTION("Matching feeds starting with https://") {
-			ignores.handle_action("ignore-article", {"regex:^https://.*", "author = \"John Doe\""});
+    SECTION("Pattern matching rules prefixed with \"regex:\"") {
+        SECTION("Matching feeds starting with https://") {
+            ignores.handle_action("ignore-article", {"regex:^https://.*", "author = \"John Doe\""});
 
-			REQUIRE(ignores.matches(&item));
-		}
+            REQUIRE(ignores.matches(&item));
+        }
 
-		SECTION("Matching feeds containing example.com and ending with xml") {
-			ignores.handle_action("ignore-article", {"regex:.*example.com/.*\\.xml", "author = \"John Doe\""});
+        SECTION("Matching feeds containing example.com and ending with xml") {
+            ignores.handle_action("ignore-article", {"regex:.*example.com/.*\\.xml", "author = \"John Doe\""});
 
-			REQUIRE(ignores.matches(&item));
-		}
-	}
+            REQUIRE(ignores.matches(&item));
+        }
+    }
 
-	SECTION("Rules with URL of \"*\" match any feed") {
-		ignores.handle_action("ignore-article", {"*", "author = \"John Doe\""});
+    SECTION("Rules with URL of \"*\" match any feed") {
+        ignores.handle_action("ignore-article", {"*", "author = \"John Doe\""});
 
-		REQUIRE(ignores.matches(&item));
-	}
+        REQUIRE(ignores.matches(&item));
+    }
 }

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -150,11 +150,11 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 		REQUIRE(config.size() == 4); // three actions plus one comment
 		REQUIRE(config_set.count(comment) == 1);
 		REQUIRE(config_set.count(
-			R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#") == 1);
+				R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#") == 1);
 		REQUIRE(config_set.count(
-			R"#(ignore-article * "title # \"interesting\"")#") == 1);
+				R"#(ignore-article * "title # \"interesting\"")#") == 1);
 		REQUIRE(config_set.count(
-			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
+				R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
 	}
 
 	SECTION("`always-download`") {
@@ -219,9 +219,9 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 		REQUIRE(config.size() == 10);
 		REQUIRE(config[0] == comment);
 		REQUIRE(config_set.count(
-			R"#(ignore-article * "title # \"interesting\"")#") == 1);
+				R"#(ignore-article * "title # \"interesting\"")#") == 1);
 		REQUIRE(config_set.count(
-			R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
+				R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
 		REQUIRE(config[3] == R"#(always-download "url1")#");
 		REQUIRE(config[4] == R"#(always-download "url2")#");
 		REQUIRE(config[5] == R"#(always-download "url3")#");

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -1,6 +1,5 @@
 #include "rssignores.h"
 
-#include <iostream>
 #include <set>
 
 #include "3rd-party/catch.hpp"


### PR DESCRIPTION
Optimize the `RssIgnores::matches` function by changing the underlying data structure that stores `ignore-article` commands from a `std::vector` to a `std::unordered_multimap`.

Only the keys for the `RssItem` feed url as well as `*` could be looked up; if none of those were present as keys in the map, then the map still has to be iterated through in order to do [feed url RegEx checking](https://github.com/newsboat/newsboat/blob/b448e5bf202d6c5656c123d2faf3c43de117c1a5/src/rssignores.cpp#L118-L123).

Part of https://github.com/newsboat/newsboat/issues/345.