### PR TITLE
Test handling of character encodings specified in xml encoding attribute and http header

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -55,6 +55,9 @@ std::string utf8_to_locale(const std::string& text);
 /// nl_langinfo(CODESET)) to UTF-8.
 std::string locale_to_utf8(const std::string& text);
 
+std::string convert_text(const std::string& text, const std::string& tocode,
+	const std::string& fromcode);
+
 std::string get_command_output(const std::string& cmd);
 std::string http_method_str(const HTTPMethod method);
 std::string link_type_str(LinkType type);

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -88,6 +88,7 @@ mod bridged {
         fn translit(tocode: &str, fromcode: &str) -> String;
         fn utf8_to_locale(text: &str) -> Vec<u8>;
         fn locale_to_utf8(text: &[u8]) -> String;
+        fn convert_text(text: &[u8], tocode: &str, fromcode: &str) -> Vec<u8>;
     }
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -40,6 +40,7 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 #include "curldatareceiver.h"
 #include "curlhandle.h"
 #include "links.h"
+#include "libnewsboat-ffi/src/utils.rs.h"
 #include "logger.h"
 #include "strprintf.h"
 
@@ -182,6 +183,19 @@ std::string utils::locale_to_utf8(const std::string& text)
 			reinterpret_cast<const unsigned char*>(text.c_str()),
 			text.length());
 	return std::string(utils::bridged::locale_to_utf8(text_slice));
+}
+
+std::string utils::convert_text(const std::string& text, const std::string& tocode,
+	const std::string& fromcode)
+{
+	const auto text_slice =
+		rust::Slice<const unsigned char>(
+			reinterpret_cast<const unsigned char*>(text.c_str()),
+			text.length());
+
+	const auto result = utils::bridged::convert_text(text_slice, tocode, fromcode);
+
+	return std::string(reinterpret_cast<const char*>(result.data()), result.size());
 }
 
 std::string utils::get_command_output(const std::string& cmd)

--- a/test/feedretriever.cpp
+++ b/test/feedretriever.cpp
@@ -7,7 +7,7 @@
 #include "rss/exception.h"
 #include "rssfeed.h"
 #include "strprintf.h"
-#include "test/test_helpers/httptestserver.h"
+#include "test_helpers/httptestserver.h"
 #include "test_helpers/misc.h"
 #include <cstdint>
 #include <vector>


### PR DESCRIPTION
This splits of part of the work from https://github.com/newsboat/newsboat/pull/2340