### PR TITLE
CI: bump Rust to 1.80.0

### DIFF
--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.79.0 by default.
+# and Rust 1.80.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-8
-# - rust_version -- Rust version to install. Default: 1.79.0
+# - rust_version -- Rust version to install. Default: 1.80.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-8
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -97,7 +97,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.79.0
+ARG rust_version=1.80.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -86,7 +86,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain 1.79.0 \
+        --default-toolchain 1.80.0 \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 9 and Rust 1.79.0 by default.
+# compilers. Contains GCC 9 and Rust 1.80.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.79.0
+# - rust_version -- Rust version to install. Default: 1.80.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -97,7 +97,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.79.0
+ARG rust_version=1.80.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_22.04-build-tools.dockerfile
+++ b/docker/ubuntu_22.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 12 and Rust 1.79.0 by default.
+# compilers. Contains GCC 12 and Rust 1.80.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-12
-# - rust_version -- Rust version to install. Default: 1.79.0
+# - rust_version -- Rust version to install. Default: 1.80.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-12
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -98,7 +98,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.79.0
+ARG rust_version=1.80.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_24.04-build-tools.dockerfile
+++ b/docker/ubuntu_24.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 14 and Rust 1.79.0 by default.
+# compilers. Contains GCC 14 and Rust 1.80.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-14
-# - rust_version -- Rust version to install. Default: 1.79.0
+# - rust_version -- Rust version to install. Default: 1.80.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-14
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -99,7 +99,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.79.0
+ARG rust_version=1.80.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/rust/libnewsboat/src/human_panic.rs
+++ b/rust/libnewsboat/src/human_panic.rs
@@ -112,7 +112,6 @@ fn print_panic_msg(panic_info: &PanicInfo) -> io::Result<()> {
         "Newsboat version: {}",
         env!("CARGO_PKG_VERSION")
     )?;
-    writeln!(&mut stderr, "{}", get_crash_cause(panic_info))?;
     writeln!(&mut stderr, "{}", get_error_message(panic_info))?;
     writeln!(&mut stderr, "{}", get_location(panic_info))?;
 
@@ -124,19 +123,6 @@ fn print_panic_msg(panic_info: &PanicInfo) -> io::Result<()> {
     )?;
 
     Ok(())
-}
-
-#[cfg(feature = "nightly")]
-fn get_crash_cause(panic_info: &PanicInfo) -> String {
-    match panic_info.message() {
-        Some(m) => format!("Crash cause: {m}"),
-        None => "Crash cause unknown".into(),
-    };
-}
-
-#[cfg(not(feature = "nightly"))]
-fn get_crash_cause(_panic_info: &PanicInfo) -> String {
-    String::from("Couldn't determine the crash cause.")
 }
 
 fn get_error_message(panic_info: &PanicInfo) -> String {


### PR DESCRIPTION
This release enabled automatic checking of `cfg`s at compile-time[1], so Clippy started warning us about the use of `#[cfg(feature = "nightly")]`. Apparently I misunderstood how it works when I was copying code from the human-panic crate.

While trying to make the warning go away, I also realized that the Nightly-only code doesn't even compile, because we declare a function to return `String` but actually return `()`.

Apparently the proper way to fix this is to add compiler auto-detection to build.rs. This will slow down compilation a bit, for what I perceive to be a very small benefit; after all, we got this far without that Nightly-only API. Thus I removed the code that used the API.

1. https://blog.rust-lang.org/2024/05/06/check-cfg.html