### PR TITLE
Update code-formatting-tools to a supported base image

### DIFF
--- a/docker/code-formatting-tools.dockerfile
+++ b/docker/code-formatting-tools.dockerfile
@@ -20,9 +20,7 @@
 #       newsboat-code-formatting-tools \
 #       make fmt
 
-# Use Alpine 3.18 because 3.19 ships astyle 3.4, which is buggy for us:
-# https://gitlab.com/saalen/astyle/-/issues/45
-FROM rust:1.79.0-alpine3.18
+FROM rust:1.79.0-alpine3.19
 WORKDIR /workspace
-RUN apk add --no-cache astyle==3.1-r4 git make
+RUN apk add --no-cache astyle==3.4.10-r0 git make
 RUN rustup component add rustfmt

--- a/rss/atomparser.cpp
+++ b/rss/atomparser.cpp
@@ -50,7 +50,7 @@ void AtomParser::parse_feed(Feed& f, xmlNode* rootNode)
 			const std::string rel = get_prop(node, "rel");
 			if (rel == "alternate") {
 				f.link = newsboat::utils::absolute_url(
-						globalbase, get_prop(node, "href"));
+							globalbase, get_prop(node, "href"));
 			}
 		} else if (node_is(node, "updated", ns)) {
 			f.pubDate = w3cdtf_to_rfc822(get_content(node));
@@ -129,7 +129,7 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 			if (rel == "" || rel == "alternate") {
 				if (it.link.empty() || !newsboat::utils::is_http_url(it.link)) {
 					it.link = newsboat::utils::absolute_url(
-							base, get_prop(node, "href"));
+								base, get_prop(node, "href"));
 				}
 			} else if (rel == "enclosure") {
 				it.enclosures.push_back(
@@ -139,7 +139,7 @@ Item AtomParser::parse_entry(xmlNode* entryNode)
 					"",
 					"",
 				}
-				);
+					);
 			}
 		} else if (node_is(node, "summary", ns)) {
 			const std::string mode = get_prop(node, "mode");

--- a/rss/medianamespace.cpp
+++ b/rss/medianamespace.cpp
@@ -27,7 +27,7 @@ void parse_media_node(xmlNode* node, Item& it, Enclosure* enclosure)
 			"",
 			"",
 		}
-		);
+			);
 		for (xmlNode* mnode = node->children; mnode != nullptr; mnode = mnode->next) {
 			parse_media_node(mnode, it, &it.enclosures.back());
 		}

--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -39,7 +39,7 @@ void Rss09xParser::parse_feed(Feed& f, xmlNode* rootNode)
 			f.title_type = "text";
 		} else if (node_is(node, "link", ns)) {
 			f.link = utils::absolute_url(
-					globalbase, get_content(node));
+						globalbase, get_content(node));
 		} else if (node_is(node, "description", ns)) {
 			f.description = get_content(node);
 		} else if (node_is(node, "language", ns)) {
@@ -126,7 +126,7 @@ Item Rss09xParser::parse_item(xmlNode* itemNode)
 				"",
 				"",
 			}
-			);
+				);
 		} else if (is_media_node(node)) {
 			parse_media_node(node, it);
 		}

--- a/rss/rss10parser.cpp
+++ b/rss/rss10parser.cpp
@@ -34,7 +34,7 @@ void Rss10Parser::parse_feed(Feed& f, xmlNode* rootNode)
 					f.description = get_content(cnode);
 				} else if (node_is(cnode, "date", DC_URI)) {
 					f.pubDate = w3cdtf_to_rfc822(
-							get_content(cnode));
+								get_content(cnode));
 				} else if (node_is(cnode, "creator", DC_URI)) {
 					f.dc_creator = get_content(cnode);
 				}
@@ -59,7 +59,7 @@ void Rss10Parser::parse_feed(Feed& f, xmlNode* rootNode)
 					it.description_mime_type = "";
 				} else if (node_is(itnode, "date", DC_URI)) {
 					it.pubDate = w3cdtf_to_rfc822(
-							get_content(itnode));
+								get_content(itnode));
 				} else if (node_is(itnode,
 						"encoded",
 						CONTENT_URI)) {

--- a/rss/xmlutilities.cpp
+++ b/rss/xmlutilities.cpp
@@ -29,7 +29,7 @@ std::string get_xml_content(xmlNode* node, xmlDocPtr doc)
 			ptr = ptr->next) {
 			if (xmlNodeDump(buf, doc, ptr, 0, 0) >= 0) {
 				result.append(
-					reinterpret_cast<const char*>(xmlBufferContent(buf)));
+						reinterpret_cast<const char*>(xmlBufferContent(buf)));
 				xmlBufferEmpty(buf);
 			} else {
 				result.append(get_content(ptr));

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -485,8 +485,8 @@ void Cache::update_lastmodified(const std::string& feedurl,
 	}
 	if (etag.length() > 0) {
 		query.append(prepare_query("%c etag = %s",
-				(t > 0 ? ',' : ' '),
-				prepare_query("'%q'", etag)));
+					(t > 0 ? ',' : ' '),
+					prepare_query("'%q'", etag)));
 	}
 	query.append(" WHERE rssurl = ");
 	query.append(prepare_query("'%q'", feedurl));
@@ -632,15 +632,13 @@ std::shared_ptr<RssFeed> Cache::internalize_rssfeed(std::string rssurl,
 	if (ign != nullptr) {
 		auto& items = feed->items();
 		items.erase(
-			std::remove_if(
-				items.begin(),
-				items.end(),
+				std::remove_if(
+					items.begin(),
+					items.end(),
 		[&](std::shared_ptr<RssItem> item) -> bool {
-			try
-			{
+			try {
 				return ign->matches(item.get());
-			} catch (const MatcherException& ex)
-			{
+			} catch (const MatcherException& ex) {
 				LOG(Level::DEBUG,
 					"oops, Matcher exception: %s",
 					ex.what());
@@ -718,15 +716,13 @@ std::vector<std::shared_ptr<RssItem>> Cache::search_for_items(
 		item->set_cache(this);
 	}
 	items.erase(
-		std::remove_if(
-			items.begin(),
-			items.end(),
+			std::remove_if(
+				items.begin(),
+				items.end(),
 	[&](std::shared_ptr<RssItem> item) -> bool {
-		try
-		{
+		try {
 			return ign.matches(item.get());
-		} catch (const MatcherException& ex)
-		{
+		} catch (const MatcherException& ex) {
 			LOG(Level::DEBUG,
 				"Cache::search_for_items: oops, Matcher exception: %s",
 				ex.what());

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -494,9 +494,9 @@ void ConfigContainer::dump_config(std::vector<std::string>& config_output) const
 			configline.append(cfg.second.value());
 			if (cfg.second.value() != cfg.second.default_value()) {
 				configline.append(
-					strprintf::fmt(
-						" # default: %s",
-						cfg.second.default_value()));
+						strprintf::fmt(
+							" # default: %s",
+							cfg.second.default_value()));
 			}
 			break;
 		case ConfigDataType::ENUM:
@@ -512,8 +512,8 @@ void ConfigContainer::dump_config(std::vector<std::string>& config_output) const
 				configline.append(utils::quote(cfg.second.value()));
 				if (cfg.second.value() != cfg.second.default_value()) {
 					configline.append(strprintf::fmt(
-							" # default: %s",
-							cfg.second.default_value()));
+								" # default: %s",
+								cfg.second.default_value()));
 				}
 			}
 			break;

--- a/src/configdata.cpp
+++ b/src/configdata.cpp
@@ -86,7 +86,6 @@ nonstd::expected<void, std::string> ConfigData::set_value(
 		break;
 	}
 
-
 	return {};
 }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -689,8 +689,8 @@ void Controller::mark_all_read(unsigned int pos)
 		}
 	}
 	m.stopover(
-		"after rsscache->mark_all_read, before iteration over "
-		"items");
+			"after rsscache->mark_all_read, before iteration over "
+			"items");
 
 	feedcontainer.mark_all_feed_items_read(feed);
 }

--- a/src/dialogsformaction.cpp
+++ b/src/dialogsformaction.cpp
@@ -87,7 +87,7 @@ bool DialogsFormAction::process_operation(Operation op,
 			do_redraw = true;
 		} else {
 			v.get_statusline().show_error(
-				_("Error: you can't remove the feed list!"));
+					_("Error: you can't remove the feed list!"));
 		}
 	}
 	break;

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -137,13 +137,13 @@ bool DirBrowserFormAction::process_operation(Operation op,
 	case OP_SK_PGUP:
 		if (f.get_focus() == "files") {
 			files_list.move_page_up(
-				cfg->get_configvalue_as_bool("wrap-scroll"));
+					cfg->get_configvalue_as_bool("wrap-scroll"));
 		}
 		break;
 	case OP_SK_PGDOWN:
 		if (f.get_focus() == "files") {
 			files_list.move_page_down(
-				cfg->get_configvalue_as_bool("wrap-scroll"));
+					cfg->get_configvalue_as_bool("wrap-scroll"));
 		}
 		break;
 	case OP_SK_HALF_PAGE_UP:

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -116,7 +116,7 @@ REDO:
 			v.get_ctrl()->get_reloader()->reload(pos);
 		} else {
 			v.get_statusline().show_error(
-				_("No feed selected!")); // should not happen
+					_("No feed selected!")); // should not happen
 		}
 	}
 	break;
@@ -232,7 +232,7 @@ REDO:
 					return false;
 				} else if (*exit_code != 0) {
 					v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
-							*exit_code));
+								*exit_code));
 					return false;
 				}
 			}
@@ -259,7 +259,7 @@ REDO:
 					return false;
 				} else if (*exit_code != 0) {
 					v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
-							*exit_code));
+								*exit_code));
 					return false;
 				}
 
@@ -307,12 +307,12 @@ REDO:
 					}
 				} catch (const DbException& e) {
 					v.get_statusline().show_error(strprintf::fmt(
-							_("Error: couldn't mark feed read: %s"),
-							e.what()));
+								_("Error: couldn't mark feed read: %s"),
+								e.what()));
 				}
 			} else {
 				v.get_statusline().show_error(
-					_("No feed selected!")); // should not happen
+						_("No feed selected!")); // should not happen
 			}
 		}
 	}
@@ -423,7 +423,7 @@ REDO:
 					apply_filter(filter.value());
 				} else {
 					v.get_statusline().show_error(strprintf::fmt(_("No filter found with name `%s'."),
-							filter_name));
+								filter_name));
 				}
 			} else {
 				const std::string filter_text = v.select_filter(filter_container.get_filters());
@@ -579,7 +579,7 @@ bool FeedListFormAction::open_position_in_browser(unsigned int pos,
 			return false;
 		} else if (*exit_code != 0) {
 			v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
-					*exit_code));
+						*exit_code));
 			return false;
 		}
 	}
