### PR TITLE
Fix rearranging order of rss feeds on exiting edit mode

### DIFF
--- a/include/feedcontainer.h
+++ b/include/feedcontainer.h
@@ -29,6 +29,7 @@ public:
 	/// Count unread items in feeds tagged with `tag`
 	unsigned int get_unread_item_count_per_tag(const std::string& tag);
 
+	void erase_feed_by_order(const unsigned int order);
 	std::shared_ptr<RssFeed> get_feed_by_url(const std::string& feedurl);
 	void populate_query_feeds();
 	unsigned int get_pos_of_next_unread(unsigned int pos);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -842,6 +842,7 @@ void Controller::reload_urls_file()
 	for (const auto& url : urlcfg->get_urls()) {
 		const auto feed = feedcontainer.get_feed_by_url(url);
 		if (feed) {
+			feedcontainer.erase_feed_by_order(feed->get_order());
 			feed->set_tags(urlcfg->get_tags(url));
 			feed->set_order(i);
 			new_feeds.push_back(feed);

--- a/src/feedcontainer.cpp
+++ b/src/feedcontainer.cpp
@@ -201,6 +201,23 @@ unsigned int FeedContainer::get_unread_item_count_per_tag(
 	return count;
 }
 
+void FeedContainer::erase_feed_by_order(
+	const unsigned int order)
+{
+	std::lock_guard<std::mutex> feedslock(feeds_mutex);
+	auto pos = std::find_if(feeds.begin(), feeds.end(), [order](const std::shared_ptr<RssFeed> feed){
+		return (feed->get_order()) == order;
+	});
+	if(pos != feeds.end()) {
+		feeds.erase(pos);
+		return;
+	}
+	LOG(Level::ERROR,
+		"FeedContainer:erase_feed_by_order failed for %s",
+		order);
+	return;
+}
+
 std::shared_ptr<RssFeed> FeedContainer::get_feed_by_url(
 	const std::string& feedurl)
 {

--- a/src/feedcontainer.cpp
+++ b/src/feedcontainer.cpp
@@ -205,10 +205,11 @@ void FeedContainer::erase_feed_by_order(
 	const unsigned int order)
 {
 	std::lock_guard<std::mutex> feedslock(feeds_mutex);
-	auto pos = std::find_if(feeds.begin(), feeds.end(), [order](const std::shared_ptr<RssFeed> feed){
-		return (feed->get_order()) == order;
-	});
-	if(pos != feeds.end()) {
+	auto pos = std::find_if(feeds.begin(), feeds.end(),
+		 [order](const std::shared_ptr<RssFeed> feed){
+			 return (feed->get_order()) == order;
+		 });
+	if (pos != feeds.end()) {
 		feeds.erase(pos);
 		return;
 	}


### PR DESCRIPTION
I use " " as urls to seperate sections in my url file.

The present implementation of Controller::reload_urls_file() replaces all entries which contain the same url with the same entry, and messes up the order of entries.

Consider a url list containing
```
abc.html --> {0}
abc.html --> {1}
abc.html --> {2}
abc.html --> {3}
```

When the application starts, it allots 4 pointers to each of those. However, on calling reload_urls_file(), this is changed to
```
abc.html --> {0}
abc.html --> {0}
abc.html --> {0}
abc.html --> {0}
```
since reload_urls_file() uses FeedContainer::get_feed_by_url(), which returns the first match with the same url. This isn't a big problem since the url file is replaced in the next line, and shared pointer probably destroys each but the first entry with the same url (assuming nothing else is using the pointer).

I added a function which removes the first url which matches the given url. This fixes the error.