### PR TITLE
(GPG|PGP) → OpenPGP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ you can help:
 
 If you happen to stumble upon a security vulnerability, **do not open a GitHub issue**.
 Instead, send an email to security@newsboat.org and encrypt your emails using
-[PGP key 4ED6CD61932B9EBE](https://newsboat.org/newsboat.pgp).
+[OpenPGP key 4ED6CD61932B9EBE](https://newsboat.org/newsboat.pgp).
 
 
 ## Feature Requests and Bug Reports

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Support
   [documentation](https://newsboat.org/releases/2.36/docs/newsboat.html) and
   [FAQ](https://newsboat.org/releases/2.36/docs/faq.html)
 * Report security vulnerabilities to security@newsboat.org. Please encrypt your emails to
-  [PGP key 4ED6CD61932B9EBE](https://newsboat.org/newsboat.pgp) if you can.
+  [OpenPGP key 4ED6CD61932B9EBE](https://newsboat.org/newsboat.pgp) if you can.
 * Report bugs and ask questions on
   [the issue tracker](https://github.com/newsboat/newsboat/issues) and
   [the mailing list](https://groups.google.com/group/newsboat)

--- a/doc/internal/howto-release.md
+++ b/doc/internal/howto-release.md
@@ -171,7 +171,7 @@ branch off the latest release and backport the bugfixes onto it.
         git checkout -b feature/prepare-next-release
         git commit -am'Prepare for next release'
         git push origin -u feature/prepare-next-release
-3. If it's September, bump the expiry date on the GPG key:
+3. If it's September, bump the expiry date on the OpenPGP key:
 
     * edit the key, upload it to keyservers and export it to a file:
 

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1628,7 +1628,7 @@ include::chapter-environment-variables.asciidoc[]
 == Feedback and security
 
 Please report security vulnerabilities to security@newsboat.org, encrypting your
-emails to https://newsboat.org/newsboat.pgp[PGP key 4ED6CD61932B9EBE] if at all
+emails to https://newsboat.org/newsboat.pgp[OpenPGP key 4ED6CD61932B9EBE] if at all
 possible.
 
 Non-security issues and general questions can be discussed on


### PR DESCRIPTION
There's a fork in specifications, so I want to highlight that we'm using IETF's standard (OpenPGP) rather than GnuPG's (LibrePGP): https://lwn.net/Articles/953797/