### PR TITLE
Http request testing (mock server in separate binary)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -394,7 +394,7 @@ task:
     # we don't pass --keep-going to the build: failures can be debugged with
     # logs of other jobs.
     after_cache_script: *after_cache_script
-    build_script: make -j${JOBS} test/test
+    build_script: make -j${JOBS} test
     test_script: cd test && ./test --order=rand --rng-seed=time
     before_cache_script: *before_cache_script
 
@@ -423,7 +423,7 @@ task:
     # we don't pass --keep-going to the build: failures can be debugged with
     # logs of other jobs.
     after_cache_script: *after_cache_script
-    build_script: make -j${JOBS} test/test
+    build_script: make -j${JOBS} test
     test_script: cd test && ./test --order=rand --rng-seed=time
     before_cache_script: *before_cache_script
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ po/*.mo
 stfl/*.h
 newsboat
 podboat
+test/http-test-server
 test/test
 test/testlog.txt
 xlicense.h

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,240 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.1.0",
+ "futures-lite 2.3.0",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io 2.3.3",
+ "async-lock 3.4.0",
+ "blocking",
+ "futures-lite 2.3.0",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
+dependencies = [
+ "async-lock 3.4.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "parking",
+ "polling 3.7.2",
+ "rustix 0.38.34",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.3.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb901c30ebc2fc4ab46395bbfbdba9542c16559d853645d75190c3056caf3bc"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.34",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794f185324c2f00e771cd9f1ae8b5ac68be2ca7abb129a87afd6e86d228bc54d"
+dependencies = [
+ "async-io 2.3.3",
+ "async-lock 3.4.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.34",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 1.13.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.67",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +297,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +330,12 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
@@ -90,10 +347,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
@@ -118,7 +394,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -132,10 +408,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "curl-sys"
@@ -148,7 +445,7 @@ dependencies = [
  "libz-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -175,7 +472,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -192,8 +489,50 @@ checksum = "4b2c1c1776b986979be68bb2285da855f8d8a35851a769fca8740df7c3d07877"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.67",
 ]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "either"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -202,7 +541,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener 5.3.1",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -210,6 +596,12 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -224,6 +616,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand 2.1.0",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.67",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -264,6 +736,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-test-server"
+version = "0.1.0"
+dependencies = [
+ "httpmock",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.7",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +891,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,10 +945,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "lexopt"
@@ -336,7 +1021,7 @@ dependencies = [
  "backtrace",
  "chrono",
  "curl-sys",
- "fastrand",
+ "fastrand 2.1.0",
  "gettext-rs",
  "lexopt",
  "libc",
@@ -365,6 +1050,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.5.0",
+ "libc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +1082,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
@@ -405,10 +1106,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -447,10 +1161,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "natord"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -470,6 +1201,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
 ]
 
 [[package]]
@@ -517,10 +1258,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.1.0",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -529,10 +1347,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix 0.38.34",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -551,7 +1406,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.5.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -618,6 +1473,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,7 +1519,7 @@ dependencies = [
 name = "regex-rs"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "gettext-rs",
  "libc",
  "strprintf",
@@ -664,16 +1539,36 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rusty-fork"
@@ -688,6 +1583,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "scratch"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,10 +1616,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd2493b68af689f4863060b240cbdffb350cee9ed69e2c50f8d71a62ca2aea1"
 
 [[package]]
+name = "serde"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.67",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "strprintf"
 version = "0.1.0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -730,9 +1767,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand",
- "rustix",
- "windows-sys",
+ "fastrand 2.1.0",
+ "rustix 0.38.34",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -742,6 +1790,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.67",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -758,6 +1835,65 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+dependencies = [
+ "backtrace",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2 0.5.7",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.67",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unarray"
@@ -793,6 +1929,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +1944,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
 
 [[package]]
 name = "vcpkg"
@@ -816,6 +1964,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -845,8 +2018,20 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.67",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -867,7 +2052,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -877,6 +2062,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -900,7 +2095,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -915,7 +2110,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -924,7 +2128,22 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -933,15 +2152,21 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -951,9 +2176,21 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -969,9 +2206,21 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -981,9 +2230,21 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "rust/libnewsboat-ffi",
     "rust/strprintf",
     "rust/regex-rs",
+    "rust/http-test-server",
 ]
 resolver = "2"

--- a/rust/http-test-server/Cargo.toml
+++ b/rust/http-test-server/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "http-test-server"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+httpmock = "0.7.0"

--- a/rust/http-test-server/src/main.rs
+++ b/rust/http-test-server/src/main.rs
@@ -1,4 +1,4 @@
-use httpmock::{Method::GET, MockServer};
+use httpmock::{Method::GET, Mock, MockServer};
 use std::io::{stdin, Read};
 
 fn main() {
@@ -24,6 +24,7 @@ fn main() {
         match command {
             "exit" => break,
             "add_endpoint" => add_endpoint(&server),
+            "remove_endpoint" => remove_endpoint(&server),
             _ => (),
         };
     }
@@ -86,4 +87,10 @@ fn add_endpoint(server: &MockServer) {
     });
 
     println!("{}", mock.id);
+}
+
+fn remove_endpoint(server: &MockServer) {
+    let mock_id: usize = read_line().parse().unwrap();
+    let mut mock = Mock::new(mock_id, server);
+    mock.delete();
 }

--- a/rust/http-test-server/src/main.rs
+++ b/rust/http-test-server/src/main.rs
@@ -25,6 +25,7 @@ fn main() {
             "exit" => break,
             "add_endpoint" => add_endpoint(&server),
             "remove_endpoint" => remove_endpoint(&server),
+            "num_hits" => num_hits(&server),
             _ => (),
         };
     }
@@ -93,4 +94,11 @@ fn remove_endpoint(server: &MockServer) {
     let mock_id: usize = read_line().parse().unwrap();
     let mut mock = Mock::new(mock_id, server);
     mock.delete();
+}
+
+fn num_hits(server: &MockServer) {
+    let mock_id: usize = read_line().parse().unwrap();
+    let mock = Mock::new(mock_id, server);
+
+    println!("{}", mock.hits());
 }

--- a/rust/http-test-server/src/main.rs
+++ b/rust/http-test-server/src/main.rs
@@ -1,0 +1,30 @@
+use httpmock::MockServer;
+use std::io::stdin;
+
+fn main() {
+    let server = MockServer::start();
+    let address = server.address().to_string();
+
+    eprintln!("listening on {}", address);
+    println!("{}", address);
+
+    let mut input = String::new();
+    loop {
+        input.clear();
+        let read_result = stdin().read_line(&mut input);
+        if let Ok(0) = read_result {
+            // Reached eof
+            break;
+        }
+        if let Err(e) = read_result {
+            eprintln!("reading failed: {:?}", e);
+            break;
+        }
+        let command = input.trim();
+        match command {
+            "exit" => break,
+            _ => (),
+        };
+    }
+    eprintln!("shutting down http test server");
+}

--- a/test/feedretriever.cpp
+++ b/test/feedretriever.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Feed retriever retrieves feed successfully", "[FeedRetriever]")
 	FeedRetriever feedRetriever(cfg, rsscache, easyHandle);
 
 	auto& testServer = test_helpers::HttpTestServer::get_instance();
-	testServer.add_endpoint("/feed", {}, 200, {
+	auto endpointLifetime = testServer.add_endpoint("/feed", {}, 200, {
 		{"content-type", "text/xml"},
 	}, feed_xml);
 

--- a/test/feedretriever.cpp
+++ b/test/feedretriever.cpp
@@ -4,6 +4,7 @@
 #include "cache.h"
 #include "configcontainer.h"
 #include "curlhandle.h"
+#include "rssfeed.h"
 #include "strprintf.h"
 #include "test/test_helpers/httptestserver.h"
 #include "test_helpers/misc.h"
@@ -20,7 +21,7 @@ TEST_CASE("Feed retriever retrieves feed successfully", "[FeedRetriever]")
 	FeedRetriever feedRetriever(cfg, rsscache, easyHandle);
 
 	auto& testServer = test_helpers::HttpTestServer::get_instance();
-	auto endpointLifetime = testServer.add_endpoint("/feed", {}, 200, {
+	auto mockRegistration = testServer.add_endpoint("/feed", {}, 200, {
 		{"content-type", "text/xml"},
 	}, feed_xml);
 
@@ -28,5 +29,65 @@ TEST_CASE("Feed retriever retrieves feed successfully", "[FeedRetriever]")
 	const auto url = strprintf::fmt("http://%s/feed", address);
 
 	const auto feed = feedRetriever.retrieve(url);
+	REQUIRE(testServer.num_hits(mockRegistration) == 1);
 	REQUIRE(feed.items.size() == 3);
+}
+
+TEST_CASE("Feed retriever adds header with etag info if available", "[FeedRetriever]")
+{
+	ConfigContainer cfg;
+	Cache rsscache(":memory:", &cfg);
+	CurlHandle easyHandle;
+	FeedRetriever feedRetriever(cfg, rsscache, easyHandle);
+
+	auto& testServer = test_helpers::HttpTestServer::get_instance();
+	const auto address = testServer.get_address();
+	const auto url = strprintf::fmt("http://%s/feed", address);
+
+	auto feed_with_etag = std::make_shared<RssFeed>(&rsscache, url);
+	rsscache.externalize_rssfeed(feed_with_etag, false);
+	rsscache.update_lastmodified(url, {}, "some-random-etag");
+
+	auto mockRegistration = testServer.add_endpoint("/feed", {
+		{"If-None-Match", "some-random-etag"},
+	}, 304, {
+		{"content-type", "text/xml"},
+	}, {});
+
+	const auto feed = feedRetriever.retrieve(url);
+	REQUIRE(testServer.num_hits(mockRegistration) == 1);
+	REQUIRE(feed.items.size() == 0);
+}
+
+TEST_CASE("Feed retriever does not retry download on HTTP 304 (Not Modified)",
+	"[FeedRetriever]")
+{
+	ConfigContainer cfg;
+	Cache rsscache(":memory:", &cfg);
+	CurlHandle easyHandle;
+	FeedRetriever feedRetriever(cfg, rsscache, easyHandle);
+
+	auto& testServer = test_helpers::HttpTestServer::get_instance();
+	const auto address = testServer.get_address();
+	const auto url = strprintf::fmt("http://%s/feed", address);
+
+	auto feed_with_etag = std::make_shared<RssFeed>(&rsscache, url);
+	rsscache.externalize_rssfeed(feed_with_etag, false);
+	rsscache.update_lastmodified(url, {}, "some-random-etag");
+
+	auto mockRegistration = testServer.add_endpoint("/feed", {
+		{"If-None-Match", "some-random-etag"},
+	}, 304, {
+		{"content-type", "text/xml"},
+	}, {});
+
+	cfg.set_configvalue("download-retries", "5");
+
+	const auto feed = feedRetriever.retrieve(url);
+	// TODO: Fix behavior and update this test.
+	// There should only be 1 request.
+	// Added an assertion for the wrong amount to make sure we update this test when fixing the behavior.
+	// See https://github.com/newsboat/newsboat/issues/2732
+	REQUIRE(testServer.num_hits(mockRegistration) == 5);
+	//REQUIRE(testServer.num_Hits(mockRegistration) == 1);
 }

--- a/test/feedretriever.cpp
+++ b/test/feedretriever.cpp
@@ -1,0 +1,32 @@
+#include "feedretriever.h"
+
+#include "3rd-party/catch.hpp"
+#include "cache.h"
+#include "configcontainer.h"
+#include "curlhandle.h"
+#include "strprintf.h"
+#include "test/test_helpers/httptestserver.h"
+#include "test_helpers/misc.h"
+
+using namespace newsboat;
+
+TEST_CASE("Feed retriever retrieves feed successfully", "[FeedRetriever]")
+{
+	auto feed_xml = test_helpers::read_binary_file("data/atom10_1.xml");
+
+	ConfigContainer cfg;
+	Cache rsscache(":memory:", &cfg);
+	CurlHandle easyHandle;
+	FeedRetriever feedRetriever(cfg, rsscache, easyHandle);
+
+	auto& testServer = test_helpers::HttpTestServer::get_instance();
+	testServer.add_endpoint("/feed", {}, 200, {
+		{"content-type", "text/xml"},
+	}, feed_xml);
+
+	const auto address = testServer.get_address();
+	const auto url = strprintf::fmt("http://%s/feed", address);
+
+	const auto feed = feedRetriever.retrieve(url);
+	REQUIRE(feed.items.size() == 3);
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,11 +1,15 @@
 #define CATCH_CONFIG_RUNNER
 #include "3rd-party/catch.hpp"
 
+#include "test_helpers/httptestserver.h"
+
 int main(int argc, char* argv[])
 {
 	setlocale(LC_CTYPE, "");
 
 	srand(static_cast<unsigned int>(std::time(0)));
+
+	test_helpers::HttpTestServer server;
 
 	return Catch::Session().run(argc, argv);
 }

--- a/test/test_helpers/httptestserver.cpp
+++ b/test/test_helpers/httptestserver.cpp
@@ -34,7 +34,7 @@ std::string HttpTestServer::get_address()
 	return address;
 }
 
-void HttpTestServer::add_endpoint(const std::string& path,
+std::shared_ptr<void> HttpTestServer::add_endpoint(const std::string& path,
 	std::vector<std::pair<std::string, std::string>> expectedHeaders,
 	std::uint16_t status,
 	std::vector<std::pair<std::string, std::string>> responseHeaders,
@@ -61,6 +61,18 @@ void HttpTestServer::add_endpoint(const std::string& path,
 	process.write_binary(body.data(), body.size());
 
 	auto mock_id = process.read_line();
+
+	// Use shared_ptr's custom deleter feature to automatically remove endpoint
+	// when the shared_ptr goes out of scope
+	return std::shared_ptr<void>(nullptr, [=](void*) {
+		remove_endpoint(mock_id);
+	});
+}
+
+void HttpTestServer::remove_endpoint(const std::string& mockId)
+{
+	process.write_line("remove_endpoint");
+	process.write_line(mockId);
 }
 
 } // namespace test_helpers

--- a/test/test_helpers/httptestserver.cpp
+++ b/test/test_helpers/httptestserver.cpp
@@ -1,17 +1,66 @@
 #include "httptestserver.h"
 
+#include <stdexcept>
+#include <string>
+
 namespace test_helpers {
+
+static HttpTestServer* instance = nullptr;
 
 HttpTestServer::HttpTestServer()
 	: process({"./http-test-server"})
 {
 	address = process.read_line();
+	instance = this;
 }
 
 HttpTestServer::~HttpTestServer()
 {
 	process.write_line("exit");
 	process.wait_for_exit();
+	instance = nullptr;
+}
+
+HttpTestServer& HttpTestServer::get_instance()
+{
+	if (instance == nullptr) {
+		throw std::runtime_error("No HttpTestServer instantiated");
+	}
+	return *instance;
+}
+
+std::string HttpTestServer::get_address()
+{
+	return address;
+}
+
+void HttpTestServer::add_endpoint(const std::string& path,
+	std::vector<std::pair<std::string, std::string>> expectedHeaders,
+	std::uint16_t status,
+	std::vector<std::pair<std::string, std::string>> responseHeaders,
+	std::vector<std::uint8_t> body)
+{
+	process.write_line("add_endpoint");
+	process.write_line(path);
+
+	process.write_line(std::to_string(expectedHeaders.size()));
+	for (const auto& header : expectedHeaders) {
+		process.write_line(header.first);
+		process.write_line(header.second);
+	}
+
+	process.write_line(std::to_string(status));
+
+	process.write_line(std::to_string(responseHeaders.size()));
+	for (const auto& header : responseHeaders) {
+		process.write_line(header.first);
+		process.write_line(header.second);
+	}
+
+	process.write_line(std::to_string(body.size()));
+	process.write_binary(body.data(), body.size());
+
+	auto mock_id = process.read_line();
 }
 
 } // namespace test_helpers

--- a/test/test_helpers/httptestserver.cpp
+++ b/test/test_helpers/httptestserver.cpp
@@ -1,0 +1,17 @@
+#include "httptestserver.h"
+
+namespace test_helpers {
+
+HttpTestServer::HttpTestServer()
+	: process({"./http-test-server"})
+{
+	address = process.read_line();
+}
+
+HttpTestServer::~HttpTestServer()
+{
+	process.write_line("exit");
+	process.wait_for_exit();
+}
+
+} // namespace test_helpers

--- a/test/test_helpers/httptestserver.h
+++ b/test/test_helpers/httptestserver.h
@@ -3,7 +3,10 @@
 
 #include "inputoutputprocess.h"
 
+#include <cstdint>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace test_helpers {
 
@@ -11,6 +14,18 @@ class HttpTestServer {
 public:
 	HttpTestServer();
 	~HttpTestServer();
+
+	HttpTestServer(const HttpTestServer&) = delete;
+	HttpTestServer& operator=(const HttpTestServer&) = delete;
+
+	static HttpTestServer& get_instance();
+
+	std::string get_address();
+	void add_endpoint(const std::string& path,
+		std::vector<std::pair<std::string, std::string>> expectedHeaders,
+		std::uint16_t status,
+		std::vector<std::pair<std::string, std::string>> responseHeaders,
+		std::vector<std::uint8_t> body);
 
 private:
 	InputOutputProcess process;

--- a/test/test_helpers/httptestserver.h
+++ b/test/test_helpers/httptestserver.h
@@ -4,6 +4,7 @@
 #include "inputoutputprocess.h"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -21,13 +22,17 @@ public:
 	static HttpTestServer& get_instance();
 
 	std::string get_address();
-	void add_endpoint(const std::string& path,
+
+	// Returns a shared_ptr which will remove the endpoint when it goes out of scope
+	std::shared_ptr<void> add_endpoint(const std::string& path,
 		std::vector<std::pair<std::string, std::string>> expectedHeaders,
 		std::uint16_t status,
 		std::vector<std::pair<std::string, std::string>> responseHeaders,
 		std::vector<std::uint8_t> body);
 
 private:
+	void remove_endpoint(const std::string& mockId);
+
 	InputOutputProcess process;
 	std::string address;
 };

--- a/test/test_helpers/httptestserver.h
+++ b/test/test_helpers/httptestserver.h
@@ -1,0 +1,22 @@
+#ifndef NEWSBOAT_TEST_HELPERS_HTTPTESTSERVER_H_
+#define NEWSBOAT_TEST_HELPERS_HTTPTESTSERVER_H_
+
+#include "inputoutputprocess.h"
+
+#include <string>
+
+namespace test_helpers {
+
+class HttpTestServer {
+public:
+	HttpTestServer();
+	~HttpTestServer();
+
+private:
+	InputOutputProcess process;
+	std::string address;
+};
+
+} // namespace test_helpers
+
+#endif /* NEWSBOAT_TEST_HELPERS_HTTPTESTSERVER_H_ */

