### PR TITLE
Copy all contrib files/directories recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ CLANG_TIDY?=clang-tidy
 
 TEXTCONV=./txt2h
 RM=rm -f
+CP=cp -f
 
 all: doc $(NEWSBOAT) $(PODBOAT) mo-files
 
@@ -350,22 +351,9 @@ install-docs: doc
 	$(MKDIR) $(DESTDIR)$(docdir)
 	$(INSTALL) -m 644 doc/xhtml/* $(DESTDIR)$(docdir)
 	$(INSTALL) -m 644 CHANGELOG.md $(DESTDIR)$(docdir)
-	$(MKDIR) $(DESTDIR)$(docdir)/contrib
-	$(INSTALL) -m 644 contrib/README.md $(DESTDIR)$(docdir)/contrib
-	$(INSTALL) -m 755 contrib/*.sh $(DESTDIR)$(docdir)/contrib
-	$(INSTALL) -m 755 contrib/*.rb $(DESTDIR)$(docdir)/contrib
-	$(INSTALL) -m 755 contrib/*.pl $(DESTDIR)$(docdir)/contrib
-	$(INSTALL) -m 755 contrib/*.py $(DESTDIR)$(docdir)/contrib
-	$(MKDIR) $(DESTDIR)$(docdir)/contrib/colorschemes
-	$(INSTALL) -m 644 contrib/colorschemes/* $(DESTDIR)$(docdir)/contrib/colorschemes
-	$(MKDIR) $(DESTDIR)$(docdir)/contrib/getpocket.com
-	$(INSTALL) -m 755 contrib/getpocket.com/*.sh $(DESTDIR)$(docdir)/contrib/getpocket.com
-	$(INSTALL) -m 644 contrib/getpocket.com/*.md $(DESTDIR)$(docdir)/contrib/getpocket.com
-	$(MKDIR) $(DESTDIR)$(docdir)/contrib/image-preview
-	$(INSTALL) -m 755 contrib/image-preview/vifmimg $(DESTDIR)$(docdir)/contrib/image-preview
-	$(INSTALL) -m 755 contrib/image-preview/nbrun $(DESTDIR)$(docdir)/contrib/image-preview
-	$(INSTALL) -m 755 contrib/image-preview/nbparser $(DESTDIR)$(docdir)/contrib/image-preview
-	$(INSTALL) -m 644 contrib/image-preview/README.org $(DESTDIR)$(docdir)/contrib/image-preview
+	find contrib/ -type d -print0 | xargs -0 -I@ mkdir -p $(DESTDIR)$(docdir)/@
+	find contrib/ -type f -perm /0111 -print0 | xargs -0 -I@ install -m 755 @ $(DESTDIR)$(docdir)/@
+	find contrib/ -type f ! -perm /0111 -print0 | xargs -0 -I@ install -m 644 @ $(DESTDIR)$(docdir)/@
 	$(MKDIR) $(DESTDIR)$(mandir)/man1
 	$(INSTALL) -m 644 doc/$(NEWSBOAT).1 $(DESTDIR)$(mandir)/man1
 	$(INSTALL) -m 644 doc/$(PODBOAT).1 $(DESTDIR)$(mandir)/man1


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/2724

Given that Git already checks out directories with 755 permissions and files with 644 permissions(or 755 for executable scripts), a simple copy should be enough.