### PR TITLE
Readeck bookmark scripts

### DIFF
--- a/contrib/readeck/README.md
+++ b/contrib/readeck/README.md
@@ -1,0 +1,36 @@
+# Intention
+These scripts will allow you to create bookmarks for the [Readeck](https://readeck.org/en/) bookmark manager.
+
+# Requirements
+- [Babashka](https://github.com/babashka/babashka#installation)
+  These are clojure programs and using babashka to run them instead of JVM Clojure means that you get much faster startup times.
+
+# Usage
+Edit the script that you want with your installation to fill in:
+
+1) Your readeck address: If you're hosting it on your local machine it might be "http://localhost:8000"
+   Alternatively, if you're using a custom domain, it would be that (with no port number).
+
+2) Your API token: You can create an API token at <your-readeck-address>/profile/tokens
+   Whatever token you generate will need to have the **Bookmarks: Write Only** permission
+
+3) Default-tags: Both scripts give you the option of adding default tags.
+   In the case of the standard-readeck.clj the default tags will **always** be added
+   In the case of the interactive-labels-readeck.clj they will only be added if no alternative tags are supplied when prompted.
+
+To accept the default title and url suggestions when creating a bookmark, you can add
+`bookmark-autopilot yes` to your config file.
+
+
+## Standard Script
+If you'd like to save bookmarks without adding labels (ie tags) to them, then
+you would set
+`bookmark-cmd` `standard-readeck.clj` in your newsdeck config file
+
+
+## Interactive Script (with labels)
+If you'd like to add labels when you add bookmarks, then you would set
+`bookmark-cmd` to be `interactive-labels-readeck.clj` in your newsdeck config file.
+
+Now, calling the bookmark command will allow you to add a comma separated list of labels
+that are submitted with the <Return> key.

--- a/contrib/readeck/interactive-labels-readeck.clj
+++ b/contrib/readeck/interactive-labels-readeck.clj
@@ -1,0 +1,40 @@
+#!/usr/bin/env bb
+
+(ns readeck-bookmark-interactive
+  (:require [cheshire.core :as json]
+            [babashka.curl :as curl]
+            [babashka.tasks :as tasks]
+            [clojure.string :as s]))
+
+;; User Configuration
+
+(def my-readeck-address "<your-address-here>")
+(def my-token "<your-token-here>")
+
+;; Optionally you can set the default label(s) to be a vector such as
+;; ["label-1" "label-2"]
+;; Leaving it as an empty vector adds no labels on bookmark creation
+(def default-labels [])
+
+;; End User Configuration
+
+
+(def readeck-endpoint (str my-readeck-address "/api/bookmarks"))
+
+(def auth-headers {"Accept" "application/json"
+                   "Authorization" (str "Bearer " my-token)
+                   "content-type" "application/json"})
+
+(defn add-bookmark [endpoint headers]
+  (tasks/shell "clear")
+  (println "Add a comma separated list of labels")
+  (let [[url title desc] *command-line-args*
+        read-labels (read-line)
+        labels (s/split read-labels #",")
+        body {"labels" (if (seq read-labels) labels default-labels)
+              "title" title
+              "url" url}]
+    (curl/post endpoint {:headers headers
+                         :body (json/generate-string body)})))
+
+(add-bookmark readeck-endpoint auth-headers)

--- a/contrib/readeck/interactive-labels-readeck.clj
+++ b/contrib/readeck/interactive-labels-readeck.clj
@@ -1,6 +1,6 @@
 #!/usr/bin/env bb
 
-(ns readeck-bookmark-interactive
+(ns interactive-labels-readeck
   (:require [cheshire.core :as json]
             [babashka.curl :as curl]
             [babashka.tasks :as tasks]

--- a/contrib/readeck/standard-readeck.clj
+++ b/contrib/readeck/standard-readeck.clj
@@ -1,0 +1,38 @@
+#!/usr/bin/env bb
+
+(ns readeck-bookmark-interactive
+  (:require [cheshire.core :as json]
+            [babashka.curl :as curl]
+            [babashka.tasks :as tasks]
+            [clojure.string :as s]))
+
+;; User Configuration
+
+(def my-readeck-address "<your-address-here>")
+(def my-token "<your-token-here>")
+
+;; Optionally you can set the default label(s) to be a vector such as
+;; ["label-1" "label-2"]
+;; Leaving it as an empty vector adds no labels on bookmark creation
+(def default-labels [])
+
+;; End User Configuration
+
+
+(def readeck-endpoint (str my-readeck-address "/api/bookmarks"))
+
+(def auth-headers {"Accept" "application/json"
+                   "Authorization" (str "Bearer " my-token)
+                   "content-type" "application/json"})
+
+(defn add-bookmark [endpoint headers]
+  (let [[url title desc] *command-line-args*
+        body {"title" title
+              "url" url}
+        body-with-labels (if (seq default-labels)
+                           (conj body {"labels" default-labels})
+                           body)]
+    (curl/post endpoint {:headers headers
+                         :body (json/generate-string body-with-labels)})))
+
+(add-bookmark readeck-endpoint auth-headers)

--- a/contrib/readeck/standard-readeck.clj
+++ b/contrib/readeck/standard-readeck.clj
@@ -1,6 +1,6 @@
 #!/usr/bin/env bb
 
-(ns readeck-bookmark-interactive
+(ns standard-readeck
   (:require [cheshire.core :as json]
             [babashka.curl :as curl]
             [babashka.tasks :as tasks]


### PR DESCRIPTION
Hi,
This adds two scripts to allow bookmarking to your [Readeck](https://readeck.org) installation.

They are Clojure scripts which need the added dependency of [Babashka](https://github.com/babashka/babashka#installation) to run, but using babashka allows for much faster startup times and memory usage than would be possible with JVM Clojure.

See the readme for more details :) 