### PR TITLE
Convert feed to utf-8 based on Content-Type header

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -165,6 +165,8 @@ bool is_valid_podcast_type(const std::string& mimetype);
 nonstd::optional<LinkType> podcast_mime_to_link_type(const std::string&
 	mimetype);
 
+std::string string_from_utf8_lossy(const std::vector<std::uint8_t>& text);
+
 std::string get_default_browser();
 
 std::string md5hash(const std::string& input);

--- a/mk/libboat.deps
+++ b/mk/libboat.deps
@@ -1,4 +1,3 @@
-src/charencoding.cpp
 src/colormanager.cpp
 src/configcontainer.cpp
 src/configdata.cpp

--- a/mk/newsboat.deps
+++ b/mk/newsboat.deps
@@ -1,5 +1,6 @@
 newsboat.cpp
 src/cache.cpp
+src/charencoding.cpp
 src/cliargsparser.cpp
 src/configactionhandler.cpp
 src/configpaths.cpp

--- a/rss/parser.cpp
+++ b/rss/parser.cpp
@@ -210,7 +210,7 @@ Feed Parser::parse_url(const std::string& url,
 		throw NotModifiedException();
 	}
 
-	const std::string buf = curlDataReceiver->get_data();
+	std::string buf = curlDataReceiver->get_data();
 	LOG(Level::DEBUG,
 		"Parser::parse_url: retrieved data for %s: %s",
 		url,
@@ -228,7 +228,8 @@ Feed Parser::parse_url(const std::string& url,
 	} else if (charset_content_type.has_value()) {
 		charset = charset_content_type;
 	} else {
-		charset = nonstd::nullopt;
+		buf = utils::string_from_utf8_lossy(data);
+		charset = "utf-8";
 	}
 
 	if (buf.length() > 0) {

--- a/rss/parser.h
+++ b/rss/parser.h
@@ -5,6 +5,7 @@
 #include <libxml/parser.h>
 #include <string>
 
+#include "3rd-party/optional.hpp"
 #include "remoteapi.h"
 #include "feed.h"
 
@@ -32,7 +33,7 @@ public:
 		newsboat::RemoteApi* api = 0,
 		const std::string& cookie_cache = "");
 	Feed parse_buffer(const std::string& buffer,
-		const std::string& url = "");
+		const std::string& url = "", nonstd::optional<std::string> charset = nonstd::nullopt);
 	Feed parse_file(const std::string& filename);
 	time_t get_last_modified()
 	{

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -89,6 +89,7 @@ mod bridged {
         fn utf8_to_locale(text: &str) -> Vec<u8>;
         fn locale_to_utf8(text: &[u8]) -> String;
         fn convert_text(text: &[u8], tocode: &str, fromcode: &str) -> Vec<u8>;
+        fn string_from_utf8_lossy(text: &[u8]) -> String;
     }
 }
 
@@ -241,6 +242,10 @@ fn podcast_mime_to_link_type(mime_type: &str, result: &mut i64) -> bool {
             false
         }
     }
+}
+
+fn string_from_utf8_lossy(text: &[u8]) -> String {
+    String::from_utf8_lossy(text).to_string()
 }
 
 #[no_mangle]

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -790,6 +790,13 @@ nonstd::optional<LinkType> utils::podcast_mime_to_link_type(
 	return nonstd::nullopt;
 }
 
