### PR TITLE
Replace setup-rust action which disappeard (repo/user no longer exist)

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -46,9 +46,7 @@ jobs:
           sudo locale-gen
 
       - name: Install Rust
-        uses: ATiltedTree/setup-rust@v1.0.5
-        with:
-          rust-version: nightly
+        uses: dtolnay/rust-toolchain@nightly
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The user/repo `ATiltedTree/setup-rust` seems to have disappeared.

Based on https://github.com/rust-lang/rustup/issues/3409, there does not seem to be one specific action implementation which others are using for Rust setup.
However, `dtolnay/rust-toolchain` was mentioned in that issue and looks good to me.