### PR TITLE
Show keymap hint for "clear filter" when filter is active

### DIFF
--- a/include/dialogsformaction.h
+++ b/include/dialogsformaction.h
@@ -12,7 +12,7 @@ public:
 	~DialogsFormAction() override = default;
 	void prepare() override;
 	void init() override;
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 	std::string id() const override
 	{
 		return "dialogs";

--- a/include/dirbrowserformaction.h
+++ b/include/dirbrowserformaction.h
@@ -18,7 +18,7 @@ public:
 	~DirBrowserFormAction() override = default;
 	void prepare() override;
 	void init() override;
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 
 	std::string id() const override
 	{

--- a/include/emptyformaction.h
+++ b/include/emptyformaction.h
@@ -16,7 +16,7 @@ public:
 	void init() override;
 	void prepare() override;
 
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 
 protected:
 	bool process_operation(Operation op,

--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -28,7 +28,7 @@ public:
 	void init() override;
 	void set_feedlist(std::vector<std::shared_ptr<RssFeed>>& feeds);
 	void update_visible_feeds(std::vector<std::shared_ptr<RssFeed>>& feeds);
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 	std::shared_ptr<RssFeed> get_feed();
 
 	std::string id() const override

--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -18,7 +18,7 @@ public:
 	~FileBrowserFormAction() override = default;
 	void prepare() override;
 	void init() override;
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 
 	void set_default_filename(const std::string& fn)
 	{

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -60,7 +60,7 @@ public:
 		do_redraw = b;
 	}
 
-	virtual const std::vector<KeyMapHintEntry>& get_keymap_hint() const = 0;
+	virtual std::vector<KeyMapHintEntry> get_keymap_hint() const = 0;
 
 	virtual std::string id() const = 0;
 
@@ -119,7 +119,7 @@ protected:
 	virtual bool process_operation(Operation op,
 		const std::vector<std::string>& args,
 		BindingType bindingType = BindingType::BindKey) = 0;
-	virtual void set_keymap_hints();
+	void set_keymap_hints();
 
 	/// The name of the "main" STFL widget, i.e. the one that should be focused
 	/// by default.

--- a/include/helpformaction.h
+++ b/include/helpformaction.h
@@ -13,7 +13,7 @@ public:
 	~HelpFormAction() override = default;
 	void prepare() override;
 	void init() override;
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 	std::string id() const override
 	{
 		return "help";

--- a/include/itemlistformaction.h
+++ b/include/itemlistformaction.h
@@ -49,7 +49,7 @@ public:
 		pos = p;
 	}
 	std::string get_guid();
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 
 	bool jump_to_next_unread_item(bool start_with_first);
 	bool jump_to_previous_unread_item(bool start_with_last);

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -33,7 +33,7 @@ public:
 		feed = fd;
 	}
 	void set_highlightphrase(const std::string& text);
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 	void handle_cmdline(const std::string& cmd) override;
 
 	std::string id() const override

--- a/include/searchresultslistformaction.h
+++ b/include/searchresultslistformaction.h
@@ -38,7 +38,7 @@ public:
 		search_phrase = s;
 	}
 
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 
 	void add_to_history(const std::shared_ptr<RssFeed>& feed, const std::string& str);
 

--- a/include/selectformaction.h
+++ b/include/selectformaction.h
@@ -15,7 +15,7 @@ public:
 	~SelectFormAction() override = default;
 	void prepare() override;
 	void init() override;
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 	void set_selected_value(const std::string& new_value)
 	{
 		value = new_value;

--- a/include/urlviewformaction.h
+++ b/include/urlviewformaction.h
@@ -16,7 +16,7 @@ public:
 	~UrlViewFormAction() override = default;
 	void prepare() override;
 	void init() override;
-	const std::vector<KeyMapHintEntry>& get_keymap_hint() const override;
+	std::vector<KeyMapHintEntry> get_keymap_hint() const override;
 	void set_links(const Links& l)
 	{
 		links = l;

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -61,7 +61,7 @@ void DialogsFormAction::update_heading()
 	set_title(fmt.do_format(title_format, width));
 }
 
-const std::vector<KeyMapHintEntry>& DialogsFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> DialogsFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Close")},
 		{OP_OPEN, _("Goto Dialog")},

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -292,7 +292,7 @@ void DirBrowserFormAction::init()
 	set_value("filenametext_pos", std::to_string(save_path.length()));
 }
 
-const std::vector<KeyMapHintEntry>& DirBrowserFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> DirBrowserFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Cancel")},
 		{OP_OPEN, _("Save")}

--- a/src/emptyformaction.cpp
+++ b/src/emptyformaction.cpp
@@ -26,7 +26,7 @@ void EmptyFormAction::prepare()
 {
 }
 
-const std::vector<KeyMapHintEntry>& EmptyFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> EmptyFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints;
 	return hints;

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -641,6 +641,9 @@ std::vector<KeyMapHintEntry> FeedListFormAction::get_keymap_hint() const
 	if (filter_active) {
 		hints.push_back({OP_CLEARFILTER, _("Clear filter")});
 	}
+	if (!tag.empty()) {
+		hints.push_back({OP_CLEARTAG, _("Clear tag")});
+	}
 	hints.push_back({OP_QUIT, _("Quit")});
 	hints.push_back({OP_OPEN, _("Open")});
 	hints.push_back({OP_NEXTUNREAD, _("Next Unread")});

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -46,8 +46,6 @@ FeedListFormAction::FeedListFormAction(View& vv,
 
 void FeedListFormAction::init()
 {
-	set_keymap_hints();
-
 	recalculate_widget_dimensions();
 
 	if (v.get_ctrl()->get_refresh_on_start()) {
@@ -66,6 +64,8 @@ void FeedListFormAction::init()
 
 void FeedListFormAction::prepare()
 {
+	set_keymap_hints();
+
 	const auto sort_strategy = cfg->get_feed_sort_strategy();
 	if (!old_sort_strategy || sort_strategy != *old_sort_strategy) {
 		v.get_ctrl()->get_feedcontainer()->sort_feeds(sort_strategy);
@@ -635,18 +635,21 @@ void FeedListFormAction::set_feedlist(
 	update_form_title(width);
 }
 
-const std::vector<KeyMapHintEntry>& FeedListFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> FeedListFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
-		{OP_OPEN, _("Open")},
-		{OP_NEXTUNREAD, _("Next Unread")},
-		{OP_RELOAD, _("Reload")},
-		{OP_RELOADALL, _("Reload All")},
-		{OP_MARKFEEDREAD, _("Mark Read")},
-		{OP_MARKALLFEEDSREAD, _("Mark All Read")},
-		{OP_SEARCH, _("Search")},
-		{OP_HELP, _("Help")}
-	};
+	std::vector<KeyMapHintEntry> hints;
+	if (filter_active) {
+		hints.push_back({OP_CLEARFILTER, _("Clear filter")});
+	}
+	hints.push_back({OP_QUIT, _("Quit")});
+	hints.push_back({OP_OPEN, _("Open")});
+	hints.push_back({OP_NEXTUNREAD, _("Next Unread")});
+	hints.push_back({OP_RELOAD, _("Reload")});
+	hints.push_back({OP_RELOADALL, _("Reload All")});
+	hints.push_back({OP_MARKFEEDREAD, _("Mark Read")});
+	hints.push_back({OP_MARKALLFEEDSREAD, _("Mark All Read")});
+	hints.push_back({OP_SEARCH, _("Search")});
+	hints.push_back({OP_HELP, _("Help")});
 	return hints;
 }
 

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -316,7 +316,7 @@ void FileBrowserFormAction::init()
 	set_value("filenametext_pos", std::to_string(default_filename.length()));
 }
 
-const std::vector<KeyMapHintEntry>& FileBrowserFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> FileBrowserFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Cancel")},
 		{OP_OPEN, _("Save")}

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -66,6 +66,7 @@ void HelpFormAction::prepare()
 {
 	if (do_redraw) {
 		recalculate_widget_dimensions();
+		set_keymap_hints();
 
 		const unsigned int width = textview.get_width();
 
@@ -182,15 +183,16 @@ void HelpFormAction::prepare()
 
 void HelpFormAction::init()
 {
-	set_keymap_hints();
 }
 
 std::vector<KeyMapHintEntry> HelpFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
-		{OP_SEARCH, _("Search")},
-		{OP_CLEARFILTER, _("Clear")}
-	};
+	std::vector<KeyMapHintEntry> hints;
+	hints.push_back({OP_QUIT, _("Quit")});
+	hints.push_back({OP_SEARCH, _("Search")});
+	if (apply_search) {
+		hints.push_back({OP_CLEARFILTER, _("Clear")});
+	}
 	return hints;
 }
 

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -185,7 +185,7 @@ void HelpFormAction::init()
 	set_keymap_hints();
 }
 
-const std::vector<KeyMapHintEntry>& HelpFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> HelpFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
 		{OP_SEARCH, _("Search")},

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1088,6 +1088,8 @@ void ItemListFormAction::draw_items()
 
 void ItemListFormAction::prepare()
 {
+	set_keymap_hints();
+
 	std::lock_guard<std::mutex> mtx(redraw_mtx);
 
 	const auto sort_strategy = cfg->get_article_sort_strategy();
@@ -1226,7 +1228,6 @@ void ItemListFormAction::init()
 	recalculate_widget_dimensions();
 	list.set_position(0);
 	set_status("");
-	set_keymap_hints();
 	invalidate_list();
 	do_update_visible_items();
 	draw_items();
@@ -1391,17 +1392,20 @@ std::string ItemListFormAction::get_guid()
 	return visible_items[itempos].first->guid();
 }
 
-const std::vector<KeyMapHintEntry>& ItemListFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> ItemListFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
-		{OP_OPEN, _("Open")},
-		{OP_SAVE, _("Save")},
-		{OP_RELOAD, _("Reload")},
-		{OP_NEXTUNREAD, _("Next Unread")},
-		{OP_MARKFEEDREAD, _("Mark All Read")},
-		{OP_SEARCH, _("Search")},
-		{OP_HELP, _("Help")}
-	};
+	std::vector<KeyMapHintEntry> hints;
+	if (filter_active) {
+		hints.push_back({OP_CLEARFILTER, _("Clear filter")});
+	}
+	hints.push_back({OP_QUIT, _("Quit")});
+	hints.push_back({OP_OPEN, _("Open")});
+	hints.push_back({OP_SAVE, _("Save")});
+	hints.push_back({OP_RELOAD, _("Reload")});
+	hints.push_back({OP_NEXTUNREAD, _("Next Unread")});
+	hints.push_back({OP_MARKFEEDREAD, _("Mark All Read")});
+	hints.push_back({OP_SEARCH, _("Search")});
+	hints.push_back({OP_HELP, _("Help")});
 	return hints;
 }
 

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -575,7 +575,7 @@ bool ItemViewFormAction::open_link_in_browser(const std::string& link,
 	return true;
 }
 