@@ -623,8 +623,7 @@ void FeedListFormAction::set_feedlist(
 
 	auto render_line = [this, feedlist_format](std::uint32_t line,
 	std::uint32_t width) -> StflRichText {
-		if (line >= visible_feeds.size())
-		{
+		if (line >= visible_feeds.size()) {
 			return StflRichText::from_plaintext("ERROR");
 		}
 		auto& feed = visible_feeds[line];
@@ -996,9 +995,9 @@ void FeedListFormAction::op_start_search()
 					utf8searchphrase, nullptr);
 		} catch (const DbException& e) {
 			v.get_statusline().show_error(strprintf::fmt(
-					_("Error while searching for `%s': %s"),
-					searchphrase,
-					e.what()));
+						_("Error while searching for `%s': %s"),
+						searchphrase,
+						e.what()));
 			return;
 		}
 		message_lifetime.reset();
@@ -1070,9 +1069,9 @@ StflRichText FeedListFormAction::format_line(const std::string& feedlist_format,
 
 	fmt.register_fmt('i', strprintf::fmt("%u", pos + 1));
 	fmt.register_fmt('u',
-		strprintf::fmt("(%u/%u)",
-			unread_count,
-			static_cast<unsigned int>(feed->total_item_count())));
+			strprintf::fmt("(%u/%u)",
+				unread_count,
+				static_cast<unsigned int>(feed->total_item_count())));
 	fmt.register_fmt('U', std::to_string(unread_count));
 	fmt.register_fmt('c', std::to_string(feed->total_item_count()));
 	fmt.register_fmt('n', unread_count > 0 ? "N" : " ");
@@ -1115,9 +1114,9 @@ void FeedListFormAction::apply_filter(const std::string& filtertext)
 	filterhistory.add_line(filtertext);
 	if (!matcher.parse(filtertext)) {
 		v.get_statusline().show_error(strprintf::fmt(
-				_("Error: couldn't parse filter expression `%s': %s"),
-				filtertext,
-				matcher.get_parse_error()));
+					_("Error: couldn't parse filter expression `%s': %s"),
+					filtertext,
+					matcher.get_parse_error()));
 	} else {
 		save_filterpos();
 		filter_active = true;

--- a/src/feedretriever.cpp
+++ b/src/feedretriever.cpp
@@ -230,11 +230,11 @@ rsspp::Feed FeedRetriever::download_http(const std::string& uri)
 				etag,
 				p.get_etag());
 			ch.update_lastmodified(uri,
-				(p.get_last_modified() != lm)
-				? p.get_last_modified()
-				: 0,
-				(etag != p.get_etag()) ? p.get_etag()
-				: "");
+					(p.get_last_modified() != lm)
+					? p.get_last_modified()
+					: 0,
+					(etag != p.get_etag()) ? p.get_etag()
+					: "");
 		}
 	}
 	LOG(Level::DEBUG,
@@ -294,6 +294,5 @@ rsspp::Feed FeedRetriever::parse_file(const std::string& file)
 
 	return f;
 }
-
 
 } // namespace newsboat

--- a/src/file_system.cpp
+++ b/src/file_system.cpp
@@ -59,7 +59,6 @@ char filetype_to_char(FileType type)
 	return unknown;
 }
 
-
 nonstd::optional<char> mode_suffix(mode_t mode)
 {
 	const auto type = mode_to_filetype(mode);

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -75,8 +75,8 @@ bool FileBrowserFormAction::process_operation(Operation op,
 						fn.append(fnstr);
 					} else {
 						fn.append(fnstr,
-							base + 1,
-							std::string::npos);
+								base + 1,
+								std::string::npos);
 					}
 					set_value("filenametext", fn);
 					do_redraw = true;
@@ -170,13 +170,13 @@ bool FileBrowserFormAction::process_operation(Operation op,
 	case OP_SK_PGUP:
 		if (f.get_focus() == "files") {
 			files_list.move_page_up(
-				cfg->get_configvalue_as_bool("wrap-scroll"));
+					cfg->get_configvalue_as_bool("wrap-scroll"));
 		}
 		break;
 	case OP_SK_PGDOWN:
 		if (f.get_focus() == "files") {
 			files_list.move_page_down(
-				cfg->get_configvalue_as_bool("wrap-scroll"));
+					cfg->get_configvalue_as_bool("wrap-scroll"));
 		}
 		break;
 	case OP_SK_HALF_PAGE_UP:
@@ -267,7 +267,6 @@ void FileBrowserFormAction::prepare()
 		for (std::string filename : files) {
 			add_file(id_at_position, filename);
 		}
-
 
 		auto render_line = [this](std::uint32_t line, std::uint32_t width) -> StflRichText {
 			(void)width;

--- a/src/filtercontainer.cpp
+++ b/src/filtercontainer.cpp
@@ -49,8 +49,8 @@ void FilterContainer::dump_config(std::vector<std::string>& config_output) const
 {
 	for (const auto& filter : filters) {
 		config_output.push_back(strprintf::fmt("define-filter %s %s",
-				utils::quote(filter.name),
-				utils::quote(filter.expr)));
+					utils::quote(filter.name),
+					utils::quote(filter.expr)));
 	}
 }
 

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -245,8 +245,8 @@ void FormAction::handle_set(const std::vector<std::string>& args)
 			return;
 		}
 		v.get_statusline().show_message(strprintf::fmt("  %s=%s",
-				args[0],
-				utils::quote_if_necessary(cfg->get_configvalue(args[0]))));
+					args[0],
+					utils::quote_if_necessary(cfg->get_configvalue(args[0]))));
 	} else if (args.size() == 2) {
 		std::string result = ConfigParser::evaluate_backticks(args[1]);
 		utils::trim_end(result);
@@ -255,7 +255,7 @@ void FormAction::handle_set(const std::vector<std::string>& args)
 		set_redraw(true);
 	} else {
 		v.get_statusline().show_error(
-			_("usage: set <variable>[=<value>]"));
+				_("usage: set <variable>[=<value>]"));
 	}
 }
 
@@ -274,8 +274,8 @@ void FormAction::handle_source(const std::vector<std::string>& args)
 		for (const auto& param : args) {
 			try {
 				v.get_ctrl()->load_configfile(
-					utils::resolve_tilde(
-						param));
+						utils::resolve_tilde(
+							param));
 			} catch (const ConfigException& ex) {
 				v.get_statusline().show_error(ex.what());
 				break;
@@ -290,10 +290,10 @@ void FormAction::handle_dumpconfig(const std::vector<std::string>& args)
 		v.get_statusline().show_error(_("usage: dumpconfig <file>"));
 	} else {
 		v.get_ctrl()->dump_config(
-			utils::resolve_tilde(args[0]));
+				utils::resolve_tilde(args[0]));
 		v.get_statusline().show_message(strprintf::fmt(
-				_("Saved configuration to %s"),
-				args[0]));
+					_("Saved configuration to %s"),
+					args[0]));
 	}
 }
 
@@ -516,7 +516,7 @@ void FormAction::finished_qna(Operation op)
 			v.get_statusline().show_message(_("Saved bookmark."));
 		} else {
 			v.get_statusline().show_message(
-				_s("Error while saving bookmark: ") + retval);
+					_s("Error while saving bookmark: ") + retval);
 			LOG(Level::DEBUG,
 				"FormAction::finished_qna: error while saving "
 				"bookmark, retval = `%s'",
@@ -588,8 +588,8 @@ void FormAction::start_bookmark_qna(const std::string& default_title,
 				v.get_statusline().show_message(_("Saved bookmark."));
 			} else {
 				v.get_statusline().show_message(
-					_s("Error while saving bookmark: ") +
-					retval);
+						_s("Error while saving bookmark: ") +
+						retval);
 				LOG(Level::DEBUG,
 					"FormAction::finished_qna: error while "
 					"saving bookmark, retval = `%s'",

--- a/src/freshrssapi.cpp
+++ b/src/freshrssapi.cpp
@@ -449,7 +449,6 @@ rsspp::Feed FreshRssApi::fetch_feed(const std::string& id, CurlHandle& cached_ha
 		return feed;
 	}
 
-
 	const nlohmann::json entries = content["items"];
 	if (!entries.is_array()) {
 		LOG(Level::ERROR,
@@ -505,8 +504,8 @@ rsspp::Feed FreshRssApi::fetch_feed(const std::string& id, CurlHandle& cached_ha
 				time_t updated = static_cast<time_t>(pub_time);
 
 				item.pubDate = utils::mt_strf_localtime(
-						"%a, %d %b %Y %H:%M:%S %z",
-						updated);
+							"%a, %d %b %Y %H:%M:%S %z",
+							updated);
 				item.pubDate_ts = pub_time;
 			}
 
@@ -522,7 +521,7 @@ rsspp::Feed FreshRssApi::fetch_feed(const std::string& id, CurlHandle& cached_ha
 							"",
 							"",
 						}
-						);
+							);
 						break;
 					}
 				}

--- a/src/htmlrenderer.cpp
+++ b/src/htmlrenderer.cpp
@@ -202,9 +202,9 @@ void HtmlRenderer::render(std::istream& input,
 									link),
 								LinkType::EMBED);
 						curline.append(strprintf::fmt(
-								"[%s %u]",
-								_("embedded flash:"),
-								link_num));
+									"[%s %u]",
+									_("embedded flash:"),
+									link_num));
 					}
 				}
 			}
@@ -403,12 +403,12 @@ void HtmlRenderer::render(std::istream& input,
 				}
 				if (inside_ordered_list && ol_counts.size() != 0) {
 					curline.append(strprintf::fmt("%s. ",
-							format_ol_count(
-								ol_counts[ol_counts
-									.size() -
-									1],
-								ol_types[ol_types.size() -
-											1])));
+								format_ol_count(
+									ol_counts[ol_counts
+										.size() -
+										1],
+									ol_types[ol_types.size() -
+										1])));
 					++ol_counts[ol_counts.size() - 1];
 				} else {
 					curline.append("  * ");
@@ -773,7 +773,7 @@ void HtmlRenderer::render(std::istream& input,
 						curline.append("</>");
 					}
 					curline.append(strprintf::fmt(
-							"[%d]", link_num));
+								"[%d]", link_num));
 					link_num = -1;
 				}
 				break;
