### PR TITLE
Handling author name ending with ')'

### DIFF
--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -106,8 +106,12 @@ Item Rss09xParser::parse_item(xmlNode* itemNode)
 					start > 0 && authorfield[start] != '(';
 					start--) {
 				}
-				it.author = authorfield.substr(
-						start + 1, end - start);
+				if (start <= 0) {
+					it.author_email = authorfield;
+					it.author = authorfield;
+				} else {
+					it.author = authorfield.substr(start + 1, end - start);
+				}
 			} else {
 				it.author_email = authorfield;
 				it.author = authorfield;

--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -106,7 +106,7 @@ Item Rss09xParser::parse_item(xmlNode* itemNode)
 					start > 0 && authorfield[start] != '(';
 					start--) {
 				}
-				if (start <= 0) {
+				if (start == 0) {
 					it.author_email = authorfield;
 					it.author = authorfield;
 				} else {

--- a/test/data/rss_091_with_bracket_author.xml
+++ b/test/data/rss_091_with_bracket_author.xml
@@ -18,7 +18,7 @@
 		<item>
 			<title>This one has an author name with an email in brackets</title>
 			<link>http://example.com/test_2.html</link>
-            <author>Author (email@example.com)</author>
+            <author>email@example.com (Author)</author>
 			<description>This is empty description (no).</description>
 		</item>
 

--- a/test/data/rss_091_with_bracket_author.xml
+++ b/test/data/rss_091_with_bracket_author.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<!DOCTYPE rss
+  SYSTEM 'http://my.netscape.com/publish/formats/rss-0.91.dtd'>
+<rss version="0.91">
+	<channel>
+		<title>A Channel with Authors With Names Containing Brackets</title>
+		<link>http://example.com/</link>
+		<description>an example feed</description>
+		<language>en</language>
+
+		<item>
+			<title>This one has an author name ending with a closing bracket</title>
+			<link>http://example.com/test_1.html</link>
+            <author>Author name)</author>
+			<description>Non-empty description.</description>
+		</item>
+
+		<item>
+			<title>This one has an author name with an email in brackets</title>
+			<link>http://example.com/test_2.html</link>
+            <author>Author (email@example.com)</author>
+			<description>This is empty description (no).</description>
+		</item>
+
+		<item>
+			<title>This one has an author name with a non-email next in brackets</title>
+			<link>http://example.com/test_3.html</link>
+            <author>Author (name)</author>
+			<description>This is empty description (yes (no)).</description>
+		</item>
+	</channel>
+</rss>

--- a/test/data/rss_092_with_bracket_author.xml
+++ b/test/data/rss_092_with_bracket_author.xml
@@ -15,7 +15,7 @@
 		<item>
 			<title>This one has an author name with an email in brackets</title>
 			<link>http://example.com/test_2.html</link>
-            <author>Author (email@example.com)</author>
+            <author>email@example.com (Author)</author>
 			<description>This is empty description (no).</description>
 		</item>
 

--- a/test/data/rss_092_with_bracket_author.xml
+++ b/test/data/rss_092_with_bracket_author.xml
@@ -1,0 +1,29 @@
+<rss version="0.92" xml:base="http://example.com/feed/rss_testing.html">
+	<channel>
+		<title>A Channel with Authors With Names Containing Brackets</title>
+		<link>http://example.com/</link>
+		<description>an example feed</description>
+		<language>en</language>
+
+		<item>
+			<title>This one has an author name ending with a closing bracket</title>
+			<link>http://example.com/test_1.html</link>
+            <author>Author name)</author>
+			<description>Non-empty description.</description>
+		</item>
+
+		<item>
+			<title>This one has an author name with an email in brackets</title>
+			<link>http://example.com/test_2.html</link>
+            <author>Author (email@example.com)</author>
+			<description>This is empty description (no).</description>
+		</item>
+
+		<item>
+			<title>This one has an author name with a non-email next in brackets</title>
+			<link>http://example.com/test_3.html</link>
+            <author>Author (name)</author>
+			<description>This is empty description (yes (no)).</description>
+		</item>
+	</channel>
+</rss>

--- a/test/data/rss_094_with_bracket_author.xml
+++ b/test/data/rss_094_with_bracket_author.xml
@@ -1,0 +1,29 @@
+<rss version="0.94" xml:base="http://example.com/feed/rss_testing.html">
+	<channel>
+		<title>A Channel with Authors With Names Containing Brackets</title>
+		<link>http://example.com/</link>
+		<description>an example feed</description>
+		<language>en</language>
+
+		<item>
+			<title>This one has an author name ending with a closing bracket</title>
+			<link>http://example.com/test_1.html</link>
+            <author>Author name)</author>
+			<description>Non-empty description.</description>
+		</item>
+
+		<item>
+			<title>This one has an author name with an email in brackets</title>
+			<link>http://example.com/test_2.html</link>
+            <author>Author (email@example.com)</author>
+			<description>This is empty description (no).</description>
+		</item>
+
+		<item>
+			<title>This one has an author name with a non-email next in brackets</title>
+			<link>http://example.com/test_3.html</link>
+            <author>Author (name)</author>
+			<description>This is empty description (yes (no)).</description>
+		</item>
+	</channel>
+</rss>

