### PR TITLE
Match current user's uid/gid at docker build time

### DIFF
--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -13,6 +13,8 @@
 # Build with defaults:
 #
 #   docker build \
+#       --build-arg UID=$(id -u) \
+#       --build-arg GID=$(id -g) \
 #       --tag=newsboat-build-tools \
 #       --file=docker/ubuntu_18.04-build-tools.dockerfile \
 #       docker
@@ -20,6 +22,8 @@
 # Build with non-default compiler and Rust version:
 #
 #   docker build \
+#       --build-arg UID=$(id -u) \
+#       --build-arg GID=$(id -g) \
 #       --tag=newsboat-build-tools \
 #       --file=docker/ubuntu_18.04-build-tools.dockerfile \
 #       --build-arg cxx_package=clang-7 \
@@ -38,7 +42,6 @@
 #   docker run \
 #       --rm \
 #       --mount type=bind,source=$(pwd),target=/home/builder/src \
-#       --user $(id -u):$(id -g) \
 #       newsboat-build-tools \
 #       make
 #
@@ -73,8 +76,11 @@ RUN apt-get update \
     && apt-get autoremove \
     && apt-get clean
 
-RUN addgroup --gid 1000 builder \
-    && adduser --home /home/builder --uid 1000 --ingroup builder \
+ARG UID=1000
+ARG GID=1000
+
+RUN addgroup --gid $GID builder \
+    && adduser --home /home/builder --uid $UID --ingroup builder \
         --disabled-password --shell /bin/bash builder \
     && mkdir -p /home/builder/src \
     && chown -R builder:builder /home/builder

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -3,6 +3,8 @@
 # Build with defaults:
 #
 #   docker build \
+#       --build-arg UID=$(id -u) \
+#       --build-arg GID=$(id -g) \
 #       --tag=newsboat-i686-build-tools \
 #       --file=docker/ubuntu_18.04-i686.dockerfile \
 #       docker
@@ -17,7 +19,6 @@
 #   docker run \
 #       --rm \
 #       --mount type=bind,source=$(pwd),target=/home/builder/src \
-#       --user $(id -u):$(id -g) \
 #       newsboat-i686-build-tools \
 #       make
 #
@@ -59,8 +60,11 @@ RUN apt-get update \
     && apt-get autoremove \
     && apt-get clean
 
-RUN addgroup --gid 1000 builder \
-    && adduser --home /home/builder --uid 1000 --ingroup builder \
+ARG UID=1000
+ARG GID=1000
+
+RUN addgroup --gid $GID builder \
+    && adduser --home /home/builder --uid $UID --ingroup builder \
         --disabled-password --shell /bin/bash builder \
     && mkdir -p /home/builder/src \
     && chown -R builder:builder /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -13,6 +13,8 @@
 # Build with defaults:
 #
 #   docker build \
+#       --build-arg UID=$(id -u) \
+#       --build-arg GID=$(id -g) \
 #       --tag=newsboat-build-tools \
 #       --file=docker/ubuntu_20.04-build-tools.dockerfile \
 #       docker
@@ -20,6 +22,8 @@
 # Build with non-default compiler and Rust version:
 #
 #   docker build \
+#       --build-arg UID=$(id -u) \
+#       --build-arg GID=$(id -g) \
 #       --tag=newsboat-build-tools \
 #       --file=docker/ubuntu_20.04-build-tools.dockerfile \
 #       --build-arg cxx_package=clang-10 \
@@ -38,7 +42,6 @@
 #   docker run \
 #       --rm \
 #       --mount type=bind,source=$(pwd),target=/home/builder/src \
-#       --user $(id -u):$(id -g) \
 #       newsboat-build-tools \
 #       make
 #
@@ -73,8 +76,11 @@ RUN apt-get update \
     && apt-get autoremove \
     && apt-get clean
 
-RUN addgroup --gid 1000 builder \
-    && adduser --home /home/builder --uid 1000 --ingroup builder \
+ARG UID=1000
+ARG GID=1000
+
+RUN addgroup --gid $GID builder \
+    && adduser --home /home/builder --uid $UID --ingroup builder \
         --disabled-password --shell /bin/bash builder \
     && mkdir -p /home/builder/src \
     && chown -R builder:builder /home/builder

