### PR TITLE
convert_text: Improve performance by using bigger output buffer

### DIFF
--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -942,7 +942,7 @@ pub fn convert_text(text: &[u8], tocode: &str, fromcode: &str) -> Vec<u8> {
     }
 
     unsafe {
-        let mut outbuf: [u8; 16] = [0; 16];
+        let mut outbuf = vec![0u8; 65536];
         let mut outbufp = outbuf.as_mut_ptr() as *mut c_char;
         let mut outbytesleft = outbuf.len();
 


### PR DESCRIPTION
We recently started using `utils::convert_text()` for regular feeds retrieved over http/https (in https://github.com/newsboat/newsboat/pull/2804).
It looks like that slowed down reloads, as reported in https://github.com/newsboat/newsboat/issues/2815#issuecomment-2276411526 and https://github.com/newsboat/newsboat/issues/2815#issuecomment-2276583709.

It looks like convert_text can be improved significantly by using a bigger buffer.
That avoids a lot of overhead by letting `iconv()` go through bigger parts of data at a time.

Performance informally checked with a quick testcase.
The referenced `atom.xml` file size is approximately 520 KB
```
TEST_CASE("convert_text() performance", "[utils]")
{
	const auto input = test_helpers::read_binary_file("/tmp/ttt/atom.xml");
	const auto text = std::string(input.begin(), input.end());

	auto begin = std::chrono::steady_clock::now();
	utils::convert_text(text, "utf-8", "utf-8");
	auto end = std::chrono::steady_clock::now();

	auto time_taken = std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
	std::cout << "Convert time taken: " << time_taken / 1000.0 << " [ms]" << std::endl;
}
```

I repeated every measurement 5 times to partially ignore noise:
outbuf size (bytes) | 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384 | 32768 | 65536
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
sample 1 (ms) | 186.858 | 95.201 | 48.391 | 25.494 | 14.494 | 8.203 | 5.419 | 4.198 | 3.151 | 2.891 | 2.825 | 2.592 | 2.493
sample 2 (ms) | 187.1 | 95.863 | 49.617 | 26.183 | 14.171 | 8.393 | 5.013 | 3.726 | 3.073 | 2.775 | 2.696 | 2.476 | 2.403
sample 3 (ms) | 184.235 | 95.95 | 48.016 | 25.903 | 14.12 | 8.48 | 5.443 | 4.216 | 3.246 | 2.734 | 2.602 | 2.465 | 2.405
sample 4 (ms) | 185.991 | 96.297 | 49.159 | 25.642 | 14.144 | 8.115 | 5.836 | 4.031 | 3.016 | 2.691 | 2.46 | 2.42 | 2.727
sample 5 (ms) | 186.915 | 96.062 | 48.545 | 25.89 | 14.567 | 8.177 | 5.049 | 3.863 | 3.2 | 2.77 | 2.47 | 2.406 | 2.763
Average (ms) | 186.2198 | 95.8746 | 48.7456 | 25.8224 | 14.2992 | 8.2736 | 5.352 | 4.0068 | 3.1372 | 2.7722 | 2.6106 | 2.4718 | 2.5582

Line chart from averages.
Horizontal: buffer size in bytes, logarithmic scale
Vertical: average time (ms)
![image](https://github.com/user-attachments/assets/bf82b091-a382-412e-98cf-26921ca9da05)
