### PR TITLE
Move cursor next to end of "confirm" question

### DIFF
--- a/include/formaction.h
+++ b/include/formaction.h
@@ -72,6 +72,8 @@ public:
 	std::string draw_form_wait_for_event(unsigned int timeout);
 	void recalculate_widget_dimensions();
 
+	char confirm(const std::string& prompt, const std::string& charset);
+
 	virtual void handle_cmdline(const std::string& cmd);
 
 	bool process_op(Operation op,

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -198,7 +198,7 @@ public:
 	Operation get_operation(const KeyCombination& key_combination,
 		const std::string& context);
 	std::vector<MacroCmd> get_macro(const KeyCombination& key_combination);
-	char get_key(const std::string& keycode);
+	static char get_key(const std::string& keycode);
 	std::vector<KeyCombination> get_keys(Operation op, const std::string& context);
 	void handle_action(const std::string& action,
 		const std::string& params) override;

--- a/include/view.h
+++ b/include/view.h
@@ -66,7 +66,6 @@ public:
 	{
 		return formaction_stack.size();
 	}
-	char confirm(const std::string& prompt, const std::string& charset);
 
 	void push_itemlist(unsigned int pos);
 	std::shared_ptr<ItemListFormAction> push_itemlist(std::shared_ptr<RssFeed>

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -128,7 +128,7 @@ REDO:
 		// "Sort by (f)irsttag/..." and "Reverse Sort by
 		// (f)irsttag/..." messages
 		std::string input_options = _("ftauln");
-		char c = v.confirm(
+		char c = confirm(
 				_("Sort by "
 					"(f)irsttag/(t)itle/(a)rticlecount/"
 					"(u)nreadarticlecount/(l)astupdated/(n)one?"),
@@ -168,7 +168,7 @@ REDO:
 	break;
 	case OP_REVSORT: {
 		std::string input_options = _("ftauln");
-		char c = v.confirm(
+		char c = confirm(
 				_("Reverse Sort by "
 					"(f)irsttag/(t)itle/(a)rticlecount/"
 					"(u)nreadarticlecount/(l)astupdated/(n)one?"),
@@ -290,7 +290,7 @@ REDO:
 	case OP_MARKFEEDREAD: {
 		if (!cfg->get_configvalue_as_bool(
 				"confirm-mark-feed-read") ||
-			v.confirm(_("Do you really want to mark this feed as read (y:Yes n:No)? "),
+			confirm(_("Do you really want to mark this feed as read (y:Yes n:No)? "),
 				_("yn")) == *_("y")) {
 			LOG(Level::INFO, "FeedListFormAction: marking feed read at position `%d'", pos);
 			if (visible_feeds.size() > 0) {
@@ -375,7 +375,7 @@ REDO:
 	case OP_MARKALLFEEDSREAD:
 		if (!cfg->get_configvalue_as_bool(
 				"confirm-mark-all-feeds-read") ||
-			v.confirm(_("Do you really want to mark all feeds as read (y:Yes n:No)? "),
+			confirm(_("Do you really want to mark all feeds as read (y:Yes n:No)? "),
 				_("yn")) == *_("y")) {
 			LOG(Level::INFO, "FeedListFormAction: marking all feeds read");
 			const auto message_lifetime = v.get_statusline().show_message_until_finished(
@@ -503,7 +503,7 @@ REDO:
 		LOG(Level::INFO, "FeedListFormAction: quitting");
 		if (bindingType == BindingType::Macro ||
 			!cfg->get_configvalue_as_bool("confirm-exit") ||
-			v.confirm(
+			confirm(
 				_("Do you really want to quit (y:Yes n:No)? "),
 				_("yn")) == *_("y")) {
 			quit = true;

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -107,7 +107,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 				 */
 				if (::stat(fn.c_str(), &sbuf) != -1) {
 					f.set_focus("files");
-					if (v.confirm(
+					if (confirm(
 							strprintf::fmt(
 								_("Do you really want to overwrite `%s' "
 									"(y:Yes n:No)? "),

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -105,7 +105,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	break;
 	case OP_DELETE_ALL: {
 		if (!cfg->get_configvalue_as_bool("confirm-delete-all-articles") ||
-			v.confirm(_("Do you really want to delete all articles (y:Yes n:No)? "),
+			confirm(_("Do you really want to delete all articles (y:Yes n:No)? "),
 				_("yn")) == *_("y")) {
 			ScopeMeasure m1("OP_DELETE_ALL");
 
@@ -523,7 +523,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_MARKFEEDREAD:
 		if (!cfg->get_configvalue_as_bool(
 				"confirm-mark-feed-read") ||
-			v.confirm(_("Do you really want to mark this feed as read (y:Yes n:No)? "),
+			confirm(_("Do you really want to mark this feed as read (y:Yes n:No)? "),
 				_("yn")) == *_("y")) {
 			LOG(Level::INFO, "ItemListFormAction: marking feed read");
 			try {
@@ -760,7 +760,7 @@ bool ItemListFormAction::process_operation(Operation op,
 		// "Sort by (d)ate/..." and "Reverse Sort by (d)ate/..."
 		// messages
 		std::string input_options = _("dtfalgr");
-		char c = v.confirm(
+		char c = confirm(
 				_("Sort by "
 					"(d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"),
 				input_options);
@@ -798,7 +798,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	break;
 	case OP_REVSORT: {
 		std::string input_options = _("dtfalgr");
-		char c = v.confirm(
+		char c = confirm(
 				_("Reverse Sort by "
 					"(d)ate/(t)itle/(f)lags/(a)uthor/(l)ink/(g)uid/(r)andom?"),
 				input_options);
@@ -1647,14 +1647,14 @@ void ItemListFormAction::handle_op_saveall()
 
 			char c;
 			if (nfiles_exist > 1) {
-				c = v.confirm(strprintf::fmt(
+				c = confirm(strprintf::fmt(
 							_("Overwrite `%s' in `%s'? "
 								"There are %d more conflicts like this "
 								"(y:Yes a:Yes to all n:No q:No to all)"),
 							filename, directory.value(), --nfiles_exist),
 						input_options);
 			} else {
-				c = v.confirm(strprintf::fmt(
+				c = confirm(strprintf::fmt(
 							_("Overwrite `%s' in `%s'? "
 								"(y:Yes n:No)"),
 							filename, directory.value()),

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -9,7 +9,6 @@
 #include <limits.h>
 #include <ncurses.h>
 #include <pwd.h>
-#include <string.h>
 #include <sys/param.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -185,8 +184,7 @@ int View::run()
 			fa->cancel_qna();
 			if (!get_cfg()->get_configvalue_as_bool(
 					"confirm-exit") ||
-				confirm(_("Do you really want to quit "
-						"(y:Yes n:No)? "),
+				fa->confirm(_("Do you really want to quit (y:Yes n:No)? "),
 					_("yn")) == *_("y")) {
 				Stfl::reset();
 				return EXIT_FAILURE;
@@ -665,45 +663,6 @@ std::string View::select_filter(const std::vector<FilterNameExprPair>& filters)
 	selecttag->set_filters(filters);
 	run_modal(selecttag, "");
 	return selecttag->get_selected_value();
-}
-
-char View::confirm(const std::string& prompt, const std::string& charset)
-{
-	LOG(Level::DEBUG, "View::confirm: charset = %s", charset);
-
-	std::shared_ptr<FormAction> f = get_current_formaction();
-	// Push empty formaction so our status message is not overwritten on form `f`
-	push_empty_formaction();
-	f->set_status(prompt);
-
-	char result = 0;
-
-	do {
-		const std::string event = f->draw_form_wait_for_event(0);
-		LOG(Level::DEBUG, "View::confirm: event = %s", event);
-		if (event.empty()) {
-			continue;
-		}
-		if (event == "ESC" || event == "ENTER") {
-			result = 0;
-			LOG(Level::DEBUG,
-				"View::confirm: user pressed ESC or ENTER, we "
-				"cancel confirmation dialog");
-			break;
-		}
-		result = keys->get_key(event);
-		LOG(Level::DEBUG,
-			"View::confirm: key = %c (%u)",
-			result,
-			result);
-	} while (!result || strchr(charset.c_str(), result) == nullptr);
-
-	f->set_status("");
-	f->draw_form();
-
-	pop_current_formaction();
-
-	return result;
 }
 
 void View::notify_itemlist_change(std::shared_ptr<RssFeed> feed)

--- a/stfl/dialogs.stfl
+++ b/stfl/dialogs.stfl
@@ -49,3 +49,4 @@ vbox
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0
+      process[qna_process]:1

--- a/stfl/empty.stfl
+++ b/stfl/empty.stfl
@@ -24,3 +24,4 @@ vbox
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0
+      process[qna_process]:1

--- a/stfl/feedlist.stfl
+++ b/stfl/feedlist.stfl
@@ -51,3 +51,4 @@ vbox
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0
+      process[qna_process]:1

--- a/stfl/filebrowser.stfl
+++ b/stfl/filebrowser.stfl
@@ -60,3 +60,4 @@ vbox
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0
+      process[qna_process]:1

--- a/stfl/help.stfl
+++ b/stfl/help.stfl
@@ -49,3 +49,4 @@
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0
+      process[qna_process]:1

--- a/stfl/itemlist.stfl
+++ b/stfl/itemlist.stfl
@@ -51,3 +51,4 @@ vbox
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0
+      process[qna_process]:1

--- a/stfl/itemview.stfl
+++ b/stfl/itemview.stfl
@@ -54,3 +54,4 @@
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0
+      process[qna_process]:1

--- a/stfl/selecttag.stfl
+++ b/stfl/selecttag.stfl
@@ -49,3 +49,4 @@ vbox
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0
+      process[qna_process]:1

--- a/stfl/urlview.stfl
+++ b/stfl/urlview.stfl
@@ -49,3 +49,4 @@ vbox
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0
+      process[qna_process]:1


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2881

Summary:
- Moved confirm functionality from `View` into `FormAction`
- Reuse "qnainput" instead of status line
- Enable cursor in "qnainput" while disabling typing in it (or any other key processing like backspace)