@@ -838,8 +838,8 @@ void HtmlRenderer::render(std::istream& input,
 							++idx)
 							// add rendered table to current cell
 							tables.back().add_text(
-								table_text[idx]
-								.second);
+									table_text[idx]
+									.second);
 					} else {
 						for (size_t idx = 0;
 							idx < table_text.size();
@@ -1223,7 +1223,7 @@ void HtmlRenderer::render_table(const HtmlRenderer::Table& table,
 	// render the table
 	if (table.has_border)
 		lines.push_back(
-			std::make_pair(LineType::nonwrappable, separator));
+				std::make_pair(LineType::nonwrappable, separator));
 	for (size_t row = 0; row < rows; row++) {
 		// calc height of this row
 		size_t height = 0;
@@ -1287,11 +1287,11 @@ void HtmlRenderer::render_table(const HtmlRenderer::Table& table,
 				line += vsep;
 			}
 			lines.push_back(
-				std::make_pair(LineType::nonwrappable, line));
+					std::make_pair(LineType::nonwrappable, line));
 		}
 		if (table.has_border)
 			lines.push_back(std::make_pair(
-					LineType::nonwrappable, separator));
+						LineType::nonwrappable, separator));
 	}
 }
 

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -72,11 +72,11 @@ bool ItemListFormAction::process_operation(Operation op,
 			// that
 			old_itempos = itempos;
 			v.push_itemview(feed,
-				visible_items[itempos].first->guid());
+					visible_items[itempos].first->guid());
 			invalidate(itempos);
 		} else {
 			v.get_statusline().show_error(
-				_("No item selected!")); // should not happen
+					_("No item selected!")); // should not happen
 		}
 	}
 	break;
@@ -85,7 +85,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		if (!visible_items.empty()) {
 			// mark as read
 			v.get_ctrl()->mark_article_read(
-				visible_items[itempos].first->guid(), true);
+					visible_items[itempos].first->guid(), true);
 			visible_items[itempos].first->set_unread(false);
 			// mark as deleted
 			visible_items[itempos].first->set_deleted(
@@ -99,7 +99,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			invalidate(itempos);
 		} else {
 			v.get_statusline().show_error(
-				_("No item selected!")); // should not happen
+					_("No item selected!")); // should not happen
 		}
 	}
 	break;
@@ -184,7 +184,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				return false;
 			} else if (*exit_code != 0) {
 				v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
-						*exit_code));
+							*exit_code));
 				return false;
 			}
 		}
@@ -207,7 +207,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				return false;
 			} else if (*exit_code != 0) {
 				v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
-						*exit_code));
+							*exit_code));
 				return false;
 			}
 			invalidate_list();
@@ -226,17 +226,17 @@ bool ItemListFormAction::process_operation(Operation op,
 						.first->set_unread(
 							false);
 						v.get_ctrl()->mark_article_read(
-							visible_items[itempos]
-							.first->guid(),
-							true);
+								visible_items[itempos]
+								.first->guid(),
+								true);
 					} else if (args.front() == "unread") {
 						visible_items[itempos]
 						.first->set_unread(
 							true);
 						v.get_ctrl()->mark_article_read(
-							visible_items[itempos]
-							.first->guid(),
-							false);
+								visible_items[itempos]
+								.first->guid(),
+								false);
 					}
 				} else {
 					// mark as undeleted
@@ -252,14 +252,14 @@ bool ItemListFormAction::process_operation(Operation op,
 					visible_items[itempos]
 					.first->set_unread(!unread);
 					v.get_ctrl()->mark_article_read(
-						visible_items[itempos]
-						.first->guid(),
-						unread);
+							visible_items[itempos]
+							.first->guid(),
+							unread);
 				}
 			} catch (const DbException& e) {
 				v.get_statusline().show_error(strprintf::fmt(
-						_("Error while toggling read flag: %s"),
-						e.what()));
+							_("Error while toggling read flag: %s"),
+							e.what()));
 			}
 			if (!cfg->get_configvalue_as_bool(
 					"toggleitemread-jumps-to-next-unread")) {
@@ -295,15 +295,15 @@ bool ItemListFormAction::process_operation(Operation op,
 						: visible_items[itempos]
 						.first->feedurl();
 					rnd.render(
-						utils::utf8_to_locale(visible_items[itempos].first->description().text),
-						lines,
-						links,
-						baseurl);
+							utils::utf8_to_locale(visible_items[itempos].first->description().text),
+							lines,
+							links,
+							baseurl);
 					if (!links.empty()) {
 						v.push_urlview(links, feed);
 					} else {
 						v.get_statusline().show_error(
-							_("URL list empty."));
+								_("URL list empty."));
 					}
 				} else {
 					qna_responses.clear();
@@ -313,7 +313,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			}
 		} else {
 			v.get_statusline().show_error(
-				_("No item selected!")); // should not happen
+					_("No item selected!")); // should not happen
 		}
 		break;
 	case OP_BOOKMARK: {
@@ -332,7 +332,7 @@ bool ItemListFormAction::process_operation(Operation op,
 							visible_items[itempos].first->link(),
 							utils::utf8_to_locale(visible_items[itempos].first->title()),
 							args.front(),
-							feed->title(),
+								feed->title(),
 						};
 						this->finished_qna(OP_INT_BM_END);
 					}
@@ -340,13 +340,13 @@ bool ItemListFormAction::process_operation(Operation op,
 				case BindingType::Macro:
 					qna_responses.clear();
 					qna_responses.push_back(
-						visible_items[itempos]
-						.first->link());
+							visible_items[itempos]
+							.first->link());
 					qna_responses.push_back(utils::utf8_to_locale(
-							visible_items[itempos].first->title()));
+								visible_items[itempos].first->title()));
 					qna_responses.push_back(args.size() > 0
-						? args.front()
-						: "");
+							? args.front()
+							: "");
 					qna_responses.push_back(feed->title());
 					this->finished_qna(OP_INT_BM_END);
 					break;
@@ -360,7 +360,7 @@ bool ItemListFormAction::process_operation(Operation op,
 			}
 		} else {
 			v.get_statusline().show_error(
-				_("No item selected!")); // should not happen
+					_("No item selected!")); // should not happen
 		}
 	}
 	break;
@@ -383,7 +383,7 @@ bool ItemListFormAction::process_operation(Operation op,
 					if (args.size() > 0) {
 						qna_responses.clear();
 						qna_responses.push_back(
-							args.front());
+								args.front());
 						finished_qna(
 							OP_INT_EDITFLAGS_END);
 					}
@@ -391,14 +391,14 @@ bool ItemListFormAction::process_operation(Operation op,
 				case BindingType::BindKey:
 					std::vector<QnaPair> qna;
 					qna.push_back(QnaPair(_("Flags: "),
-							visible_items[itempos].first->flags()));
+								visible_items[itempos].first->flags()));
 					this->start_qna(qna, OP_INT_EDITFLAGS_END);
 					break;
 				}
 			}
 		} else {
 			v.get_statusline().show_error(
-				_("No item selected!")); // should not happen
+					_("No item selected!")); // should not happen
 		}
 	}
 	break;
@@ -574,8 +574,8 @@ bool ItemListFormAction::process_operation(Operation op,
 				invalidate_list();
 			} catch (const DbException& e) {
 				v.get_statusline().show_error(strprintf::fmt(
-						_("Error: couldn't mark feed read: %s"),
-						e.what()));
+							_("Error: couldn't mark feed read: %s"),
+							e.what()));
 			}
 		}
 		break;
@@ -590,8 +590,8 @@ bool ItemListFormAction::process_operation(Operation op,
 					visible_items[i].first->set_unread(
 						false);
 					v.get_ctrl()->mark_article_read(
-						visible_items[i].first->guid(),
-						true);
+							visible_items[i].first->guid(),
+							true);
 				}
 			}
 			if (!cfg->get_configvalue_as_bool(
@@ -635,7 +635,7 @@ bool ItemListFormAction::process_operation(Operation op,
 				break;
 			case BindingType::BindKey:
 				qna.push_back(QnaPair(
-						_("Pipe article to command: "), ""));
+							_("Pipe article to command: "), ""));
 				this->start_qna(
 					qna, OP_PIPE_TO, &cmdlinehistory);
 				break;
@@ -711,7 +711,7 @@ bool ItemListFormAction::process_operation(Operation op,
 					apply_filter(filter.value());
 				} else {
 					v.get_statusline().show_error(strprintf::fmt(_("No filter found with name `%s'."),
-							filter_name));
+								filter_name));
 				}
 			} else {
 				const std::string filter_text = v.select_filter(filter_container.get_filters());
@@ -891,7 +891,7 @@ bool ItemListFormAction::open_position_in_browser(
 			return false;
 		} else if (*exit_code != 0) {
 			v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
-					*exit_code));
+						*exit_code));
 			return false;
 		}
 		return true;
@@ -928,7 +928,7 @@ void ItemListFormAction::finished_qna(Operation op)
 			std::string cmd = qna_responses[0];
 			std::ostringstream ostr;
 			v.get_ctrl()->write_item(
-				visible_items[itempos].first, ostr);
+					visible_items[itempos].first, ostr);
 			v.push_empty_formaction();
 			Stfl::reset();
 			FILE* f = popen(cmd.c_str(), "w");
@@ -989,9 +989,9 @@ void ItemListFormAction::qna_start_search()
 				utf8searchphrase, feed);
 	} catch (const DbException& e) {
 		v.get_statusline().show_error(
-			strprintf::fmt(_("Error while searching for `%s': %s"),
-				searchphrase,
-				e.what()));
+				strprintf::fmt(_("Error while searching for `%s': %s"),
+					searchphrase,
+					e.what()));
 		return;
 	}
 
@@ -1073,8 +1073,7 @@ void ItemListFormAction::draw_items()
 
 	auto render_line = [this, itemlist_format, datetime_format](std::uint32_t line,
 	std::uint32_t width) -> StflRichText {
-		if (line >= visible_items.size())
-		{
+		if (line >= visible_items.size()) {
 			return StflRichText::from_plaintext("ERROR");
 		}
 		auto& item = visible_items[line];
@@ -1101,7 +1100,7 @@ void ItemListFormAction::prepare()
 		do_update_visible_items();
 	} catch (MatcherException& e) {
 		v.get_statusline().show_error(strprintf::fmt(
-				_("Error: applying the filter failed: %s"), e.what()));
+					_("Error: applying the filter failed: %s"), e.what()));
 		return;
 	}
 
@@ -1111,8 +1110,8 @@ void ItemListFormAction::prepare()
 			if (visible_items[itempos].first->unread()) {
 				visible_items[itempos].first->set_unread(false);
 				v.get_ctrl()->mark_article_read(
-					visible_items[itempos].first->guid(),
-					true);
+						visible_items[itempos].first->guid(),
+						true);
 				invalidate(itempos);
 			}
 		}
