### PR TITLE
Cleanup unused overloaded methods

### DIFF
--- a/include/feedbinapi.h
+++ b/include/feedbinapi.h
@@ -24,7 +24,6 @@ public:
 	bool update_article_flags(const std::string& oldflags,
 		const std::string& newflags,
 		const std::string& guid) override;
-	rsspp::Feed fetch_feed(const std::string& id);
 	rsspp::Feed fetch_feed(const std::string& id, CurlHandle& cached_handle);
 
 private:

--- a/include/feedretriever.h
+++ b/include/feedretriever.h
@@ -15,8 +15,8 @@ class RssIgnores;
 
 class FeedRetriever {
 public:
-	FeedRetriever(ConfigContainer& cfg, Cache& ch, RssIgnores* ign = nullptr,
-		RemoteApi* api = nullptr, CurlHandle* easyhandle = nullptr);
+	FeedRetriever(ConfigContainer& cfg, Cache& ch, CurlHandle& easyhandle,
+		RssIgnores* ign = nullptr, RemoteApi* api = nullptr);
 
 	rsspp::Feed retrieve(const std::string& uri);
 
@@ -36,7 +36,7 @@ private:
 	Cache& ch;
 	RssIgnores* ign;
 	RemoteApi* api;
-	CurlHandle* easyhandle;
+	CurlHandle& easyhandle;
 };
 
 } // namespace newsboat

--- a/include/freshrssapi.h
+++ b/include/freshrssapi.h
@@ -27,7 +27,6 @@ public:
 	bool update_article_flags(const std::string& oldflags,
 		const std::string& newflags,
 		const std::string& guid) override;
-	rsspp::Feed fetch_feed(const std::string& id);
 	rsspp::Feed fetch_feed(const std::string& id, CurlHandle& cached_handle);
 
 private:

--- a/include/minifluxapi.h
+++ b/include/minifluxapi.h
@@ -24,7 +24,6 @@ public:
 		const std::string& newflags,
 		const std::string& guid) override;
 	void add_custom_headers(curl_slist**) override;
-	rsspp::Feed fetch_feed(const std::string& id);
 	rsspp::Feed fetch_feed(const std::string& id, CurlHandle& easyhandle);
 
 private:

