### PR TITLE
Reduce shared_ptr usage

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -47,9 +47,7 @@ public:
 		bool reset_unread);
 	std::shared_ptr<RssFeed> internalize_rssfeed(std::string rssurl,
 		RssIgnores* ign);
-	void update_rssitem_unread_and_enqueued(std::shared_ptr<RssItem> item,
-		const std::string& feedurl);
-	void update_rssitem_unread_and_enqueued(RssItem* item,
+	void update_rssitem_unread_and_enqueued(RssItem& item,
 		const std::string& feedurl);
 	/// If requested, removes unreachable data stored in cache.
 	/// Returns a list of unreachable feeds.

--- a/include/cache.h
+++ b/include/cache.h
@@ -62,7 +62,7 @@ public:
 		const std::string& querystr,
 		const std::unordered_set<std::string>& guids);
 	void mark_all_read(const std::string& feedurl = "");
-	void mark_all_read(std::shared_ptr<RssFeed> feed);
+	void mark_all_read(RssFeed& feed);
 	void update_rssitem_flags(RssItem* item);
 	void fetch_lastmodified(const std::string& uri,
 		time_t& t,
@@ -81,9 +81,9 @@ private:
 	SchemaVersion get_schema_version();
 	void populate_tables();
 	void set_pragmas();
-	void delete_item_unlocked(const std::shared_ptr<RssItem>& item);
+	void delete_item_unlocked(const RssItem& item);
 	void clean_old_articles();
-	void update_rssitem_unlocked(std::shared_ptr<RssItem> item,
+	void update_rssitem_unlocked(RssItem& item,
 		const std::string& feedurl,
 		bool reset_unread);
 

--- a/include/cache.h
+++ b/include/cache.h
@@ -43,7 +43,7 @@ class Cache {
 public:
 	Cache(const std::string& cachefile, ConfigContainer* c);
 	~Cache();
-	void externalize_rssfeed(std::shared_ptr<RssFeed> feed,
+	void externalize_rssfeed(RssFeed& feed,
 		bool reset_unread);
 	std::shared_ptr<RssFeed> internalize_rssfeed(std::string rssurl,
 		RssIgnores* ign);

--- a/include/controller.h
+++ b/include/controller.h
@@ -52,8 +52,7 @@ public:
 	{
 		return refresh_on_start;
 	}
-	EnqueueResult enqueue_url(std::shared_ptr<RssItem> item,
-		std::shared_ptr<RssFeed> feed);
+	EnqueueResult enqueue_url(RssItem& item, RssFeed& feed);
 
 	void reload_urls_file();
 	void edit_urls_file();

--- a/include/controller.h
+++ b/include/controller.h
@@ -80,10 +80,7 @@ public:
 		return reloader.get();
 	}
 
-	void replace_feed(std::shared_ptr<RssFeed> oldfeed,
-		std::shared_ptr<RssFeed> newfeed,
-		unsigned int pos,
-		bool unattended);
+	void replace_feed(RssFeed& oldfeed, RssFeed& newfeed, unsigned int pos, bool unattended);
 
 	ConfigContainer* get_config()
 	{

--- a/include/controller.h
+++ b/include/controller.h
@@ -62,10 +62,9 @@ public:
 		return &feedcontainer;
 	}
 
-	void write_item(std::shared_ptr<RssItem> item,
-		const std::string& filename);
-	void write_item(std::shared_ptr<RssItem> item, std::ostream& ostr);
-	std::string write_temporary_item(std::shared_ptr<RssItem> item);
+	void write_item(RssItem& item, const std::string& filename);
+	void write_item(RssItem& item, std::ostream& ostr);
+	std::string write_temporary_item(RssItem& item);
 
 	void update_config();
 

--- a/include/controller.h
+++ b/include/controller.h
@@ -43,7 +43,7 @@ public:
 	void mark_all_read(unsigned int pos);
 	void mark_article_read(const std::string& guid, bool read);
 	void mark_all_read(const std::string& feedurl);
-	void mark_all_read(std::shared_ptr<RssFeed> feed)
+	void mark_all_read(RssFeed& feed)
 	{
 		rsscache->mark_all_read(feed);
 	}

--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -1,7 +1,6 @@
 #ifndef NEWSBOAT_ITEMRENDERER_H_
 #define NEWSBOAT_ITEMRENDERER_H_
 
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -23,7 +22,7 @@ enum class OutputFormat {
 
 /// \brief Returns feed's title of the item, or some replacement value if
 /// the title isn't available.
-std::string get_feedtitle(std::shared_ptr<RssItem> item);
+std::string get_feedtitle(RssItem& item);
 
 /// \brief Splits text into lines marked as wrappable
 void render_plaintext(const std::string& source,
@@ -35,7 +34,7 @@ void render_plaintext(const std::string& source,
 /// wrapped at the width specified by the `text-width` setting.
 std::string to_plain_text(
 	ConfigContainer& cfg,
-	std::shared_ptr<RssItem> item);
+	RssItem& item);
 
 /// \brief Returns RssItem as STFL list.
 ///
@@ -47,7 +46,7 @@ std::string to_plain_text(
 /// users open the links by their number).
 std::pair<std::string, size_t> to_stfl_list(
 	ConfigContainer& cfg,
-	std::shared_ptr<RssItem> item,
+	RssItem& item,
 	unsigned int text_width,
 	unsigned int window_width,
 	RegexManager* rxman,
@@ -60,7 +59,7 @@ std::pair<std::string, size_t> to_stfl_list(
 /// where URLs are wrapped. \a rxman rules for \a location are used to
 /// highlight the resulting text.
 std::pair<std::string, size_t> source_to_stfl_list(
-	std::shared_ptr<RssItem> item,
+	RssItem& item,
 	unsigned int text_width,
 	unsigned int window_width,
 	RegexManager* rxman,

--- a/include/itemutils.h
+++ b/include/itemutils.h
@@ -1,8 +1,6 @@
 #ifndef NEWSBOAT_ITEMUTILS_H_
 #define NEWSBOAT_ITEMUTILS_H_
 
-#include <memory>
-
 #include "cache.h"
 #include "rssfeed.h"
 #include "rssitem.h"
@@ -16,7 +14,7 @@ namespace newsboat {
 ///
 /// Returns true if URL was successfully added to queue or was already queued before,
 ///         false otherwise.
-bool enqueue_item_enclosure(std::shared_ptr<RssItem> item, std::shared_ptr<RssFeed> feed,
+bool enqueue_item_enclosure(RssItem& item, RssFeed& feed,
 	View& v, Cache& cache);
 
 } // namespace newsboat

--- a/include/itemviewformaction.h
+++ b/include/itemviewformaction.h
@@ -68,7 +68,7 @@ private:
 	bool open_link_in_browser(const std::string& link, const std::string& type,
 		const std::string& title, bool interactive) const;
 
-	void update_head(const std::shared_ptr<RssItem>& item);
+	void update_head(RssItem& item);
 	void set_head(const std::string& s,
 		const std::string& feedtitle,
 		unsigned int unread,

--- a/include/queuemanager.h
+++ b/include/queuemanager.h
@@ -32,15 +32,13 @@ public:
 	QueueManager(ConfigContainer* cfg, std::string queue_file);
 
 	/// Adds the podcast URL to Podboat's queue file
-	EnqueueResult enqueue_url(std::shared_ptr<RssItem> item,
-		std::shared_ptr<RssFeed> feed);
+	EnqueueResult enqueue_url(std::shared_ptr<RssItem> item, RssFeed& feed);
 
 	/// Add all HTTP and HTTPS enclosures to the queue file
-	EnqueueResult autoenqueue(std::shared_ptr<RssFeed> feed);
+	EnqueueResult autoenqueue(RssFeed& feed);
 
 private:
-	std::string generate_enqueue_filename(std::shared_ptr<RssItem> item,
-		std::shared_ptr<RssFeed> feed);
+	std::string generate_enqueue_filename(std::shared_ptr<RssItem> item, RssFeed& feed);
 };
 
 }

--- a/include/queuemanager.h
+++ b/include/queuemanager.h
@@ -1,7 +1,6 @@
 #ifndef NEWSBOAT_QUEUEMANAGER_H_
 #define NEWSBOAT_QUEUEMANAGER_H_
 
-#include <memory>
 #include <string>
 
 namespace newsboat {
@@ -32,13 +31,13 @@ public:
 	QueueManager(ConfigContainer* cfg, std::string queue_file);
 
 	/// Adds the podcast URL to Podboat's queue file
-	EnqueueResult enqueue_url(std::shared_ptr<RssItem> item, RssFeed& feed);
+	EnqueueResult enqueue_url(RssItem& item, RssFeed& feed);
 
 	/// Add all HTTP and HTTPS enclosures to the queue file
 	EnqueueResult autoenqueue(RssFeed& feed);
 
 private:
-	std::string generate_enqueue_filename(std::shared_ptr<RssItem> item, RssFeed& feed);
+	std::string generate_enqueue_filename(RssItem& item, RssFeed& feed);
 };
 
 }

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -998,7 +998,7 @@ void Cache::mark_all_read(const std::string& feedurl)
 	run_sql(query);
 }
 
-void Cache::update_rssitem_unread_and_enqueued(RssItem* item,
+void Cache::update_rssitem_unread_and_enqueued(RssItem& item,
 	const std::string& /* feedurl */)
 {
 	std::lock_guard<std::recursive_mutex> lock(mtx);
@@ -1007,17 +1007,10 @@ void Cache::update_rssitem_unread_and_enqueued(RssItem* item,
 			"UPDATE rss_item "
 			"SET unread = '%d', enqueued = '%d' "
 			"WHERE guid = '%q'",
-			item->unread() ? 1 : 0,
-			item->enqueued() ? 1 : 0,
-			item->guid());
+			item.unread() ? 1 : 0,
+			item.enqueued() ? 1 : 0,
+			item.guid());
 	run_sql(query);
-}
-
-/* this function updates the unread and enqueued flags */
-void Cache::update_rssitem_unread_and_enqueued(std::shared_ptr<RssItem> item,
-	const std::string& feedurl)
-{
-	update_rssitem_unread_and_enqueued(item.get(), feedurl);
 }
 
 /* helper function to wrap std::string around the sqlite3_*mprintf function */

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -744,7 +744,7 @@ void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
 	}
 
 	for (const auto& item : feed->items()) {
-		rsscache->update_rssitem_unread_and_enqueued(item, feed->rssurl());
+		rsscache->update_rssitem_unread_and_enqueued(*item, feed->rssurl());
 	}
 
 	v->notify_itemlist_change(feed);
@@ -822,10 +822,9 @@ std::vector<std::shared_ptr<RssItem>> Controller::search_for_items(
 	return items;
 }
 
-EnqueueResult Controller::enqueue_url(std::shared_ptr<RssItem> item,
-	std::shared_ptr<RssFeed> feed)
+EnqueueResult Controller::enqueue_url(RssItem& item, RssFeed& feed)
 {
-	return queueManager.enqueue_url(*item, *feed);
+	return queueManager.enqueue_url(item, feed);
 }
 
 void Controller::reload_urls_file()

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -703,25 +703,23 @@ void Controller::mark_all_read(const std::vector<std::string>& item_guids)
 	}
 }
 
-void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
-	std::shared_ptr<RssFeed> newfeed,
-	unsigned int pos,
+void Controller::replace_feed(RssFeed& oldfeed, RssFeed& newfeed, unsigned int pos,
 	bool unattended)
 {
 	LOG(Level::DEBUG, "Controller::replace_feed: saving");
 	rsscache->externalize_rssfeed(
-		*newfeed, ign.matches_resetunread(newfeed->rssurl()));
+		newfeed, ign.matches_resetunread(newfeed.rssurl()));
 	LOG(Level::DEBUG,
 		"Controller::replace_feed: after externalize_rssfeed");
 
 	bool ignore_disp = (cfg.get_configvalue("ignore-mode") == "display");
 	std::shared_ptr<RssFeed> feed = rsscache->internalize_rssfeed(
-			oldfeed->rssurl(), ignore_disp ? &ign : nullptr);
+			oldfeed.rssurl(), ignore_disp ? &ign : nullptr);
 	LOG(Level::DEBUG,
 		"Controller::replace_feed: after internalize_rssfeed");
 
-	feed->set_tags(urlcfg->get_tags(oldfeed->rssurl()));
-	feed->set_order(oldfeed->get_order());
+	feed->set_tags(urlcfg->get_tags(oldfeed.rssurl()));
+	feed->set_order(oldfeed.get_order());
 	feedcontainer.replace_feed(pos, feed);
 
 	if (cfg.get_configvalue_as_bool("podcast-auto-enqueue")) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -681,7 +681,7 @@ void Controller::mark_all_read(unsigned int pos)
 			}
 			api->mark_articles_read(item_guids);
 		}
-		rsscache->mark_all_read(feed);
+		rsscache->mark_all_read(*feed);
 	} else {
 		rsscache->mark_all_read(feed->rssurl());
 		if (api) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -710,7 +710,7 @@ void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
 {
 	LOG(Level::DEBUG, "Controller::replace_feed: saving");
 	rsscache->externalize_rssfeed(
-		newfeed, ign.matches_resetunread(newfeed->rssurl()));
+		*newfeed, ign.matches_resetunread(newfeed->rssurl()));
 	LOG(Level::DEBUG,
 		"Controller::replace_feed: after externalize_rssfeed");
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -725,7 +725,7 @@ void Controller::replace_feed(std::shared_ptr<RssFeed> oldfeed,
 	feedcontainer.replace_feed(pos, feed);
 
 	if (cfg.get_configvalue_as_bool("podcast-auto-enqueue")) {
-		const auto result = queueManager.autoenqueue(feed);
+		const auto result = queueManager.autoenqueue(*feed);
 		switch (result.status) {
 		case EnqueueStatus::QUEUED_SUCCESSFULLY:
 		case EnqueueStatus::URL_QUEUED_ALREADY:
@@ -825,7 +825,7 @@ std::vector<std::shared_ptr<RssItem>> Controller::search_for_items(
 EnqueueResult Controller::enqueue_url(std::shared_ptr<RssItem> item,
 	std::shared_ptr<RssFeed> feed)
 {
-	return queueManager.enqueue_url(item, feed);
+	return queueManager.enqueue_url(item, *feed);
 }
 
 void Controller::reload_urls_file()

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -924,7 +924,7 @@ int Controller::execute_commands(const std::vector<std::string>& cmds)
 	return EXIT_SUCCESS;
 }
 
-std::string Controller::write_temporary_item(std::shared_ptr<RssItem> item)
+std::string Controller::write_temporary_item(RssItem& item)
 {
 	char filename[_POSIX_PATH_MAX];
 	char* tmpdir = getenv("TMPDIR");
@@ -948,8 +948,7 @@ std::string Controller::write_temporary_item(std::shared_ptr<RssItem> item)
 	}
 }
 
-void Controller::write_item(std::shared_ptr<RssItem> item,
-	const std::string& filename)
+void Controller::write_item(RssItem& item, const std::string& filename)
 {
 	const std::string save_path = cfg.get_configvalue("save-path");
 	auto spath = save_path.back() == '/' ? save_path : save_path + "/";
@@ -975,7 +974,7 @@ void Controller::write_item(std::shared_ptr<RssItem> item,
 	write_item(item, f);
 }
 
-void Controller::write_item(std::shared_ptr<RssItem> item, std::ostream& ostr)
+void Controller::write_item(RssItem& item, std::ostream& ostr)
 {
 	ostr << item_renderer::to_plain_text(cfg, item) << std::endl;
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -825,7 +825,7 @@ std::vector<std::shared_ptr<RssItem>> Controller::search_for_items(
 EnqueueResult Controller::enqueue_url(std::shared_ptr<RssItem> item,
 	std::shared_ptr<RssFeed> feed)
 {
-	return queueManager.enqueue_url(item, *feed);
+	return queueManager.enqueue_url(*item, *feed);
 }
 
 void Controller::reload_urls_file()

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -928,7 +928,7 @@ void ItemListFormAction::finished_qna(Operation op)
 			std::string cmd = qna_responses[0];
 			std::ostringstream ostr;
 			v.get_ctrl()->write_item(
-				visible_items[itempos].first, ostr);
+				*visible_items[itempos].first, ostr);
 			v.push_empty_formaction();
 			Stfl::reset();
 			FILE* f = popen(cmd.c_str(), "w");
@@ -1473,7 +1473,7 @@ void ItemListFormAction::save_article(const nonstd::optional<std::string>& filen
 		v.get_statusline().show_error(_("Aborted saving."));
 	} else {
 		try {
-			v.get_ctrl()->write_item(item, filename.value());
+			v.get_ctrl()->write_item(*item, filename.value());
 			v.get_statusline().show_message(strprintf::fmt(
 					_("Saved article to %s"), filename.value()));
 		} catch (...) {

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -839,7 +839,7 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_ENQUEUE:
 		if (!visible_items.empty() && itempos < visible_items.size()) {
 			const auto item = visible_items[itempos].first;
-			return enqueue_item_enclosure(item, feed, v, *rsscache);
+			return enqueue_item_enclosure(*item, *feed, v, *rsscache);
 		} else {
 			v.get_statusline().show_error(_("No item selected!"));
 			return false;

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -25,9 +25,9 @@ bool should_render_as_html(const std::string mime_type)
 	return (html_mime_types.count(mime_type) >= 1);
 }
 
-std::string item_renderer::get_feedtitle(std::shared_ptr<RssItem> item)
+std::string item_renderer::get_feedtitle(RssItem& item)
 {
-	const std::shared_ptr<RssFeed> feedptr = item->get_feedptr();
+	const std::shared_ptr<RssFeed> feedptr = item.get_feedptr();
 
 	if (!feedptr) {
 		return {};
@@ -47,7 +47,7 @@ std::string item_renderer::get_feedtitle(std::shared_ptr<RssItem> item)
 }
 
 void prepare_header(
-	std::shared_ptr<RssItem> item,
+	RssItem& item,
 	std::vector<std::pair<LineType, std::string>>& lines,
 	Links& /*links*/, bool raw = false)
 {
@@ -72,27 +72,27 @@ void prepare_header(
 
 	const std::string feedtitle = item_renderer::get_feedtitle(item);
 	add_line(stfl_quote_if_needed(feedtitle), _("Feed: "), LineType::wrappable);
-	add_line(stfl_quote_if_needed(utils::utf8_to_locale(item->title())),
+	add_line(stfl_quote_if_needed(utils::utf8_to_locale(item.title())),
 		_("Title: "), LineType::wrappable);
-	add_line(stfl_quote_if_needed(utils::utf8_to_locale(item->author())),
+	add_line(stfl_quote_if_needed(utils::utf8_to_locale(item.author())),
 		_("Author: "), LineType::wrappable);
-	add_line(item->pubDate(), _("Date: "), LineType::wrappable);
-	add_line(item->link(), _("Link: "), LineType::softwrappable);
-	add_line(item->flags(), _("Flags: "), LineType::wrappable);
+	add_line(item.pubDate(), _("Date: "), LineType::wrappable);
+	add_line(item.link(), _("Link: "), LineType::softwrappable);
+	add_line(item.flags(), _("Flags: "), LineType::wrappable);
 
-	const bool could_be_podcast = item->enclosure_type().empty()
-		|| utils::is_valid_podcast_type(item->enclosure_type());
+	const bool could_be_podcast = item.enclosure_type().empty()
+		|| utils::is_valid_podcast_type(item.enclosure_type());
 
-	if (!item->enclosure_url().empty() && could_be_podcast) {
+	if (!item.enclosure_url().empty() && could_be_podcast) {
 		auto dlurl = strprintf::fmt(
 				"%s%s",
 				_("Podcast Download URL: "),
-				utils::censor_url(item->enclosure_url()));
-		if (!item->enclosure_type().empty()) {
+				utils::censor_url(item.enclosure_url()));
+		if (!item.enclosure_type().empty()) {
 			dlurl.append(
 				strprintf::fmt(" (%s%s)",
 					_("type: "),
-					item->enclosure_type()));
+					item.enclosure_type()));
 		}
 		lines.push_back(std::make_pair(LineType::softwrappable, dlurl));
 	}
@@ -230,16 +230,16 @@ void render_links_summary(std::vector<std::pair<LineType, std::string>>& lines,
 
 std::string item_renderer::to_plain_text(
 	ConfigContainer& cfg,
-	std::shared_ptr<RssItem> item)
+	RssItem& item)
 {
 	std::vector<std::pair<LineType, std::string>> lines;
 	Links links;
-	const auto item_description = item->description();
+	const auto item_description = item.description();
 
 	prepare_header(item, lines, links, true);
-	prepare_enclosure(*item, lines, links, true);
+	prepare_enclosure(item, lines, links, true);
 
-	const auto base = get_item_base_link(*item);
+	const auto base = get_item_base_link(item);
 	const auto body = utils::utf8_to_locale(item_description.text);
 
 	if (should_render_as_html(item_description.mime)) {
@@ -263,7 +263,7 @@ std::string item_renderer::to_plain_text(
 
 std::pair<std::string, size_t> item_renderer::to_stfl_list(
 	ConfigContainer& cfg,
-	std::shared_ptr<RssItem> item,
+	RssItem& item,
 	unsigned int text_width,
 	unsigned int window_width,
 	RegexManager* rxman,
@@ -271,12 +271,12 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 	Links& links)
 {
 	std::vector<std::pair<LineType, std::string>> lines;
-	const auto item_description = item->description();
+	const auto item_description = item.description();
 
 	prepare_header(item, lines, links);
-	prepare_enclosure(*item, lines, links, false);
+	prepare_enclosure(item, lines, links, false);
 
-	const std::string baseurl = get_item_base_link(*item);
+	const std::string baseurl = get_item_base_link(item);
 	const auto body = utils::utf8_to_locale(item_description.text);
 
 	if (should_render_as_html(item_description.mime)) {
@@ -316,7 +316,7 @@ void render_source(
 }
 
 std::pair<std::string, size_t> item_renderer::source_to_stfl_list(
-	std::shared_ptr<RssItem> item,
+	RssItem& item,
 	unsigned int text_width,
 	unsigned int window_width,
 	RegexManager* rxman,
@@ -327,7 +327,7 @@ std::pair<std::string, size_t> item_renderer::source_to_stfl_list(
 
 	prepare_header(item, lines, links);
 	render_source(lines, utils::quote_for_stfl(utils::utf8_to_locale(
-				item->description().text)));
+				item.description().text)));
 
 	TextFormatter txtfmt;
 	txtfmt.add_lines(lines);

--- a/src/itemutils.cpp
+++ b/src/itemutils.cpp
@@ -5,29 +5,29 @@
 
 namespace newsboat {
 
-bool enqueue_item_enclosure(std::shared_ptr<RssItem> item, std::shared_ptr<RssFeed> feed,
+bool enqueue_item_enclosure(RssItem& item, RssFeed& feed,
 	View& v, Cache& cache)
 {
-	if (item->enclosure_url().empty()) {
+	if (item.enclosure_url().empty()) {
 		v.get_statusline().show_error(_("Item has no enclosures."));
 		return false;
-	} else if (!utils::is_http_url(item->enclosure_url())) {
+	} else if (!utils::is_http_url(item.enclosure_url())) {
 		v.get_statusline().show_error(strprintf::fmt(
-				_("Item's enclosure has non-http link: '%s'"), item->enclosure_url()));
+				_("Item's enclosure has non-http link: '%s'"), item.enclosure_url()));
 		return false;
 	} else {
 		const EnqueueResult result = v.get_ctrl()->enqueue_url(item, feed);
-		cache.update_rssitem_unread_and_enqueued(item, feed->rssurl());
+		cache.update_rssitem_unread_and_enqueued(item, feed.rssurl());
 		switch (result.status) {
 		case EnqueueStatus::QUEUED_SUCCESSFULLY:
 			v.get_statusline().show_message(
 				strprintf::fmt(_("Added %s to download queue."),
-					item->enclosure_url()));
+					item.enclosure_url()));
 			return true;
 		case EnqueueStatus::URL_QUEUED_ALREADY:
 			v.get_statusline().show_message(
 				strprintf::fmt(_("%s is already queued."),
-					item->enclosure_url()));
+					item.enclosure_url()));
 			return true; // Not a failure, just an idempotent action
 		case EnqueueStatus::OUTPUT_FILENAME_USED_ALREADY:
 			v.get_statusline().show_error(

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -186,7 +186,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 		textview.set_scroll_offset(0);
 		break;
 	case OP_ENQUEUE:
-		return enqueue_item_enclosure(item, feed, v, *rsscache);
+		return enqueue_item_enclosure(*item, *feed, v, *rsscache);
 	case OP_SAVE: {
 		LOG(Level::INFO, "ItemViewFormAction::process_operation: saving article");
 		nonstd::optional<std::string> filename;

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -65,17 +65,17 @@ void ItemViewFormAction::init()
 	item = feed->get_item_by_guid(guid);
 }
 
-void ItemViewFormAction::update_head(const std::shared_ptr<RssItem>& item)
+void ItemViewFormAction::update_head(RssItem& item)
 {
 	const std::string feedtitle = item_renderer::get_feedtitle(item);
 
 	unsigned int unread_item_count = feed->unread_item_count();
 	// we need to subtract because the current item isn't yet marked
 	// as read
-	if (item->unread()) {
+	if (item.unread()) {
 		unread_item_count--;
 	}
-	set_head(utils::utf8_to_locale(item->title()),
+	set_head(utils::utf8_to_locale(item.title()),
 		feedtitle,
 		unread_item_count,
 		feed->total_item_count());
@@ -96,7 +96,7 @@ void ItemViewFormAction::prepare()
 			recalculate_widget_dimensions();
 		}
 
-		update_head(item);
+		update_head(*item);
 
 		const unsigned int window_width = textview.get_width();
 
@@ -113,7 +113,7 @@ void ItemViewFormAction::prepare()
 		if (show_source) {
 			std::tie(formatted_text, num_lines) =
 				item_renderer::source_to_stfl_list(
-					item,
+					*item,
 					text_width,
 					window_width,
 					&rxman,
@@ -132,7 +132,7 @@ void ItemViewFormAction::prepare()
 					// cfg can't be nullptr because that's a long-lived object
 					// created at the very start of the program.
 					*cfg,
-					item,
+					*item,
 					text_width,
 					window_width,
 					&rxman,
@@ -213,7 +213,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 			v.get_statusline().show_error(_("Aborted saving."));
 		} else {
 			try {
-				v.get_ctrl()->write_item(item, filename.value());
+				v.get_ctrl()->write_item(*item, filename.value());
 				v.get_statusline().show_message(strprintf::fmt(
 						_("Saved article to %s."), filename.value()));
 			} catch (...) {
@@ -634,7 +634,7 @@ void ItemViewFormAction::handle_save(const std::string& filename_param)
 	} else {
 		try {
 			v.get_ctrl()->write_item(
-				item, filename);
+				*item, filename);
 			v.get_statusline().show_message(strprintf::fmt(
 					_("Saved article to %s"),
 					filename));
@@ -664,7 +664,7 @@ void ItemViewFormAction::finished_qna(Operation op)
 	case OP_PIPE_TO: {
 		std::string cmd = qna_responses[0];
 		std::ostringstream ostr;
-		v.get_ctrl()->write_item(feed->get_item_by_guid(guid), ostr);
+		v.get_ctrl()->write_item(*feed->get_item_by_guid(guid), ostr);
 		v.push_empty_formaction();
 		Stfl::reset();
 		FILE* f = popen(cmd.c_str(), "w");

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -15,9 +15,9 @@ QueueManager::QueueManager(ConfigContainer* cfg_, std::string queue_file)
 	, queue_file(std::move(queue_file))
 {}
 
-EnqueueResult QueueManager::enqueue_url(std::shared_ptr<RssItem> item, RssFeed& feed)
+EnqueueResult QueueManager::enqueue_url(RssItem& item, RssFeed& feed)
 {
-	const std::string& url = item->enclosure_url();
+	const std::string& url = item.enclosure_url();
 	const std::string filename = generate_enqueue_filename(item, feed);
 
 	std::fstream f;
@@ -46,7 +46,7 @@ EnqueueResult QueueManager::enqueue_url(std::shared_ptr<RssItem> item, RssFeed& 
 	f << url << " " << utils::quote(filename) << std::endl;
 	f.close();
 
-	item->set_enqueued(true);
+	item.set_enqueued(true);
 
 	return {EnqueueStatus::QUEUED_SUCCESSFULLY, ""};
 }
@@ -63,12 +63,12 @@ std::string get_hostname_from_url(const std::string& url)
 }
 
 std::string QueueManager::generate_enqueue_filename(
-	std::shared_ptr<RssItem> item,
+	RssItem& item,
 	RssFeed& feed)
 {
-	const std::string& url = item->enclosure_url();
-	const std::string& title = utils::utf8_to_locale(item->title());
-	const time_t pubDate = item->pubDate_timestamp();
+	const std::string& url = item.enclosure_url();
+	const std::string& title = utils::utf8_to_locale(item.title());
+	const time_t pubDate = item.pubDate_timestamp();
 
 	std::string dlformat = cfg->get_configvalue("download-path");
 	if (dlformat[dlformat.length() - 1] != NEWSBEUTER_PATH_SEP) {
@@ -101,9 +101,9 @@ std::string QueueManager::generate_enqueue_filename(
 	fmt.register_fmt('t', utils::replace_all(title, "/", "_"));
 	fmt.register_fmt('e', utils::replace_all(extension, "/", "_"));
 
-	if (feed.rssurl() != item->feedurl() &&
-		item->get_feedptr() != nullptr) {
-		std::string feedtitle = item->get_feedptr()->title();
+	if (feed.rssurl() != item.feedurl() &&
+		item.get_feedptr() != nullptr) {
+		std::string feedtitle = item.get_feedptr()->title();
 		utils::remove_soft_hyphens(feedtitle);
 		fmt.register_fmt('N', utils::replace_all(feedtitle, "/", "_"));
 	} else {
@@ -139,7 +139,7 @@ EnqueueResult QueueManager::autoenqueue(RssFeed& feed)
 			LOG(Level::INFO,
 				"QueueManager::autoenqueue: enqueuing `%s'",
 				item->enclosure_url());
-			const auto result = enqueue_url(item, feed);
+			const auto result = enqueue_url(*item, feed);
 			switch (result.status) {
 			case EnqueueStatus::QUEUED_SUCCESSFULLY:
 			case EnqueueStatus::URL_QUEUED_ALREADY:

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -117,7 +117,7 @@ void Reloader::reload(unsigned int pos,
 			sm.stopover("start replacing feed");
 			if (newfeed != nullptr) {
 				ctrl->replace_feed(
-					oldfeed, newfeed, pos, unattended);
+					*oldfeed, *newfeed, pos, unattended);
 				if (newfeed->total_item_count() == 0) {
 					LOG(Level::DEBUG,
 						"Reloader::reload: feed is empty");

--- a/src/rssitem.cpp
+++ b/src/rssitem.cpp
@@ -111,7 +111,7 @@ void RssItem::set_unread(bool u)
 		try {
 			if (ch) {
 				ch->update_rssitem_unread_and_enqueued(
-					this, feedurl_);
+					*this, feedurl_);
 			}
 		} catch (const DbException& e) {
 			// if the update failed, restore the old unread flag and

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -541,7 +541,7 @@ void View::push_itemview(std::shared_ptr<RssFeed> f,
 		current_formaction = formaction_stack_size() - 1;
 	} else {
 		std::shared_ptr<RssItem> item = f->get_item_by_guid(guid);
-		std::string filename = get_ctrl()->write_temporary_item(item);
+		std::string filename = get_ctrl()->write_temporary_item(*item);
 		open_in_pager(filename);
 		try {
 			bool old_unread = item->unread();

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -24,7 +24,7 @@ TEST_CASE("items in search result can be marked read", "[Cache]")
 	RssParser parser(uri, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
 	REQUIRE(feed->total_item_count() == 8);
-	rsscache.externalize_rssfeed(feed, false);
+	rsscache.externalize_rssfeed(*feed, false);
 
 	RssIgnores ign;
 	auto search_items = rsscache.search_for_items("Botox", "", ign);
@@ -65,7 +65,7 @@ TEST_CASE("Cleaning old articles works", "[Cache]")
 	item->set_unread(true);
 	feed->add_item(item);
 
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 
 	/* Simulating a restart of Newsboat. */
 
@@ -93,7 +93,7 @@ TEST_CASE("Last-Modified and ETag values are persisted to DB", "[Cache]")
 	FeedRetriever feed_retriever(*cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, *cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 
 	/* We will run this lambda on different inputs to check different
 	 * situations. */
@@ -182,7 +182,7 @@ TEST_CASE("mark_all_read marks all items in the feed read", "[Cache]")
 
 		test_feed->add_item(feed->items()[0]);
 
-		rsscache.externalize_rssfeed(feed, false);
+		rsscache.externalize_rssfeed(*feed, false);
 	}
 
 	SECTION("empty feedurl") {
@@ -219,7 +219,7 @@ TEST_CASE("mark_all_read marks all items in the feed read", "[Cache]")
 	SECTION("actual feed") {
 		INFO("All items that are in the specific feed should be marked "
 			"as read");
-		rsscache.externalize_rssfeed(test_feed, false);
+		rsscache.externalize_rssfeed(*test_feed, false);
 		rsscache.mark_all_read(test_feed);
 
 		/* Since test_feed contains the first item of each feed, only
@@ -279,7 +279,7 @@ TEST_CASE(
 		RssParser parser(url, *rsscache, *cfg, nullptr);
 		auto feed = parser.parse(feed_retriever.retrieve(url));
 		feeds.push_back(feed);
-		rsscache->externalize_rssfeed(feed, false);
+		rsscache->externalize_rssfeed(*feed, false);
 	}
 
 	SECTION("cleanup-on-quit set to \"no\"") {
@@ -388,7 +388,7 @@ TEST_CASE("fetch_descriptions fills out feed item's descriptions", "[Cache]")
 	RssParser parser(feedurl, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 
-	rsscache.externalize_rssfeed(feed, false);
+	rsscache.externalize_rssfeed(*feed, false);
 
 	for (auto& item : feed->items()) {
 		item->set_description("your test failed!", "text/plain");
@@ -439,7 +439,7 @@ TEST_CASE("get_read_item_guids returns GUIDs of items that are marked read",
 	};
 
 	mark_read(feed->items()[0]);
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 
 	INFO("Testing on single feed");
 	check(rsscache->get_read_item_guids());
@@ -452,7 +452,7 @@ TEST_CASE("get_read_item_guids returns GUIDs of items that are marked read",
 	mark_read(feed->items()[0]);
 	mark_read(feed->items()[2]);
 
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 	INFO("Testing on two feeds");
 	check(rsscache->get_read_item_guids());
 
@@ -478,7 +478,7 @@ TEST_CASE("mark_item_deleted changes \"deleted\" flag of item with given GUID ",
 	auto item = feed->items()[1];
 	auto guid = item->guid();
 	REQUIRE(feed->total_item_count() == 8);
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 	rsscache->mark_item_deleted(guid, true);
 
 	rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
@@ -502,7 +502,7 @@ TEST_CASE("mark_items_read_by_guid marks items with given GUIDs as unread ",
 	REQUIRE(feed->unread_item_count() == 8);
 
 	SECTION("Not marking any items read") {
-		rsscache->externalize_rssfeed(feed, false);
+		rsscache->externalize_rssfeed(*feed, false);
 
 		REQUIRE_NOTHROW(rsscache->mark_items_read_by_guid({}));
 
@@ -515,7 +515,7 @@ TEST_CASE("mark_items_read_by_guid marks items with given GUIDs as unread ",
 		auto guids = {
 			feed->items()[0]->guid(), feed->items()[2]->guid()
 		};
-		rsscache->externalize_rssfeed(feed, false);
+		rsscache->externalize_rssfeed(*feed, false);
 
 		REQUIRE_NOTHROW(rsscache->mark_items_read_by_guid(guids));
 
@@ -547,7 +547,7 @@ TEST_CASE(
 		feed->items()[2]->guid(), feed->items()[5]->guid()
 	};
 
-	rsscache.externalize_rssfeed(feed, false);
+	rsscache.externalize_rssfeed(*feed, false);
 
 	for (const auto& guid : should_be_absent) {
 		rsscache.mark_item_deleted(guid, true);
@@ -594,7 +594,7 @@ TEST_CASE("search_for_items finds all items with matching title or content",
 		RssParser parser(url, rsscache, cfg, nullptr);
 		auto feed = parser.parse(feed_retriever.retrieve(url));
 
-		rsscache.externalize_rssfeed(feed, false);
+		rsscache.externalize_rssfeed(*feed, false);
 	}
 
 	auto query = "content";
@@ -628,7 +628,7 @@ TEST_CASE("update_rssitem_flags dumps `rss_item` object's flags to DB",
 	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 
 	auto item = feed->items()[0];
 	item->set_flags("abc");
@@ -656,7 +656,7 @@ TEST_CASE(
 
 	auto item = feed->items()[0];
 
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 
 	SECTION("\"unread\" field is updated") {
 		REQUIRE(item->unread());
@@ -759,7 +759,7 @@ TEST_CASE(
 	initial_feed->load();
 
 	SECTION("Simple case") {
-		rsscache->externalize_rssfeed(initial_feed, false);
+		rsscache->externalize_rssfeed(*initial_feed, false);
 
 		rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 		auto new_feed = rsscache->internalize_rssfeed(feedurl, nullptr);
@@ -770,8 +770,8 @@ TEST_CASE(
 
 	SECTION("Calling externalize_rssfeed twice in a row shouldn't break "
 		"anything") {
-		rsscache->externalize_rssfeed(initial_feed, false);
-		rsscache->externalize_rssfeed(initial_feed, false);
+		rsscache->externalize_rssfeed(*initial_feed, false);
+		rsscache->externalize_rssfeed(*initial_feed, false);
 
 		rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 		auto new_feed = rsscache->internalize_rssfeed(feedurl, nullptr);
@@ -795,7 +795,7 @@ TEST_CASE("externalize_rssfeed doesn't store more than `max-items` items",
 	RssParser parser(feedurl, *rsscache, *cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	REQUIRE(feed->total_item_count() == 8);
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 
 	cfg = std::make_unique<ConfigContainer>();
 	rsscache = std::make_unique<Cache>(dbfile.get_path(), cfg.get());
@@ -825,7 +825,7 @@ TEST_CASE(
 	REQUIRE(feed->total_item_count() == 8);
 
 	SECTION("no flagged items") {
-		rsscache->externalize_rssfeed(feed, false);
+		rsscache->externalize_rssfeed(*feed, false);
 
 		cfg = std::make_unique<ConfigContainer>();
 		cfg->set_configvalue("max-items", "3");
@@ -837,7 +837,7 @@ TEST_CASE(
 	SECTION("a couple of flagged items") {
 		feed->items()[0]->set_flags("a");
 		feed->items()[1]->set_flags("b");
-		rsscache->externalize_rssfeed(feed, false);
+		rsscache->externalize_rssfeed(*feed, false);
 		rsscache->update_rssitem_flags(feed->items()[0].get());
 		rsscache->update_rssitem_flags(feed->items()[1].get());
 
@@ -881,7 +881,7 @@ TEST_CASE("internalize_rssfeed doesn't return items that are ignored",
 	RssParser parser(feedurl, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	REQUIRE(feed->total_item_count() == 3);
-	rsscache.externalize_rssfeed(feed, false);
+	rsscache.externalize_rssfeed(*feed, false);
 
 	RssIgnores ign;
 	ign.handle_action("ignore-article", {"*", "title =~ \"third\""});
@@ -906,7 +906,7 @@ TEST_CASE(
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	feed->items()[0]->set_unread_nowrite(false);
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 
 	rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	feed = rsscache->internalize_rssfeed(feedurl, nullptr);
@@ -916,14 +916,14 @@ TEST_CASE(
 	feed->items()[0]->set_description("changed!", "text/plain");
 
 	SECTION("reset_unread = false; item remains read") {
-		rsscache->externalize_rssfeed(feed, false);
+		rsscache->externalize_rssfeed(*feed, false);
 		rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 		feed = rsscache->internalize_rssfeed(feedurl, nullptr);
 		REQUIRE_FALSE(feed->items()[0]->unread());
 	}
 
 	SECTION("reset_unread = true; item becomes unread") {
-		rsscache->externalize_rssfeed(feed, true);
+		rsscache->externalize_rssfeed(*feed, true);
 		rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 		feed = rsscache->internalize_rssfeed(feedurl, nullptr);
 		REQUIRE(feed->items()[0]->unread());
@@ -944,7 +944,7 @@ TEST_CASE(
 	RssParser parser(feedurl, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
 	feed->items()[0]->set_unread_nowrite(false);
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 
 	rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 	feed = rsscache->internalize_rssfeed(feedurl, nullptr);
@@ -952,7 +952,7 @@ TEST_CASE(
 	item->set_unread_nowrite(true);
 
 	SECTION("override_unread not set; item remains read") {
-		rsscache->externalize_rssfeed(feed, false);
+		rsscache->externalize_rssfeed(*feed, false);
 		rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 		feed = rsscache->internalize_rssfeed(feedurl, nullptr);
 		REQUIRE_FALSE(feed->items()[0]->unread());
@@ -960,7 +960,7 @@ TEST_CASE(
 
 	SECTION("override_unread is set; item becomes unread") {
 		item->set_override_unread(true);
-		rsscache->externalize_rssfeed(feed, false);
+		rsscache->externalize_rssfeed(*feed, false);
 		rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 		feed = rsscache->internalize_rssfeed(feedurl, nullptr);
 		REQUIRE(feed->items()[0]->unread());
@@ -979,7 +979,7 @@ TEST_CASE(
 	auto feed = std::make_shared<RssFeed>(rsscache.get(),
 			"query:All unread:unread = \"yes\"");
 
-	REQUIRE_NOTHROW(rsscache->externalize_rssfeed(feed, false));
+	REQUIRE_NOTHROW(rsscache->externalize_rssfeed(*feed, false));
 
 	// Getting rid of `Cache` instance to make sure it doesn't hold the
 	// database anymore and did everything it wanted to
@@ -1036,7 +1036,7 @@ TEST_CASE("do_vacuum doesn't throw an exception", "[Cache]")
 	FeedRetriever feed_retriever(cfg, *rsscache, easyHandle);
 	RssParser parser(uri, *rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
-	rsscache->externalize_rssfeed(feed, false);
+	rsscache->externalize_rssfeed(*feed, false);
 
 	REQUIRE_NOTHROW(rsscache->do_vacuum());
 
@@ -1055,7 +1055,7 @@ TEST_CASE("search_in_items returns items that contain given substring",
 	RssParser parser(uri, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
 	REQUIRE(feed->total_item_count() == 8);
-	rsscache.externalize_rssfeed(feed, false);
+	rsscache.externalize_rssfeed(*feed, false);
 
 	using guids = std::unordered_set<std::string>;
 
@@ -1097,7 +1097,7 @@ TEST_CASE("search_in_items returns empty set if input set is empty", "[Cache]")
 	FeedRetriever feed_retriever(cfg, rsscache, easyHandle);
 	RssParser parser(uri, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
-	rsscache.externalize_rssfeed(feed, false);
+	rsscache.externalize_rssfeed(*feed, false);
 
 	using guids = std::unordered_set<std::string>;
 	std::unordered_set<std::string> empty;
@@ -1116,7 +1116,7 @@ TEST_CASE("Ignoring articles in search", "[Cache]")
 	RssParser parser(uri, rsscache, cfg, nullptr);
 	auto feed = parser.parse(feed_retriever.retrieve(uri));
 	REQUIRE(feed->total_item_count() == 8);
-	rsscache.externalize_rssfeed(feed, false);
+	rsscache.externalize_rssfeed(*feed, false);
 
 	RssIgnores ign, empty_ign;
 	ign.handle_action("ignore-article", {"*", "title =~ \"Botox\""});

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -220,7 +220,7 @@ TEST_CASE("mark_all_read marks all items in the feed read", "[Cache]")
 		INFO("All items that are in the specific feed should be marked "
 			"as read");
 		rsscache.externalize_rssfeed(*test_feed, false);
-		rsscache.mark_all_read(test_feed);
+		rsscache.mark_all_read(*test_feed);
 
 		/* Since test_feed contains the first item of each feed, only
 		 * these two items should be marked read. */

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -663,7 +663,7 @@ TEST_CASE(
 		item->set_unread_nowrite(false);
 
 		REQUIRE_NOTHROW(rsscache->update_rssitem_unread_and_enqueued(
-				item, feedurl));
+				*item, feedurl));
 		rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 		feed = rsscache->internalize_rssfeed(feedurl, nullptr);
 
@@ -675,7 +675,7 @@ TEST_CASE(
 		item->set_enqueued(true);
 
 		REQUIRE_NOTHROW(rsscache->update_rssitem_unread_and_enqueued(
-				item, feedurl));
+				*item, feedurl));
 		rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 		feed = rsscache->internalize_rssfeed(feedurl, nullptr);
 
@@ -689,7 +689,7 @@ TEST_CASE(
 		item->set_enqueued(true);
 
 		REQUIRE_NOTHROW(rsscache->update_rssitem_unread_and_enqueued(
-				item, feedurl));
+				*item, feedurl));
 		rsscache = std::make_unique<Cache>(dbfile.get_path(), &cfg);
 		feed = rsscache->internalize_rssfeed(feedurl, nullptr);
 

--- a/test/controller.cpp
+++ b/test/controller.cpp
@@ -33,10 +33,10 @@ TEST_CASE("write_item correctly parses path", "[Controller]")
 	Cache rsscache(":memory:", cfg);
 
 
-	auto item = std::make_shared<RssItem>(&rsscache);
-	item->set_title("title");
+	RssItem item(&rsscache);
+	item.set_title("title");
 	const auto description = "First line.\nSecond one.\nAnd finally the third";
-	item->set_description(description, "text/plain");
+	item.set_description(description, "text/plain");
 
 	c.write_item(item, tmp.get_path() + name);
 	c.write_item(item, "~/" + name);

--- a/test/feedretriever.cpp
+++ b/test/feedretriever.cpp
@@ -47,7 +47,7 @@ TEST_CASE("Feed retriever adds header with etag info if available", "[FeedRetrie
 	const auto address = testServer.get_address();
 	const auto url = strprintf::fmt("http://%s/feed", address);
 
-	auto feed_with_etag = std::make_shared<RssFeed>(&rsscache, url);
+	RssFeed feed_with_etag(&rsscache, url);
 	rsscache.externalize_rssfeed(feed_with_etag, false);
 	rsscache.update_lastmodified(url, {}, "some-random-etag");
 
@@ -96,7 +96,7 @@ TEST_CASE("Feed retriever does not retry download on HTTP 304 (Not Modified), 42
 	const auto address = testServer.get_address();
 	const auto url = strprintf::fmt("http://%s/feed", address);
 
-	auto feed_with_etag = std::make_shared<RssFeed>(&rsscache, url);
+	RssFeed feed_with_etag(&rsscache, url);
 	rsscache.externalize_rssfeed(feed_with_etag, false);
 	rsscache.update_lastmodified(url, {}, "some-random-etag");
 

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -77,7 +77,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 	SECTION("Item without an enclosure") {
 		item->set_description(ITEM_DESCRIPTON, "text/html");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -96,7 +96,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 		item->set_description(ITEM_DESCRIPTON, "text/html");
 		item->set_enclosure_url(ITEM_PODCAST_ENCLOSURE_URL);
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -117,7 +117,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 		item->set_enclosure_url(ITEM_PODCAST_ENCLOSURE_URL);
 		item->set_enclosure_type(ITEM_PODCAST_ENCLOSURE_TYPE);
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -139,7 +139,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 		item->set_enclosure_url(ITEM_IMAGE_ENCLOSURE_URL);
 		item->set_enclosure_type(ITEM_IMAGE_ENCLOSURE_TYPE);
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -164,7 +164,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 			ITEM_DESCRIPTON +
 			"<p>See also <a href='https://example.com'>this site</a>.</p>", "text/html");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -189,7 +189,7 @@ TEST_CASE("item_renderer::to_plain_text() produces a rendered representation "
 		item->set_enclosure_url("https://example.com/test.png");
 		item->set_enclosure_type("image/png");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -241,7 +241,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 		" \n";
 
 	SECTION("If `text-width` is not set, text is rendered in 80 columns") {
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nisl \n"
@@ -256,7 +256,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 	SECTION("If `text-width` is set to zero, text is rendered in 80 columns") {
 		cfg.set_configvalue("text-width", "0");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque nisl \n"
@@ -271,7 +271,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 	SECTION("Text is rendered in 37 columns") {
 		cfg.set_configvalue("text-width", "37");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, \n"
@@ -288,7 +288,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 	SECTION("Text is rendered in 120 columns") {
 		cfg.set_configvalue("text-width", "120");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = header +
 			"Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
@@ -308,7 +308,7 @@ TEST_CASE("item_renderer::to_plain_text() renders text to the width specified "
 			"&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;&gt;" // 10 characters
 			"Lorem ipsum dolor sit amet", "text/html");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = header +
 			"<<<<<<<<<<>>>>>>>>>>Lorem ipsum dolor\n"
@@ -347,7 +347,7 @@ TEST_CASE("to_plain_text() does not escape '<' and '>' in header and body",
 		" \n" +
 		"<test>\n";
 
-	const auto result = item_renderer::to_plain_text(cfg, item);
+	const auto result = item_renderer::to_plain_text(cfg, *item);
 	REQUIRE(result == expected);
 }
 
@@ -370,7 +370,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 	SECTION("Item without a feed title") {
 		item->get_feedptr()->set_title("");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Title: " + ITEM_TITLE + '\n' +
@@ -386,7 +386,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 	SECTION("Item without a title") {
 		item->set_title("");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -402,7 +402,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 	SECTION("Item without an author") {
 		item->set_author("");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -418,7 +418,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 	SECTION("Item without a link") {
 		item->set_link("");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -434,7 +434,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 	SECTION("Item without an enclosure") {
 		item->set_description(ITEM_DESCRIPTON, "text/html");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -452,7 +452,7 @@ TEST_CASE("Empty fields are not rendered", "[item_renderer]")
 	SECTION("Item without flags") {
 		item->set_flags("");
 
-		const auto result = item_renderer::to_plain_text(cfg, item);
+		const auto result = item_renderer::to_plain_text(cfg, *item);
 
 		const auto expected = std::string() +
 			"Feed: " + FEED_TITLE + '\n' +
@@ -490,7 +490,7 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 		SECTION("internal renderer") {
 			cfg.set_configvalue("html-renderer", "internal");
 
-			const auto result = item_renderer::to_plain_text(cfg, item);
+			const auto result = item_renderer::to_plain_text(cfg, *item);
 
 			const auto expected = std::string() +
 				"Feed: " + FEED_TITLE + '\n' +
@@ -513,7 +513,7 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 		SECTION("/bin/cat as a renderer") {
 			cfg.set_configvalue("html-renderer", "/bin/cat");
 
-			const auto result = item_renderer::to_plain_text(cfg, item);
+			const auto result = item_renderer::to_plain_text(cfg, *item);
 
 			const auto expected = std::string() +
 				"Feed: " + FEED_TITLE + '\n' +
@@ -539,7 +539,7 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 		SECTION("internal renderer") {
 			cfg.set_configvalue("html-renderer", "internal");
 
-			const auto result = item_renderer::to_plain_text(cfg, item);
+			const auto result = item_renderer::to_plain_text(cfg, *item);
 
 			const auto expected = std::string() +
 				"Feed: " + FEED_TITLE + '\n' +
@@ -564,7 +564,7 @@ TEST_CASE("item_renderer::to_plain_text honours `html-renderer` setting",
 		SECTION("/bin/cat as a renderer") {
 			cfg.set_configvalue("html-renderer", "/bin/cat");
 
-			const auto result = item_renderer::to_plain_text(cfg, item);
+			const auto result = item_renderer::to_plain_text(cfg, *item);
 
 			const auto expected = std::string() +
 				"Feed: " + FEED_TITLE + '\n' +
@@ -595,7 +595,7 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed title without "
 	std::tie(item, feed) = create_test_item(&rsscache);
 
 	const auto check = [&]() {
-		const auto result = item_renderer::get_feedtitle(item);
+		const auto result = item_renderer::get_feedtitle(*item);
 		REQUIRE(result == "Welcome, lovely strangers!");
 	};
 
@@ -626,7 +626,7 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed self-link "
 	feed->set_title("");
 	feed->set_link(feedlink);
 
-	const auto result = item_renderer::get_feedtitle(item);
+	const auto result = item_renderer::get_feedtitle(*item);
 	REQUIRE(result == feedlink);
 }
 
@@ -647,7 +647,7 @@ TEST_CASE("item_renderer::get_feedtitle() returns item's feed URL "
 	feed->set_title("");
 	feed->set_link("");
 
-	const auto result = item_renderer::get_feedtitle(item);
+	const auto result = item_renderer::get_feedtitle(*item);
 	REQUIRE(result == feedurl);
 }
 
@@ -685,7 +685,7 @@ TEST_CASE("Functions used for rendering articles escape '<' into `<>` for use wi
 			"}";
 
 		Links links;
-		const auto result = item_renderer::to_stfl_list(cfg, item, 80, 80, &rxman,
+		const auto result = item_renderer::to_stfl_list(cfg, *item, 80, 80, &rxman,
 				"article", links);
 		REQUIRE(result.first == expected);
 	}
@@ -704,7 +704,7 @@ TEST_CASE("Functions used for rendering articles escape '<' into `<>` for use wi
 			"}";
 
 		Links links;
-		const auto result = item_renderer::source_to_stfl_list(item, 80, 80, &rxman,
+		const auto result = item_renderer::source_to_stfl_list(*item, 80, 80, &rxman,
 				"article");
 		REQUIRE(result.first == expected);
 	}

--- a/test/queuemanager.cpp
+++ b/test/queuemanager.cpp
@@ -20,10 +20,10 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 
 		Cache cache(":memory:", &cfg);
 
-		auto item = std::make_shared<RssItem>(&cache);
+		RssItem item(&cache);
 		const std::string enclosure_url("https://example.com/podcast.mp3");
-		item->set_enclosure_url(enclosure_url);
-		item->set_enclosure_type("audio/mpeg");
+		item.set_enclosure_url(enclosure_url);
+		item.set_enclosure_type("audio/mpeg");
 
 		RssFeed feed(&cache, "https://example.com/news.atom");
 
@@ -54,7 +54,7 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 			}
 
 			THEN("the item is marked as enqueued") {
-				REQUIRE(item->enqueued());
+				REQUIRE(item.enqueued());
 			}
 		}
 
@@ -79,21 +79,21 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 			}
 
 			THEN("the item is marked as enqueued") {
-				REQUIRE(item->enqueued());
+				REQUIRE(item.enqueued());
 			}
 		}
 
 		WHEN("enqueue_url() is called for multiple different items") {
 			const auto result = manager.enqueue_url(item, feed);
 
-			auto item2 = std::make_shared<RssItem>(&cache);
-			item2->set_enclosure_url("https://www.example.com/another.mp3");
-			item2->set_enclosure_type("audio/mpeg");
+			RssItem item2(&cache);
+			item2.set_enclosure_url("https://www.example.com/another.mp3");
+			item2.set_enclosure_type("audio/mpeg");
 			const auto result2 = manager.enqueue_url(item2, feed);
 
-			auto item3 = std::make_shared<RssItem>(&cache);
-			item3->set_enclosure_url("https://joe.example.com/vacation.jpg");
-			item3->set_enclosure_type("image/jpeg");
+			RssItem item3(&cache);
+			item3.set_enclosure_url("https://joe.example.com/vacation.jpg");
+			item3.set_enclosure_type("image/jpeg");
 			const auto result3 = manager.enqueue_url(item3, feed);
 
 			THEN("return values indicate success") {
@@ -119,9 +119,9 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 			}
 
 			THEN("items are marked as enqueued") {
-				REQUIRE(item->enqueued());
-				REQUIRE(item2->enqueued());
-				REQUIRE(item3->enqueued());
+				REQUIRE(item.enqueued());
+				REQUIRE(item2.enqueued());
+				REQUIRE(item3.enqueued());
 			}
 		}
 	}
@@ -134,15 +134,15 @@ SCENARIO("enqueue_url() errors if the filename is already used", "[QueueManager]
 
 		Cache cache(":memory:", &cfg);
 
-		auto item1 = std::make_shared<RssItem>(&cache);
+		RssItem item1(&cache);
 		const std::string enclosure_url1("https://example.com/podcast.mp3");
-		item1->set_enclosure_url(enclosure_url1);
-		item1->set_enclosure_type("audio/mpeg");
+		item1.set_enclosure_url(enclosure_url1);
+		item1.set_enclosure_type("audio/mpeg");
 
-		auto item2 = std::make_shared<RssItem>(&cache);
+		RssItem item2(&cache);
 		const std::string enclosure_url2("https://example.com/~joe/podcast.mp3");
-		item2->set_enclosure_url(enclosure_url2);
-		item2->set_enclosure_type("audio/mpeg");
+		item2.set_enclosure_url(enclosure_url2);
+		item2.set_enclosure_type("audio/mpeg");
 
 		RssFeed feed(&cache, "https://example.com/news.atom");
 
@@ -169,7 +169,7 @@ SCENARIO("enqueue_url() errors if the filename is already used", "[QueueManager]
 			}
 
 			THEN("the item is marked as enqueued") {
-				REQUIRE(item1->enqueued());
+				REQUIRE(item1.enqueued());
 			}
 
 			AND_WHEN("second item is enqueued") {
@@ -194,7 +194,7 @@ SCENARIO("enqueue_url() errors if the filename is already used", "[QueueManager]
 				}
 
 				THEN("the item is NOT marked as enqueued") {
-					REQUIRE_FALSE(item2->enqueued());
+					REQUIRE_FALSE(item2.enqueued());
 				}
 			}
 
@@ -210,9 +210,9 @@ SCENARIO("enqueue_url() errors if the queue file can't be opened for writing",
 
 		Cache cache(":memory:", &cfg);
 
-		auto item = std::make_shared<RssItem>(&cache);
-		item->set_enclosure_url("https://example.com/podcast.mp3");
-		item->set_enclosure_type("audio/mpeg");
+		RssItem item(&cache);
+		item.set_enclosure_url("https://example.com/podcast.mp3");
+		item.set_enclosure_type("audio/mpeg");
 
 		RssFeed feed(&cache, "https://example.com/news.atom");
 
@@ -232,7 +232,7 @@ SCENARIO("enqueue_url() errors if the queue file can't be opened for writing",
 			}
 
 			THEN("the item is NOT marked as enqueued") {
-				REQUIRE_FALSE(item->enqueued());
+				REQUIRE_FALSE(item.enqueued());
 			}
 		}
 	}
@@ -251,15 +251,15 @@ TEST_CASE("QueueManager puts files into a location configured by `download-path`
 
 	Cache cache(":memory:", &cfg);
 
-	auto item1 = std::make_shared<RssItem>(&cache);
+	RssItem item1(&cache);
 	const std::string enclosure_url1("https://example.com/podcast.mp3");
-	item1->set_enclosure_url(enclosure_url1);
-	item1->set_enclosure_type("audio/mpeg");
+	item1.set_enclosure_url(enclosure_url1);
+	item1.set_enclosure_type("audio/mpeg");
 
-	auto item2 = std::make_shared<RssItem>(&cache);
+	RssItem item2(&cache);
 	const std::string enclosure_url2("https://example.com/~joe/podcast.ogg");
-	item2->set_enclosure_url(enclosure_url2);
-	item2->set_enclosure_type("audio/vorbis");
+	item2.set_enclosure_url(enclosure_url2);
+	item2.set_enclosure_type("audio/vorbis");
 
 	RssFeed feed(&cache, "https://example.com/podcasts.atom");
 
@@ -270,13 +270,13 @@ TEST_CASE("QueueManager puts files into a location configured by `download-path`
 	REQUIRE(result1.status == EnqueueStatus::QUEUED_SUCCESSFULLY);
 	REQUIRE(result1.extra_info == "");
 
-	REQUIRE(item1->enqueued());
+	REQUIRE(item1.enqueued());
 
 	const auto result2 = manager.enqueue_url(item2, feed);
 	REQUIRE(result2.status == EnqueueStatus::QUEUED_SUCCESSFULLY);
 	REQUIRE(result2.extra_info == "");
 
-	REQUIRE(item2->enqueued());
+	REQUIRE(item2.enqueued());
 
 	REQUIRE(test_helpers::file_exists(queue_file.get_path()));
 
@@ -299,9 +299,9 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 
 	Cache cache(":memory:", &cfg);
 
-	auto item = std::make_shared<RssItem>(&cache);
-	item->set_enclosure_url("https://example.com/~adam/podcast.mp3");
-	item->set_enclosure_type("audio/mpeg");
+	RssItem item(&cache);
+	item.set_enclosure_url("https://example.com/~adam/podcast.mp3");
+	item.set_enclosure_type("audio/mpeg");
 
 	auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/podcasts.atom");
 
@@ -350,7 +350,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 
 		cfg.set_configvalue("download-filename-format", "%F, %m, %b, %d, %H, %M, %S, %y, and %Y");
 		// Tue, 06 Apr 2021 15:38:19 +0000
-		item->set_pubDate(1617723499);
+		item.set_pubDate(1617723499);
 
 		manager.enqueue_url(item, *feed);
 
@@ -363,7 +363,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 
 	SECTION("%t for item title, with slashes replaced by underscores") {
 		cfg.set_configvalue("download-filename-format", "%t");
-		item->set_title("Rain/snow/sun in a single day");
+		item.set_title("Rain/snow/sun in a single day");
 
 		manager.enqueue_url(item, *feed);
 
@@ -392,7 +392,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 		SECTION("`feed` argument is irrelevant") {
 			feed->set_title("Relevant feed");
 
-			item->set_feedptr(feed);
+			item.set_feedptr(feed);
 
 			RssFeed irrelevant_feed(&cache, "https://example.com/podcasts.atom");
 			irrelevant_feed.set_title("Irrelevant");
@@ -408,7 +408,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 
 		SECTION("`feed` argument is relevant") {
 			feed->set_title("Relevant feed");
-			item->set_feedptr(feed);
+			item.set_feedptr(feed);
 
 			manager.enqueue_url(item, *feed);
 

--- a/test/queuemanager.cpp
+++ b/test/queuemanager.cpp
@@ -25,7 +25,7 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 		item->set_enclosure_url(enclosure_url);
 		item->set_enclosure_type("audio/mpeg");
 
-		auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/news.atom");
+		RssFeed feed(&cache, "https://example.com/news.atom");
 
 		test_helpers::TempFile queue_file;
 		QueueManager manager(&cfg, queue_file.get_path());
@@ -144,7 +144,7 @@ SCENARIO("enqueue_url() errors if the filename is already used", "[QueueManager]
 		item2->set_enclosure_url(enclosure_url2);
 		item2->set_enclosure_type("audio/mpeg");
 
-		auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/news.atom");
+		RssFeed feed(&cache, "https://example.com/news.atom");
 
 		test_helpers::TempFile queue_file;
 		QueueManager manager(&cfg, queue_file.get_path());
@@ -214,7 +214,7 @@ SCENARIO("enqueue_url() errors if the queue file can't be opened for writing",
 		item->set_enclosure_url("https://example.com/podcast.mp3");
 		item->set_enclosure_type("audio/mpeg");
 
-		auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/news.atom");
+		RssFeed feed(&cache, "https://example.com/news.atom");
 
 		test_helpers::TempFile queue_file;
 		QueueManager manager(&cfg, queue_file.get_path());
@@ -261,7 +261,7 @@ TEST_CASE("QueueManager puts files into a location configured by `download-path`
 	item2->set_enclosure_url(enclosure_url2);
 	item2->set_enclosure_type("audio/vorbis");
 
-	auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/podcasts.atom");
+	RssFeed feed(&cache, "https://example.com/podcasts.atom");
 
 	test_helpers::TempFile queue_file;
 	QueueManager manager(&cfg, queue_file.get_path());
@@ -312,7 +312,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 		cfg.set_configvalue("download-filename-format", "%n");
 		feed->set_title("Feed title/theme");
 
-		manager.enqueue_url(item, feed);
+		manager.enqueue_url(item, *feed);
 
 		const auto lines = test_helpers::file_contents(queue_file.get_path());
 		REQUIRE(lines.size() == 2);
@@ -324,7 +324,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 	SECTION("%h for the enclosure URL's hostname") {
 		cfg.set_configvalue("download-filename-format", "%h");
 
-		manager.enqueue_url(item, feed);
+		manager.enqueue_url(item, *feed);
 
 		const auto lines = test_helpers::file_contents(queue_file.get_path());
 		REQUIRE(lines.size() == 2);
@@ -335,7 +335,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 	SECTION("%u for the enclosure URL's basename") {
 		cfg.set_configvalue("download-filename-format", "%u");
 
-		manager.enqueue_url(item, feed);
+		manager.enqueue_url(item, *feed);
 
 		const auto lines = test_helpers::file_contents(queue_file.get_path());
 		REQUIRE(lines.size() == 2);
@@ -352,7 +352,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 		// Tue, 06 Apr 2021 15:38:19 +0000
 		item->set_pubDate(1617723499);
 
-		manager.enqueue_url(item, feed);
+		manager.enqueue_url(item, *feed);
 
 		const auto lines = test_helpers::file_contents(queue_file.get_path());
 		REQUIRE(lines.size() == 2);
@@ -365,7 +365,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 		cfg.set_configvalue("download-filename-format", "%t");
 		item->set_title("Rain/snow/sun in a single day");
 
-		manager.enqueue_url(item, feed);
+		manager.enqueue_url(item, *feed);
 
 		const auto lines = test_helpers::file_contents(queue_file.get_path());
 		REQUIRE(lines.size() == 2);
@@ -377,7 +377,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 	SECTION("%e for enclosure's filename extension") {
 		cfg.set_configvalue("download-filename-format", "%e");
 
-		manager.enqueue_url(item, feed);
+		manager.enqueue_url(item, *feed);
 
 		const auto lines = test_helpers::file_contents(queue_file.get_path());
 		REQUIRE(lines.size() == 2);
@@ -394,9 +394,8 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 
 			item->set_feedptr(feed);
 
-			auto irrelevant_feed = std::make_shared<RssFeed>(&cache,
-					"https://example.com/podcasts.atom");
-			irrelevant_feed->set_title("Irrelevant");
+			RssFeed irrelevant_feed(&cache, "https://example.com/podcasts.atom");
+			irrelevant_feed.set_title("Irrelevant");
 
 			manager.enqueue_url(item, irrelevant_feed);
 
@@ -411,7 +410,7 @@ TEST_CASE("QueueManager names files according to the `download-filename-format` 
 			feed->set_title("Relevant feed");
 			item->set_feedptr(feed);
 
-			manager.enqueue_url(item, feed);
+			manager.enqueue_url(item, *feed);
 
 			const auto lines = test_helpers::file_contents(queue_file.get_path());
 			REQUIRE(lines.size() == 2);
@@ -429,22 +428,22 @@ TEST_CASE("autoenqueue() adds all enclosures of all items to the queue", "[Queue
 
 		Cache cache(":memory:", &cfg);
 
-		auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/podcasts.atom");
+		RssFeed feed(&cache, "https://example.com/podcasts.atom");
 
 		auto item1 = std::make_shared<RssItem>(&cache);
 		item1->set_enclosure_url("https://example.com/~adam/podcast.mp3");
 		item1->set_enclosure_type("audio/mpeg");
-		feed->add_item(item1);
+		feed.add_item(item1);
 
 		auto item2 = std::make_shared<RssItem>(&cache);
 		item2->set_enclosure_url("https://example.com/episode.ogg");
 		item2->set_enclosure_type("audio/vorbis");
-		feed->add_item(item2);
+		feed.add_item(item2);
 
 		auto item3 = std::make_shared<RssItem>(&cache);
 		item3->set_enclosure_url("https://example.com/~fae/painting.jpg");
 		item3->set_enclosure_type("");
-		feed->add_item(item3);
+		feed.add_item(item3);
 
 		test_helpers::TempFile queue_file;
 		QueueManager manager(&cfg, queue_file.get_path());
@@ -484,19 +483,19 @@ SCENARIO("autoenqueue() errors if the filename is already used", "[QueueManager]
 
 		Cache cache(":memory:", &cfg);
 
-		auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/news.atom");
+		RssFeed feed(&cache, "https://example.com/news.atom");
 
 		auto item1 = std::make_shared<RssItem>(&cache);
 		const std::string enclosure_url1("https://example.com/podcast.mp3");
 		item1->set_enclosure_url(enclosure_url1);
 		item1->set_enclosure_type("audio/mpeg");
-		feed->add_item(item1);
+		feed.add_item(item1);
 
 		auto item2 = std::make_shared<RssItem>(&cache);
 		const std::string enclosure_url2("https://example.com/~joe/podcast.mp3");
 		item2->set_enclosure_url(enclosure_url2);
 		item2->set_enclosure_type("audio/mpeg");
-		feed->add_item(item2);
+		feed.add_item(item2);
 
 		test_helpers::TempFile queue_file;
 		QueueManager manager(&cfg, queue_file.get_path());
@@ -538,12 +537,12 @@ SCENARIO("autoenqueue() errors if the queue file can't be opened for writing",
 
 		Cache cache(":memory:", &cfg);
 
-		auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/news.atom");
+		RssFeed feed(&cache, "https://example.com/news.atom");
 
 		auto item = std::make_shared<RssItem>(&cache);
 		item->set_enclosure_url("https://example.com/podcast.mp3");
 		item->set_enclosure_type("audio/mpeg");
-		feed->add_item(item);
+		feed.add_item(item);
 
 		test_helpers::TempFile queue_file;
 		QueueManager manager(&cfg, queue_file.get_path());
@@ -576,23 +575,23 @@ TEST_CASE("autoenqueue() skips already-enqueued items", "[QueueManager]")
 
 	Cache cache(":memory:", &cfg);
 
-	auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/news.atom");
+	RssFeed feed(&cache, "https://example.com/news.atom");
 
 	auto item1 = std::make_shared<RssItem>(&cache);
 	item1->set_enclosure_url("https://example.com/podcast.mp3");
 	item1->set_enclosure_type("audio/mpeg");
-	feed->add_item(item1);
+	feed.add_item(item1);
 
 	auto item2 = std::make_shared<RssItem>(&cache);
 	item2->set_enclosure_url("https://example.com/podcast2.mp3");
 	item2->set_enclosure_type("audio/mpeg");
 	item2->set_enqueued(true);
-	feed->add_item(item2);
+	feed.add_item(item2);
 
 	auto item3 = std::make_shared<RssItem>(&cache);
 	item3->set_enclosure_url("https://example.com/podcast3.mp3");
 	item3->set_enclosure_type("audio/mpeg");
-	feed->add_item(item3);
+	feed.add_item(item3);
 
 	test_helpers::TempFile queue_file;
 	QueueManager manager(&cfg, queue_file.get_path());
@@ -619,22 +618,22 @@ TEST_CASE("autoenqueue() only enqueues HTTP and HTTPS URLs", "[QueueManager]")
 
 	Cache cache(":memory:", &cfg);
 
-	auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/news.atom");
+	RssFeed feed(&cache, "https://example.com/news.atom");
 
 	auto item1 = std::make_shared<RssItem>(&cache);
 	item1->set_enclosure_url("https://example.com/podcast.mp3");
 	item1->set_enclosure_type("audio/mpeg");
-	feed->add_item(item1);
+	feed.add_item(item1);
 
 	auto item2 = std::make_shared<RssItem>(&cache);
 	item2->set_enclosure_url("http://example.com/podcast2.mp3");
 	item2->set_enclosure_type("audio/mpeg");
-	feed->add_item(item2);
+	feed.add_item(item2);
 
 	auto item3 = std::make_shared<RssItem>(&cache);
 	item3->set_enclosure_url("ftp://user@example.com/podcast3.mp3");
 	item3->set_enclosure_type("audio/mpeg");
-	feed->add_item(item3);
+	feed.add_item(item3);
 
 	test_helpers::TempFile queue_file;
 	QueueManager manager(&cfg, queue_file.get_path());
@@ -659,27 +658,27 @@ TEST_CASE("autoenqueue() does not enqueue items with an invalid podcast type",
 		ConfigContainer cfg;
 		Cache cache(":memory:", &cfg);
 
-		auto feed = std::make_shared<RssFeed>(&cache, "https://example.com/news.atom");
+		RssFeed feed(&cache, "https://example.com/news.atom");
 
 		auto item1 = std::make_shared<RssItem>(&cache);
 		item1->set_enclosure_url("https://example.com/podcast1.mp3");
 		item1->set_enclosure_type("audio/mpeg");
-		feed->add_item(item1);
+		feed.add_item(item1);
 
 		auto item2 = std::make_shared<RssItem>(&cache);
 		item2->set_enclosure_url("http://example.com/not-a-podcast.jpg");
 		item2->set_enclosure_type("image/jpeg");
-		feed->add_item(item2);
+		feed.add_item(item2);
 
 		auto item3 = std::make_shared<RssItem>(&cache);
 		item3->set_enclosure_url("https://example.com/podcast2.mp3");
 		item3->set_enclosure_type("audio/mpeg");
-		feed->add_item(item3);
+		feed.add_item(item3);
 
 		auto item4 = std::make_shared<RssItem>(&cache);
 		item4->set_enclosure_url("https://example.com/podcast3.mp3");
 		item4->set_enclosure_type("");
-		feed->add_item(item4);
+		feed.add_item(item4);
 
 		test_helpers::TempFile queue_file;
 		QueueManager manager(&cfg, queue_file.get_path());


### PR DESCRIPTION
I remember seeing some reports a while back about memory usage growing over time.
Not sure if we reproduced it, but I recently got reminded that cycles of `std::shared_ptr`s can lead to memory being leaked.
I would like to reduce the amount of places where a `shared_ptr` is passed instead of a simple reference to simplify analysis at a later moment.