### PR TITLE
Fix default color documentation

### DIFF
--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -250,12 +250,12 @@ The default color configuration of Newsboat looks like this:
 	color background          white   black
 	color listnormal          white   black
 	color listfocus           yellow  blue   bold
-	color listnormal_unread   magenta black
-	color listfocus_unread    magenta blue   bold
+	color listnormal_unread   white   black  bold
+	color listfocus_unread    yellow  blue   bold
 	color title               yellow  blue   bold
 	color info                yellow  blue   bold
 	color hint-key            yellow  blue   bold
-	color hint-keys-delimiter yellow  white
-	color hint-separator      yellow  white  bold
-	color hint-description    yellow  white
+	color hint-keys-delimiter white   blue
+	color hint-separator      white   blue   bold
+	color hint-description    white   blue
 	color article             white   black


### PR DESCRIPTION
Fix default color documentation according to current code ./stfl/feedlist.stfl

Commit 368048b changed listnormal_unread and listfocus_unread, then commit a8971bd fixed those, but they did not correct the documentation. Commit 602d35b added hint-keys-delimiter, hint-separator, and hint-description; then commit 63b6c2f added the wrong documentation.