@@ -1163,7 +1162,7 @@ StflRichText ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 			datetime_format, "%L", strprintf::fmt(
 				ngettext("1 day ago", "%u days ago", article_age), article_age));
 	fmt.register_fmt('D', utils::mt_strf_localtime(new_datetime_format,
-			item.first->pubDate_timestamp()));
+				item.first->pubDate_timestamp()));
 
 	if (feed->rssurl() != item.first->feedurl() &&
 		item.first->get_feedptr() != nullptr) {
@@ -1475,11 +1474,11 @@ void ItemListFormAction::save_article(const nonstd::optional<std::string>& filen
 		try {
 			v.get_ctrl()->write_item(item, filename.value());
 			v.get_statusline().show_message(strprintf::fmt(
-					_("Saved article to %s"), filename.value()));
+						_("Saved article to %s"), filename.value()));
 		} catch (...) {
 			v.get_statusline().show_error(strprintf::fmt(
-					_("Error: couldn't save article to %s"),
-					filename.value()));
+						_("Error: couldn't save article to %s"),
+						filename.value()));
 		}
 	}
 }
@@ -1605,7 +1604,7 @@ void ItemListFormAction::handle_op_saveall()
 	std::vector<std::string> filenames;
 	for (const auto& item : visible_items) {
 		filenames.emplace_back( utils::utf8_to_locale(v.get_filename_suggestion(
-					item.first->title())));
+						item.first->title())));
 	}
 
 	const auto unique_filenames = std::set<std::string>(
@@ -1690,9 +1689,9 @@ void ItemListFormAction::apply_filter(const std::string& filtertext)
 	filterhistory.add_line(filtertext);
 	if (!matcher.parse(filtertext)) {
 		v.get_statusline().show_error(strprintf::fmt(
-				_("Error: couldn't parse filter expression `%s': %s"),
-				filtertext,
-				matcher.get_parse_error()));
+					_("Error: couldn't parse filter expression `%s': %s"),
+					filtertext,
+					matcher.get_parse_error()));
 	} else {
 		save_filterpos();
 		filter_active = true;

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -90,9 +90,9 @@ void prepare_header(
 				utils::censor_url(item->enclosure_url()));
 		if (!item->enclosure_type().empty()) {
 			dlurl.append(
-				strprintf::fmt(" (%s%s)",
-					_("type: "),
-					item->enclosure_type()));
+					strprintf::fmt(" (%s%s)",
+						_("type: "),
+						item->enclosure_type()));
 		}
 		lines.push_back(std::make_pair(LineType::softwrappable, dlurl));
 	}

--- a/src/itemutils.cpp
+++ b/src/itemutils.cpp
@@ -13,7 +13,7 @@ bool enqueue_item_enclosure(std::shared_ptr<RssItem> item, std::shared_ptr<RssFe
 		return false;
 	} else if (!utils::is_http_url(item->enclosure_url())) {
 		v.get_statusline().show_error(strprintf::fmt(
-				_("Item's enclosure has non-http link: '%s'"), item->enclosure_url()));
+					_("Item's enclosure has non-http link: '%s'"), item->enclosure_url()));
 		return false;
 	} else {
 		const EnqueueResult result = v.get_ctrl()->enqueue_url(item, feed);
@@ -21,22 +21,22 @@ bool enqueue_item_enclosure(std::shared_ptr<RssItem> item, std::shared_ptr<RssFe
 		switch (result.status) {
 		case EnqueueStatus::QUEUED_SUCCESSFULLY:
 			v.get_statusline().show_message(
-				strprintf::fmt(_("Added %s to download queue."),
-					item->enclosure_url()));
+					strprintf::fmt(_("Added %s to download queue."),
+						item->enclosure_url()));
 			return true;
 		case EnqueueStatus::URL_QUEUED_ALREADY:
 			v.get_statusline().show_message(
-				strprintf::fmt(_("%s is already queued."),
-					item->enclosure_url()));
+					strprintf::fmt(_("%s is already queued."),
+						item->enclosure_url()));
 			return true; // Not a failure, just an idempotent action
 		case EnqueueStatus::OUTPUT_FILENAME_USED_ALREADY:
 			v.get_statusline().show_error(
-				strprintf::fmt(_("Generated filename (%s) is used already."),
-					result.extra_info));
+					strprintf::fmt(_("Generated filename (%s) is used already."),
+						result.extra_info));
 			return false;
 		case EnqueueStatus::QUEUE_FILE_OPEN_ERROR:
 			v.get_statusline().show_error(
-				strprintf::fmt(_("Failed to open queue file: %s."), result.extra_info));
+					strprintf::fmt(_("Failed to open queue file: %s."), result.extra_info));
 			return false;
 		}
 

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -174,8 +174,8 @@ bool ItemViewFormAction::process_operation(Operation op,
 		}
 	} catch (const DbException& e) {
 		v.get_statusline().show_error(strprintf::fmt(
-				_("Error while marking article as read: %s"),
-				e.what()));
+					_("Error while marking article as read: %s"),
+					e.what()));
 	}
 
 	switch (op) {
@@ -215,12 +215,12 @@ bool ItemViewFormAction::process_operation(Operation op,
 			try {
 				v.get_ctrl()->write_item(item, filename.value());
 				v.get_statusline().show_message(strprintf::fmt(
-						_("Saved article to %s."), filename.value()));
+							_("Saved article to %s."), filename.value()));
 			} catch (...) {
 				v.get_statusline().show_error(strprintf::fmt(
-						_("Error: couldn't write article to "
-							"file %s"),
-						filename.value()));
+							_("Error: couldn't write article to "
+								"file %s"),
+							filename.value()));
 			}
 		}
 	}
@@ -251,7 +251,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 					item->link(),
 					utils::utf8_to_locale(item->title()),
 					args.front(),
-					feed->title(),
+						feed->title(),
 				};
 				finished_qna(OP_INT_BM_END);
 			}
@@ -261,7 +261,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 			qna_responses.push_back(item->link());
 			qna_responses.push_back(utils::utf8_to_locale(item->title()));
 			qna_responses.push_back(
-				args.size() > 0 ? args.front() : "");
+					args.size() > 0 ? args.front() : "");
 			qna_responses.push_back(feed->title());
 			finished_qna(OP_INT_BM_END);
 			break;
@@ -320,7 +320,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 			break;
 		case BindingType::BindKey:
 			qna.push_back(
-				QnaPair(_("Pipe article to command: "), ""));
+					QnaPair(_("Pipe article to command: "), ""));
 			this->start_qna(qna, OP_PIPE_TO, &cmdlinehistory);
 			break;
 		}
@@ -452,8 +452,8 @@ bool ItemViewFormAction::process_operation(Operation op,
 			}
 		} catch (const DbException& e) {
 			v.get_statusline().show_error(strprintf::fmt(
-					_("Error while marking article as unread: %s"),
-					e.what()));
+						_("Error while marking article as unread: %s"),
+						e.what()));
 		}
 		quit = true;
 		break;
@@ -569,7 +569,7 @@ bool ItemViewFormAction::open_link_in_browser(const std::string& link,
 		return false;
 	} else if (*exit_code != 0) {
 		v.get_statusline().show_error(strprintf::fmt(_("Browser returned error code %i"),
-				*exit_code));
+					*exit_code));
 		return false;
 	}
 	return true;
@@ -634,15 +634,15 @@ void ItemViewFormAction::handle_save(const std::string& filename_param)
 	} else {
 		try {
 			v.get_ctrl()->write_item(
-				item, filename);
+					item, filename);
 			v.get_statusline().show_message(strprintf::fmt(
-					_("Saved article to %s"),
-					filename));
+						_("Saved article to %s"),
+						filename));
 		} catch (...) {
 			v.get_statusline().show_error(strprintf::fmt(
-					_("Error: couldn't save "
-						"article to %s"),
-					filename));
+						_("Error: couldn't save "
+							"article to %s"),
+						filename));
 		}
 	}
 }
@@ -696,8 +696,8 @@ void ItemViewFormAction::register_format_styles()
 {
 	std::string attrstr = rxman.get_attrs_stfl_string("article", false);
 	attrstr.append(
-		"@style_b_normal[color_bold]:attr=bold "
-		"@style_u_normal[color_underline]:attr=underline ");
+			"@style_b_normal[color_bold]:attr=bold "
+			"@style_u_normal[color_underline]:attr=underline ");
 	std::string stfl_textview = strprintf::fmt(
 			"{textview[article] style_normal[article]: "
 			"style_end[end-of-text-marker]:fg=blue,attr=bold %s .expand:vh "

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -1002,7 +1002,6 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 	}
 }
 
-
 ParsedOperations KeyMap::parse_operation_sequence(const std::string& line,
 	const std::string& command_name, bool allow_description)
 {
@@ -1101,7 +1100,6 @@ unsigned short KeyMap::get_flag_from_context(const std::string& context)
 
 	return 0; // shouldn't happen
 }
-
 
 std::string KeyMap::prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints,
 	const std::string& context)

--- a/src/lineview.cpp
+++ b/src/lineview.cpp
@@ -28,5 +28,4 @@ void LineView::hide()
 	f.set("show_" + name, "0");
 }
 
-
 } // namespace newsboat

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -46,7 +46,7 @@ std::string ListFormatter::format_list() const
 			rxman->quote_and_highlight(str, location);
 		}
 		format_cache.append(strprintf::fmt(
-				"{listitem text:%s}", Stfl::quote(str.stfl_quoted())));
+					"{listitem text:%s}", Stfl::quote(str.stfl_quoted())));
 	}
 	format_cache.push_back('}');
 	return format_cache;

--- a/src/newsblurapi.cpp
+++ b/src/newsblurapi.cpp
@@ -344,8 +344,8 @@ rsspp::Feed NewsBlurApi::fetch_feed(const std::string& id)
 				}
 
 				item.pubDate = utils::mt_strf_localtime(
-						"%a, %d %b %Y %H:%M:%S %z",
-						item.pubDate_ts);
+							"%a, %d %b %Y %H:%M:%S %z",
+							item.pubDate_ts);
 			}
 
 			f.items.push_back(item);

--- a/src/ocnewsapi.cpp
+++ b/src/ocnewsapi.cpp
@@ -291,7 +291,7 @@ rsspp::Feed OcNewsApi::fetch_feed(const std::string& feed_id)
 					"",
 					"",
 				}
-				);
+					);
 			}
 		}
 
