### PR TITLE
add some development files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ doc/podboat-cmds-linked.asciidoc
 *.dSYM
 /.deps/
 /compile_flags.txt
+log.txt

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ doc/podboat-cmds-linked.asciidoc
 /.deps/
 /compile_flags.txt
 log.txt
+compile_commands.json
+.cache/


### PR DESCRIPTION
Add some files used in development to `.gitignore`.
- `log.txt` This file is generated when running Newsboat in debug mode e.g. `./newsboat -d log.txt -l 6`.
- `compile_commands.txt` and `.cache/` These files are generated by tools such as [Bear](https://github.com/rizsotto/Bear), and are necessary to utilize the [clangd language server](https://clangd.llvm.org/).