### PR TITLE
Add xslt transformation for replacing Slashdot's newlines

### DIFF
--- a/contrib/slashdot-replace-newlines.xslt
+++ b/contrib/slashdot-replace-newlines.xslt
@@ -1,0 +1,24 @@
+<!--
+Replaces newline characters in description field of Slashdot's RDF/RSS feed with html linebreaks (`<br>`)
+Uses xsltproc (part of libxslt)
+
+Can be used with a filter url, for example:
+"filter:xsltproc /usr/share/doc/newsboat/contrib/slashdot-replace-newlines.xslt -:https://rss.slashdot.org/Slashdot/slashdotMain"
+-->
+<xsl:stylesheet version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+ xmlns:str="http://exslt.org/strings"
+ xmlns:purl="http://purl.org/rss/1.0/">
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="purl:description">
+        <xsl:copy>
+            <!-- '&#10;' encodes a newline character (\n) -->
+            <xsl:value-of select="str:replace(node(), '&#10;', '&lt;br&gt;')"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
User **lv8pv** mentioned on the \#newsboat IRC channel that the newlines in Slashdot articles are not shown in Newsboat.
Feed url: http://rss.slashdot.org/Slashdot/slashdotMain

I don't know if newsboat does anything wrong in parsing the feed, but this script can be used to transform newlines into explicit html `<br>` elements.