@@ -304,7 +304,7 @@ rsspp::Feed OcNewsApi::fetch_feed(const std::string& feed_id)
 		json_object_object_get_ex(item_j, "guid", &node);
 		const auto guid = json_object_get_string(node);
 		item.guid = std::to_string(id) + ":" + std::to_string(f_id) +
-			"/" + (guid ? std::string(guid) : std::to_string(i));
+				"/" + (guid ? std::string(guid) : std::to_string(i));
 
 		json_object_object_get_ex(item_j, "unread", &node);
 		bool unread = json_object_get_boolean(node);
@@ -318,8 +318,8 @@ rsspp::Feed OcNewsApi::fetch_feed(const std::string& feed_id)
 		time_t updated = (time_t)json_object_get_int(node);
 
 		item.pubDate = utils::mt_strf_localtime(
-				"%a, %d %b %Y %H:%M:%S %z",
-				updated);
+					"%a, %d %b %Y %H:%M:%S %z",
+					updated);
 
 		feed.items.push_back(item);
 	}

--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -132,8 +132,8 @@ void rec_find_rss_outlines(
 						filtercmd,
 						nurl);
 					nurl.insert(0,
-						strprintf::fmt("filter:%s:",
-							filtercmd));
+							strprintf::fmt("filter:%s:",
+								filtercmd));
 					xmlFree(filtercmd);
 				}
 

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -196,12 +196,12 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 					status == DlStatus::PLAYED ||
 					status == DlStatus::READY) {
 					ctrl.play_file(ctrl.downloads()[idx]
-						.filename());
+							.filename());
 					ctrl.downloads()[idx].set_status(
-						DlStatus::PLAYED);
+							DlStatus::PLAYED);
 				} else {
 					msg_line_dllist_form.set_text(_("Error: download needs to be "
-							"finished before the file can be played."));
+								"finished before the file can be played."));
 				}
 			}
 		}
@@ -227,7 +227,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 				if (ctrl.downloads()[idx].status() ==
 					DlStatus::DOWNLOADING) {
 					ctrl.downloads()[idx].set_status(
-						DlStatus::CANCELLED);
+							DlStatus::CANCELLED);
 				}
 			}
 		}
@@ -249,7 +249,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		case OP_PB_PURGE:
 			if (ctrl.downloads_in_progress() > 0) {
 				msg_line_dllist_form.set_text(_("Error: unable to perform operation: "
-						"download(s) in progress."));
+							"download(s) in progress."));
 			} else {
 				ctrl.purge_queue();
 			}
@@ -278,9 +278,9 @@ void PbView::apply_colors_to_all_forms()
 {
 	using namespace std::placeholders;
 	colorman.apply_colors(std::bind(&newsboat::Stfl::Form::set, &dllist_form, _1,
-			_2));
+				_2));
 	colorman.apply_colors(std::bind(&newsboat::Stfl::Form::set, &help_form, _1,
-			_2));
+				_2));
 }
 
 std::pair<double, std::string> PbView::get_speed_human_readable(double kbps)
@@ -314,7 +314,7 @@ void PbView::run_help()
 	}
 
 	help_textview.stfl_replace_lines(listfmt.get_lines_count(),
-		listfmt.format_list());
+			listfmt.format_list());
 
 	bool quit = false;
 
@@ -403,9 +403,9 @@ StflRichText PbView::format_line(const std::string& podlist_format,
 
 	fmt.register_fmt('i', strprintf::fmt("%u", pos + 1));
 	fmt.register_fmt('d',
-		strprintf::fmt("%.1f", dl.current_size() / (1024 * 1024)));
+			strprintf::fmt("%.1f", dl.current_size() / (1024 * 1024)));
 	fmt.register_fmt(
-		't', strprintf::fmt("%.1f", dl.total_size() / (1024 * 1024)));
+			't', strprintf::fmt("%.1f", dl.total_size() / (1024 * 1024)));
 	fmt.register_fmt('p', strprintf::fmt("%.1f", dl.percents_finished()));
 	fmt.register_fmt('k', strprintf::fmt("%.2f", speed_kbps));
 	fmt.register_fmt('K', strprintf::fmt("%.2f %s", speed.first, speed.second));

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -261,12 +261,12 @@ void RegexManager::handle_highlight_item_action(const std::string& action,
 		int pos = locations["articlelist"].size();
 		locations["articlelist"].push_back({nullptr, colorstr});
 		matchers_article.push_back(
-			std::pair<std::shared_ptr<Matcher>, int>(m, pos));
+				std::pair<std::shared_ptr<Matcher>, int>(m, pos));
 	} else if (action == "highlight-feed") {
 		int pos = locations["feedlist"].size();
 		locations["feedlist"].push_back({nullptr, colorstr});
 		matchers_feed.push_back(
-			std::pair<std::shared_ptr<Matcher>, int>(m, pos));
+				std::pair<std::shared_ptr<Matcher>, int>(m, pos));
 	} else {
 		throw ConfigHandlerException(
 			ActionHandlerStatus::INVALID_COMMAND);

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -331,9 +331,9 @@ void Reloader::notify_reload_finished(unsigned int unread_feeds_before,
 		fmt.register_fmt('f', std::to_string(unread_feeds));
 		fmt.register_fmt('n', std::to_string(unread_articles));
 		fmt.register_fmt('d',
-			std::to_string(article_count >= 0 ? article_count : 0));
+				std::to_string(article_count >= 0 ? article_count : 0));
 		fmt.register_fmt(
-			'D', std::to_string(feed_count >= 0 ? feed_count : 0));
+				'D', std::to_string(feed_count >= 0 ? feed_count : 0));
 		notify(fmt.do_format(cfg.get_configvalue("notify-format")));
 	}
 }

--- a/src/rssfeed.cpp
+++ b/src/rssfeed.cpp
@@ -351,7 +351,7 @@ void RssFeed::purge_deleted_items()
 	}
 
 	items_.erase(std::remove_if(items_.begin(),
-			items_.end(),
+				items_.end(),
 	[](const std::shared_ptr<RssItem> item) {
 		return item->deleted();
 	}),

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -94,11 +94,11 @@ void RssIgnores::dump_config(std::vector<std::string>& config_output) const
 	}
 	for (const auto& ign_lm : ignores_lastmodified) {
 		config_output.push_back(strprintf::fmt(
-				"always-download %s", utils::quote(ign_lm)));
+					"always-download %s", utils::quote(ign_lm)));
 	}
 	for (const auto& rf : resetflag) {
 		config_output.push_back(strprintf::fmt(
-				"reset-unread-on-update %s", utils::quote(rf)));
+					"reset-unread-on-update %s", utils::quote(rf)));
 	}
 }
 

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -240,7 +240,7 @@ void RssItem::sort_flags()
 
 	// Erase non-alpha characters
 	flags_.erase(std::remove_if(flags_.begin(),
-			flags_.end(),
+				flags_.end(),
 	[](const char c) {
 		return !isalpha(c);
 	}),

--- a/src/searchresultslistformaction.cpp
+++ b/src/searchresultslistformaction.cpp
@@ -49,11 +49,11 @@ bool SearchResultsListFormAction::process_operation(
 			// that
 			old_itempos = itempos;
 			v.push_itemview(feed,
-				visible_items[itempos].first->guid(), search_phrase);
+					visible_items[itempos].first->guid(), search_phrase);
 			invalidate(itempos);
 		} else {
 			v.get_statusline().show_error(
-				_("No item selected!")); // should not happen
+					_("No item selected!")); // should not happen
 		}
 		break;
 	case OP_PREVSEARCHRESULTS:
@@ -101,6 +101,5 @@ FmtStrFormatter SearchResultsListFormAction::setup_head_formatter(
 
 	return fmt;
 };
-
 
 } // namespace newsboat

