### PR TITLE
Store bind-key and bind configuration in the same map/tree-structure; Support multi-key sequences in a few places

### DIFF
--- a/include/formaction.h
+++ b/include/formaction.h
@@ -33,12 +33,6 @@ enum class CommandType {
 	INVALID, 	/// differs from UNKNOWN in that no input was parsed
 };
 
-enum class BindingType {
-	BindKey,
-	Macro,
-	Bind,
-};
-
 struct Command {
 	CommandType type;
 	std::vector<std::string> args;

--- a/include/view.h
+++ b/include/view.h
@@ -8,6 +8,7 @@
 
 #include "3rd-party/optional.hpp"
 
+#include "formaction.h"
 #include "links.h"
 #include "statusline.h"
 
@@ -141,7 +142,7 @@ public:
 	static void ctrl_c_action(int sig);
 
 protected:
-	bool run_commands(const std::vector<MacroCmd>& commands);
+	bool run_commands(const std::vector<MacroCmd>& commands, BindingType binding_type);
 
 	void apply_colors(std::shared_ptr<FormAction> fa);
 

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -55,6 +55,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 
 	set_dllist_keymap_hint();
 
+	std::vector<KeyCombination> key_sequence;
 	do {
 		if (update_view) {
 			const double total_kbps = ctrl.get_total_kbps();
@@ -122,7 +123,30 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 		}
 
 		const auto key_combination = KeyCombination::from_bindkey(event);
-		Operation op = keys.get_operation(key_combination, "podboat");
+		if (key_combination == KeyCombination("ESC") && !key_sequence.empty()) {
+			key_sequence.clear();
+		} else {
+			key_sequence.push_back(key_combination);
+		}
+		auto binding_state = MultiKeyBindingState::NotFound;
+		BindingType type = BindingType::Bind;
+		auto cmds = keys.get_operation(key_sequence, "podboat", binding_state, type);
+
+		if (binding_state == MultiKeyBindingState::MoreInputNeeded) {
+			continue;
+		}
+
+		key_sequence.clear();
+
+		if (cmds.size() != 1) {
+			// TODO: Add support to podboat for running a list of commands
+			continue;
+		}
+		if (cmds.size() != 1) {
+			// TODO: Add support to podboat for running commands with arguments
+			continue;
+		}
+		Operation op = cmds.front().op;
 
 		if (msg_line_dllist_form.get_text().length() > 0) {
 			msg_line_dllist_form.set_text("");
@@ -318,6 +342,7 @@ void PbView::run_help()
 
 	bool quit = false;
 
+	std::vector<KeyCombination> key_sequence;
 	do {
 		const auto event = help_form.run(0);
 		if (event.empty()) {
@@ -330,7 +355,30 @@ void PbView::run_help()
 		}
 
 		const auto key_combination = KeyCombination::from_bindkey(event);
-		Operation op = keys.get_operation(key_combination, "help");
+		if (key_combination == KeyCombination("ESC") && !key_sequence.empty()) {
+			key_sequence.clear();
+		} else {
+			key_sequence.push_back(key_combination);
+		}
+		auto binding_state = MultiKeyBindingState::NotFound;
+		BindingType type = BindingType::Bind;
+		auto cmds = keys.get_operation(key_sequence, "help", binding_state, type);
+
+		if (binding_state == MultiKeyBindingState::MoreInputNeeded) {
+			continue;
+		}
+
+		key_sequence.clear();
+
+		if (cmds.size() != 1) {
+			// TODO: Add support to podboat for running a list of commands
+			continue;
+		}
+		if (cmds.size() != 1) {
+			// TODO: Add support to podboat for running commands with arguments
+			continue;
+		}
+		Operation op = cmds.front().op;
 
 		switch (op) {
 		case OP_SK_UP:

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -183,7 +183,12 @@ TEST_CASE("evaluate_backticks replaces command in backticks with its output",
 		KeyMap keys(KM_NEWSBOAT);
 		cfgparser.register_handler("bind-key", keys);
 		REQUIRE_NOTHROW(cfgparser.parse_file("data/config-space-backticks"));
-		REQUIRE(keys.get_operation(KeyCombination("s"), "feedlist") == OP_SORT);
+		MultiKeyBindingState binding_state{};
+		BindingType binding_type{};
+		const auto& cmds = keys.get_operation({KeyCombination("s")}, "feedlist", binding_state,
+				binding_type);
+		REQUIRE(cmds.size() == 1);
+		REQUIRE(cmds.at(0).op == OP_SORT);
 	}
 
 	SECTION("Unbalanced backtick does *not* start a command") {


### PR DESCRIPTION
Part of https://github.com/newsboat/newsboat/pull/2364 (I've updated the list with TODOs based on code comments added in these commits)

The existing automatic tests for KeyMap were very useful in this case (caught several issues).
To test these changes manually:
- uncomment the `cfgparser.register_handler("bind", keys);` lines in `src/controller.cpp` and `src/pbcontroller.cpp`
- add a few `bind` commands to your config, e.g.:
    ```
    bind gg everywhere home
    bind G everywhere end
    bind gt everywhere next-dialog
    bind gT everywhere prev-dialog
    ```

All existing bind-key configs should still be working as before.