### PR TITLE
Make it possible to apply FilePath changes incrementally

### DIFF
--- a/include/filepath.h
+++ b/include/filepath.h
@@ -36,21 +36,21 @@ public:
 	{
 	}
 
-	Filepath(rust::Box<filepath::bridged::PathBuf>&& rs_object)
-		: rs_object(std::move(rs_object))
-	{
-	}
-
 	operator std::string() const
 	{
 		return to_locale_string();
+	}
+#endif
+
+	Filepath(rust::Box<filepath::bridged::PathBuf>&& rs_object)
+		: rs_object(std::move(rs_object))
+	{
 	}
 
 	operator const filepath::bridged::PathBuf& () const
 	{
 		return *rs_object;
 	}
-#endif
 
 	/// Constructs an empty path.
 	Filepath();

--- a/include/filepath.h
+++ b/include/filepath.h
@@ -4,14 +4,8 @@
 #include "libnewsboat-ffi/src/filepath.rs.h"
 #include "3rd-party/optional.hpp"
 
-#include <cstdint>
 #include <ostream>
 #include <string>
-
-#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
-#ifdef ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
-
-#endif
 
 namespace newsboat {
 

--- a/include/fileurlreader.h
+++ b/include/fileurlreader.h
@@ -9,7 +9,7 @@ namespace newsboat {
 
 class FileUrlReader : public UrlReader {
 public:
-	explicit FileUrlReader(const Filepath& file = "");
+	explicit FileUrlReader(const Filepath& file = {});
 
 	/// \brief Load URLs from the urls file.
 	///

--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include <algorithm>
 #include <cstddef>
 #include <iostream>

--- a/src/cliargsparser.cpp
+++ b/src/cliargsparser.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "cliargsparser.h"
 
 namespace newsboat {

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "configcontainer.h"
 
 #include <algorithm>

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "configparser.h"
 
 #include <algorithm>

--- a/src/configpaths.cpp
+++ b/src/configpaths.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "configpaths.h"
 
 namespace newsboat {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "controller.h"
 
 #include <cassert>

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "dirbrowserformaction.h"
 
 #include <algorithm>

--- a/src/feedbinurlreader.cpp
+++ b/src/feedbinurlreader.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "feedbinurlreader.h"
 
 #include <cinttypes>

--- a/src/feedretriever.cpp
+++ b/src/feedretriever.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "feedretriever.h"
 
 #include <cinttypes>

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "filebrowserformaction.h"
 
 #include <algorithm>

--- a/src/filepath.cpp
+++ b/src/filepath.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "filepath.h"
 
 namespace newsboat {

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "fileurlreader.h"
 
 #include <cstring>

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "formaction.h"
 
 #include <cassert>

--- a/src/fslock.cpp
+++ b/src/fslock.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "fslock.h"
 
 #include <fcntl.h>

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "history.h"
 
 namespace newsboat {

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include <itemlistformaction.h>
 
 #include <cinttypes>

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "itemviewformaction.h"
 
 #include <algorithm>

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "pbcontroller.h"
 
 #include <cstdlib>

--- a/src/poddlthread.cpp
+++ b/src/poddlthread.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "poddlthread.h"
 
 #include <cstring>

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "queueloader.h"
 
 #include <cerrno>

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "queuemanager.h"
 
 #include <fstream>

--- a/src/remoteapi.cpp
+++ b/src/remoteapi.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "remoteapi.h"
 
 #include <fstream>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "utils.h"
 
 #include <cinttypes>

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "view.h"
 
 #include <assert.h>

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "cache.h"
 
 #include <memory>

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 // This has to be included before Catch2 in order to provide the comparison
 // operator
 #include "filepath.h"

--- a/test/colormanager.cpp
+++ b/test/colormanager.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "colormanager.h"
 
 #include <string>

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "configcontainer.h"
 
 #include <unordered_set>

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "configparser.h"
 
 #include <fstream>

--- a/test/configpaths.cpp
+++ b/test/configpaths.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "configpaths.h"
 
 #include <fstream>

--- a/test/controller.cpp
+++ b/test/controller.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "controller.h"
 
 #include <string>

--- a/test/download.cpp
+++ b/test/download.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "download.h"
 
 #include <set>

--- a/test/feedcontainer.cpp
+++ b/test/feedcontainer.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "3rd-party/catch.hpp"
 
 #include <memory>

--- a/test/feedretriever.cpp
+++ b/test/feedretriever.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "feedretriever.h"
 
 #include "3rd-party/catch.hpp"

--- a/test/filepath.cpp
+++ b/test/filepath.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "3rd-party/catch.hpp"
 
 #include "filepath.h"

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "fileurlreader.h"
 
 #include <fstream>

--- a/test/fslock.cpp
+++ b/test/fslock.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "fslock.h"
 
 #include <fcntl.h>

--- a/test/history.cpp
+++ b/test/history.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "history.h"
 
 #include <unistd.h>

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "itemlistformaction.h"
 
 #include <fstream>

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "itemrenderer.h"
 
 #include "3rd-party/catch.hpp"

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "opml.h"
 
 #include <libxml/xmlsave.h>

--- a/test/opmlurlreader.cpp
+++ b/test/opmlurlreader.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "opmlurlreader.h"
 
 #include <map>

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "queueloader.h"
 
 #include "3rd-party/catch.hpp"

--- a/test/queuemanager.cpp
+++ b/test/queuemanager.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "queuemanager.h"
 
 #include "3rd-party/catch.hpp"

--- a/test/remoteapi.cpp
+++ b/test/remoteapi.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "remoteapi.h"
 
 #include <memory>

--- a/test/rssfeed.cpp
+++ b/test/rssfeed.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "rssfeed.h"
 
 #include "3rd-party/catch.hpp"

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "rssignores.h"
 
 #include <set>

--- a/test/rssitem.cpp
+++ b/test/rssitem.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "rssitem.h"
 
 #include <unistd.h>

--- a/test/rssparser.cpp
+++ b/test/rssparser.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "rssparser.h"
 
 #include "3rd-party/catch.hpp"

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "rss/parser.h"
 
 #include "3rd-party/catch.hpp"

--- a/test/scopemeasure.cpp
+++ b/test/scopemeasure.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "scopemeasure.h"
 
 #include "3rd-party/catch.hpp"

--- a/test/test_helpers/loggerresetter.cpp
+++ b/test/test_helpers/loggerresetter.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "loggerresetter.h"
 
 #include "logger.h"

--- a/test/test_helpers/misc.cpp
+++ b/test/test_helpers/misc.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "misc.h"
 
 #include <fstream>

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "utils.h"
 
 #include <chrono>

--- a/test/view.cpp
+++ b/test/view.cpp
@@ -1,3 +1,5 @@
+#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
+
 #include "view.h"
 
 #include <string>


### PR DESCRIPTION
Related to https://github.com/newsboat/newsboat/issues/2326

After these changes, fixing up a compilation unit is as simple as:
1. Remove `#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS` from a cpp file
2. Fix compilation errors