### PR TITLE
Avoid underflows in limited-width string formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,7 @@ dependencies = [
  "section_testing",
  "strprintf",
  "tempfile",
+ "unicode-segmentation",
  "unicode-width",
  "url",
  "xdg",
@@ -1921,6 +1922,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -20,6 +20,7 @@ natord = "1.0.9"
 md5 = "0.7.0"
 lexopt = "0.3.0"
 chrono = "0.4.34"
+unicode-segmentation = "1.11.0"
 
 [dependencies.gettext-rs]
 version = "0.7.0"

--- a/rust/libnewsboat/proptest-regressions/fmtstrformatter/limited_string.txt
+++ b/rust/libnewsboat/proptest-regressions/fmtstrformatter/limited_string.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c9d3a19d4a957d53a85db87c325121e7edafaf73f8884ba8073a9251c3949f32 # shrinks to limit = 1, ref input1 = "0\u{fe0f}", ref input2 = "", ref input3 = ""

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1281,12 +1281,8 @@ TEST_CASE(
 		REQUIRE(utils::substr_with_width("a<>b<>c", 3) == "a<>");
 	}
 
-	SECTION("treat non-printable has zero width") {
-		REQUIRE(utils::substr_with_width("\x01\x02"
-				"abc",
-				1) ==
-			"\x01\x02"
-			"a");
+	SECTION("treats non-printable characters as 1 wide") {
+		REQUIRE(utils::substr_with_width("\x01\x02" "abc", 1) == "\x01");
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2805

It looks like our handling of limited-width strings has some trouble with the unicode sequence `⚛️` consisting of:
- U+269B (Atom symbol)
- U+FE0F (Variation selector-16, indicates that preceding character should be displayed with emoji presentation)

We add unicode code points to the result string one-by-one, checking their individual length one at a time.
We use the `unicode-width` crate to determine the width of strings and separate code points.
For the above 2 code points, `unicode-width` returns a width of 1 and 0 respectively.
However, for the combination of the 2 code points it returns a total width of 2 columns.
When the result string gets bigger than the specified max length, several places of subtractions can result in an underflow.

This PR avoids the crashes reported in the linked issue.

There might be more improvements possible, especially given the following paragraphs from the `unicode-width` readme:
> NOTE: The computed width values may not match the actual rendered column width. For example, many Brahmic scripts like Devanagari have complex rendering rules which this crate does not currently handle (and will never fully handle, because the exact rendering depends on the font)
> …
> Additionally, [defective combining character sequences](https://unicode.org/glossary/#defective_combining_character_sequence) and nonstandard [Korean jamo](https://unicode.org/glossary/#jamo) sequences may be rendered with a different width than what this crate says. (This is not an exhaustive list.) For a list of what this crate does handle, see [docs.rs](https://docs.rs/unicode-width/latest/unicode_width/#rules-for-determining-width).

Another possible improvement is to use [the unicode-segmentation crate](https://crates.io/crates/unicode-segmentation) to iterate over Grapheme clusters instead of individual code points.