### PR TITLE
Add download_status attribute for feeds

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -864,6 +864,7 @@ Attribute:Context:Meaning
 [[attr-tags]]<<attr-tags,+tags+>>:feed, article:space-separated list of tags that are associated with the feed. Note that for tags that have spaces in them, it's impossible to tell where they start and end, so +#+ and +!#+ operators don't work for such tags.
 [[attr-feedindex]]<<attr-feedindex,+feedindex+>>:feed, article:Index of a feed in the feed list
 [[attr-latest_article_age]]<<attr-latest_article_age,+latest_article_age+>>:feed, article:Number of days since the most recent article in a feed was published
+[[attr-download_status]]<<attr-download_status,+download_status+>>:feed, article:Download status of feed. One of ' ' (success), '_' (queued for download), '.' (downloading), and 'x' (download failed). Also available as <<feedlist-format-S,a format string identifier>> in <<feedlist-format,`feedlist-format`>>.
 |=========================================================================
 
 Note that it's also possible to filter for feed attributes when you query for

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -170,7 +170,7 @@ public:
 
 	void set_feedptrs(std::shared_ptr<RssFeed> self);
 
-	std::string get_status();
+	std::string get_status() const;
 
 	void reset_status()
 	{
@@ -212,7 +212,7 @@ private:
 	std::mutex items_guid_map_mutex;
 
 	DlStatus status_;
-	std::mutex status_mutex_;
+	mutable std::mutex status_mutex_;
 };
 
 } // namespace newsboat

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -202,6 +202,8 @@ nonstd::optional<std::string> RssFeed::attribute_value(const std::string&
 			return std::to_string((time(nullptr) - timestamp) / 86400);
 		}
 		return "0";
+	} else if (attribname == "download_status") {
+		return get_status();
 	}
 	return nonstd::nullopt;
 }
@@ -366,7 +368,7 @@ void RssFeed::set_feedptrs(std::shared_ptr<RssFeed> self)
 	}
 }
 
-std::string RssFeed::get_status()
+std::string RssFeed::get_status() const
 {
 	std::lock_guard<std::mutex> guard(status_mutex_);
 


### PR DESCRIPTION
Just a quick experiment to see if this works for https://github.com/newsboat/newsboat/issues/2791#issuecomment-2213805073
This is not a full solution to https://github.com/newsboat/newsboat/issues/2791

Example config option (press `f` to select the defined filter):
```
define-filter "feeds - unread and/or error" "unread_count > 0 or download_status = \"x\""
```

This filter does work but it might break easy usage of `toggle-show-read-feeds` (has no visible effect as long as the filter is active)