### PR TITLE
Fix clippy warnings

### DIFF
--- a/rust/libnewsboat-ffi/src/charencoding.rs
+++ b/rust/libnewsboat-ffi/src/charencoding.rs
@@ -8,6 +8,9 @@ mod bridged {
     }
 }
 
+// Temporarily ignore clippy lint until PR is merged:
+// https://github.com/rust-lang/rust-clippy/pull/12756
+#[allow(clippy::assigning_clones)]
 fn charset_from_bom(content: &[u8], output: &mut String) -> bool {
     match charencoding::charset_from_bom(content) {
         Some(charset) => {
@@ -18,6 +21,9 @@ fn charset_from_bom(content: &[u8], output: &mut String) -> bool {
     }
 }
 
+// Temporarily ignore clippy lint until PR is merged:
+// https://github.com/rust-lang/rust-clippy/pull/12756
+#[allow(clippy::assigning_clones)]
 fn charset_from_xml_declaration(content: &[u8], output: &mut String) -> bool {
     match charencoding::charset_from_xml_declaration(content) {
         Some(charset) => {

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -157,6 +157,9 @@ fn read_text_file(
     }
 }
 
+// Temporarily ignore clippy lint until PR is merged:
+// https://github.com/rust-lang/rust-clippy/pull/12756
+#[allow(clippy::assigning_clones)]
 fn extract_token_quoted(line: &mut String, delimiters: &str, token: &mut String) -> bool {
     let (token_opt, remainder) = utils::extract_token_quoted(line, delimiters);
     *line = remainder.to_owned();

--- a/rust/libnewsboat/src/configpaths.rs
+++ b/rust/libnewsboat/src/configpaths.rs
@@ -252,7 +252,7 @@ impl ConfigPaths {
     fn find_dirs(&mut self) {
         self.config_dir = self.env_home.join(NEWSBOAT_CONFIG_SUBDIR);
 
-        self.data_dir = self.config_dir.clone();
+        self.data_dir.clone_from(&self.config_dir);
 
         // Will change config_dir and data_dir to point to XDG if XDG
         // directories are available.
@@ -308,31 +308,31 @@ impl ConfigPaths {
     /// Initializes paths to config, cache etc. from CLI arguments.
     pub fn process_args(&mut self, args: &CliArgsParser) {
         if let Some(ref url_file) = args.url_file {
-            self.url_file = url_file.to_owned();
+            self.url_file.clone_from(url_file);
         }
 
         if let Some(ref cache_file) = args.cache_file {
-            self.cache_file = cache_file.to_owned();
+            self.cache_file.clone_from(cache_file);
         }
 
         if let Some(ref lock_file) = args.lock_file {
-            self.lock_file = lock_file.to_owned();
+            self.lock_file.clone_from(lock_file);
         }
 
         if let Some(ref config_file) = args.config_file {
-            self.config_file = config_file.to_owned();
+            self.config_file.clone_from(config_file);
         }
 
         if let Some(ref queue_file) = args.queue_file {
-            self.queue_file = queue_file.to_owned();
+            self.queue_file.clone_from(queue_file);
         }
 
         if let Some(ref search_history_file) = args.search_history_file {
-            self.search_history_file = search_history_file.to_owned();
+            self.search_history_file.clone_from(search_history_file);
         }
 
         if let Some(ref cmdline_history_file) = args.cmdline_history_file {
-            self.cmdline_history_file = cmdline_history_file.to_owned();
+            self.cmdline_history_file.clone_from(cmdline_history_file);
         }
 
         self.silent = args.silent;
@@ -365,7 +365,7 @@ impl ConfigPaths {
     // midway. That logic should be moved into ConfigPaths, and this method
     // removed.
     pub fn set_cache_file(&mut self, mut path: PathBuf) {
-        self.cache_file = path.clone();
+        path.clone_into(&mut self.cache_file);
         self.lock_file = {
             let current_extension = path
                 .extension()

--- a/rust/libnewsboat/src/fslock.rs
+++ b/rust/libnewsboat/src/fslock.rs
@@ -32,6 +32,9 @@ impl Drop for FsLock {
     }
 }
 
+// Temporarily ignore clippy lint until PR is merged:
+// https://github.com/rust-lang/rust-clippy/pull/12756
+#[allow(clippy::assigning_clones)]
 impl FsLock {
     pub fn try_lock(&mut self, new_lock_path: &Path, pid: &mut libc::pid_t) -> Result<(), String> {
         if self.lock_file.is_some() && self.lock_path == new_lock_path {


### PR DESCRIPTION
There seem to be some issues with the `assigning_clones` Clippy lint.
I plan to remove the `#[allow(clippy::assigning_clones)]` attributes when the related issues in Clippy are resolved.