### PR TITLE
add a note in the style guide for the code fmt dockerfile

### DIFF
--- a/doc/internal/code-style.markdown
+++ b/doc/internal/code-style.markdown
@@ -23,6 +23,8 @@ Guidelines that could be easily automated, have been. Please install:
 
 You can then run `make fmt` to format both C++ and Rust code.
 
+*Note: If you are running into issues running `make fmt` locally, there is a lightweight Docker container available you can use to format. Instructions are in the [Docker file](../../docker/code-formatting-tools.dockerfile).*
+
 [editorconfig]: https://editorconfig.org/ "EditorConfig"
 
 [astyle]: http://astyle.sourceforge.net/ "Artistic Style"

--- a/doc/internal/code-style.markdown
+++ b/doc/internal/code-style.markdown
@@ -23,7 +23,7 @@ Guidelines that could be easily automated, have been. Please install:
 
 You can then run `make fmt` to format both C++ and Rust code.
 
-*Note: If you are running into issues running `make fmt` locally, there is a lightweight Docker container available you can use to format. Instructions are in the [Docker file](../../docker/code-formatting-tools.dockerfile).*
+Note: If you are running into issues running `make fmt` locally, there is a lightweight Docker container available you can use to format. Instructions are in the [Docker file](../../docker/code-formatting-tools.dockerfile).
 
 [editorconfig]: https://editorconfig.org/ "EditorConfig"
 


### PR DESCRIPTION
For my first contribution, I ran into issues running `make fmt` locally; it would reformat a ton of files I hadn't touched. I eventually realized there was a Docker container available for formatting, but the style guide didn't mention it. This PR adds a note for future contributors who might run into the same issue.