+std::string utils::string_from_utf8_lossy(const std::vector<std::uint8_t>& text)
+{
+	auto input = rust::Slice<std::uint8_t const>(text.data(), text.size());
+	auto result = utils::bridged::string_from_utf8_lossy(input);
+	return std::string(result);
+}
+
 /*
  * See
  * http://curl.haxx.se/libcurl/c/libcurl-tutorial.html#Multi-threading

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -550,3 +550,30 @@ TEST_CASE("parse_url() applies encoding specified in http header if no xml encod
 	REQUIRE(parsed_feed.items.size() == 1);
 	REQUIRE(parsed_feed.title == title_utf8);
 }
+
+TEST_CASE("parse_url() assumes utf-8 if no encoding specified and replaces invalid code units",
+	"[rsspp::Parser]")
+{
+	using namespace newsboat;
+
+	constexpr auto title_utf8 = u8"Prøve"; // Danish for "test"
+	constexpr auto expected_title = u8"Pr�ve";
+
+	auto feed_xml_utf8 = strprintf::fmt(atom_feed_without_encoding, title_utf8);
+
+	auto feed_xml_iso8859_1 = utils::convert_text(feed_xml_utf8, "iso-8859-1", "utf-8");
+	auto feed_xml = std::vector<std::uint8_t>(feed_xml_iso8859_1.begin(),
+			feed_xml_iso8859_1.end());
+
+	auto& test_server = test_helpers::HttpTestServer::get_instance();
+	auto mock_registration = test_server.add_endpoint("/feed", {}, 200, {}, feed_xml);
+	const auto address = test_server.get_address();
+	const auto url = strprintf::fmt("http://%s/feed", address);
+
+	rsspp::Parser parser;
+	CurlHandle easyhandle;
+	auto parsed_feed = parser.parse_url(url, easyhandle);
+
+	REQUIRE(parsed_feed.items.size() == 1);
+	REQUIRE(parsed_feed.title == expected_title);
+}

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -507,3 +507,46 @@ TEST_CASE("parse_url() uses xml encoding if specified encodings conflict (xml en
 	REQUIRE(parsed_feed.items.size() == 1);
 	REQUIRE(parsed_feed.title == title_utf8);
 }
+
+// Placeholders:
+// %s: feed title
+constexpr auto atom_feed_without_encoding =
+	R"(<?xml version="1.0"?>)"
+	R"(<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">)"
+	R"(<id>tag:example.com</id>)"
+	R"(<title type="text">%s</title>)"
+	R"(<updated>2008-12-30T18:26:15Z</updated>)"
+	R"(<entry>)"
+	R"(<id>tag:example.com,2008-12-30:/atom_testing</id>)"
+	R"(<title>regular title</title>)"
+	R"(<updated>2008-12-30T20:04:15Z</updated>)"
+	R"(</entry>)"
+	R"(</feed>)";
+
+TEST_CASE("parse_url() applies encoding specified in http header if no xml encoding specified",
+	"[rsspp::Parser]")
+{
+	using namespace newsboat;
+
+	constexpr auto title_utf8 = u8"Prøve"; // Danish for "test"
+
+	auto feed_xml_utf8 = strprintf::fmt(atom_feed_without_encoding, title_utf8);
+
+	auto feed_xml_iso8859_1 = utils::convert_text(feed_xml_utf8, "iso-8859-1", "utf-8");
+	auto feed_xml = std::vector<std::uint8_t>(feed_xml_iso8859_1.begin(),
+			feed_xml_iso8859_1.end());
+
+	auto& test_server = test_helpers::HttpTestServer::get_instance();
+	auto mock_registration = test_server.add_endpoint("/feed", {}, 200, {
+		{"content-type", "text/xml; charset=iso-8859-1"},
+	}, feed_xml);
+	const auto address = test_server.get_address();
+	const auto url = strprintf::fmt("http://%s/feed", address);
+
+	rsspp::Parser parser;
+	CurlHandle easyhandle;
+	auto parsed_feed = parser.parse_url(url, easyhandle);
+
+	REQUIRE(parsed_feed.items.size() == 1);
+	REQUIRE(parsed_feed.title == title_utf8);
+}

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1501,6 +1501,15 @@ TEST_CASE("podcast_mime_to_link_type() returns HtmlRenderer's LinkType that "
 	}
 }
 
+TEST_CASE("string_from_utf8_lossy() replaces invalid utf-8 code units with replacement characters",
+	"[utils]")
+{
+	const std::string input_str = "abc" "\x81" "def";
+	const std::vector<std::uint8_t> input(input_str.begin(), input_str.end());
+	const auto output = utils::string_from_utf8_lossy(input);
+	REQUIRE(output == "abc�def");
+}
+
 TEST_CASE(
 	"is_valid_color() returns false for things that aren't valid STFL "
 	"colors",


### PR DESCRIPTION
This implements the idea from https://github.com/newsboat/newsboat/pull/2660#discussion_r1449461867.

Fixes https://github.com/newsboat/newsboat/issues/1436.
It might make sense to apply the changes in this PR to `utils::retrieve_url()` as well.

Previous attempts at fixing https://github.com/newsboat/newsboat/issues/1436 had some issues.
I believe we can avoid these using the recently added tests (this PR and https://github.com/newsboat/newsboat/pull/2801)

Previous attempts with issues they caused:
- https://github.com/newsboat/newsboat/pull/2214
    - HTTP headers not handled correctly in case of a redirect
    - Converted data twice if encoding was specified in `Content-Type` header and XML encoding attribute
    - reverted via https://github.com/newsboat/newsboat/commit/fa363edd2d61e598aff0de5848ae955a5b35d3c0
- https://github.com/newsboat/newsboat/pull/2340
    - `Content-Type` headers parsing in C++ would have failed in some possible corner cases