### PR TITLE
Report error when miniflux authentication check fails outside 401

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -381,7 +381,7 @@ int Controller::run(const CliArgsParser& args)
 	}
 	if (api) {
 		if (!api->authenticate()) {
-			std::cout << "Authentication failed." << std::endl;
+			std::cerr << _("Authentication failed.") << std::endl;
 			return EXIT_FAILURE;
 		}
 	}


### PR DESCRIPTION
Intended to make issues like https://github.com/newsboat/newsboat/issues/2870 easier to diagnose.

I'm not sure why `get_subscribed_urls()` only logs errors without stopping startup.
Only reason I can come up with is that it might also get called after an `edit-urls` command, in which case we probably don't want to crash/stop newsboat.