### PR TITLE
Don't retry feed retrieval on HTTP 304 (Not Modified)

### DIFF
--- a/rss/exception.h
+++ b/rss/exception.h
@@ -16,6 +16,9 @@ private:
 	std::string emsg;
 };
 
+class NotModifiedException : public std::exception {
+};
+
 } // namespace rsspp
 
 #endif /* NEWSBOAT_RSSPPEXCEPTION_H_ */

--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -220,6 +220,9 @@ Feed Parser::parse_url(const std::string& url,
 		}
 		throw Exception(msg);
 	}
+	if (infoOk == CURLE_OK && status == 304) {
+		throw NotModifiedException();
+	}
 
 	const std::string buf = curlDataReceiver->get_data();
 	LOG(Level::DEBUG,

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -134,11 +134,14 @@ void Reloader::reload(unsigned int pos,
 					_("Error while retrieving %s: %s"),
 					utils::censor_url(oldfeed->rssurl()),
 					emsg);
-		} catch (rsspp::Exception& e) {
+		} catch (const rsspp::Exception& e) {
 			errmsg = strprintf::fmt(
 					_("Error while retrieving %s: %s"),
 					utils::censor_url(oldfeed->rssurl()),
 					e.what());
+		} catch (const rsspp::NotModifiedException&) {
+			// Nothing to be done, feed was not chaned since last retrieve
+			oldfeed->set_status(DlStatus::SUCCESS);
 		}
 		if (!errmsg.empty()) {
 			oldfeed->set_status(DlStatus::DL_ERROR);

--- a/test/feedretriever.cpp
+++ b/test/feedretriever.cpp
@@ -55,9 +55,8 @@ TEST_CASE("Feed retriever adds header with etag info if available", "[FeedRetrie
 		{"content-type", "text/xml"},
 	}, {});
 
-	const auto feed = feedRetriever.retrieve(url);
+	REQUIRE_THROWS_AS(feedRetriever.retrieve(url), rsspp::NotModifiedException);
 	REQUIRE(testServer.num_hits(mockRegistration) == 1);
-	REQUIRE(feed.items.size() == 0);
 }
 
 TEST_CASE("Feed retriever does not retry download on HTTP 304 (Not Modified)",
@@ -84,13 +83,8 @@ TEST_CASE("Feed retriever does not retry download on HTTP 304 (Not Modified)",
 
 	cfg.set_configvalue("download-retries", "5");
 
-	const auto feed = feedRetriever.retrieve(url);
-	// TODO: Fix behavior and update this test.
-	// There should only be 1 request.
-	// Added an assertion for the wrong amount to make sure we update this test when fixing the behavior.
-	// See https://github.com/newsboat/newsboat/issues/2732
-	REQUIRE(testServer.num_hits(mockRegistration) == 5);
-	//REQUIRE(testServer.num_Hits(mockRegistration) == 1);
+	REQUIRE_THROWS_AS(feedRetriever.retrieve(url), rsspp::NotModifiedException);
+	REQUIRE(testServer.num_hits(mockRegistration) == 1);
 }
 
 TEST_CASE("Feed retriever throws on HTTP error status codes", "[FeedRetriever]")


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2732