--- a/include/reloader.h
+++ b/include/reloader.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "configcontainer.h"
+#include "curlhandle.h"
 
 namespace newsboat {
 
@@ -34,7 +35,8 @@ public:
 	/// feedscontainer). Only updates status bar if \a unattended is false.
 	void reload(unsigned int pos, bool unattended = false)
 	{
-		reload(pos, false, unattended);
+		CurlHandle easyHandle;
+		reload(pos, easyHandle, false, unattended);
 	}
 
 	/// \brief Reloads all feeds, spawning threads as necessary.
@@ -68,10 +70,6 @@ private:
 	/// if \a unattended is false. All network requests are made through
 	/// \a easyhandle. If the handle is not provided, this method creates
 	/// a temporary handle which is destroyed before returning from it.
-	void reload(unsigned int pos,
-		bool show_progress,
-		bool unattended);
-
 	void reload(unsigned int pos,
 		CurlHandle& easyhandle,
 		bool show_progress,

--- a/include/rssparser.h
+++ b/include/rssparser.h
@@ -15,7 +15,6 @@ namespace newsboat {
 
 class Cache;
 class ConfigContainer;
-class CurlHandle;
 class RssFeed;
 class RssIgnores;
 class RssItem;

--- a/include/ttrssapi.h
+++ b/include/ttrssapi.h
@@ -32,7 +32,6 @@ public:
 	bool update_article_flags(const std::string& oldflags,
 		const std::string& newflags,
 		const std::string& guid) override;
-	rsspp::Feed fetch_feed(const std::string& id);
 	rsspp::Feed fetch_feed(const std::string& id, CurlHandle& cached_handle);
 	bool update_article(const std::string& guid, int field, int mode);
 

--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -95,16 +95,6 @@ static size_t handle_headers(void* ptr, size_t size, size_t nmemb, void* data)
 }
 
 Feed Parser::parse_url(const std::string& url,
-	time_t lastmodified,
-	const std::string& etag,
-	newsboat::RemoteApi* api,
-	const std::string& cookie_cache)
-{
-	CurlHandle handle;
-	return parse_url(url, handle, lastmodified, etag, api, cookie_cache);
-}
-
-Feed Parser::parse_url(const std::string& url,
 	newsboat::CurlHandle& easyhandle,
 	time_t lastmodified,
 	const std::string& etag,

--- a/rss/parser.h
+++ b/rss/parser.h
@@ -31,11 +31,6 @@ public:
 		const std::string& etag = "",
 		newsboat::RemoteApi* api = 0,
 		const std::string& cookie_cache = "");
-	Feed parse_url(const std::string& url,
-		time_t lastmodified = 0,
-		const std::string& etag = "",
-		newsboat::RemoteApi* api = 0,
-		const std::string& cookie_cache = "");
 	Feed parse_buffer(const std::string& buffer,
 		const std::string& url = "");
 	Feed parse_file(const std::string& filename);

--- a/src/feedbinapi.cpp
+++ b/src/feedbinapi.cpp
@@ -147,12 +147,6 @@ bool FeedbinApi::mark_article_read(const std::string& guid, bool read)
 	return mark_entries_read(entry_ids, read);
 }
 
-rsspp::Feed FeedbinApi::fetch_feed(const std::string& id)
-{
-	CurlHandle handle;
-	return fetch_feed(id, handle);
-}
-
 rsspp::Feed FeedbinApi::fetch_feed(const std::string& id,
 	CurlHandle& cached_handle)
 {

--- a/src/feedretriever.cpp
+++ b/src/feedretriever.cpp
@@ -21,8 +21,8 @@
 
 namespace newsboat {
 
-FeedRetriever::FeedRetriever(ConfigContainer& cfg, Cache& ch, RssIgnores* ign,
-	RemoteApi* api, CurlHandle* easyhandle)
+FeedRetriever::FeedRetriever(ConfigContainer& cfg, Cache& ch, CurlHandle&
+	easyhandle, RssIgnores* ign, RemoteApi* api)
 	: cfg(cfg)
 	, ch(ch)
 	, ign(ign)
@@ -85,13 +85,7 @@ rsspp::Feed FeedRetriever::fetch_ttrss(const std::string& feed_id)
 	rsspp::Feed f;
 	TtRssApi* tapi = dynamic_cast<TtRssApi*>(api);
 	if (tapi) {
-		if (easyhandle) {
-			f = tapi->fetch_feed(
-					feed_id, *easyhandle);
-		} else {
-			f = tapi->fetch_feed(
-					feed_id);
-		}
+		f = tapi->fetch_feed(feed_id, easyhandle);
 	}
 	LOG(Level::DEBUG,
 		"FeedRetriever::fetch_ttrss: f.items.size = %" PRIu64,
@@ -133,11 +127,7 @@ rsspp::Feed FeedRetriever::fetch_miniflux(const std::string& feed_id)
 	rsspp::Feed f;
 	MinifluxApi* mapi = dynamic_cast<MinifluxApi*>(api);
 	if (mapi) {
-		if (easyhandle) {
-			f = mapi->fetch_feed(feed_id, *easyhandle);
-		} else {
-			f = mapi->fetch_feed(feed_id);
-		}
+		f = mapi->fetch_feed(feed_id, easyhandle);
 	}
 	LOG(Level::INFO,
 		"FeedRetriever::fetch_miniflux: f.items.size = %" PRIu64,
@@ -151,12 +141,7 @@ rsspp::Feed FeedRetriever::fetch_feedbin(const std::string& feed_id)
 	rsspp::Feed f;
 	FeedbinApi* fapi = dynamic_cast<FeedbinApi*>(api);
 	if (fapi) {
-		if (easyhandle) {
-			f = fapi->fetch_feed(feed_id, *easyhandle);
-		} else {
-			f = fapi->fetch_feed(feed_id);
-		}
-
+		f = fapi->fetch_feed(feed_id, easyhandle);
 	}
 	LOG(Level::INFO,
 		"FeedRetriever::fetch_feedbin: f.items.size = %" PRIu64,
@@ -170,12 +155,7 @@ rsspp::Feed FeedRetriever::fetch_freshrss(const std::string& feed_id)
 	rsspp::Feed f;
 	FreshRssApi* fapi = dynamic_cast<FreshRssApi*>(api);
 	if (fapi) {
-		if (easyhandle) {
-			f = fapi->fetch_feed(feed_id, *easyhandle);
-		} else {
-			f = fapi->fetch_feed(feed_id);
-		}
-
+		f = fapi->fetch_feed(feed_id, easyhandle);
 	}
 	LOG(Level::INFO,
 		"FeedRetriever::fetch_freshrss: f.items.size = %" PRIu64,
@@ -217,20 +197,12 @@ rsspp::Feed FeedRetriever::download_http(const std::string& uri)
 		if (!ign || !ign->matches_lastmodified(uri)) {
 			ch.fetch_lastmodified(uri, lm, etag);
 		}
-		if (easyhandle) {
-			f = p.parse_url(uri,
-					*easyhandle,
-					lm,
-					etag,
-					api,
-					cfg.get_configvalue("cookie-cache"));
-		} else {
-			f = p.parse_url(uri,
-					lm,
-					etag,
-					api,
-					cfg.get_configvalue("cookie-cache"));
-		}
+		f = p.parse_url(uri,
+				easyhandle,
+				lm,
+				etag,
+				api,
+				cfg.get_configvalue("cookie-cache"));
 		LOG(Level::DEBUG,
 			"FeedRetriever::download_http: lm = %" PRId64 " etag = %s",
 			// On GCC, `time_t` is `long int`, which is at least 32 bits

--- a/src/freshrssapi.cpp
+++ b/src/freshrssapi.cpp
@@ -397,12 +397,6 @@ std::string FreshRssApi::post_content(const std::string& url,
 	return result;
 }
 
-rsspp::Feed FreshRssApi::fetch_feed(const std::string& id)
-{
-	CurlHandle handle;
-	return fetch_feed(id, handle);
-}
-
 rsspp::Feed FreshRssApi::fetch_feed(const std::string& id, CurlHandle& cached_handle)
 {
 	rsspp::Feed feed;

--- a/src/minifluxapi.cpp
+++ b/src/minifluxapi.cpp
@@ -107,7 +107,8 @@ bool MinifluxApi::mark_all_read(const std::string& id)
 {
 	// TODO create Miniflux PR to add endpoint for marking all entries in feed
 	// as read
-	const rsspp::Feed feed = fetch_feed(id);
+	CurlHandle easyHandle;
+	const rsspp::Feed feed = fetch_feed(id, easyHandle);
 
 	std::vector<std::string> guids;
 	for (const auto& item : feed.items) {
@@ -174,12 +175,6 @@ bool MinifluxApi::update_article_flags(const std::string&  oldflags,
 	}
 
 	return success;
-}
-
-rsspp::Feed MinifluxApi::fetch_feed(const std::string& id)
-{
-	CurlHandle handle;
-	return fetch_feed(id, handle);
 }
 
 rsspp::Feed MinifluxApi::fetch_feed(const std::string& id, CurlHandle& cached_handle)

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -114,7 +114,7 @@ void Reloader::reload(unsigned int pos,
 
 			LOG(Level::INFO, "Reloader::reload: retrieving feed");
 			sm.stopover("start retrieving");
-			FeedRetriever feed_retriever(cfg, *rsscache, ign, ctrl->get_api(), &easyhandle);
+			FeedRetriever feed_retriever(cfg, *rsscache, easyhandle, ign, ctrl->get_api());
 			const rsspp::Feed feed = feed_retriever.retrieve(oldfeed->rssurl());
 
 			LOG(Level::INFO, "Reloader::reload: parsing feed");

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -65,14 +65,6 @@ bool Reloader::trylock_reload_mutex()
 }
 
 void Reloader::reload(unsigned int pos,
-	bool show_progress,
-	bool unattended)
-{
-	CurlHandle handle;
-	reload(pos, handle, show_progress, unattended);
-}
-
-void Reloader::reload(unsigned int pos,
 	CurlHandle& easyhandle,
 	bool show_progress,
 	bool unattended)
@@ -243,7 +235,8 @@ void Reloader::reload_indexes(const std::vector<int>& indexes, bool unattended)
 
 	partition_reload_to_threads([&](unsigned int start, unsigned int end) {
 		for (auto i = start; i <= end; ++i) {
-			reload(indexes[i], true, unattended);
+			CurlHandle easyhandle;
+			reload(indexes[i], easyhandle, true, unattended);
 		}
 	}, indexes.size());
 

--- a/src/ttrssapi.cpp
+++ b/src/ttrssapi.cpp
@@ -362,12 +362,6 @@ bool TtRssApi::update_article_flags(const std::string& oldflags,
 	return success;
 }
 
-rsspp::Feed TtRssApi::fetch_feed(const std::string& id)
-{
-	CurlHandle handle;
-	return fetch_feed(id, handle);
-}
-
 rsspp::Feed TtRssApi::fetch_feed(const std::string& id, CurlHandle& cached_handle)
 {
 	rsspp::Feed f;

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -5,6 +5,7 @@
 
 #include "3rd-party/catch.hpp"
 #include "configcontainer.h"
+#include "curlhandle.h"
 #include "feedretriever.h"
 #include "rssfeed.h"
 #include "rssignores.h"
@@ -18,7 +19,8 @@ TEST_CASE("items in search result can be marked read", "[Cache]")
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	const std::string uri = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 	RssParser parser(uri, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
 	REQUIRE(feed->total_item_count() == 8);
@@ -45,7 +47,8 @@ TEST_CASE("Cleaning old articles works", "[Cache]")
 	auto cfg = std::make_unique<ConfigContainer>();
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), cfg.get());
 	const std::string uri = "file://data/rss.xml";
-	FeedRetriever feed_retriever(*cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(*cfg, *rsscache, easyHandle);
 	RssParser parser(uri, *rsscache, *cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
 
@@ -86,7 +89,8 @@ TEST_CASE("Last-Modified and ETag values are persisted to DB", "[Cache]")
 	test_helpers::TempFile dbfile;
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), cfg.get());
 	const auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(*cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(*cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, *cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	rsscache->externalize_rssfeed(feed, false);
@@ -151,7 +155,8 @@ TEST_CASE("mark_all_read marks all items in the feed read", "[Cache]")
 	/* Ensure that the feeds contain expected number of items, then
 	 * externalize them (put into Cache). */
 	for (const auto& feed_data : feeds) {
-		FeedRetriever feed_retriever(cfg, rsscache);
+		CurlHandle easyHandle;
+		FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 		RssParser parser(feed_data.first, rsscache, cfg, nullptr);
 		feed = parser.parse(feed_retriever.retrieve(feed_data.first));
 		REQUIRE(feed->total_item_count() == feed_data.second);
@@ -250,7 +255,8 @@ TEST_CASE(
 	auto cfg = std::make_unique<ConfigContainer>();
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), cfg.get());
 	for (const auto& url : feedurls) {
-		FeedRetriever feed_retriever(*cfg, *rsscache);
+		CurlHandle easyHandle;
+		FeedRetriever feed_retriever(*cfg, *rsscache, easyHandle);
 		RssParser parser(url, *rsscache, *cfg, nullptr);
 		auto feed = parser.parse(feed_retriever.retrieve(url));
 		feeds.push_back(feed);
@@ -358,7 +364,8 @@ TEST_CASE("fetch_descriptions fills out feed item's descriptions", "[Cache]")
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	const auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 	RssParser parser(feedurl, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 
@@ -385,7 +392,8 @@ TEST_CASE("get_read_item_guids returns GUIDs of items that are marked read",
 	// We'll keep our own count of which GUIDs are unread
 	std::unordered_set<std::string> read_guids;
 	const std::string uri1 = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	auto parser = std::make_unique<RssParser>(uri1, *rsscache, cfg, nullptr);
 	auto feed = parser->parse(feed_retriever.retrieve(uri1));
 
@@ -443,7 +451,8 @@ TEST_CASE("mark_item_deleted changes \"deleted\" flag of item with given GUID ",
 	ConfigContainer cfg;
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 
@@ -466,7 +475,8 @@ TEST_CASE("mark_items_read_by_guid marks items with given GUIDs as unread ",
 	ConfigContainer cfg;
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 
@@ -504,7 +514,8 @@ TEST_CASE(
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 	RssParser parser(feedurl, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 
@@ -559,7 +570,8 @@ TEST_CASE("search_for_items finds all items with matching title or content",
 		"file://data/atom10_1.xml", "file://data/rss20_1.xml"
 	};
 	for (const auto& url : feedurls) {
-		FeedRetriever feed_retriever(cfg, rsscache);
+		CurlHandle easyHandle;
+		FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 		RssParser parser(url, rsscache, cfg, nullptr);
 		auto feed = parser.parse(feed_retriever.retrieve(url));
 
@@ -593,7 +605,8 @@ TEST_CASE("update_rssitem_flags dumps `rss_item` object's flags to DB",
 	ConfigContainer cfg;
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	const auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	rsscache->externalize_rssfeed(feed, false);
@@ -617,7 +630,8 @@ TEST_CASE(
 	ConfigContainer cfg;
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	const auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 
@@ -717,7 +731,8 @@ TEST_CASE(
 	ConfigContainer cfg;
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	const auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto initial_feed = parser.parse(feed_retriever.retrieve(feedurl));
 	initial_feed->load();
@@ -756,7 +771,8 @@ TEST_CASE("externalize_rssfeed doesn't store more than `max-items` items",
 
 	cfg->set_configvalue("max-items", "3");
 	const auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(*cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(*cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, *cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	REQUIRE(feed->total_item_count() == 8);
@@ -783,7 +799,8 @@ TEST_CASE(
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), cfg.get());
 
 	const auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(*cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(*cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, *cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	REQUIRE(feed->total_item_count() == 8);
@@ -840,7 +857,8 @@ TEST_CASE("internalize_rssfeed doesn't return items that are ignored",
 	Cache rsscache(":memory:", &cfg);
 
 	const std::string feedurl("file://data/rss092_1.xml");
-	FeedRetriever feed_retriever(cfg, rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 	RssParser parser(feedurl, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	REQUIRE(feed->total_item_count() == 3);
@@ -864,7 +882,8 @@ TEST_CASE(
 	ConfigContainer cfg;
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	feed->items()[0]->set_unread_nowrite(false);
@@ -901,7 +920,8 @@ TEST_CASE(
 	ConfigContainer cfg;
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	auto feedurl = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	feed->items()[0]->set_unread_nowrite(false);
@@ -993,7 +1013,8 @@ TEST_CASE("do_vacuum doesn't throw an exception", "[Cache]")
 	ConfigContainer cfg;
 	auto rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	const std::string uri = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, *rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(uri, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
 	rsscache->externalize_rssfeed(feed, false);
@@ -1010,7 +1031,8 @@ TEST_CASE("search_in_items returns items that contain given substring",
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	const std::string uri = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 	RssParser parser(uri, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
 	REQUIRE(feed->total_item_count() == 8);
@@ -1052,7 +1074,8 @@ TEST_CASE("search_in_items returns empty set if input set is empty", "[Cache]")
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
 	const std::string uri = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 	RssParser parser(uri, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
 	rsscache.externalize_rssfeed(feed, false);
@@ -1069,7 +1092,8 @@ TEST_CASE("Ignoring articles in search", "[Cache]")
 	Cache rsscache(":memory:", &cfg);
 
 	const std::string uri = "file://data/rss.xml";
-	FeedRetriever feed_retriever(cfg, rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 	RssParser parser(uri, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
 	REQUIRE(feed->total_item_count() == 8);

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -3,6 +3,7 @@
 #include "3rd-party/catch.hpp"
 #include "cache.h"
 #include "configcontainer.h"
+#include "curlhandle.h"
 #include "feedretriever.h"
 #include "rssparser.h"
 
@@ -370,7 +371,8 @@ TEST_CASE("If item's <title> is empty, try to deduce it from the URL",
 {
 	ConfigContainer cfg;
 	Cache rsscache(":memory:", &cfg);
-	FeedRetriever feed_retriever(cfg, rsscache);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 	const std::string uri = "file://data/items_without_titles.xml";
 	RssParser p(uri,
 		rsscache,


### PR DESCRIPTION
I noticed that our production code always instantiates `FeedRetriever` with a non-null `CurlHandle`.
Changed the argument to a reference to make this obvious (and updated tests to make them use `FeedRetriever` in the same way as the production code).
Extended these changes to external APIs and other places where we use a `CurlHandle`.

Additionally I noticed that my C++ Vim plugin started highlighting unused header includes.
~~I've removed those unnecessary header includes in the files I had open for this PR.
If preferred, I can take out those changes and apply them in a separate PR.~~
-> I ran into some issues so will move these changes into a separate PR