### PR TITLE
CI: bump Coveralls action

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -73,7 +73,7 @@ jobs:
         run: GCOV=$(pwd)/gcov grcov . --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
 
       - name: Submit coverage to Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov


### PR DESCRIPTION
When I first added the Coveralls workflow (in
3176869088e6451f853e2b826f88958afa07f972), I copied instructions from the then-current README:
https://github.com/coverallsapp/github-action/tree/8cbef1dea373ebce56de0a14c68d6267baa10b44 That README suggested the use of `coverallsapp/github-action@master`, i.e. the "master" branch.

Sometime in 2023, Coveralls changed their default branch to "main" and stopped updating "master". I haven't found any mention of this in their README and GitHub Releases; they don't keep a changelog.

As time went by, GitHub Actions deprecated Node 16, so Coveralls action from "master" started throwing warnings.

This if easily fixed on our end by using the tagged version of the action.