--- a/src/statusline.cpp
+++ b/src/statusline.cpp
@@ -54,7 +54,7 @@ void StatusLine::mark_finished(std::uint32_t message_id)
 	std::lock_guard<std::mutex> guard(m);
 
 	active_messages.erase(
-		std::remove_if(active_messages.begin(),
+			std::remove_if(active_messages.begin(),
 	active_messages.end(), [&](std::pair<std::uint32_t, std::string> x) {
 		return x.first == message_id;
 	}));

--- a/src/stflpp.cpp
+++ b/src/stflpp.cpp
@@ -88,7 +88,7 @@ void Stfl::Form::modify(const std::string& name,
 	const std::string& mode,
 	const std::string& text)
 {
-	const wchar_t* wname, *wmode, *wtext;
+	const wchar_t* wname, * wmode, * wtext;
 	wname = stfl_ipool_towc(ipool, name.c_str());
 	wmode = stfl_ipool_towc(ipool, mode.c_str());
 	wtext = stfl_ipool_towc(ipool, text.c_str());

--- a/src/strprintf.cpp
+++ b/src/strprintf.cpp
@@ -28,7 +28,6 @@ std::string strprintf::fmt(const std::string& format)
 	return result;
 }
 
-
 /* Splits a printf-like format string into two parts, where first part contains
  * at most one format while the second part contains the rest of the input
  * string:

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -220,7 +220,7 @@ std::pair<std::string, std::size_t> TextFormatter::format_text_to_list(
 		if (line != "") {
 			utils::trim_end(line);
 			format_cache.append(strprintf::fmt(
-					"{listitem text:%s}", Stfl::quote(line)));
+						"{listitem text:%s}", Stfl::quote(line)));
 		}
 	}
 	format_cache.push_back('}');

--- a/src/textviewwidget.cpp
+++ b/src/textviewwidget.cpp
@@ -135,7 +135,6 @@ void TextviewWidget::scroll_halfpage_down()
 	}
 }
 
-
 std::uint32_t TextviewWidget::get_scroll_offset()
 {
 	const std::string offset = form.get(textview_name + "_offset");

--- a/src/ttrssapi.cpp
+++ b/src/ttrssapi.cpp
@@ -417,7 +417,7 @@ rsspp::Feed TtRssApi::fetch_feed(const std::string& id, CurlHandle& cached_handl
 							"",
 							"",
 						}
-						);
+							);
 						break;
 					}
 				}
@@ -437,8 +437,8 @@ rsspp::Feed TtRssApi::fetch_feed(const std::string& id, CurlHandle& cached_handl
 			time_t updated = static_cast<time_t>(updated_time);
 
 			item.pubDate = utils::mt_strf_localtime(
-					"%a, %d %b %Y %H:%M:%S %z",
-					updated);
+						"%a, %d %b %Y %H:%M:%S %z",
+						updated);
 			item.pubDate_ts = updated;
 
 			f.items.push_back(item);

--- a/src/urlviewformaction.cpp
+++ b/src/urlviewformaction.cpp
@@ -78,7 +78,7 @@ bool UrlViewFormAction::process_operation(Operation op,
 			const std::string feedurl = (feed != nullptr ?  feed->rssurl() : "");
 			const bool interactive = true;
 			v.open_in_browser(links[idx].url, feedurl, utils::link_type_str(links[idx].type),
-				feed->title(), interactive);
+					feed->title(), interactive);
 		}
 	}
 	break;
@@ -113,7 +113,7 @@ void UrlViewFormAction::open_current_position_in_browser(bool interactive)
 		const unsigned int pos = urls_list.get_position();
 		const std::string feedurl = (feed != nullptr ?  feed->rssurl() : "");
 		v.open_in_browser(links[pos].url, feedurl, utils::link_type_str(links[pos].type),
-			feed->title(), interactive);
+				feed->title(), interactive);
 	} else {
 		v.get_statusline().show_error(_("No links available!"));
 	}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -485,7 +485,7 @@ std::vector<std::pair<unsigned int, unsigned int>> utils::partition_indexes(
 
 	for (unsigned int i = 0; i < parts - 1; i++) {
 		partitions.push_back(std::pair<unsigned int, unsigned int>(
-				start, start + size - 1));
+					start, start + size - 1));
 		start += size;
 	}
 
@@ -517,7 +517,7 @@ std::string utils::join(const std::vector<std::string>& strings,
 
 	if (result.length() > 0)
 		result.erase(
-			result.length() - separator.length(), result.length());
+				result.length() - separator.length(), result.length());
 
 	return result;
 }
@@ -756,11 +756,11 @@ nonstd::expected<std::vector<std::string>, utils::ReadTextFileError> utils::read
 		if (error_line_number == 0) {
 			error.kind = ReadTextFileErrorKind::CantOpen;
 			error.message = strprintf::fmt(_("Failed to open file: %s"),
-					std::string(error_reason));
+						std::string(error_reason));
 		} else {
 			error.kind = ReadTextFileErrorKind::LineError;
 			error.message = strprintf::fmt(_("Failed to read line %u: %s"),
-					error_line_number, std::string(error_reason));
+						error_line_number, std::string(error_reason));
 		}
 
 		return nonstd::make_unexpected(error);

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -419,7 +419,7 @@ void View::update_visible_feeds(std::vector<std::shared_ptr<RssFeed>> feeds)
 		}
 	} catch (const MatcherException& e) {
 		status_line.show_message(strprintf::fmt(
-				_("Error: applying the filter failed: %s"), e.what()));
+					_("Error: applying the filter failed: %s"), e.what()));
 		LOG(Level::DEBUG,
 			"View::update_visible_feeds: inside catch: %s",
 			e.what());
@@ -442,7 +442,7 @@ void View::set_feedlist(std::vector<std::shared_ptr<RssFeed>> feeds)
 		}
 	} catch (const MatcherException& e) {
 		status_line.show_message(strprintf::fmt(
-				_("Error: applying the filter failed: %s"), e.what()));
+					_("Error: applying the filter failed: %s"), e.what()));
 	}
 }
 
@@ -552,8 +552,8 @@ void View::push_itemview(std::shared_ptr<RssFeed> f,
 			}
 		} catch (const DbException& e) {
 			status_line.show_error(strprintf::fmt(
-					_("Error while marking article as read: %s"),
-					e.what()));
+						_("Error while marking article as read: %s"),
+						e.what()));
 		}
 		::unlink(filename.c_str());
 	}
@@ -1119,8 +1119,8 @@ std::vector<std::pair<unsigned int, std::string>> View::get_formaction_names()
 	for (const auto& form : formaction_stack) {
 		if (form && form->id() != "dialogs") {
 			formaction_names.push_back(
-				std::pair<unsigned int, std::string>(
-					i, form->title()));
+					std::pair<unsigned int, std::string>(
+						i, form->title()));
 		}
 		i++;
 	}

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -1007,8 +1007,7 @@ TEST_CASE(
 	auto count_callback = [](void* data, int argc, char** argv, char**
 	/* azColName */) -> int {
 		int* count = static_cast<int*>(data);
-		if (argc > 0)
-		{
+		if (argc > 0) {
 			std::istringstream is(argv[0]);
 			is >> *count;
 		}

--- a/test/colormanager.cpp
+++ b/test/colormanager.cpp
@@ -219,8 +219,7 @@ TEST_CASE("dump_config() returns everything we put into ColorManager",
 	// and nothing more.
 	auto equivalent = [&]() -> bool {
 		std::size_t found = 0;
-		for (const auto& line : config)
-		{
+		for (const auto& line : config) {
 			if (expected.find(line) == expected.end()) {
 				return false;
 			}

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -447,14 +447,14 @@ TEST_CASE(
 		REQUIRE(sort_strategy.sd == SortDirection::DESC);
 
 		cfg.set_configvalue(
-			"feed-sort-order", "unreadarticlecount-desc");
+				"feed-sort-order", "unreadarticlecount-desc");
 		sort_strategy = cfg.get_feed_sort_strategy();
 		REQUIRE(sort_strategy.sm ==
 			FeedSortMethod::UNREAD_ARTICLE_COUNT);
 		REQUIRE(sort_strategy.sd == SortDirection::DESC);
 
 		cfg.set_configvalue(
-			"feed-sort-order", "unreadarticlecount-asc");
+				"feed-sort-order", "unreadarticlecount-asc");
 		sort_strategy = cfg.get_feed_sort_strategy();
 		REQUIRE(sort_strategy.sm ==
 			FeedSortMethod::UNREAD_ARTICLE_COUNT);

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -209,7 +209,7 @@ TEST_CASE("evaluate_backticks replaces command in backticks with its output",
 		// output of that command would be empty, so nothing will be inserted
 		// in place of backticks.
 		const auto expected2 = std::string(R"#(a "b  f)#");
-		REQUIRE(ConfigParser::evaluate_backticks(input2) == expected2);
+			REQUIRE(ConfigParser::evaluate_backticks(input2) == expected2);
 	}
 }
 

--- a/test/controller.cpp
+++ b/test/controller.cpp
@@ -32,7 +32,6 @@ TEST_CASE("write_item correctly parses path", "[Controller]")
 	cfg->set_configvalue("save-path", save_path);
 	Cache rsscache(":memory:", cfg);
 
-
 	auto item = std::make_shared<RssItem>(&rsscache);
 	item->set_title("title");
 	const auto description = "First line.\nSecond one.\nAnd finally the third";

--- a/test/download.cpp
+++ b/test/download.cpp
@@ -64,7 +64,6 @@ TEST_CASE("filename() returns download's target filename", "[Download]")
 		REQUIRE(d.filename() == "");
 	}
 
-
 	SECTION("filename returns same string which is set via set_filename") {
 		d.set_filename("abc");
 		REQUIRE(d.filename() == "abc");

--- a/test/feedcontainer.cpp
+++ b/test/feedcontainer.cpp
@@ -683,7 +683,7 @@ TEST_CASE("sort_feeds() sorts by number of unread articles if `feed-sort-order` 
 
 	SECTION("`unreadarticlecount-asc` -- feed with most unread items is at the top") {
 		cfg.set_configvalue(
-			"feed-sort-order", "unreadarticlecount-asc");
+				"feed-sort-order", "unreadarticlecount-asc");
 		feedcontainer.sort_feeds(cfg.get_feed_sort_strategy());
 		const auto sorted_feeds = feedcontainer.get_all_feeds();
 		REQUIRE(sorted_feeds[0]->unread_item_count() == 3);
@@ -695,7 +695,7 @@ TEST_CASE("sort_feeds() sorts by number of unread articles if `feed-sort-order` 
 
 	SECTION("`unreadarticlecount-desc` -- feed with most unread items is at the bottom") {
 		cfg.set_configvalue(
-			"feed-sort-order", "unreadarticlecount-desc");
+				"feed-sort-order", "unreadarticlecount-desc");
 		feedcontainer.sort_feeds(cfg.get_feed_sort_strategy());
 		const auto sorted_feeds = feedcontainer.get_all_feeds();
 		REQUIRE(sorted_feeds[0]->unread_item_count() == 0);

--- a/test/fslock.cpp
+++ b/test/fslock.cpp
@@ -69,7 +69,6 @@ private:
 	sem_t* sem_stop;
 };
 
-
 TEST_CASE("try_lock() returns an error if lock-file permissions or location are invalid",
 	"[FsLock]")
 {
@@ -159,4 +158,3 @@ TEST_CASE("try_lock() succeeds if lock file location is valid and not locked by 
 		REQUIRE(0 == ::access(new_lock_location.get_path().c_str(), F_OK));
 	}
 }
-

--- a/test/htmlrenderer.cpp
+++ b/test/htmlrenderer.cpp
@@ -84,9 +84,9 @@ TEST_CASE(
 	Links links;
 
 	rnd.render("<a href=\"http://slashdot.org/\">slashdot</a>",
-		lines,
-		links,
-		"");
+			lines,
+			links,
+			"");
 
 	REQUIRE(lines.size() == 1);
 

--- a/test/itemlistformaction.cpp
+++ b/test/itemlistformaction.cpp
@@ -289,7 +289,7 @@ TEST_CASE("OP_OPENALLUNREADINBROWSER passes the url list to the browser",
 		int maxItemsToOpen = 4;
 		int openedItemsCount = 0;
 		cfg.set_configvalue(
-			"max-browser-tabs", std::to_string(maxItemsToOpen));
+				"max-browser-tabs", std::to_string(maxItemsToOpen));
 
 		const std::vector<std::string> args;
 		itemlist.process_op(OP_OPENALLUNREADINBROWSER, args);
@@ -313,7 +313,7 @@ TEST_CASE("OP_OPENALLUNREADINBROWSER passes the url list to the browser",
 		int maxItemsToOpen = 9;
 		int openedItemsCount = 0;
 		cfg.set_configvalue(
-			"max-browser-tabs", std::to_string(maxItemsToOpen));
+				"max-browser-tabs", std::to_string(maxItemsToOpen));
 
 		const std::vector<std::string> args;
 		itemlist.process_op(OP_OPENALLUNREADINBROWSER, args);
@@ -375,7 +375,7 @@ TEST_CASE(
 		const unsigned int maxItemsToOpen = 4;
 		unsigned int openedItemsCount = 0;
 		cfg.set_configvalue(
-			"max-browser-tabs", std::to_string(maxItemsToOpen));
+				"max-browser-tabs", std::to_string(maxItemsToOpen));
 
 		const std::vector<std::string> args;
 		itemlist.process_op(OP_OPENALLUNREADINBROWSER_AND_MARK, args);
@@ -400,7 +400,7 @@ TEST_CASE(
 		int maxItemsToOpen = 9;
 		int openedItemsCount = 0;
 		cfg.set_configvalue(
-			"max-browser-tabs", std::to_string(maxItemsToOpen));
+				"max-browser-tabs", std::to_string(maxItemsToOpen));
 
 		const std::vector<std::string> args;
 		itemlist.process_op(OP_OPENALLUNREADINBROWSER_AND_MARK, args);
@@ -460,7 +460,7 @@ TEST_CASE("OP_SHOWURLS shows the article's properties", "[ItemListFormAction]")
 		feed->add_item(item);
 		itemlist.set_feed(feed);
 		cfg.set_configvalue(
-			"external-url-viewer", "tee > " + urlFile.get_path());
+				"external-url-viewer", "tee > " + urlFile.get_path());
 
 		const std::vector<std::string> args;
 		REQUIRE_NOTHROW(itemlist.process_op(OP_SHOWURLS, args));
@@ -522,7 +522,7 @@ TEST_CASE("OP_BOOKMARK pipes articles url and title to bookmark-command",
 	itemlist.set_feed(feed);
 
 	cfg.set_configvalue(
-		"bookmark-cmd", "echo > " + bookmarkFile.get_path());
+			"bookmark-cmd", "echo > " + bookmarkFile.get_path());
 
 	bookmark_args.push_back(extra_arg);
 
@@ -733,7 +733,7 @@ TEST_CASE("Navigate back and forth using OP_NEXT and OP_PREV",
 	newsboat::View v(&c);
 	ConfigContainer cfg;
 	cfg.set_configvalue(
-		"external-url-viewer", "tee > " + articleFile.get_path());
+			"external-url-viewer", "tee > " + articleFile.get_path());
 	Cache rsscache(":memory:", &cfg);
 	std::string line;
 

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -23,8 +23,7 @@ std::shared_ptr<RssFeed> create_test_feed(Cache* c)
 static const auto ITEM_TITLE = std::string("A frivolous test item");
 static const auto ITEM_AUTHOR = std::string("Johnny Doe Jr.");
 // Sun Sep 30 19:34:25 UTC 2018
-static const auto ITEM_PUBDATE = time_t
-{
+static const auto ITEM_PUBDATE = time_t {
 	1538336065
 };
 static const auto ITEM_LINK = std::string("https://example.com/see-more");
@@ -529,7 +528,6 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 		}
 	}
 
-
 	SECTION("Multi-paragraph description") {
 		const auto description = std::string() +
 			"<p>Hello, world!</p>\n\n"
@@ -642,7 +640,6 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed URL "
 	std::shared_ptr<RssFeed> feed = std::make_shared<RssFeed>(&rsscache, feedurl);
 	auto item = std::make_shared<RssItem>(&rsscache);
 	item->set_feedptr(feed);
-
 
 	feed->set_title("");
 	feed->set_link("");

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -592,19 +592,19 @@ TEST_CASE("Whitespace around semicolons in macros is optional", "[KeyMap]")
 
 	SECTION("Whitespace not required before the semicolon") {
 		k.handle_action("macro",
-			R"(x open; set browser "firefox --private-window"; quit)");
+				R"(x open; set browser "firefox --private-window"; quit)");
 		check();
 	}
 
 	SECTION("Whitespace not required after the semicolon") {
 		k.handle_action("macro",
-			R"(x open ;set browser "firefox --private-window" ;quit)");
+				R"(x open ;set browser "firefox --private-window" ;quit)");
 		check();
 	}
 
 	SECTION("Whitespace not required on either side of the semicolon") {
 		k.handle_action("macro",
-			R"(x open;set browser "firefox --private-window";quit)");
+				R"(x open;set browser "firefox --private-window";quit)");
 		check();
 	}
 }