--- a/test/data/rss_094_with_bracket_author.xml
+++ b/test/data/rss_094_with_bracket_author.xml
@@ -15,7 +15,7 @@
 		<item>
 			<title>This one has an author name with an email in brackets</title>
 			<link>http://example.com/test_2.html</link>
-            <author>Author (email@example.com)</author>
+            <author>email@example.com (Author)</author>
 			<description>This is empty description (no).</description>
 		</item>
 

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -103,6 +103,59 @@ TEST_CASE("Doesn't crash or garble data if an item in RSS 0.9x contains "
 	}
 }
 
+TEST_CASE("Doesn't crash or garble data if an item in RSS 0.9x contains "
+	"an author tag which ends with a bracket",
+	"[rsspp::Parser][issue2834]")
+{
+	rsspp::Parser p;
+	rsspp::Feed f;
+
+	const auto check = [&]() {
+		REQUIRE(f.title == "A Channel with Authors With Names Containing Brackets");
+		REQUIRE(f.description == "an example feed");
+		REQUIRE(f.link == "http://example.com/");
+		REQUIRE(f.language == "en");
+
+		REQUIRE(f.items.size() == 3u);
+
+		REQUIRE(f.items[0].title == "This one has an author name ending with a closing bracket");
+		REQUIRE(f.items[0].link == "http://example.com/test_1.html");
+		REQUIRE(f.items[0].description == "Non-empty description.");
+		REQUIRE(f.items[0].author == "Author name)");
+		REQUIRE(f.items[0].guid == "");
+
+		REQUIRE(f.items[1].title == "This one has an author name with an email in brackets");
+		REQUIRE(f.items[1].link == "http://example.com/test_2.html");
+		REQUIRE(f.items[1].description == "This is empty description (no).");
+		REQUIRE(f.items[1].author == "email@example.com");
+		REQUIRE(f.items[1].guid == "");
+
+		REQUIRE(f.items[2].title == "This one has an author name with a non-email next in brackets");
+		REQUIRE(f.items[2].link == "http://example.com/test_3.html");
+		REQUIRE(f.items[2].description == "This is empty description (yes (no)).");
+		REQUIRE(f.items[2].author == "name");
+		REQUIRE(f.items[2].guid == "");
+	};
+
+	SECTION("RSS 0.91") {
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_091_with_bracket_author.xml"));
+		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_91);
+		check();
+	}
+
+	SECTION("RSS 0.92") {
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_092_with_bracket_author.xml"));
+		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_92);
+		check();
+	}
+
+	SECTION("RSS 0.94") {
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_094_with_bracket_author.xml"));
+		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_94);
+		check();
+	}
+}
+
 TEST_CASE("Extracts data from RSS 0.92", "[rsspp::Parser]")
 {
 	rsspp::Parser p;

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -130,7 +130,8 @@ TEST_CASE("Doesn't crash or garble data if an item in RSS 0.9x contains "
 		REQUIRE(f.items[1].author == "email@example.com");
 		REQUIRE(f.items[1].guid == "");
 
-		REQUIRE(f.items[2].title == "This one has an author name with a non-email next in brackets");
+		REQUIRE(f.items[2].title ==
+			"This one has an author name with a non-email next in brackets");
 		REQUIRE(f.items[2].link == "http://example.com/test_3.html");
 		REQUIRE(f.items[2].description == "This is empty description (yes (no)).");
 		REQUIRE(f.items[2].author == "name");

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -127,7 +127,7 @@ TEST_CASE("Doesn't crash or garble data if an item in RSS 0.9x contains "
 		REQUIRE(f.items[1].title == "This one has an author name with an email in brackets");
 		REQUIRE(f.items[1].link == "http://example.com/test_2.html");
 		REQUIRE(f.items[1].description == "This is empty description (no).");
-		REQUIRE(f.items[1].author == "email@example.com");
+		REQUIRE(f.items[1].author == "Author");
 		REQUIRE(f.items[1].guid == "");
 
 		REQUIRE(f.items[2].title ==


### PR DESCRIPTION
**Newsboat version (copy the output of `newsboat -v` or the first line of `git show`)**: r2.36

Config file (copy from ~/.newsboat/config or ~/.config/newsboat/config): no config

Steps to reproduce the issue:

1.  Add `https://forum.awd.ru/smartfeed.php?forum=978&limit=3_MONTH&sort_by=user&feed_type=ATOM1.0&feed_style=HTML&max_word_size=250` to `~/.newsboat/urls`
2. run `/usr/bin/newsboat -x reload`
3. get error:
```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  data for rust::String is not utf-8
Aborted (core dumped)
```
This happens because of the post from a user with name Лю)): https://forum.awd.ru/viewtopic.php?f=978&t=36102&p=11902305#p11902305
This username is being handled by the snippet below. It finds ')' at the end of `authorfield` and then performs `it.author = authorfield.substr(start + 1, end - start);` which evaluates to `it.author = authorfield.substr(1, end);`
https://github.com/newsboat/newsboat/blob/7238cf00c07c3ffad29ad2853bec89ea2f684e50/rss/rss09xparser.cpp#L99-L114

Since the `authorfield` is utf-8 string, `it.author` becomes incorrect utf-8 string `<9B>ю)` (because 'Л' = `D0 9B`).

---
idk if this 16 years old bug will trigger for anyone else, but a bug is a bug