--- a/test/test_helpers/httptestserver.h
+++ b/test/test_helpers/httptestserver.h
@@ -13,6 +13,11 @@ namespace test_helpers {
 
 class HttpTestServer {
 public:
+	struct MockRegistration {
+		std::shared_ptr<void> lifetime;
+		std::string mockId;
+	};
+
 	HttpTestServer();
 	~HttpTestServer();
 
@@ -23,12 +28,14 @@ public:
 
 	std::string get_address();
 
-	// Returns a shared_ptr which will remove the endpoint when it goes out of scope
-	std::shared_ptr<void> add_endpoint(const std::string& path,
+	// Returns a `MockRegistration` with a lifetime object which will remove the endpoint when it goes out of scope
+	MockRegistration add_endpoint(const std::string& path,
 		std::vector<std::pair<std::string, std::string>> expectedHeaders,
 		std::uint16_t status,
 		std::vector<std::pair<std::string, std::string>> responseHeaders,
 		std::vector<std::uint8_t> body);
+
+	std::uint32_t num_hits(MockRegistration& mockRegistration);
 
 private:
 	void remove_endpoint(const std::string& mockId);

--- a/test/test_helpers/inputoutputprocess.cpp
+++ b/test/test_helpers/inputoutputprocess.cpp
@@ -1,0 +1,163 @@
+#include "inputoutputprocess.h"
+
+#include <cstddef>
+#include <cstdio>
+#include <stdexcept>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <system_error>
+#include <unistd.h>
+#include <errno.h>
+
+namespace test_helpers {
+
+Pipe::Pipe()
+{
+	const auto result = pipe(handles);
+	if (result < 0) {
+		throw std::runtime_error("Failed to create pipe");
+	}
+}
+
+Pipe::~Pipe()
+{
+	close_read_side();
+	close_write_side();
+}
+
+void Pipe::close_read_side()
+{
+	if (handles[0] != -1) {
+		close(handles[0]);
+		handles[0] = -1;
+	}
+}
+
+void Pipe::close_write_side()
+{
+	if (handles[1] != -1) {
+		close(handles[1]);
+		handles[1] = -1;
+	}
+}
+
+int Pipe::read_side()
+{
+	return handles[0];
+}
+
+int Pipe::write_side()
+{
+	return handles[1];
+}
+
+InputOutputProcess::InputOutputProcess(std::vector<std::string>&& arguments)
+	: argsStorage(arguments)
+{
+	for (const auto& arg : argsStorage) {
+		args.push_back(const_cast<char*>(arg.c_str()));
+	}
+	args.push_back(nullptr);
+	envVars.push_back(nullptr);
+
+	start_process();
+	stdoutStream = fdopen(stdoutPipe.read_side(), "r");
+	if (stdoutStream == nullptr) {
+		throw std::system_error(errno, std::generic_category());
+	}
+}
+
+InputOutputProcess::~InputOutputProcess()
+{
+	fclose(stdoutStream);
+}
+
+// Based on: https://stackoverflow.com/questions/9405985/linux-executing-child-process-with-piped-stdin-stdout
+void InputOutputProcess::start_process()
+{
+	childPid = fork();
+	if (childPid == 0) {
+		// We are the child process
+
+		// redirect stdin
+		if (dup2(stdinPipe.read_side(), STDIN_FILENO) == -1) {
+			exit(errno);
+		}
+
+		// redirect stdout
+		if (dup2(stdoutPipe.write_side(), STDOUT_FILENO) == -1) {
+			exit(errno);
+		}
+
+		// all these are for use by parent only
+		stdinPipe.close_read_side();
+		stdinPipe.close_write_side();
+		stdoutPipe.close_read_side();
+		stdoutPipe.close_write_side();
+
+		// run child process image
+		auto result = execve(args[0], args.data(), envVars.data());
+
+		// if we get here at all, an error occurred, but we are in the child process, so just exit
+		exit(result);
+	} else if (childPid > 0) {
+		// We are the parent process
+
+		stdinPipe.close_read_side();
+		stdoutPipe.close_write_side();
+	} else {
+		throw std::runtime_error("Failed to fork");
+	}
+}
+
+std::vector<std::uint8_t> InputOutputProcess::read_binary(std::size_t length)
+{
+	std::vector<std::uint8_t> buffer;
+	buffer.resize(length);
+	fread(buffer.data(), buffer.size(), 1, stdoutStream);
+
+	return buffer;
+}
+
+std::string InputOutputProcess::read_line()
+{
+	char buffer[1024];
+	if (fgets(buffer, sizeof(buffer), stdoutStream) == nullptr) {
+		throw std::system_error(errno, std::generic_category());
+	}
+	auto input = std::string(buffer);
+	if (input.length() > 0) {
+		// Remove newline character
+		input.resize(input.size() - 1);
+	}
+	return input;
+}
+
+void InputOutputProcess::write_binary(const std::uint8_t* data, std::size_t length)
+{
+	const std::uint8_t* current = data;
+	std::size_t remaining = length;
+	while (remaining > 0) {
+		const auto bytes_written = write(stdinPipe.write_side(), current, remaining);
+		if (bytes_written < 0) {
+			throw std::system_error(errno, std::generic_category());
+		}
+		current += bytes_written;
+		remaining -= bytes_written;
+	}
+}
+
+void InputOutputProcess::write_line(std::string data)
+{
+	data += "\n";
+
+	write_binary(reinterpret_cast<const std::uint8_t*>(data.c_str()), data.length());
+}
+
+void InputOutputProcess::wait_for_exit()
+{
+	int status;
+	waitpid(childPid, &status, 0);
+}
+
+} // namespace test_helpers

--- a/test/test_helpers/inputoutputprocess.cpp
+++ b/test/test_helpers/inputoutputprocess.cpp
@@ -114,7 +114,10 @@ std::vector<std::uint8_t> InputOutputProcess::read_binary(std::size_t length)
 {
 	std::vector<std::uint8_t> buffer;
 	buffer.resize(length);
-	fread(buffer.data(), buffer.size(), 1, stdoutStream);
+	const auto bytesRead = fread(buffer.data(), buffer.size(), 1, stdoutStream);
+	if (bytesRead != length) {
+		throw std::runtime_error("Failed to read binary data from pipe");
+	}
 
 	return buffer;
 }

--- a/test/test_helpers/inputoutputprocess.h
+++ b/test/test_helpers/inputoutputprocess.h
@@ -13,6 +13,10 @@ class Pipe {
 public:
 	Pipe();
 	~Pipe();
+
+	Pipe(const Pipe&) = delete;
+	Pipe& operator=(const Pipe&) = delete;
+
 	void close_read_side();
 	void close_write_side();
 	int read_side();
@@ -26,6 +30,9 @@ class InputOutputProcess {
 public:
 	InputOutputProcess(std::vector<std::string>&& args);
 	~InputOutputProcess();
+
+	InputOutputProcess(const InputOutputProcess&) = delete;
+	InputOutputProcess& operator=(const InputOutputProcess&) = delete;
 
 	std::vector<std::uint8_t> read_binary(std::size_t length);
 	std::string read_line();

--- a/test/test_helpers/inputoutputprocess.h
+++ b/test/test_helpers/inputoutputprocess.h
@@ -1,0 +1,51 @@
+#ifndef NEWSBOAT_TEST_HELPERS_INPUTOUTPUTPROCESS_H_
+#define NEWSBOAT_TEST_HELPERS_INPUTOUTPUTPROCESS_H_
+
+#include <cstdint>
+#include <cstddef>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace test_helpers {
+
+class Pipe {
+public:
+	Pipe();
+	~Pipe();
+	void close_read_side();
+	void close_write_side();
+	int read_side();
+	int write_side();
+
+private:
+	int handles[2];
+};
+
+class InputOutputProcess {
+public:
+	InputOutputProcess(std::vector<std::string>&& args);
+	~InputOutputProcess();
+
+	std::vector<std::uint8_t> read_binary(std::size_t length);
+	std::string read_line();
+	void write_binary(const std::uint8_t* data, std::size_t length);
+	void write_line(std::string data);
+
+	void wait_for_exit();
+
+private:
+	void start_process();
+
+	const std::vector<std::string> argsStorage;
+	std::vector<char*> args;
+	std::vector<char*> envVars;
+	Pipe stdinPipe;
+	Pipe stdoutPipe;
+	FILE* stdoutStream;
+	int childPid;
+};
+
+} // namespace test_helpers
+
+#endif /* NEWSBOAT_TEST_HELPERS_INPUTOUTPUTPROCESS_H_ */

--- a/test/test_helpers/misc.cpp
+++ b/test/test_helpers/misc.cpp
@@ -67,6 +67,17 @@ std::vector<std::string> test_helpers::file_contents(const std::string& filepath
 	return lines;
 }
 
+std::vector<std::uint8_t> test_helpers::read_binary_file(const std::string& filepath)
+{
+	std::ifstream file(filepath, std::ios::binary | std::ios::ate);
+	std::streampos length = file.tellg();
+	file.seekg(0, std::ios::beg);
+
+	std::vector<std::uint8_t> buffer(length);
+	file.read(reinterpret_cast<char*>(buffer.data()), length);
+	return buffer;
+}
+
 bool test_helpers::starts_with(const std::string& prefix,
 	const std::string& input)
 {

--- a/test/test_helpers/misc.h
+++ b/test/test_helpers/misc.h
@@ -1,6 +1,7 @@
 #ifndef NEWSBOAT_TEST_HELPERS_MISC_H_
 #define NEWSBOAT_TEST_HELPERS_MISC_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -28,6 +29,10 @@ void copy_file(const std::string& source, const std::string& destination);
  * the file couldn't be opened.
  */
 std::vector<std::string> file_contents(const std::string& filepath);
+
+/* \brief Returns the contents of the file as a single binary blob
+ */
+std::vector<std::uint8_t> read_binary_file(const std::string& filepath);
 
 /* \brief Returns `true` if `input` starts with `prefix`.
  */


### PR DESCRIPTION
Alternative approach to https://github.com/newsboat/newsboat/pull/2736.

Http test server is now contained in a separate binary to avoid increasing the size of the regular newsboat/podboat binaries.
The C++ test code communicates with the http test server using (piped) stdin/stdout.