### PR TITLE
Remove unused header includes

### DIFF
--- a/include/configexception.h
+++ b/include/configexception.h
@@ -1,7 +1,6 @@
 #ifndef NEWSBOAT_CONFIGEXCEPTION_H_
 #define NEWSBOAT_CONFIGEXCEPTION_H_
 
-#include <stdexcept>
 #include <string>
 
 namespace newsboat {

--- a/include/confighandlerexception.h
+++ b/include/confighandlerexception.h
@@ -1,7 +1,6 @@
 #ifndef NEWSBOAT_CONFIGHANDLEREXCEPTION_H_
 #define NEWSBOAT_CONFIGHANDLEREXCEPTION_H_
 
-#include <stdexcept>
 #include <string>
 
 namespace newsboat {

--- a/include/controller.h
+++ b/include/controller.h
@@ -10,7 +10,6 @@
 #include "feedcontainer.h"
 #include "filtercontainer.h"
 #include "fslock.h"
-#include "opml.h"
 #include "queuemanager.h"
 #include "regexmanager.h"
 #include "reloader.h"

--- a/include/curldatareceiver.h
+++ b/include/curldatareceiver.h
@@ -1,7 +1,6 @@
 #ifndef NEWSBOAT_CURLDATARECEIVER_H_
 #define NEWSBOAT_CURLDATARECEIVER_H_
 
-#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/include/dbexception.h
+++ b/include/dbexception.h
@@ -2,7 +2,6 @@
 #define NEWSBOAT_DBEXCEPTION_H_
 
 #include <sqlite3.h>
-#include <stdexcept>
 #include <string>
 
 namespace newsboat {

--- a/include/dialogsformaction.h
+++ b/include/dialogsformaction.h
@@ -2,7 +2,6 @@
 #define NEWSBOAT_DIALOGSFORMACTION_H_
 
 #include "listformaction.h"
-#include "listwidget.h"
 #include "regexmanager.h"
 
 namespace newsboat {

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -7,7 +7,6 @@
 #include "configcontainer.h"
 #include "file_system.h"
 #include "formaction.h"
-#include "listformatter.h"
 #include "listwidget.h"
 #include "stflrichtext.h"
 

--- a/include/feedhqapi.h
+++ b/include/feedhqapi.h
@@ -3,7 +3,6 @@
 
 #include <libxml/tree.h>
 
-#include "cache.h"
 #include "remoteapi.h"
 
 namespace newsboat {

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -7,7 +7,6 @@
 #include "configcontainer.h"
 #include "file_system.h"
 #include "formaction.h"
-#include "listformatter.h"
 #include "listwidget.h"
 #include "stflrichtext.h"
 

--- a/include/freshrssapi.h
+++ b/include/freshrssapi.h
@@ -3,10 +3,8 @@
 
 #include <libxml/tree.h>
 
-#include "cache.h"
 #include "remoteapi.h"
 #include "rss/feed.h"
-#include "3rd-party/json.hpp"
 #include "utils.h"
 
 class CurlHandle;

--- a/include/inoreaderapi.h
+++ b/include/inoreaderapi.h
@@ -3,9 +3,7 @@
 
 #include <libxml/tree.h>
 
-#include "cache.h"
 #include "remoteapi.h"
-#include "urlreader.h"
 
 namespace newsboat {
 

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -1,8 +1,6 @@
 #ifndef NEWSBOAT_ITEMLISTFORMACTION_H_
 #define NEWSBOAT_ITEMLISTFORMACTION_H_
 
-#include <assert.h>
-
 #include "3rd-party/optional.hpp"
 
 #include "configcontainer.h"

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "htmlrenderer.h"
+#include "links.h"
 #include "textformatter.h"
 
 namespace newsboat {

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -2,7 +2,7 @@
 #define NEWSBOAT_ITEMVIEWFORMACTION_H_
 
 #include "formaction.h"
-#include "htmlrenderer.h"
+#include "links.h"
 #include "regexmanager.h"
 #include "textformatter.h"
 #include "textviewwidget.h"

--- a/include/keycombination.h
+++ b/include/keycombination.h
@@ -1,7 +1,6 @@
 #ifndef NEWSBOAT_KEYCOMBINATION_H_
 #define NEWSBOAT_KEYCOMBINATION_H_
 
-#include <ostream>
 #include <string>
 
 namespace newsboat {

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -3,7 +3,6 @@
 
 #include <map>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "configactionhandler.h"

--- a/include/links.h
+++ b/include/links.h
@@ -1,9 +1,8 @@
 #ifndef NEWSBOAT_LINKS_H_
 #define NEWSBOAT_LINKS_H_
 
-#include <vector>
-#include <utility>
 #include <string>
+#include <vector>
 
 #include "config.h"
 

--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -1,9 +1,7 @@
 #ifndef NEWSBOAT_LISTFORMATTER_H_
 #define NEWSBOAT_LISTFORMATTER_H_
 
-#include <climits>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "regexmanager.h"

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,7 +1,6 @@
 #ifndef NEWSBOAT_LOGGER_H_
 #define NEWSBOAT_LOGGER_H_
 
-#include "config.h"
 #include "strprintf.h"
 
 #include "libnewsboat-ffi/src/logger.rs.h"

--- a/include/matcherexception.h
+++ b/include/matcherexception.h
@@ -2,7 +2,6 @@
 #define NEWSBOAT_MATCHEREXCEPTON_H_
 
 #include <cstdint>
-#include <stdexcept>
 #include <string>
 
 namespace newsboat {

--- a/include/oldreaderapi.h
+++ b/include/oldreaderapi.h
@@ -3,7 +3,6 @@
 
 #include <libxml/tree.h>
 
-#include "cache.h"
 #include "remoteapi.h"
 
 namespace newsboat {

--- a/include/poddlthread.h
+++ b/include/poddlthread.h
@@ -4,7 +4,6 @@
 #include <chrono>
 #include <fstream>
 #include <memory>
-#include <thread>
 #include <time.h>
 
 #include "configcontainer.h"

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -4,7 +4,6 @@
 #include <map>
 #include <memory>
 #include <regex.h>
-#include <regex>
 #include <string>
 #include <sys/types.h>
 #include <utility>

--- a/include/reloadthread.h
+++ b/include/reloadthread.h
@@ -1,8 +1,6 @@
 #ifndef NEWSBOAT_RELOADTHREAD_H_
 #define NEWSBOAT_RELOADTHREAD_H_
 
-#include <thread>
-
 #include "configcontainer.h"
 #include "controller.h"
 

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "config.h"
 #include "matchable.h"
 #include "rssitem.h"
 #include "utils.h"

--- a/include/statusline.h
+++ b/include/statusline.h
@@ -2,7 +2,6 @@
 #define NEWSBOAT_STATUSLINE_H_
 
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/include/textviewwidget.h
+++ b/include/textviewwidget.h
@@ -2,7 +2,6 @@
 #define NEWSBOAT_TEXTVIEWWIDGET_H_
 
 #include <cstdint>
-#include <memory>
 #include <string>
 
 #include "stflpp.h"

--- a/include/ttrssapi.h
+++ b/include/ttrssapi.h
@@ -1,8 +1,9 @@
 #ifndef NEWSBOAT_TTRSSAPI_H_
 #define NEWSBOAT_TTRSSAPI_H_
 
+#include <mutex>
+
 #include "3rd-party/json.hpp"
-#include "cache.h"
 #include "remoteapi.h"
 
 namespace rsspp {

--- a/include/urlviewformaction.h
+++ b/include/urlviewformaction.h
@@ -2,7 +2,7 @@
 #define NEWSBOAT_URLVIEWFORMACTION_H_
 
 #include "formaction.h"
-#include "htmlrenderer.h"
+#include "links.h"
 #include "listwidget.h"
 
 namespace newsboat {

--- a/include/utils.h
+++ b/include/utils.h
@@ -4,8 +4,6 @@
 #include <cstdint>
 #include <curl/curl.h>
 #include <libxml/parser.h>
-#include <memory>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -14,7 +12,6 @@
 #include "3rd-party/optional.hpp"
 
 #include "configcontainer.h"
-#include "logger.h"
 
 #include "libnewsboat-ffi/src/utils.rs.h"
 

--- a/include/view.h
+++ b/include/view.h
@@ -8,7 +8,7 @@
 
 #include "3rd-party/optional.hpp"
 
-#include "htmlrenderer.h"
+#include "links.h"
 #include "statusline.h"
 
 namespace newsboat {

--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -1,5 +1,3 @@
-#include <cstring>
-#include <errno.h>
 #include <iostream>
 #include <ncurses.h>
 #include <sstream>

--- a/podboat.cpp
+++ b/podboat.cpp
@@ -1,11 +1,10 @@
-#include <cstring>
-#include <errno.h>
 #include <iostream>
 
 #include "config.h"
 #include "exception.h"
 #include "pbcontroller.h"
 #include "pbview.h"
+#include "strprintf.h"
 #include "utils.h"
 
 extern "C" {

--- a/rss/atomparser.cpp
+++ b/rss/atomparser.cpp
@@ -1,7 +1,5 @@
 #include "atomparser.h"
 
-#include <cstring>
-
 #include "config.h"
 #include "exception.h"
 #include "feed.h"

--- a/rss/medianamespace.cpp
+++ b/rss/medianamespace.cpp
@@ -2,12 +2,9 @@
 
 #include <string>
 
-#include "utils.h"
 #include "xmlutilities.h"
 
 #define MEDIA_RSS_URI "http://search.yahoo.com/mrss/"
-
-using namespace newsboat;
 
 namespace rsspp {
 

--- a/rss/rss10parser.cpp
+++ b/rss/rss10parser.cpp
@@ -1,7 +1,5 @@
 #include "rss10parser.h"
 
-#include <cstring>
-
 #include "config.h"
 #include "exception.h"
 #include "feed.h"

--- a/rss/rss20parser.cpp
+++ b/rss/rss20parser.cpp
@@ -5,13 +5,9 @@
 #include "config.h"
 #include "exception.h"
 #include "feed.h"
-#include "item.h"
 #include "rss09xparser.h"
-#include "utils.h"
 
 #define RSS20USERLAND_URI "http://backend.userland.com/rss2"
-
-using namespace newsboat;
 
 namespace rsspp {
 

--- a/rss/rssparser.cpp
+++ b/rss/rssparser.cpp
@@ -4,9 +4,6 @@
 #include <ctime>
 #include <libxml/tree.h>
 
-#include "exception.h"
-#include "xmlutilities.h"
-
 #include "utils.h"
 
 namespace rsspp {

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -2,21 +2,18 @@
 
 #include <cassert>
 #include <cinttypes>
-#include <cstdlib>
 #include <cstring>
-#include <fstream>
 #include <iostream>
 #include <sqlite3.h>
 #include <sstream>
 #include <time.h>
 
-#include "config.h"
 #include "configcontainer.h"
-#include "controller.h"
 #include "dbexception.h"
 #include "logger.h"
 #include "matcherexception.h"
 #include "rssfeed.h"
+#include "rssignores.h"
 #include "scopemeasure.h"
 #include "strprintf.h"
 #include "utils.h"

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -1,7 +1,5 @@
 #include "cliargsparser.h"
 
-#include <cstdlib>
-
 namespace newsboat {
 
 rust::Vec<cliargsparser::bridged::BytesVec> argv_to_rust_args(int argc, char* argv[])

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -3,17 +3,8 @@
 #include "config.h"
 #include "confighandlerexception.h"
 #include "configparser.h"
-#include "feedlistformaction.h"
-#include "filebrowserformaction.h"
-#include "helpformaction.h"
-#include "itemlistformaction.h"
-#include "itemviewformaction.h"
 #include "logger.h"
-#include "matcherexception.h"
-#include "pbview.h"
-#include "selectformaction.h"
 #include "strprintf.h"
-#include "urlviewformaction.h"
 #include "utils.h"
 
 using namespace podboat;

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -1,9 +1,6 @@
 #include "configparser.h"
 
 #include <algorithm>
-#include <cstdlib>
-#include <cstring>
-#include <fstream>
 #include <pwd.h>
 #include <sys/types.h>
 
@@ -12,7 +9,6 @@
 #include "confighandlerexception.h"
 #include "logger.h"
 #include "strprintf.h"
-#include "tagsouppullparser.h"
 #include "utils.h"
 
 namespace newsboat {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -7,7 +7,6 @@
 #include <ctime>
 #include <curl/curl.h>
 #include <fstream>
-#include <functional>
 #include <iostream>
 #include <langinfo.h>
 #include <libgen.h>
@@ -16,7 +15,6 @@
 #include <libxml/xmlsave.h>
 #include <libxml/xmlversion.h>
 #include <memory>
-#include <mutex>
 #include <pwd.h>
 #include <signal.h>
 #include <sys/stat.h>
@@ -53,6 +51,7 @@
 #include "ocnewsurlreader.h"
 #include "oldreaderapi.h"
 #include "oldreaderurlreader.h"
+#include "opml.h"
 #include "opmlurlreader.h"
 #include "regexmanager.h"
 #include "remoteapi.h"

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -5,7 +5,6 @@
 
 #include "config.h"
 #include "fmtstrformatter.h"
-#include "listformatter.h"
 #include "stflrichtext.h"
 #include "strprintf.h"
 #include "utils.h"

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -7,10 +7,7 @@
 #include <ncurses.h>
 #include <dirent.h>
 #include <grp.h>
-#include <iomanip>
-#include <iostream>
 #include <pwd.h>
-#include <sstream>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/download.cpp
+++ b/src/download.cpp
@@ -3,7 +3,6 @@
 #include <string>
 
 #include "config.h"
-#include "pbcontroller.h"
 
 namespace podboat {
 

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -2,8 +2,6 @@
 
 #include <cstring>
 
-#include "config.h"
-
 namespace newsboat {
 
 Exception::Exception(unsigned int error_code)

--- a/src/feedbinapi.cpp
+++ b/src/feedbinapi.cpp
@@ -7,6 +7,7 @@
 
 #include "3rd-party/json.hpp"
 #include "curlhandle.h"
+#include "logger.h"
 #include "rss/feed.h"
 #include "strprintf.h"
 #include "utils.h"

--- a/src/feedcontainer.cpp
+++ b/src/feedcontainer.cpp
@@ -4,8 +4,8 @@
 #include <numeric>   // accumulate
 #include <unordered_set>
 
+#include "logger.h"
 #include "rssfeed.h"
-#include "utils.h"
 
 namespace newsboat {
 

--- a/src/feedhqapi.cpp
+++ b/src/feedhqapi.cpp
@@ -1,6 +1,5 @@
 #include "feedhqapi.h"
 
-#include <cstring>
 #include <curl/curl.h>
 #include <json.h>
 #include <vector>
@@ -8,6 +7,7 @@
 #include "config.h"
 #include "curldatareceiver.h"
 #include "curlhandle.h"
+#include "logger.h"
 #include "strprintf.h"
 #include "utils.h"
 

--- a/src/feedhqurlreader.cpp
+++ b/src/feedhqurlreader.cpp
@@ -1,5 +1,6 @@
 #include "feedhqurlreader.h"
 
+#include "config.h"
 #include "configcontainer.h"
 #include "fileurlreader.h"
 #include "logger.h"

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -5,8 +5,6 @@
 #include <cstdint>
 #include <cstring>
 #include <langinfo.h>
-#include <numeric>
-#include <sstream>
 #include <string>
 
 #include "config.h"

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -7,17 +7,13 @@
 #include <ncurses.h>
 #include <dirent.h>
 #include <grp.h>
-#include <iomanip>
-#include <iostream>
 #include <pwd.h>
-#include <sstream>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #include "config.h"
 #include "fmtstrformatter.h"
-#include "listformatter.h"
 #include "logger.h"
 #include "strprintf.h"
 #include "utils.h"

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <fstream>
 
+#include "config.h"
 #include "strprintf.h"
 #include "utils.h"
 

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -2,15 +2,12 @@
 
 #include <cassert>
 #include <cinttypes>
-#include <exception>
 #include <ncurses.h>
 
 #include "config.h"
 #include "configexception.h"
 #include "controller.h"
-#include "listmovementcontrol.h"
 #include "logger.h"
-#include "matcherexception.h"
 #include "strprintf.h"
 #include "textviewwidget.h"
 #include "utils.h"

--- a/src/freshrssapi.cpp
+++ b/src/freshrssapi.cpp
@@ -1,6 +1,5 @@
 #include "freshrssapi.h"
 
-#include <cstring>
 #include <curl/curl.h>
 #include <json.h>
 #include <time.h>
@@ -9,6 +8,7 @@
 #include "config.h"
 #include "curldatareceiver.h"
 #include "curlhandle.h"
+#include "logger.h"
 #include "strprintf.h"
 #include "utils.h"
 #include "rss/feed.h"

--- a/src/freshrssurlreader.cpp
+++ b/src/freshrssurlreader.cpp
@@ -1,5 +1,6 @@
 #include "freshrssurlreader.h"
 
+#include "config.h"
 #include "configcontainer.h"
 #include "fileurlreader.h"
 #include "logger.h"

--- a/src/fslock.cpp
+++ b/src/fslock.cpp
@@ -1,12 +1,8 @@
 #include "fslock.h"
 
-#include <cerrno>
 #include <fcntl.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
-
-#include "logger.h"
 
 namespace newsboat {
 

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -1,8 +1,6 @@
 #include "helpformaction.h"
 
-#include <algorithm>
 #include <cstring>
-#include <sstream>
 
 #include "config.h"
 #include "fmtstrformatter.h"

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <libgen.h>
 #include <sstream>
-#include <stdexcept>
 
 #include "config.h"
 #include "logger.h"

--- a/src/inoreaderapi.cpp
+++ b/src/inoreaderapi.cpp
@@ -6,9 +6,9 @@
 #include <vector>
 #include <thread>
 
-#include "config.h"
 #include "curldatareceiver.h"
 #include "curlhandle.h"
+#include "logger.h"
 #include "strprintf.h"
 #include "utils.h"
 

--- a/src/inoreaderurlreader.cpp
+++ b/src/inoreaderurlreader.cpp
@@ -1,5 +1,6 @@
 #include "inoreaderurlreader.h"
 
+#include "config.h"
 #include "configcontainer.h"
 #include "fileurlreader.h"
 #include "logger.h"

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1,6 +1,5 @@
 #include <itemlistformaction.h>
 
-#include <cassert>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
@@ -16,6 +15,7 @@
 #include "dbexception.h"
 #include "fmtstrformatter.h"
 #include "formaction.h"
+#include "htmlrenderer.h"
 #include "itemutils.h"
 #include "logger.h"
 #include "matcherexception.h"

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -5,7 +5,9 @@
 
 #include "configcontainer.h"
 #include "htmlrenderer.h"
+#include "logger.h"
 #include "rssfeed.h"
+#include "strprintf.h"
 #include "textformatter.h"
 #include "utils.h"
 

--- a/src/itemutils.cpp
+++ b/src/itemutils.cpp
@@ -1,5 +1,7 @@
-#include "controller.h"
 #include "itemutils.h"
+
+#include "controller.h"
+#include "strprintf.h"
 
 namespace newsboat {
 

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -12,7 +12,6 @@
 #include "itemlistformaction.h"
 #include "itemrenderer.h"
 #include "itemutils.h"
-#include "htmlrenderer.h"
 #include "logger.h"
 #include "rssfeed.h"
 #include "scopemeasure.h"

--- a/src/keycombination.cpp
+++ b/src/keycombination.cpp
@@ -1,6 +1,5 @@
 #include "keycombination.h"
 
-#include <locale>
 #include <tuple>
 
 namespace newsboat {

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -1,7 +1,5 @@
 #include "keymap.h"
 
-#include <algorithm>
-#include <iostream>
 #include <map>
 #include <string>
 #include <vector>

--- a/src/links.cpp
+++ b/src/links.cpp
@@ -1,5 +1,6 @@
 #include "links.h"
 #include "utils.h"
+
 namespace newsboat {
 unsigned int Links::add_link(const std::string& url, LinkType type)
 {

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -1,8 +1,8 @@
 #include "listformatter.h"
 
-#include <assert.h>
 #include <limits.h>
 
+#include "logger.h"
 #include "stflpp.h"
 #include "stflrichtext.h"
 #include "strprintf.h"

--- a/src/matcher.cpp
+++ b/src/matcher.cpp
@@ -1,8 +1,5 @@
 #include "matcher.h"
 
-#include <cassert>
-#include <cinttypes>
-#include <ctime>
 #include <regex.h>
 #include <sstream>
 #include <vector>

--- a/src/minifluxurlreader.cpp
+++ b/src/minifluxurlreader.cpp
@@ -1,5 +1,6 @@
 #include "minifluxurlreader.h"
 
+#include "config.h"
 #include "configcontainer.h"
 #include "fileurlreader.h"
 #include "logger.h"

--- a/src/newsblurapi.cpp
+++ b/src/newsblurapi.cpp
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <time.h>
 
-#include "json.h"
+#include "logger.h"
 #include "remoteapi.h"
 #include "strprintf.h"
 #include "utils.h"

--- a/src/ocnewsapi.cpp
+++ b/src/ocnewsapi.cpp
@@ -10,6 +10,7 @@
 
 #include "curldatareceiver.h"
 #include "curlhandle.h"
+#include "logger.h"
 #include "utils.h"
 
 #define OCNEWS_API "/index.php/apps/news/api/v1-2/"

--- a/src/oldreaderapi.cpp
+++ b/src/oldreaderapi.cpp
@@ -8,6 +8,7 @@
 #include "config.h"
 #include "curldatareceiver.h"
 #include "curlhandle.h"
+#include "logger.h"
 #include "strprintf.h"
 #include "utils.h"
 

--- a/src/oldreaderurlreader.cpp
+++ b/src/oldreaderurlreader.cpp
@@ -1,5 +1,6 @@
 #include "oldreaderurlreader.h"
 
+#include "config.h"
 #include "configcontainer.h"
 #include "fileurlreader.h"
 #include "logger.h"

--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -1,11 +1,11 @@
 #include "opml.h"
 
 #include <algorithm>
-#include <cassert>
 #include <cinttypes>
 #include <cstring>
 #include <sstream>
 
+#include "logger.h"
 #include "rssfeed.h"
 
 namespace newsboat {

--- a/src/opmlurlreader.cpp
+++ b/src/opmlurlreader.cpp
@@ -2,6 +2,7 @@
 
 #include <cstring>
 
+#include "logger.h"
 #include "utils.h"
 
 namespace newsboat {

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -1,8 +1,5 @@
 #include "pbcontroller.h"
 
-#include <cinttypes>
-#include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <getopt.h>
@@ -21,7 +18,6 @@
 #include "configexception.h"
 #include "configparser.h"
 #include "logger.h"
-#include "matcherexception.h"
 #include "nullconfigactionhandler.h"
 #include "pbview.h"
 #include "poddlthread.h"

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -1,11 +1,8 @@
 #include "pbview.h"
 
 #include <cinttypes>
-#include <cstdio>
 #include <cstring>
 #include <ncurses.h>
-#include <iostream>
-#include <sstream>
 
 #include "config.h"
 #include "configcontainer.h"
@@ -17,7 +14,6 @@
 #include "logger.h"
 #include "pbcontroller.h"
 #include "strprintf.h"
-#include "utils.h"
 
 using namespace newsboat;
 

--- a/src/poddlthread.cpp
+++ b/src/poddlthread.cpp
@@ -3,7 +3,6 @@
 #include <cstring>
 #include <cinttypes>
 #include <curl/curl.h>
-#include <iostream>
 #include <libgen.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -11,7 +10,6 @@
 #include <unistd.h>
 
 #include "curlhandle.h"
-#include "config.h"
 #include "logger.h"
 #include "utils.h"
 

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -1,7 +1,6 @@
 #include "queueloader.h"
 
 #include <cerrno>
-#include <cstdlib>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
@@ -12,7 +11,6 @@
 #include "config.h"
 #include "configcontainer.h"
 #include "logger.h"
-#include "stflpp.h"
 #include "strprintf.h"
 #include "utils.h"
 

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -4,6 +4,7 @@
 #include <libxml/uri.h>
 
 #include "fmtstrformatter.h"
+#include "logger.h"
 #include "rssfeed.h"
 #include "utils.h"
 

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -1,9 +1,5 @@
 #include "regexmanager.h"
 
-#include <cstring>
-#include <iostream>
-#include <stack>
-
 #include "config.h"
 #include "confighandlerexception.h"
 #include "configparser.h"

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -1,7 +1,6 @@
 #include "reloader.h"
 
 #include <algorithm>
-#include <cinttypes>
 #include <iostream>
 #include <ncurses.h>
 #include <thread>
@@ -11,6 +10,7 @@
 #include "dbexception.h"
 #include "feedretriever.h"
 #include "fmtstrformatter.h"
+#include "logger.h"
 #include "matcherexception.h"
 #include "reloadthread.h"
 #include "rss/exception.h"

--- a/src/remoteapi.cpp
+++ b/src/remoteapi.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <glob.h>
 #include <iostream>
+#include "logger.h"
 #include <unistd.h>
 
 #include "configcontainer.h"

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -1,15 +1,11 @@
 #include "rssfeed.h"
 
 #include <algorithm>
-#include <cerrno>
 #include <cinttypes>
 #include <cstring>
 #include <curl/curl.h>
-#include <functional>
-#include <iostream>
 #include <langinfo.h>
 #include <random>
-#include <sstream>
 #include <string.h>
 #include <sys/utsname.h>
 #include <time.h>
@@ -17,13 +13,9 @@
 #include "cache.h"
 #include "config.h"
 #include "configcontainer.h"
-#include "confighandlerexception.h"
-#include "dbexception.h"
-#include "htmlrenderer.h"
 #include "logger.h"
 #include "scopemeasure.h"
 #include "strprintf.h"
-#include "tagsouppullparser.h"
 #include "utils.h"
 
 namespace newsboat {

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -1,29 +1,17 @@
 #include "rssignores.h"
 
 #include <algorithm>
-#include <cerrno>
-#include <cstring>
 #include <curl/curl.h>
-#include <functional>
-#include <iostream>
 #include <langinfo.h>
-#include <sstream>
 #include <sys/utsname.h>
-#include <string.h>
-#include <time.h>
 
 #include "cache.h"
 #include "config.h"
-#include "configcontainer.h"
 #include "confighandlerexception.h"
 #include "configparser.h"
-#include "dbexception.h"
-#include "htmlrenderer.h"
 #include "logger.h"
-#include "rssfeed.h"
 #include "regexowner.h"
 #include "strprintf.h"
-#include "tagsouppullparser.h"
 #include "utils.h"
 
 namespace newsboat {

--- a/src/rssparser.cpp
+++ b/src/rssparser.cpp
@@ -1,24 +1,18 @@
 #include "rssparser.h"
 
 #include <algorithm>
-#include <cerrno>
 #include <cinttypes>
-#include <cstring>
 #include <curl/curl.h>
-#include <sstream>
 
 #include "cache.h"
-#include "config.h"
 #include "configcontainer.h"
 #include "curlhandle.h"
 #include "htmlrenderer.h"
 #include "logger.h"
-#include "rss/exception.h"
 #include "rss/parser.h"
 #include "rss/rssparser.h"
 #include "rssfeed.h"
 #include "rssignores.h"
-#include "strprintf.h"
 #include "utils.h"
 
 namespace newsboat {

--- a/src/searchresultslistformaction.cpp
+++ b/src/searchresultslistformaction.cpp
@@ -1,5 +1,7 @@
 #include "searchresultslistformaction.h"
+
 #include "keymap.h"
+#include "logger.h"
 
 namespace newsboat {
 SearchResultsListFormAction::SearchResultsListFormAction(View& vv,

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -2,13 +2,11 @@
 
 #include <algorithm>
 #include <cassert>
-#include <sstream>
 #include <string>
 
 #include "config.h"
 #include "controller.h"
 #include "fmtstrformatter.h"
-#include "listformatter.h"
 #include "stflrichtext.h"
 #include "strprintf.h"
 #include "utils.h"

--- a/src/tagsouppullparser.cpp
+++ b/src/tagsouppullparser.cpp
@@ -8,9 +8,7 @@
 #include <iostream>
 #include <istream>
 #include <sstream>
-#include <stdexcept>
 
-#include "config.h"
 #include "logger.h"
 #include "utils.h"
 

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -1,11 +1,10 @@
 #include "textformatter.h"
 
 #include <algorithm>
-#include <assert.h>
 #include <cinttypes>
-#include <limits.h>
 
 #include "htmlrenderer.h"
+#include "logger.h"
 #include "regexmanager.h"
 #include "stflpp.h"
 #include "stflrichtext.h"

--- a/src/ttrssapi.cpp
+++ b/src/ttrssapi.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cinttypes>
-#include <cstring>
 #include <thread>
 #include <time.h>
 

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -1,11 +1,9 @@
 #include "urlviewformaction.h"
 
-#include <sstream>
 #include <string>
 
 #include "config.h"
 #include "fmtstrformatter.h"
-#include "listformatter.h"
 #include "rssfeed.h"
 #include "stflrichtext.h"
 #include "strprintf.h"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,31 +1,23 @@
 #include "utils.h"
-#include <iostream>
 
-#include <algorithm>
 #include <cinttypes>
-#include <cmath>
-#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <curl/curl.h>
 #include <cwchar>
-#include <errno.h>
 #include <fcntl.h>
 #include <iconv.h>
 #include <langinfo.h>
 #include <libxml/uri.h>
-#include <locale>
 #include <mutex>
 #include <pwd.h>
-#include <regex>
 #include <sstream>
 #include <stfl.h>
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <unistd.h>
-#include <unordered_set>
 
 #if HAVE_GCRYPT
 #include <gnutls/gnutls.h>
@@ -47,7 +39,7 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 #include "config.h"
 #include "curldatareceiver.h"
 #include "curlhandle.h"
-#include "htmlrenderer.h"
+#include "links.h"
 #include "logger.h"
 #include "strprintf.h"
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1,13 +1,9 @@
 #include "view.h"
 
 #include <assert.h>
-#include <cerrno>
-#include <cstdio>
 #include <cstring>
 #include <dirent.h>
-#include <fstream>
 #include <grp.h>
-#include <iomanip>
 #include <iostream>
 #include <libgen.h>
 #include <limits.h>
@@ -16,7 +12,6 @@
 #include <string.h>
 #include <sys/param.h>
 #include <sys/types.h>
-#include <time.h>
 #include <unistd.h>
 
 extern "C" {
@@ -35,7 +30,6 @@ extern "C" {
 #include "dirbrowserformaction.h"
 #include "emptyformaction.h"
 #include "empty.h"
-#include "exception.h"
 #include "feedlist.h"
 #include "feedlistformaction.h"
 #include "filebrowser.h"
@@ -44,7 +38,6 @@ extern "C" {
 #include "formaction.h"
 #include "help.h"
 #include "helpformaction.h"
-#include "htmlrenderer.h"
 #include "itemlist.h"
 #include "itemlistformaction.h"
 #include "itemview.h"
@@ -53,8 +46,6 @@ extern "C" {
 #include "keymap.h"
 #include "logger.h"
 #include "matcherexception.h"
-#include "regexmanager.h"
-#include "reloadthread.h"
 #include "rssfeed.h"
 #include "selectformaction.h"
 #include "selecttag.h"

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -1,7 +1,5 @@
 #include "3rd-party/catch.hpp"
 
-#include <cstring>
-
 #include "cliargsparser.h"
 #include "test_helpers/envvar.h"
 #include "test_helpers/opts.h"

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -1,8 +1,9 @@
 #include "configcontainer.h"
 
+#include <unordered_set>
+
 #include "3rd-party/catch.hpp"
 
-#include "configdata.h"
 #include "confighandlerexception.h"
 #include "configparser.h"
 #include "keymap.h"

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -1,14 +1,12 @@
 #include "fileurlreader.h"
 
 #include <fstream>
-#include <map>
 #include <unistd.h>
 
 #include "3rd-party/catch.hpp"
 #include "test_helpers/chmod.h"
 #include "test_helpers/misc.h"
 #include "test_helpers/tempfile.h"
-#include "utils.h"
 
 using namespace newsboat;
 

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -1,6 +1,5 @@
 #include "htmlrenderer.h"
 
-#include <fstream>
 #include <sstream>
 
 #include "3rd-party/catch.hpp"

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -8,7 +8,6 @@
 #include "cache.h"
 #include "configpaths.h"
 #include "controller.h"
-#include "feedlistformaction.h"
 #include "itemlist.h"
 #include "keymap.h"
 #include "regexmanager.h"

--- a/test/listwidget.cpp
+++ b/test/listwidget.cpp
@@ -2,7 +2,6 @@
 
 #include "stflpp.h"
 #include "stflrichtext.h"
-#include "utils.h"
 
 #include "3rd-party/catch.hpp"
 #include <cstdint>

--- a/test/opmlurlreader.cpp
+++ b/test/opmlurlreader.cpp
@@ -1,12 +1,9 @@
 #include "opmlurlreader.h"
 
-#include <fstream>
 #include <map>
 #include <unistd.h>
 
 #include "3rd-party/catch.hpp"
-#include "test_helpers/misc.h"
-#include "test_helpers/tempfile.h"
 #include "utils.h"
 
 using namespace newsboat;

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -1,7 +1,5 @@
 #include "queueloader.h"
 
-#include <fstream>
-
 #include "3rd-party/catch.hpp"
 #include "test_helpers/chmod.h"
 #include "test_helpers/misc.h"

--- a/test/queuemanager.cpp
+++ b/test/queuemanager.cpp
@@ -10,7 +10,6 @@
 #include "configcontainer.h"
 #include "rssfeed.h"
 #include "rssitem.h"
-#include "utils.h"
 
 using namespace newsboat;
 

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -4,7 +4,6 @@
 
 #include "confighandlerexception.h"
 #include "matchable.h"
-#include "matcherexception.h"
 #include "stflrichtext.h"
 
 using namespace newsboat;

--- a/test/regexowner.cpp
+++ b/test/regexowner.cpp
@@ -1,7 +1,6 @@
 #include "regexowner.h"
 
 #include <regex.h>
-#include <utility>
 
 #include "3rd-party/catch.hpp"
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,8 +1,6 @@
 #define CATCH_CONFIG_RUNNER
 #include "3rd-party/catch.hpp"
 
-#include "logger.h"
-
 int main(int argc, char* argv[])
 {
 	setlocale(LC_CTYPE, "");

--- a/test/test_helpers/envvar.cpp
+++ b/test/test_helpers/envvar.cpp
@@ -1,5 +1,7 @@
 #include "envvar.h"
 
+#include <stdexcept>
+
 #include "3rd-party/catch.hpp"
 
 test_helpers::EnvVar::EnvVar(std::string name_)

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1,20 +1,17 @@
 #include "utils.h"
 
-#include <algorithm>
 #include <chrono>
 #include <condition_variable>
-#include <ctype.h>
 #include <fstream>
 #include <memory>
 #include <mutex>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <thread>
-#include <tuple>
 #include <unistd.h>
 
 #include "3rd-party/catch.hpp"
-#include "htmlrenderer.h"
+#include "links.h"
 #include "test_helpers/chdir.h"
 #include "test_helpers/envvar.h"
 #include "test_helpers/stringmaker/optional.h"


### PR DESCRIPTION
From a quick (imperfect) check, it looks like this saves a few seconds on the build time.
Checked by forcing a rebuild of most of the cpp files (`make PROFILE=1 -j8 newsboat && rm rss/*.o src/*.o && time make PROFILE=1 newsboat`)

Before:
```
real    1m38.396s
user    1m32.640s
sys     0m5.426s
```
After:
```
real    1m32.995s
user    1m27.213s
sys     0m5.407s
```

I only ran it once, so don't read too much into these numbers.

---

I had to ignore a few of the plugin's highlights:
- `include "utils.h"`: In a few files, we only use Rust FFI methods so we would only need to include `utils.rs.h` instead of `utils.h`. However, I think it is nice to only specify the `libnewsboat-ffi/src/utils.rs.h` path once.
- `include <cstring>`: This include is necessary for `strcasestr()`. Somehow the plugin does not realize this.
- I believe I saw a false-positive with usage of the `MatcherException`, but can't remember which file this was happening in.