### PR TITLE
Update gettext-sys to 0.21.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,8 +27,6 @@ task:
     env:
         HOME: /home/testuser
         RUSTFLAGS: '-D warnings'
-        # Workaround for https://github.com/Koka/gettext-rs/issues/117
-        CFLAGS: '-Wno-error=incompatible-function-pointer-types'
 
     after_cache_script: &after_cache_script
       - mkdir $HOME/.cargo || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "gettext-sys"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63ce2e00f56a206778276704bbe38564c8695249fdc8f354b4ef71c57c3839d"
+checksum = "f7b8797f28f2dabfbe2caadb6db4f7fd739e251b5ede0a2ba49e506071edcf67"
 dependencies = [
  "cc",
  "temp-dir",


### PR DESCRIPTION
Remove workaround which was introduced in https://github.com/newsboat/newsboat/pull/2691 as it is now included in gettext-rs itself.