### PR TITLE
Fix order of applying unread/highlight styles

### DIFF
--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1185,14 +1185,14 @@ StflRichText ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	const auto formattedLine = fmt.do_format(itemlist_format, width);
 	auto stflFormattedLine = StflRichText::from_plaintext(formattedLine);
 
+	if (item.first->unread()) {
+		stflFormattedLine.apply_style_tag("<unread>", 0, formattedLine.length());
+	}
+
 	const int id = rxman.article_matches(item.first.get());
 	if (id != -1) {
 		const auto tag = strprintf::fmt("<%d>", id);
 		stflFormattedLine.apply_style_tag(tag, 0, formattedLine.length());
-	}
-
-	if (item.first->unread()) {
-		stflFormattedLine.apply_style_tag("<unread>", 0, formattedLine.length());
 	}
 
 	return stflFormattedLine;


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/2814
Issue was introduced in https://github.com/newsboat/newsboat/commit/0175914ee5a831fea04ecec68cf2857b9002ba3f.

Stfl style tags are placed within the text to be styled.
For example, we use `<unread>item title</>` to apply the "unread" style to a title.

Previously, we applied styles by just adding style tags at the start of the formatted string (`<unread>`, `<0>`, `<1>`, etc.).
That effectively gave them a lower priority than all of the styling already in the string.
For example, `<unread><0>Item title</></>` ignores the "unread" style because it is directly overridden with the "0" style.

With my changes from https://github.com/newsboat/newsboat/pull/2084, we use an `StflRichText` class to apply styling.
In that class, added style tags override earlier style tags.
To get the same result as before my refactoring, we need to apply the style tags in reverse order.
I already did that for the FeedListFormAction, but apparently missed it in the ItemListFormAction.