### PR TITLE
Use cURL to validate URLs

### DIFF
--- a/src/feedretriever.cpp
+++ b/src/feedretriever.cpp
@@ -1,6 +1,7 @@
 #include "feedretriever.h"
 
 #include <cinttypes>
+#include <curl/curl.h>
 
 #include "cache.h"
 #include "config.h"
@@ -64,7 +65,7 @@ rsspp::Feed FeedRetriever::retrieve(const std::string& uri)
 		}
 	} else if (urls_source == "freshrss") {
 		return fetch_freshrss(uri);
-	} else if (utils::is_http_url(uri)) {
+        } else if (CURLUE_OK == curl_url_set(curl_url(), CURLUPART_URL, uri.c_str(), 0)){
 		return download_http(uri);
 	} else if (utils::is_exec_url(uri)) {
 		return get_execplugin(uri.substr(5, uri.length() - 5));


### PR DESCRIPTION
I expect there may be several other steps to get this merged in, but at least from a very rudimentary approach -- this works.

Feeds can exist *anywere*, not just over http(s), and since [curl_url_set()](https://curl.se/libcurl/c/curl_url_set.html) already provides the functionality to parse URLs, and we're using cURL to download the feed in the first place, why not allow cURL to tell us what is/isn't a valid URL?

In my particular case, I'm one of those weirdos who still uses the [gopher protocol](https://en.wikipedia.org/wiki/Gopher_(protocol)
 and I have my own feed over at gopher://circumlunar.space/0/~wangofett/feed.xml - you can pretty easily check it out -- `curl gopher://circumlunar.space/0/~wangofett/feed.xml`

Anyway, this patch at least works with all of *my* feeds - both http(s) and gopher, and I did run `TMPDIR=/dev/shm make -j5 PROFILE=1 check` and `echo $?` was 0.

It's *probably* accurate that some code could be removed as part of this, but I wasn't exactly sure what. I wanted to drop this in the utils where `is_http_url` check was moved (I had originally hacked on this from the 2.10.1 version on the AUR), but at least from what I could find, the `curl_sys` rust library doesn't have `curl_url_set` exposed -- there may be a better way to implement this change.

All I know is that it works for me, and I'll be using this patch in my own installs!

If there's anything basic that I can/should do for this, let me know :+1:
