### PR TITLE
Require chrono 4.34 since Duration was renamed to TimeDelta

### DIFF
--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -19,7 +19,7 @@ libc = "0.2"
 natord = "1.0.9"
 md5 = "0.7.0"
 lexopt = "0.3.0"
-chrono = "0.4"
+chrono = "0.4.34"
 
 [dependencies.gettext-rs]
 version = "0.7.0"


### PR DESCRIPTION
I'm not sure why an incompatible change was made in a minor release...

Edit: Or is it actually compatible just that we used the new features without restricting the minor release?