-const std::vector<KeyMapHintEntry>& ItemViewFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> ItemViewFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
 		{OP_SAVE, _("Save")},

--- a/src/searchresultslistformaction.cpp
+++ b/src/searchresultslistformaction.cpp
@@ -12,7 +12,7 @@ SearchResultsListFormAction::SearchResultsListFormAction(View& vv,
 	RegexManager& r)
 	: ItemListFormAction(vv, formstr, cc, f, cfg, r) {};
 
-const std::vector<KeyMapHintEntry>& SearchResultsListFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> SearchResultsListFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints = {
 		{OP_QUIT, _("Quit")},

--- a/src/selectformaction.cpp
+++ b/src/selectformaction.cpp
@@ -249,7 +249,7 @@ void SelectFormAction::update_heading()
 	set_title(title);
 }
 
-const std::vector<KeyMapHintEntry>& SelectFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> SelectFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints_tag = {{OP_QUIT, _("Cancel")},
 		{OP_OPEN, _("Select Tag")}

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -154,7 +154,7 @@ void UrlViewFormAction::update_heading()
 	set_title(fmt.do_format(cfg->get_configvalue("urlview-title-format"), width));
 }
 
-const std::vector<KeyMapHintEntry>& UrlViewFormAction::get_keymap_hint() const
+std::vector<KeyMapHintEntry> UrlViewFormAction::get_keymap_hint() const
 {
 	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")},
 		{OP_OPEN, _("Open in Browser")},


### PR DESCRIPTION
Came up with the idea while looking into https://github.com/newsboat/newsboat/issues/2857.

This PR introduces a new translatable string so merging might need to wait until after the upcoming release.