### PR TITLE
Add support for two-key bindings

### DIFF
--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -121,8 +121,9 @@ configuration.
 
 === Key Bindings
 
-You can bind a key to an operation with the <<bind-key,`bind-key`>> configuration command.
-You can specify an optional dialog. This is the context in which the key binding is active.
+You can bind a single key or a two key combination to an operation with the
+<<bind-key,`bind-key`>> configuration command. You can specify an optional dialog.
+This is the context in which the key binding is active.
 
 The syntax for a key binding looks like this:
 
@@ -151,6 +152,9 @@ The following identifiers for special keys are supported:
 - `ESC` (Esc key)
 - `TAB` (Tab key)
 - `F1` to `F12` (F1 key to F12 key)
+
+Keep in mind that two key combinations are only supported for keys that can be represented
+with a single character like letters and numbers.
 
 *Operation*
 

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -192,13 +192,17 @@ TEST_CASE("handle_action()", "[KeyMap]")
 	SECTION("with one parameter") {
 		REQUIRE_THROWS_AS(k.handle_action("bind-key", "r"),
 			ConfigHandlerException);
+		REQUIRE_THROWS_AS(k.handle_action("bind-key", "rr"),
+			ConfigHandlerException);
 		REQUIRE_NOTHROW(k.handle_action("unbind-key", "r"));
+		REQUIRE_NOTHROW(k.handle_action("unbind-key", "rr"));
 		REQUIRE_THROWS_AS(k.handle_action("macro", "r"),
 			ConfigHandlerException);
 	}
 
 	SECTION("with two parameters") {
 		REQUIRE_NOTHROW(k.handle_action("bind-key", "r open"));
+		REQUIRE_NOTHROW(k.handle_action("bind-key", "rr open"));
 		REQUIRE_THROWS_AS(k.handle_action("an-invalid-action", "r open"),
 			ConfigHandlerException);
 	}


### PR DESCRIPTION
Allows for more vim-like bindings, e.g.,
```
bind-key ZZ hard-quit
bind-key gg home
```