@@ -646,7 +646,7 @@ TEST_CASE("Semicolons in operation's arguments don't break parsing of a macro",
 	KeyMap k(KM_NEWSBOAT);
 
 	k.handle_action("macro",
-		R"(x set browser "sleep 3; do-something ; echo hi"; open-in-browser)");
+			R"(x set browser "sleep 3; do-something ; echo hi"; open-in-browser)");
 
 	const auto macro = k.get_macro(KeyCombination("x"));
 	REQUIRE(macro.size() == 2);

--- a/test/listformatter.cpp
+++ b/test/listformatter.cpp
@@ -78,7 +78,7 @@ TEST_CASE("format_list() uses regex manager if one is passed",
 	// the choice of green text on red background does not reflect my
 	// personal taste (or lack thereof) :)
 	rxmgr.handle_action(
-		"highlight", {"article", "please", "green", "default"});
+			"highlight", {"article", "please", "green", "default"});
 
 	std::string expected =
 		"{list"

--- a/test/listwidget.cpp
+++ b/test/listwidget.cpp
@@ -22,7 +22,6 @@ StflRichText render_empty_line(std::uint32_t, std::uint32_t)
 	return StflRichText::from_plaintext("");
 }
 
-
 TEST_CASE("invalidate_list_content() makes sure `position < num_lines`", "[ListWidget]")
 {
 	const std::uint32_t scrolloff = 0;

--- a/test/opmlurlreader.cpp
+++ b/test/opmlurlreader.cpp
@@ -30,8 +30,8 @@ TEST_CASE("OpmlUrlReader::reload() reads URLs and tags from an OPML file",
 {
 	ConfigContainer cfg;
 	cfg.set_configvalue(
-		"opml-url",
-		"file://" + utils::getcwd() + "/data/example.opml");
+			"opml-url",
+			"file://" + utils::getcwd() + "/data/example.opml");
 
 	OpmlUrlReader reader(cfg);
 
@@ -65,8 +65,8 @@ TEST_CASE("OpmlUrlReader::reload() reads URLs and tags from an OPML file",
 	std::set<Tag> expected_tags;
 	for (const auto& entry : expected) {
 		expected_tags.insert(
-			entry.second.cbegin(),
-			entry.second.cend());
+				entry.second.cbegin(),
+				entry.second.cend());
 	}
 	std::set<Tag> tags;
 	const auto alltags = reader.get_alltags();
@@ -81,9 +81,9 @@ TEST_CASE("OpmlUrlReader::reload() loads URLs from multiple sources",
 
 	ConfigContainer cfg;
 	cfg.set_configvalue("opml-url",
-		"file://" + cwd + "/data/example.opml"
-		+ " "
-		+ "file://" + cwd + "/data/example2.opml");
+			"file://" + cwd + "/data/example.opml"
+			+ " "
+			+ "file://" + cwd + "/data/example2.opml");
 
 	OpmlUrlReader reader(cfg);
 
@@ -124,8 +124,8 @@ TEST_CASE("OpmlUrlReader::reload() loads URLs from multiple sources",
 	std::set<Tag> expected_tags;
 	for (const auto& entry : expected) {
 		expected_tags.insert(
-			entry.second.cbegin(),
-			entry.second.cend());
+				entry.second.cbegin(),
+				entry.second.cend());
 	}
 	std::set<Tag> tags;
 	const auto alltags = reader.get_alltags();
@@ -140,13 +140,13 @@ TEST_CASE("OpmlUrlReader::reload() skips things that can't be parsed",
 
 	ConfigContainer cfg;
 	cfg.set_configvalue("opml-url",
-		"file://" + cwd + "/data/example.opml"
-		+ " "
-		+ "file:///dev/null" // empty file
-		+ " "
-		+ "file://" + cwd + "/data/guaranteed-not-to-exist.xml"
-		+ " "
-		+ "file://" + cwd + "/data/example2.opml");
+			"file://" + cwd + "/data/example.opml"
+			+ " "
+			+ "file:///dev/null" // empty file
+			+ " "
+			+ "file://" + cwd + "/data/guaranteed-not-to-exist.xml"
+			+ " "
+			+ "file://" + cwd + "/data/example2.opml");
 
 	OpmlUrlReader reader(cfg);
 
@@ -187,8 +187,8 @@ TEST_CASE("OpmlUrlReader::reload() skips things that can't be parsed",
 	std::set<Tag> expected_tags;
 	for (const auto& entry : expected) {
 		expected_tags.insert(
-			entry.second.cbegin(),
-			entry.second.cend());
+				entry.second.cbegin(),
+				entry.second.cend());
 	}
 	std::set<Tag> tags;
 	const auto alltags = reader.get_alltags();

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -318,7 +318,7 @@ TEST_CASE("Generates filename if it's absent from the queue file",
 	}
 	SECTION("`download-path` set with a trailing slash") {
 		cfg.set_configvalue("download-path",
-			"/yet another/fictional path for downloads/");
+				"/yet another/fictional path for downloads/");
 		download_path = "/yet another/fictional path for downloads/";
 	}
 

--- a/test/queuemanager.cpp
+++ b/test/queuemanager.cpp
@@ -50,7 +50,7 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 				REQUIRE(test_helpers::starts_with(enclosure_url, lines[0]));
 				REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
 
-				REQUIRE(lines[1] == "");
+					REQUIRE(lines[1] == "");
 			}
 
 			THEN("the item is marked as enqueued") {
@@ -75,7 +75,7 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 				REQUIRE(test_helpers::starts_with(enclosure_url, lines[0]));
 				REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
 
-				REQUIRE(lines[1] == "");
+					REQUIRE(lines[1] == "");
 			}
 
 			THEN("the item is marked as enqueued") {
@@ -165,7 +165,7 @@ SCENARIO("enqueue_url() errors if the filename is already used", "[QueueManager]
 				REQUIRE(test_helpers::starts_with(enclosure_url1, lines[0]));
 				REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
 
-				REQUIRE(lines[1] == "");
+					REQUIRE(lines[1] == "");
 			}
 
 			THEN("the item is marked as enqueued") {
@@ -190,7 +190,7 @@ SCENARIO("enqueue_url() errors if the filename is already used", "[QueueManager]
 					REQUIRE(test_helpers::starts_with(enclosure_url1, lines[0]));
 					REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
 
-					REQUIRE(lines[1] == "");
+						REQUIRE(lines[1] == "");
 				}
 
 				THEN("the item is NOT marked as enqueued") {
@@ -519,7 +519,7 @@ SCENARIO("autoenqueue() errors if the filename is already used", "[QueueManager]
 				REQUIRE(test_helpers::starts_with(enclosure_url1, lines[0]));
 				REQUIRE(test_helpers::ends_with(R"(/podcast.mp3")", lines[0]));
 
-				REQUIRE(lines[1] == "");
+					REQUIRE(lines[1] == "");
 			}
 
 			THEN("the first item is enqueued, the second one isn't") {

--- a/test/regexmanager.cpp
+++ b/test/regexmanager.cpp
@@ -252,7 +252,7 @@ TEST_CASE("RegexManager::dump_config turns each `highlight`, "
 	SECTION("Two rules, one of them a `highlight-article`") {
 		rxman.handle_action("highlight", {"all", "keywords", "red", "blue"});
 		rxman.handle_action(
-			"highlight-article",
+				"highlight-article",
 		{"title==\"\"", "green", "black"});
 		REQUIRE_NOTHROW(rxman.dump_config(result));
 		REQUIRE(result.size() == 2);
@@ -263,10 +263,10 @@ TEST_CASE("RegexManager::dump_config turns each `highlight`, "
 	SECTION("Three rules") {
 		rxman.handle_action("highlight", {"all", "keywords", "red", "blue"});
 		rxman.handle_action(
-			"highlight-article",
+				"highlight-article",
 		{"title==\"\"", "green", "black"});
 		rxman.handle_action(
-			"highlight-feed",
+				"highlight-feed",
 		{"title==\"\"", "red", "black"});
 		REQUIRE_NOTHROW(rxman.dump_config(result));
 		REQUIRE(result.size() == 3);

--- a/test/rssignores.cpp
+++ b/test/rssignores.cpp
@@ -152,12 +152,12 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 		REQUIRE(config_set.count(comment) == 1);
 		REQUIRE(config_set.count(
 				R"#(ignore-article "https://example.com/feed.xml" "author =~ \"Joe\"")#") == 1);
-		REQUIRE(config_set.count(
-				R"#(ignore-article * "title # \"interesting\"")#") == 1);
-		REQUIRE(config_set.count(
-				R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
-		REQUIRE(config_set.count(
-				R"#(ignore-article "regex:^https://.*" "author = \"John Doe\"")#") == 1);
+				REQUIRE(config_set.count(
+						R"#(ignore-article * "title # \"interesting\"")#") == 1);
+					REQUIRE(config_set.count(
+							R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
+							REQUIRE(config_set.count(
+									R"#(ignore-article "regex:^https://.*" "author = \"John Doe\"")#") == 1);
 	}
 
 	SECTION("`always-download`") {
@@ -223,21 +223,21 @@ TEST_CASE("RssIgnores::dump_config() writes out all configured settings "
 		REQUIRE(config[0] == comment);
 		REQUIRE(config_set.count(
 				R"#(ignore-article * "title # \"interesting\"")#") == 1);
-		REQUIRE(config_set.count(
-				R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
-		REQUIRE(config[3] == R"#(always-download "url1")#");
-		REQUIRE(config[4] == R"#(always-download "url2")#");
-		REQUIRE(config[5] == R"#(always-download "url3")#");
-		REQUIRE(config[6] == R"#(always-download "url4")#");
-		REQUIRE(config[7] == R"#(reset-unread-on-update "url1")#");
-		REQUIRE(config[8] == R"#(reset-unread-on-update "url2")#");
-		REQUIRE(config[9] == R"#(reset-unread-on-update "url3")#");
+			REQUIRE(config_set.count(
+					R"#(ignore-article "https://blog.example.com/joe/posts.xml" "guid # 123")#") == 1);
+					REQUIRE(config[3] == R"#(always-download "url1")#");
+					REQUIRE(config[4] == R"#(always-download "url2")#");
+					REQUIRE(config[5] == R"#(always-download "url3")#");
+					REQUIRE(config[6] == R"#(always-download "url4")#");
+					REQUIRE(config[7] == R"#(reset-unread-on-update "url1")#");
+					REQUIRE(config[8] == R"#(reset-unread-on-update "url2")#");
+					REQUIRE(config[9] == R"#(reset-unread-on-update "url3")#");
 	}
 }
 
-TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
-	"of ignore-article rules, otherwise false",
-	"[RssIgnores]")
+	TEST_CASE("RssIgnores::matches() returns true if given RssItem matches any "
+		"of ignore-article rules, otherwise false",
+		"[RssIgnores]")
 {
 	RssIgnores ignores;
 

--- a/test/test_helpers/envvar.cpp
+++ b/test/test_helpers/envvar.cpp
@@ -76,7 +76,6 @@ test_helpers::LcCtypeEnvVar::LcCtypeEnvVar()
 	});
 }
 
-
 TEST_CASE("EnvVar object restores the environment variable to its original "
 	"state when the object is destroyed",
 	"[test_helpers]")
@@ -364,7 +363,6 @@ TEST_CASE("EnvVar::unset() runs a function (set by on_change()) after changing "
 
 		REQUIRE(checks_ok);
 	}
-
 
 	REQUIRE(::unsetenv(var) == 0);
 }

--- a/test/textformatter.cpp
+++ b/test/textformatter.cpp
@@ -12,13 +12,13 @@ TEST_CASE("lines marked as `wrappable` are wrapped to fit width",
 	TextFormatter fmt;
 
 	fmt.add_lines({std::make_pair(LineType::wrappable,
-				"this one is going to be wrapped"),
-			std::make_pair(LineType::softwrappable,
-				"this one is going to be wrapped at the window "
-				"border"),
-			std::make_pair(LineType::nonwrappable,
-				"this one is going to be preserved even though "
-				"it's much longer")});
+					"this one is going to be wrapped"),
+				std::make_pair(LineType::softwrappable,
+					"this one is going to be wrapped at the window "
+					"border"),
+				std::make_pair(LineType::nonwrappable,
+					"this one is going to be preserved even though "
+					"it's much longer")});
 
 	SECTION("formatting to plain text") {
 		const std::string expected =
@@ -61,7 +61,7 @@ TEST_CASE("line wrapping works for non-space-separated text", "[TextFormatter]")
 	TextFormatter fmt;
 
 	fmt.add_lines({std::make_pair(LineType::wrappable,
-				"    つれづれなるままに、ひぐらしすずりにむかいて、")});
+					"    つれづれなるままに、ひぐらしすずりにむかいて、")});
 
 	SECTION("preserve indent and doesn't return broken UTF-8") {
 		const std::string expected =
@@ -97,7 +97,7 @@ TEST_CASE("regex manager is used by format_text_to_list if one is passed",
 	// the choice of green text on red background does not reflect my
 	// personal taste (or lack thereof) :)
 	rxmgr.handle_action(
-		"highlight", {"article", "please", "green", "default"});
+			"highlight", {"article", "please", "green", "default"});
 
 	const std::string expected_text =
 		"{list"

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -131,7 +131,7 @@ TEST_CASE("tokenize_quoted() implicitly closes quotes at the end of the string",
 	REQUIRE(tokens[2] == "some other stuff");
 
 	tokens = utils::tokenize_quoted(R"("abc\)");
-	REQUIRE(tokens.size() == 1);
+		REQUIRE(tokens.size() == 1);
 	REQUIRE(tokens[0] == "abc");
 }
 
@@ -456,15 +456,15 @@ TEST_CASE("strip_comments ignores # characters inside double quotes",
 		const auto expected2 =
 			std::string(
 				R"#(highlight all "(https?|ftp)://[\-\.,/%~_:?&=\#a-zA-Z0-9]+" blue default bold)#");
-		const auto input2 = expected2 + "#heresacomment";
-		REQUIRE(utils::strip_comments(input2) == expected2);
+				const auto input2 = expected2 + "#heresacomment";
+				REQUIRE(utils::strip_comments(input2) == expected2);
 	}
 
-	SECTION("Escaped double quote inside double quotes is not treated "
-		"as closing quote") {
+		SECTION("Escaped double quote inside double quotes is not treated "
+	"as closing quote") {
 		const auto expected =
 			std::string(R"#(test "here \"goes # nothing\" etc" hehe)#");
-		const auto input = expected + "# and here is a comment";
+			const auto input = expected + "# and here is a comment";
 		REQUIRE(utils::strip_comments(input) == expected);
 	}
 }
@@ -503,7 +503,7 @@ TEST_CASE("strip_comments is not confused by nested double quotes and backticks"
 	{
 		const auto expected =
 			std::string(R"#(option "this `weird " command` for value")#");
-		const auto input = expected + "#and a comment";
+			const auto input = expected + "#and a comment";
 		REQUIRE(utils::strip_comments(input) == expected);
 	}
 }
@@ -1832,8 +1832,7 @@ TEST_CASE("utf8_to_locale() converts text from UTF-8 to the encoding specified "
 {
 	test_helpers::LcCtypeEnvVar lc_ctype;
 	const auto set_locale = [&lc_ctype](std::string new_locale) -> bool {
-		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr)
-		{
+		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr) {
 			WARN("Couldn't set locale " + new_locale + "; test skipped.");
 			return false;
 		}
@@ -1890,8 +1889,7 @@ TEST_CASE("utf8_to_locale() transliterates characters unsupported by the locale'
 {
 	test_helpers::LcCtypeEnvVar lc_ctype;
 	const auto set_locale = [&lc_ctype](std::string new_locale) -> bool {
-		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr)
-		{
+		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr) {
 			WARN("Couldn't set locale " + new_locale + "; test skipped.");
 			return false;
 		}
@@ -1938,8 +1936,7 @@ TEST_CASE("locale_to_utf8() converts text from the encoding specified by locale 
 {
 	test_helpers::LcCtypeEnvVar lc_ctype;
 	const auto set_locale = [&lc_ctype](std::string new_locale) -> bool {
-		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr)
-		{
+		if (::setlocale(LC_CTYPE, new_locale.c_str()) == nullptr) {
 			WARN("Couldn't set locale " + new_locale + "; test skipped.");
 			return false;
 		}


### PR DESCRIPTION
It looks like alphine3.18 is not available for rust 1.79 ([search results](https://hub.docker.com/_/rust/tags?name=1.79-alpine) only show alpine 3.19 and 3.20 which both ship different updated versions of astyle).
This PR makes a minimal update to alpine3.19.
However, looking at the diff, I don't like the indentation changes (and there have been no updates on [the ticket opened by @Minoru](https://gitlab.com/saalen/astyle/-/issues/45)).

Some alternative solutions:
- Switch back to the rust 1.77 image (`rust:1.77.0-alpine3.18`) for a while.
  However, we don't have any guarantee that the indentation issue will be solved any time soon.
- Use updated base image but build a specific version of astyle inside of the container
- Disable C++ auto-formatting for the time being. Enable it again when the astyle issue is resolved.

@Minoru Do you have any preference or maybe even a better idea to resolve this?