### PR TITLE
Remove pointless(?) lock guard

### DIFF
--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -346,10 +346,7 @@ ConfigContainer::ConfigContainer()
 {
 }
 
-ConfigContainer::~ConfigContainer()
-{
-	std::lock_guard<std::recursive_mutex> guard(config_data_mtx);
-}
+ConfigContainer::~ConfigContainer() = default;
 
 void ConfigContainer::register_commands(ConfigParser& cfgparser)
 {


### PR DESCRIPTION
I was grepping the codebase for `recursive_mutex` after seeing the stack traces on #2783. (No idea if this has anything to do with that bug.)

However, this guard seems unnecessary to me. From [this stackoverflow answer](https://stackoverflow.com/questions/55942966/is-it-safe-to-hold-a-stdlock-guard-in-the-destructor/55943065#55943065) I would understand that the guard only holds for the destructor's body, which is empty in this case.

Does this guard have a reason? Is it fine to remove, or could the reason be explained in a comment, or am I missing something obvious?