### PR TITLE
Allow returning focus to empty list

### DIFF
--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -41,12 +41,18 @@ void ListFormatter::set_line(const unsigned int itempos,
 std::string ListFormatter::format_list() const
 {
 	std::string format_cache = "{list";
-	for (auto str : lines) {
-		if (rxman) {
-			rxman->quote_and_highlight(str, location);
+	if (lines.empty()) {
+		// Stfl does not allow changing the focus to an empty list.
+		// Add an empty item to work around this.
+		format_cache.append("{listitem text:''}");
+	} else {
+		for (auto str : lines) {
+			if (rxman) {
+				rxman->quote_and_highlight(str, location);
+			}
+			format_cache.append(strprintf::fmt(
+					"{listitem text:%s}", Stfl::quote(str.stfl_quoted())));
 		}
-		format_cache.append(strprintf::fmt(
-				"{listitem text:%s}", Stfl::quote(str.stfl_quoted())));
 	}
 	format_cache.push_back('}');
 	return format_cache;


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2763

Stfl does not allow changing the focus to an empty list.
This has the unfortunate effect that changing from a text edit (like our command line) to the feedlist does not work (if all feeds are filtered out).
Instead, in that case, all keypresses end up in the (by that time) invisible command line.

This PR fixes the issue (workaround) by adding an empty item to the list.
This does create a visible change (the top row of the list will have the background color set to be the same as a focussed item)
However, I think that is not too bad and think it is better than the alternative of allowing freezes:
![image](https://github.com/newsboat/newsboat/assets/4629607/f0dfe0f1-6c1c-4d5c-bfd5-3cd34fe7bb8e)

Some alternatives with reasons why I think they are worse:
- Fix/improve STFL: It will take a long time for all distributions to take in an updated version (if ever). In addition, we want to move away from it altogether anyway.
- Hide list if it is empty: Breaks layout, making the status line move towards the top of the screen
- Add temporary item to list, switch foucs, then remove empty item again: Seems complex and error prone (given our current setup)