--- a/docker/ubuntu_22.04-build-tools.dockerfile
+++ b/docker/ubuntu_22.04-build-tools.dockerfile
@@ -13,6 +13,8 @@
 # Build with defaults:
 #
 #   docker build \
+#       --build-arg UID=$(id -u) \
+#       --build-arg GID=$(id -g) \
 #       --tag=newsboat-build-tools \
 #       --file=docker/ubuntu_22.04-build-tools.dockerfile \
 #       docker
@@ -20,6 +22,8 @@
 # Build with non-default compiler and Rust version:
 #
 #   docker build \
+#       --build-arg UID=$(id -u) \
+#       --build-arg GID=$(id -g) \
 #       --tag=newsboat-build-tools \
 #       --file=docker/ubuntu_22.04-build-tools.dockerfile \
 #       --build-arg cxx_package=clang-13 \
@@ -38,7 +42,6 @@
 #   docker run \
 #       --rm \
 #       --mount type=bind,source=$(pwd),target=/home/builder/src \
-#       --user $(id -u):$(id -g) \
 #       newsboat-build-tools \
 #       make
 #
@@ -74,8 +77,11 @@ RUN apt-get update \
     && apt-get autoremove \
     && apt-get clean
 
-RUN addgroup --gid 1000 builder \
-    && adduser --home /home/builder --uid 1000 --ingroup builder \
+ARG UID=1000
+ARG GID=1000
+
+RUN addgroup --gid $GID builder \
+    && adduser --home /home/builder --uid $UID --ingroup builder \
         --disabled-password --shell /bin/bash builder \
     && mkdir -p /home/builder/src \
     && chown -R builder:builder /home/builder

--- a/docker/ubuntu_23.10-build-tools.dockerfile
+++ b/docker/ubuntu_23.10-build-tools.dockerfile
@@ -10,7 +10,53 @@
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
 #       Default: g++-13
 #
-# For now, this Dockerfile can only be used in our CI.
+# Build with defaults:
+#
+#   docker build \
+#       --build-arg UID=$(id -u) \
+#       --build-arg GID=$(id -g) \
+#       --tag=newsboat-build-tools \
+#       --file=docker/ubuntu_23.10-build-tools.dockerfile \
+#       docker
+#
+# Build with non-default compiler and Rust version:
+#
+#   docker build \
+#       --build-arg UID=$(id -u) \
+#       --build-arg GID=$(id -g) \
+#       --tag=newsboat-build-tools \
+#       --file=docker/ubuntu_23.10-build-tools.dockerfile \
+#       --build-arg cxx_package=clang-16 \
+#       --build-arg cc=clang-16 \
+#       --build-arg cxx=clang++-16 \
+#       --build-arg rust_version=1.76.0 \
+#       docker
+#
+# Before building in a container, run this to remove any binaries that you
+# might've compiled on your host system (or in another container):
+#
+#   make distclean
+#
+# Run on your local files:
+#
+#   docker run \
+#       --rm \
+#       --mount type=bind,source=$(pwd),target=/home/builder/src \
+#       newsboat-build-tools \
+#       make
+#
+# To save bandwidth, and speed up the build slightly, share the host's Cargo
+# cache with the container:
+#
+#   mkdir -p ~/.cargo/registry
+#   docker run \
+#       --mount type=bind,source=$HOME/.cargo/registry,target=/home/builder/.cargo/registry \
+#       ... # the rest of the options
+#
+# If you want to build on the host again, run this to remove binary files
+# compiled in the container:
+#
+#   make distclean
 
 FROM ubuntu:23.10
 
@@ -31,8 +77,12 @@ RUN apt-get update \
     && apt-get autoremove \
     && apt-get clean
 
-RUN addgroup builder \
-    && adduser --home /home/builder --ingroup builder \
+ARG UID=1000
+ARG GID=1000
+
+RUN deluser ubuntu \
+    && addgroup --gid $GID builder \
+    && adduser --uid $UID --home /home/builder --ingroup builder \
         --disabled-password --shell /bin/bash builder \
     && mkdir -p /home/builder/src \
     && chown -R builder:builder /home/builder


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2474

I made a previous attempt to fix uid/gid at runtime (https://github.com/newsboat/newsboat/pull/2698)
That turned out to require a lot of workarounds, partially due to limitations in cirrus options.

Specifying uid/gid at build time seems to cause a lot less issues (to be confirmed by a successful CI build and some more local testing)