### PR TITLE
Experimental: Use ratatui instead of stfl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +37,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "android-tzdata"
@@ -345,6 +363,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +417,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +450,31 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -693,6 +765,16 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -842,10 +924,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23a0c8dfe501baac4adf6ebbfa6eddf8f0c07f56b058cc1288017e32397846c"
+dependencies = [
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -883,7 +984,7 @@ dependencies = [
  "ascii-canvas",
  "bit-set",
  "ena",
- "itertools",
+ "itertools 0.11.0",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -951,6 +1052,7 @@ dependencies = [
  "nom",
  "percent-encoding",
  "proptest",
+ "ratatui",
  "regex-rs",
  "section_testing",
  "strprintf",
@@ -1041,6 +1143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,6 +1195,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -1192,6 +1304,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1364,6 +1482,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "strum_macros",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1544,6 +1683,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1750,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1773,28 @@ name = "strprintf"
 version = "0.1.0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1806,6 +1994,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +2044,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/include/pbview.h
+++ b/include/pbview.h
@@ -7,6 +7,7 @@
 #include "textviewwidget.h"
 #include "stflpp.h"
 #include "stflrichtext.h"
+#include "tui.h"
 
 namespace newsboat {
 class KeyMap;
@@ -55,6 +56,8 @@ private:
 
 	ListWidget downloads_list;
 	TextviewWidget help_textview;
+
+	Tui tui;
 };
 
 } // namespace podboat

--- a/include/stflpp.h
+++ b/include/stflpp.h
@@ -7,6 +7,8 @@ extern "C" {
 
 #include <string>
 
+#include "tui.h"
+
 namespace newsboat {
 
 class Stfl {
@@ -43,6 +45,7 @@ public:
 	private:
 		stfl_form* f;
 		stfl_ipool* ipool;
+		RustForm form;
 	};
 
 	static void reset();

--- a/include/tui.h
+++ b/include/tui.h
@@ -1,0 +1,39 @@
+#ifndef NEWSBOAT_TUI_H_
+#define NEWSBOAT_TUI_H_
+
+#include <cstdint>
+#include <string>
+
+#include "libnewsboat-ffi/src/tui.rs.h"
+
+namespace newsboat {
+
+class RustForm {
+public:
+	RustForm();
+
+	std::string get_variable(std::string key);
+	void set_variable(std::string key, std::string value);
+	void modify_form(std::string name, std::string mode, std::string value);
+
+// TODO: Avoid leaking implementation detail?
+public:
+	rust::Box<tui::bridged::Form> rs_object;
+};
+
+class Tui {
+public:
+	Tui();
+	~Tui();
+
+	static Tui& get_instance(); // TODO: Remove
+	void reset();
+	std::string run(RustForm& form, std::int32_t timeout);
+
+private:
+	rust::Box<tui::bridged::Tui> rs_object;
+};
+
+} // namespace newsboat
+
+#endif /* NEWSBOAT_TUI_H_ */

--- a/include/view.h
+++ b/include/view.h
@@ -10,6 +10,7 @@
 
 #include "links.h"
 #include "statusline.h"
+#include "tui.h"
 
 namespace newsboat {
 
@@ -182,6 +183,8 @@ protected:
 
 private:
 	bool try_prepare_query_feed(std::shared_ptr<RssFeed> feed);
+
+	Tui tui;
 };
 
 } // namespace newsboat

--- a/mk/libboat.deps
+++ b/mk/libboat.deps
@@ -16,4 +16,5 @@ src/ruststring.cpp
 src/scopemeasure.cpp
 src/stflpp.cpp
 src/strprintf.cpp
+src/tui.cpp
 src/utils.cpp

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -22,5 +22,6 @@ fn main() {
     add_cxxbridge("logger");
     add_cxxbridge("scopemeasure");
     add_cxxbridge("stflrichtext");
+    add_cxxbridge("tui");
     add_cxxbridge("utils");
 }

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -23,6 +23,7 @@ pub mod logger;
 pub mod matchererror;
 pub mod scopemeasure;
 pub mod stflrichtext;
+pub mod tui;
 pub mod utils;
 
 /// Runs a Rust function, and if it panics, calls abort(); otherwise returns what function

--- a/rust/libnewsboat-ffi/src/tui.rs
+++ b/rust/libnewsboat-ffi/src/tui.rs
@@ -1,0 +1,53 @@
+use libnewsboat::tui;
+
+// cxx doesn't allow to share types from other crates, so we have to wrap it
+// cf. https://github.com/dtolnay/cxx/issues/496
+struct Tui(tui::Tui);
+struct Form(tui::Form);
+
+#[cxx::bridge(namespace = "newsboat::tui::bridged")]
+mod bridged {
+    extern "Rust" {
+        type Tui;
+        type Form;
+
+        fn create_form() -> Box<Form>;
+
+        fn create() -> Box<Tui>;
+        fn reset(tui: &mut Tui);
+        fn run(tui: &mut Tui, form: &mut Form, timeout: i32) -> String;
+        fn get_variable(form: &mut Form, key: &str) -> String;
+        fn set_variable(form: &mut Form, key: &str, value: &str);
+        fn modify_form(form: &mut Form, name: &str, mode: &str, value: &str);
+    }
+}
+
+fn create_form() -> Box<Form> {
+    Box::new(Form(tui::Form::new()))
+}
+
+fn create() -> Box<Tui> {
+    Box::new(Tui(tui::Tui::new()))
+}
+
+fn reset(tui: &mut Tui) {
+    tui.0.reset();
+}
+
+fn run(tui: &mut Tui, form: &mut Form, timeout: i32) -> String {
+    // TODO: Handle error?
+    let event = tui.0.run(&mut form.0, timeout).unwrap();
+    event.unwrap_or_default()
+}
+
+fn get_variable(form: &mut Form, key: &str) -> String {
+    form.0.get_variable(key)
+}
+
+fn set_variable(form: &mut Form, key: &str, value: &str) {
+    form.0.set_variable(key, value);
+}
+
+fn modify_form(form: &mut Form, name: &str, mode: &str, value: &str) {
+    form.0.modify_form(name, mode, value);
+}

--- a/rust/libnewsboat/Cargo.toml
+++ b/rust/libnewsboat/Cargo.toml
@@ -21,6 +21,7 @@ md5 = "0.7.0"
 lexopt = "0.3.0"
 chrono = "0.4.34"
 unicode-segmentation = "1.12.0"
+ratatui = "0.28.1"
 
 [dependencies.gettext-rs]
 version = "0.7.2"

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -24,3 +24,4 @@ pub mod matcher;
 pub mod matchererror;
 pub mod scopemeasure;
 pub mod stflrichtext;
+pub mod tui;

--- a/rust/libnewsboat/src/stflrichtext.rs
+++ b/rust/libnewsboat/src/stflrichtext.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use crate::utils;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct StflRichText {
     text: String,
     style_tags: BTreeMap<usize, String>,
@@ -29,6 +29,11 @@ impl StflRichText {
 
     pub fn apply_style_tag(&mut self, tag: &str, start: usize, end: usize) {
         self.merge_style_tag(tag, start, end);
+    }
+
+    // TODO: Stop leaking implementation details (BTreeMap)
+    pub fn style_switch_points(&self) -> &BTreeMap<usize, String> {
+        &self.style_tags
     }
 
     fn extract_style_tags(text: &str) -> (String, BTreeMap<usize, String>) {

--- a/rust/libnewsboat/src/tui.rs
+++ b/rust/libnewsboat/src/tui.rs
@@ -1,0 +1,398 @@
+use ratatui::prelude::Rect;
+use ratatui::{
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style, Stylize},
+    text::{Line, Span},
+    widgets::{List, ListItem},
+    DefaultTerminal, Frame,
+};
+use std::{collections::HashMap, io, str::FromStr};
+use style::StyleIdentifier;
+
+use crate::stflrichtext::StflRichText;
+
+mod input;
+mod stfl;
+mod style;
+
+pub struct Form {
+    title: String,
+    help: StflRichText,
+    message: String,
+    list_items: Vec<StflRichText>,
+    list_offset: usize,
+    list_focus: Option<usize>,
+    list_viewport_dimensions: (u16, u16),
+    text_percent: String,
+    text_percent_width: u16,
+    styles: HashMap<StyleIdentifier, Style>,
+}
+
+impl Default for Form {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Form {
+    pub fn new() -> Self {
+        Self {
+            title: String::new(),
+            help: StflRichText::default(),
+            message: String::new(),
+            list_items: vec![],
+            list_offset: 0,
+            list_focus: None,
+            list_viewport_dimensions: (0, 0),
+            text_percent: String::new(),
+            text_percent_width: 0,
+            styles: [
+                (
+                    StyleIdentifier::Title,
+                    Style::new().yellow().on_blue().bold(),
+                ),
+                (
+                    StyleIdentifier::Info,
+                    Style::new().yellow().on_blue().bold(),
+                ),
+                (
+                    StyleIdentifier::HintKey,
+                    Style::new().yellow().on_blue().bold(),
+                ),
+                (
+                    StyleIdentifier::HintKeysDelimiter,
+                    Style::new().white().on_blue(),
+                ),
+                (
+                    StyleIdentifier::HintSeparator,
+                    Style::new().white().on_blue().bold(),
+                ),
+                (
+                    StyleIdentifier::HintDescription,
+                    Style::new().white().on_blue(),
+                ),
+            ]
+            .into(),
+        }
+    }
+
+    fn replace_list_content(&mut self, value: &str) {
+        // TODO: Avoid unwrap
+        let (_remainder, items) = stfl::parse_list(value).unwrap();
+        let items = items.iter().map(|s| StflRichText::from_quoted(s)).collect();
+        self.list_items = items;
+    }
+
+    fn replace_list(&mut self, value: &str) {
+        // TODO: Avoid unwrap
+        let (_remainder, named_styles) = stfl::parse_list_replacement(value).unwrap();
+        for (name, style) in named_styles {
+            let style = Self::convert_style(style);
+            let style_identifier = StyleIdentifier::from_list_replace(name);
+            if let Some(style_identifier) = style_identifier {
+                self.styles.insert(style_identifier, style);
+            } else {
+                // TODO: Add style support
+                self.message = format!("Unknown replace_list style name: {name}");
+            }
+        }
+    }
+
+    pub fn get_variable(&mut self, key: &str) -> String {
+        match key {
+            "msg" => self.message.to_owned(),
+            "feeds:w" | "items:w" | "urls:w" | "dls:w" | "taglist:w" => {
+                self.list_viewport_dimensions.0.to_string()
+            }
+            "feeds:h" | "items:h" | "urls:h" | "dls:h" | "taglist:h" => {
+                self.list_viewport_dimensions.1.to_string()
+            }
+            "article:w" | "helptext:w" => self.list_viewport_dimensions.0.to_string(),
+            "article:h" | "helptext:h" => self.list_viewport_dimensions.1.to_string(),
+            "title:w" => self.list_viewport_dimensions.0.to_string(),
+            "article_offset" | "helptext_offset" => self.list_offset.to_string(),
+            _ => {
+                self.message = format!("unhandled get: {}", key);
+                String::new()
+            }
+        }
+    }
+
+    pub fn set_variable(&mut self, key: &str, value: &str) {
+        match key {
+            "head" => {
+                self.title = value.into();
+            }
+            "help" => {
+                self.help = StflRichText::from_quoted(value);
+            }
+            "msg" => {
+                self.message = value.into();
+            }
+            "feeds_pos" | "items_pos" | "urls_pos" | "dls_pos" | "taglist_pos" => {
+                // TODO: Handle non-numeric value?
+                self.list_focus = value.parse().ok();
+            }
+            "feeds_offset" | "items_offset" | "urls_offset" | "dls_offset" | "taglist_offset" => {
+                self.list_offset = value.parse().unwrap();
+            }
+            "percent" => {
+                self.text_percent = value.into();
+            }
+            "article_offset" | "helptext_offset" => {
+                self.list_offset = value.parse().unwrap();
+            }
+            "percentwidth" => {
+                self.text_percent_width = value.parse().unwrap();
+            }
+            "highlight" => {
+                // TODO: Handle (seems related to HelpFormAction
+            }
+            _ => {
+                let style_identifier = StyleIdentifier::from_set_var(key);
+                if let Some(style_identifier) = style_identifier {
+                    let (_, style) = stfl::parse_style(value).unwrap();
+                    let style = Self::convert_style(style);
+                    self.styles.insert(style_identifier, style);
+                } else {
+                    // TODO: Handle other variables
+                    self.message = format!("unhandled set: {} - {}", key, value);
+                }
+            }
+        };
+    }
+
+    pub fn modify_form(&mut self, name: &str, mode: &str, value: &str) {
+        match (name, mode) {
+            ("feeds" | "items" | "urls" | "dls" | "taglist", "replace_inner") => {
+                self.replace_list_content(value)
+            }
+            ("feeds" | "items" | "urls" | "dls" | "taglist", "replace") => self.replace_list(value),
+            ("article" | "helptext", "replace_inner") => self.replace_list_content(value),
+            ("article" | "helptext", "replace") => (), // TODO: Handle (update style?)
+            _ => self.message = format!("unhandled modify_form: {} {} {}", name, mode, value),
+        };
+    }
+
+    fn convert_style(stfl_style: stfl::Style) -> Style {
+        let fg = Color::from_str(stfl_style.fg).unwrap_or(Color::White);
+        let bg = Color::from_str(stfl_style.bg).unwrap_or(Color::Black);
+        let mut style = Style::new().fg(fg).bg(bg);
+        for &attribute in &stfl_style.attributes {
+            match attribute {
+                "standout" => {
+                    todo!("Find out what this did in stfl and reproduce it with ratatui")
+                }
+                "underline" => style = style.underlined(),
+                "reverse" => style = style.reversed(),
+                // TODO: Check if stfl used a slow or a fast blink
+                "blink" => style = style.slow_blink(),
+                "dim" => style = style.dim(),
+                "bold" => style = style.bold(),
+                "protect" => {
+                    todo!("Find out what this did in stfl and reproduce it with ratatui")
+                }
+                "invis" => {
+                    todo!("Find out what this did in stfl and reproduce it with ratatui")
+                }
+                _ => todo!("Unhandled attribute: {attribute}, stfl style: {stfl_style:?}"),
+            };
+        }
+        style
+    }
+}
+
+pub struct Tui {
+    terminal: Option<DefaultTerminal>,
+}
+
+impl Default for Tui {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Tui {
+    pub fn new() -> Self {
+        Tui { terminal: None }
+    }
+
+    fn draw(&mut self, form: &mut Form) -> io::Result<()> {
+        let terminal = self.terminal.as_mut().unwrap();
+        terminal.draw(|frame| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(1),
+                    Constraint::Fill(1),
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                ])
+                .split(frame.area());
+            let fallback_style = Style::new().fg(Color::White).bg(Color::Black);
+            let title_style = form
+                .styles
+                .get(&StyleIdentifier::Title)
+                .unwrap_or(&fallback_style);
+            let title = Line::styled(form.title.as_str(), title_style.to_owned());
+
+            let message = Line::from(form.message.as_str()).white().on_black();
+
+            let items: Vec<_> = form
+                .list_items
+                .iter()
+                .enumerate()
+                .map(|(i, item)| (form.list_focus == Some(i), item))
+                .skip(form.list_offset)
+                .take(chunks[1].height.into())
+                .map(|(has_focus, item)| Self::style_line(item, has_focus, &form.styles))
+                .map(ListItem::from)
+                .collect();
+            let list = List::new(items).highlight_style(Style::new().white().on_blue().bold());
+
+            frame.render_widget(title, chunks[0]);
+            frame.render_widget(list, chunks[1]);
+            frame.render_widget(message, chunks[3]);
+
+            if form.text_percent.is_empty() {
+                Self::render_help(frame, &form.help, &form.styles, chunks[2]);
+            } else {
+                let parts = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([
+                        Constraint::Fill(1),
+                        Constraint::Length(form.text_percent_width),
+                    ])
+                    .split(chunks[2]);
+
+                let percent_widget = Span::from(form.text_percent.as_str());
+
+                Self::render_help(frame, &form.help, &form.styles, parts[0]);
+                frame.render_widget(percent_widget, parts[1]);
+            }
+        })?;
+        Ok(())
+    }
+
+    fn style_line<'a>(
+        richtext: &'a StflRichText,
+        has_focus: bool,
+        styles: &HashMap<StyleIdentifier, Style>,
+    ) -> Line<'a> {
+        let text = richtext.plaintext();
+        let locs = richtext.style_switch_points().iter();
+        let fallback = if has_focus {
+            Style::new().yellow().on_blue().bold()
+        } else {
+            Style::new().white().on_black()
+        };
+        // TODO: Check if this also makes sense for text views (article, help)
+        let default = if has_focus {
+            styles.get(&StyleIdentifier::ListFocus).unwrap_or(&fallback)
+        } else {
+            styles
+                .get(&StyleIdentifier::ListNormal)
+                .unwrap_or(&fallback)
+        };
+        let mut pos = 0;
+        let mut style = default;
+        let mut line = Line::styled("", default.to_owned());
+        for (&loc, style_name) in locs {
+            if loc > pos {
+                line.push_span(Span::styled(&text[pos..loc], style.to_owned()));
+                pos = loc;
+            }
+            // TODO: Take `has_focus` into account
+            let style_identifier = StyleIdentifier::from_stye_tag(style_name);
+            style = style_identifier
+                .and_then(|s| styles.get(&s))
+                .unwrap_or(default);
+        }
+        if pos < text.len() {
+            line.push_span(Span::styled(&text[pos..], style.to_owned()));
+        }
+        line
+    }
+
+    fn render_help(
+        frame: &mut Frame,
+        richtext: &StflRichText,
+        styles: &HashMap<StyleIdentifier, Style>,
+        area: Rect,
+    ) {
+        let text = richtext.plaintext();
+        let locs = richtext.style_switch_points().iter();
+        let fallback = Style::new().fg(Color::White).bg(Color::Black);
+        let default = styles.get(&StyleIdentifier::Info).unwrap_or(&fallback);
+        let mut pos = 0;
+        let mut style = default;
+        let mut line = Line::styled("", default.to_owned());
+        for (&loc, style_name) in locs {
+            if loc > pos {
+                line.push_span(Span::styled(&text[pos..loc], style.to_owned()));
+                pos = loc;
+            }
+            let style_identifier = StyleIdentifier::from_stye_tag(style_name);
+            style = style_identifier
+                .and_then(|s| styles.get(&s))
+                .unwrap_or(default);
+        }
+        if pos < text.len() {
+            line.push_span(Span::styled(&text[pos..], style.to_owned()));
+        }
+        frame.render_widget(line, area);
+    }
+
+    // TODO: Get implementation in line with description
+    /// Draws UI and waits for next event (keypress, resize, etc.)
+    ///
+    ///
+    pub fn run(&mut self, form: &mut Form, timeout: i32) -> io::Result<Option<String>> {
+        if self.terminal.is_none() {
+            let mut terminal = ratatui::init();
+            terminal.clear()?;
+            self.terminal = Some(terminal);
+        }
+        let event = match timeout {
+            -1 => {
+                self.draw(form)?;
+                None
+            }
+            -2 => input::get_event(None)?,
+            -3 => {
+                // TODO: Check if this has changed by the time a PR is created
+                // Should be save because we initialize it at the start of this method
+                let terminal = self.terminal.as_mut().unwrap();
+                // TODO: See if we can cache this value until a ^L or RESIZE event
+                let size = terminal.size()?;
+                // TODO: Check if all forms have exactly the same number of none-list lines
+                // (assuming 3 lines: [title, help, message])
+                form.list_viewport_dimensions = (size.width, size.height - 3);
+                None
+            }
+            timeout => {
+                let event = input::get_event(None)?;
+                if event.is_some() {
+                    event
+                } else {
+                    self.draw(form)?;
+                    input::get_event(Some(timeout.unsigned_abs()))?
+                }
+            }
+        };
+        Ok(event)
+    }
+
+    pub fn reset(&mut self) {
+        if self.terminal.is_some() {
+            self.terminal = None;
+            ratatui::restore();
+        }
+    }
+}
+
+impl Drop for Tui {
+    fn drop(&mut self) {
+        self.reset();
+    }
+}

--- a/rust/libnewsboat/src/tui/input.rs
+++ b/rust/libnewsboat/src/tui/input.rs
@@ -1,0 +1,52 @@
+use ratatui::crossterm::event::{self, poll, Event, KeyCode, KeyEventKind, KeyModifiers};
+use std::{io, time::Duration};
+
+pub fn get_event(timeout: Option<u32>) -> io::Result<Option<String>> {
+    let read_event = match timeout {
+        None => poll(Duration::from_secs(0))?,
+        Some(0) => true,
+        Some(timeout) => poll(Duration::from_millis(timeout.into()))?,
+    };
+    if read_event {
+        let event = match event::read()? {
+            Event::Key(key_event)
+                if key_event.kind == KeyEventKind::Press
+                    && !key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                match key_event.code {
+                    KeyCode::Char(c) => Some(c.to_string()),
+                    KeyCode::Enter => Some("ENTER".into()),
+                    KeyCode::Backspace => Some("BACKSPACE".into()),
+                    KeyCode::Left => Some("LEFT".into()),
+                    KeyCode::Right => Some("RIGHT".into()),
+                    KeyCode::Up => Some("UP".into()),
+                    KeyCode::Down => Some("DOWN".into()),
+                    KeyCode::PageUp => Some("PPAGE".into()),
+                    KeyCode::PageDown => Some("NPAGE".into()),
+                    KeyCode::Home => Some("HOME".into()),
+                    KeyCode::End => Some("END".into()),
+                    KeyCode::Esc => Some("ESC".into()),
+                    KeyCode::Tab => Some("TAB".into()),
+                    KeyCode::F(n) => Some(format!("F{}", n)),
+                    // TODO: Handle all keys which were handled by ncurses/stfl
+                    _ => None,
+                }
+            }
+            Event::Key(key_event)
+                if key_event.kind == KeyEventKind::Press
+                    && key_event.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                match key_event.code {
+                    KeyCode::Char(c) if c.is_ascii() && c.is_alphabetic() => {
+                        Some(format!("^{}", c.to_ascii_uppercase()))
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        };
+        Ok(event)
+    } else {
+        Ok(None)
+    }
+}

--- a/rust/libnewsboat/src/tui/stfl.rs
+++ b/rust/libnewsboat/src/tui/stfl.rs
@@ -1,0 +1,148 @@
+use nom::bytes::complete::take_till1;
+use nom::character::complete::alpha1;
+use nom::character::complete::alphanumeric0;
+use nom::character::complete::alphanumeric1;
+use nom::character::complete::space0;
+use nom::character::complete::space1;
+use nom::combinator::map;
+use nom::combinator::opt;
+use nom::combinator::recognize;
+use nom::combinator::value;
+use nom::multi::separated_list0;
+use nom::{
+    branch::alt,
+    bytes::complete::{escaped_transform, is_not, tag},
+    combinator::eof,
+    multi::many0,
+    IResult,
+};
+
+#[derive(Clone, Debug)]
+pub struct Style<'a> {
+    pub fg: &'a str,
+    pub bg: &'a str,
+    pub attributes: Vec<&'a str>,
+}
+
+fn parse_fragment_single(input: &str) -> IResult<&str, String> {
+    let (input, _) = tag("'")(input)?;
+    let (input, fragment) = escaped_transform(
+        is_not(r#"'\"#),
+        '\\',
+        alt((value("\\", tag("\\")), value("'", tag("'")))),
+    )(input)?;
+    let (input, _) = tag("'")(input)?;
+    Ok((input, fragment))
+}
+
+fn parse_fragment_double(input: &str) -> IResult<&str, String> {
+    let (input, _) = tag("\"")(input)?;
+    let (input, item) = escaped_transform(
+        is_not(r#""\"#),
+        '\\',
+        alt((value("\\", tag("\\")), value("\"", tag("\"")))),
+    )(input)?;
+    let (input, _) = tag("\"")(input)?;
+    Ok((input, item))
+}
+
+fn parse_string(input: &str) -> IResult<&str, String> {
+    let (input, fragments) = many0(alt((parse_fragment_single, parse_fragment_double)))(input)?;
+    let item = fragments.concat();
+    Ok((input, item))
+}
+
+fn parse_listitem(input: &str) -> IResult<&str, String> {
+    let (input, _) = tag("{listitem text:")(input)?;
+    let (input, item) = parse_string(input)?;
+    let (input, _) = tag("}")(input)?;
+    Ok((input, item))
+}
+
+pub fn parse_list(input: &str) -> IResult<&str, Vec<String>> {
+    let (input, _) = tag("{list")(input)?;
+    let (input, items) = many0(parse_listitem)(input)?;
+    let (input, _) = tag("}")(input)?;
+    let (input, _) = eof(input)?;
+    Ok((input, items))
+}
+
+fn parse_style_fg(input: &str) -> IResult<&str, &str> {
+    let (input, _) = opt(tag(","))(input)?;
+    let (input, _) = tag("fg=")(input)?;
+    alphanumeric1(input)
+}
+
+fn parse_style_bg(input: &str) -> IResult<&str, &str> {
+    let (input, _) = opt(tag(","))(input)?;
+    let (input, _) = tag("bg=")(input)?;
+    alphanumeric1(input)
+}
+
+fn parse_attribute(input: &str) -> IResult<&str, &str> {
+    let (input, _) = opt(tag(","))(input)?;
+    let (input, _) = tag("attr=")(input)?;
+    let (input, _) = space0(input)?;
+    alpha1(input)
+}
+
+pub fn parse_style(input: &str) -> IResult<&str, Style> {
+    let (input, fg) = opt(parse_style_fg)(input)?;
+    let fg = fg.unwrap_or("white");
+    let fg = fg.strip_prefix("color").unwrap_or(fg);
+    let (input, bg) = opt(parse_style_bg)(input)?;
+    let bg = bg.unwrap_or("black");
+    let bg = bg.strip_prefix("color").unwrap_or(bg);
+    let (input, attributes) = many0(parse_attribute)(input)?;
+    Ok((input, Style { fg, bg, attributes }))
+}
+
+fn parse_var_name(input: &str) -> IResult<&str, &str> {
+    let (input, _) = tag("[")(input)?;
+    let (input, name) = take_till1(|c| c == ']')(input)?;
+    let (input, _) = tag("]")(input)?;
+    Ok((input, name))
+}
+
+fn recognize_list_attribute(input: &str) -> IResult<&str, ()> {
+    let (input, _) = opt(tag("."))(input)?;
+    let (input, _) = alphanumeric1(input)?;
+    let (input, _) = opt(parse_var_name)(input)?;
+    let (input, _) = tag(":")(input)?;
+    let (input, _) = alphanumeric0(input)?;
+    Ok((input, ()))
+}
+
+fn recognize_style_name(input: &str) -> IResult<&str, ()> {
+    let (input, _) = tag("style_")(input)?;
+    let (input, _) = take_till1(|c| c == ':' || c == '[')(input)?;
+    Ok((input, ()))
+}
+
+fn parse_list_style_attribute(input: &str) -> IResult<&str, (&str, Style)> {
+    let (input, _) = opt(tag("@"))(input)?;
+    let (input, name) = recognize(recognize_style_name)(input)?;
+    let (input, _) = opt(parse_var_name)(input)?;
+    let (input, _) = tag(":")(input)?;
+    let (input, style) = parse_style(input)?;
+    Ok((input, (name, style)))
+}
+
+fn parse_list_attribute(input: &str) -> IResult<&str, Option<(&str, Style)>> {
+    let (input, named_style) = alt((
+        map(parse_list_style_attribute, Option::Some),
+        value(None, recognize_list_attribute),
+    ))(input)?;
+    Ok((input, named_style))
+}
+
+pub fn parse_list_replacement(input: &str) -> IResult<&str, Vec<(&str, Style)>> {
+    let (input, _) = tag("{!list[")(input)?;
+    let (input, _list_name) = alphanumeric1(input)?;
+    let (input, _) = tag("]")(input)?;
+    let (input, _) = space1(input)?;
+    let (input, styles) = separated_list0(space1, parse_list_attribute)(input)?;
+    let styles = styles.into_iter().flatten().collect();
+    let (input, _) = tag("}")(input)?;
+    Ok((input, styles))
+}

--- a/rust/libnewsboat/src/tui/style.rs
+++ b/rust/libnewsboat/src/tui/style.rs
@@ -1,0 +1,66 @@
+#[derive(Eq, Hash, PartialEq)]
+pub enum StyleIdentifier {
+    Reset, // Or None/Default?
+    Info,
+    Title,
+    HintDescription,
+    HintSeparator,
+    HintKeysDelimiter,
+    HintKey,
+    ListNormal,
+    ListFocus,
+    Numbered(u16),
+}
+
+impl StyleIdentifier {
+    pub fn from_set_var(key: &str) -> Option<Self> {
+        match key {
+            "info" => Some(Self::Info),
+            "title" => Some(Self::Title),
+            "hint-description" => Some(Self::HintDescription),
+            "hint-separator" => Some(Self::HintSeparator),
+            "hint-keys-delimiter" => Some(Self::HintKeysDelimiter),
+            "hint-key" => Some(Self::HintKey),
+            "listnormal" => Some(Self::ListNormal),
+            "listfocus" => Some(Self::ListFocus),
+            // TODO: Check for missing keys, e.g.:
+            // "color_underline"
+            // "color_bold"
+            // "listnormal_unread"
+            // "listfocus_unread"
+            // "article"
+            _ => None,
+        }
+    }
+
+    pub fn from_list_replace(name: &str) -> Option<Self> {
+        // TODO: Handle all list replace names
+        Self::numbered_name(name)
+    }
+
+    fn numbered_name(name: &str) -> Option<Self> {
+        let name = name.strip_prefix("style_")?;
+        // TODO: Handle "_focus"
+        let name = name.strip_suffix("_normal")?;
+        name.parse::<u16>().ok().map(Self::Numbered)
+    }
+
+    pub fn from_stye_tag(tag: &str) -> Option<Self> {
+        match tag {
+            "</>" => Some(Self::Reset),
+            "<key>" => Some(Self::HintKey),
+            "<colon>" => Some(Self::HintSeparator),
+            "<comma>" => Some(Self::HintKeysDelimiter),
+            "<desc>" => Some(Self::HintDescription),
+            // TODO: Add missing tags
+            _ => None,
+        }
+        .or_else(|| Self::numbered_tag(tag))
+    }
+
+    fn numbered_tag(tag: &str) -> Option<Self> {
+        let tag = tag.strip_prefix("<")?;
+        let tag = tag.strip_suffix(">")?;
+        tag.parse::<u16>().ok().map(Self::Numbered)
+    }
+}

--- a/src/stflpp.cpp
+++ b/src/stflpp.cpp
@@ -44,32 +44,36 @@ Stfl::Form::~Form()
 
 std::string Stfl::Form::run(int timeout)
 {
-	const auto event = stfl_ipool_fromwc(ipool, stfl_run(f, timeout));
-	if (event != nullptr) {
-		return std::string(event);
-	} else {
-		return "";
-	}
+	// TODO: Change based on specified timeout
+	return Tui::get_instance().run(form, timeout);
+	//const auto event = stfl_ipool_fromwc(ipool, stfl_run(f, timeout));
+	//if (event != nullptr) {
+	//	return std::string(event);
+	//} else {
+	//	return "";
+	//}
 }
 
 std::string Stfl::Form::get(const std::string& name)
 {
-	const char* text = stfl_ipool_fromwc(
-			ipool, stfl_get(f, stfl_ipool_towc(ipool, name.c_str())));
-	std::string retval;
-	if (text) {
-		retval = text;
-	}
-	stfl_ipool_flush(ipool);
-	return retval;
+	return form.get_variable(name);
+	//const char* text = stfl_ipool_fromwc(
+	//		ipool, stfl_get(f, stfl_ipool_towc(ipool, name.c_str())));
+	//std::string retval;
+	//if (text) {
+	//	retval = text;
+	//}
+	//stfl_ipool_flush(ipool);
+	//return retval;
 }
 
 void Stfl::Form::set(const std::string& name, const std::string& value)
 {
-	stfl_set(f,
-		stfl_ipool_towc(ipool, name.c_str()),
-		stfl_ipool_towc(ipool, value.c_str()));
-	stfl_ipool_flush(ipool);
+	form.set_variable(name, value);
+	//stfl_set(f,
+	//	stfl_ipool_towc(ipool, name.c_str()),
+	//	stfl_ipool_towc(ipool, value.c_str()));
+	//stfl_ipool_flush(ipool);
 }
 
 std::string Stfl::Form::get_focus()
@@ -93,17 +97,19 @@ void Stfl::Form::modify(const std::string& name,
 	const std::string& mode,
 	const std::string& text)
 {
-	const wchar_t* wname, *wmode, *wtext;
-	wname = stfl_ipool_towc(ipool, name.c_str());
-	wmode = stfl_ipool_towc(ipool, mode.c_str());
-	wtext = stfl_ipool_towc(ipool, text.c_str());
-	stfl_modify(f, wname, wmode, wtext);
-	stfl_ipool_flush(ipool);
+	form.modify_form(name, mode, text);
+	//const wchar_t* wname, *wmode, *wtext;
+	//wname = stfl_ipool_towc(ipool, name.c_str());
+	//wmode = stfl_ipool_towc(ipool, mode.c_str());
+	//wtext = stfl_ipool_towc(ipool, text.c_str());
+	//stfl_modify(f, wname, wmode, wtext);
+	//stfl_ipool_flush(ipool);
 }
 
 void Stfl::reset()
 {
-	stfl_reset();
+	Tui::get_instance().reset();
+	//stfl_reset();
 }
 
 static std::mutex quote_mtx;
@@ -122,17 +128,23 @@ std::string Stfl::quote(const std::string& text)
 std::string Stfl::Form::dump(const std::string& name, const std::string& prefix,
 	int focus)
 {
-	const char* text = stfl_ipool_fromwc(ipool,
-			stfl_dump(f,
-				stfl_ipool_towc(ipool, name.c_str()),
-				stfl_ipool_towc(ipool, prefix.c_str()),
-				focus));
-	std::string retval;
-	if (text) {
-		retval = text;
-	}
-	stfl_ipool_flush(ipool);
-	return retval;
+	//const char* text = stfl_ipool_fromwc(ipool,
+	//		stfl_dump(f,
+	//			stfl_ipool_towc(ipool, name.c_str()),
+	//			stfl_ipool_towc(ipool, prefix.c_str()),
+	//			focus));
+	//std::string retval;
+	//if (text) {
+	//	retval = text;
+	//}
+	//stfl_ipool_flush(ipool);
+	//return retval;
+
+	// TODO: Make sure any old uses of this method still work (probably requires title/hint swapping to be handled in Rust)
+	(void)name;
+	(void)prefix;
+	(void)focus;
+	return "";
 }
 
 } // namespace newsboat

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -1,0 +1,63 @@
+#include "tui.h"
+
+#include <cassert>
+
+#include "libnewsboat-ffi/src/tui.rs.h"
+
+namespace {
+// TODO: Remove
+newsboat::Tui* tui_instance = nullptr;
+}
+
+namespace newsboat {
+
+RustForm::RustForm()
+	: rs_object(tui::bridged::create_form())
+{
+}
+
+std::string RustForm::get_variable(std::string key)
+{
+	return std::string(tui::bridged::get_variable(*rs_object, key));
+}
+
+void RustForm::set_variable(std::string key, std::string value)
+{
+	tui::bridged::set_variable(*rs_object, key, value);
+}
+
+void RustForm::modify_form(std::string name, std::string mode, std::string value)
+{
+	tui::bridged::modify_form(*rs_object, name, mode, value);
+}
+
+Tui::Tui()
+	: rs_object(tui::bridged::create())
+{
+	if (tui_instance == nullptr) {
+		tui_instance = this;
+	}
+}
+
+Tui::~Tui()
+{
+	//tui_instance = nullptr;
+}
+
+Tui& Tui::get_instance()
+{
+	assert(tui_instance != nullptr);
+	return *tui_instance;
+}
+
+void Tui::reset()
+{
+	tui::bridged::reset(*rs_object);
+}
+
+std::string Tui::run(RustForm& form, std::int32_t timeout)
+{
+	return std::string(tui::bridged::run(*rs_object, *form.rs_object, timeout));
+}
+
+} // namespace newsboat

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -2,6 +2,7 @@
 #include "3rd-party/catch.hpp"
 
 #include "test_helpers/httptestserver.h"
+#include "tui.h"
 
 int main(int argc, char* argv[])
 {
@@ -10,6 +11,9 @@ int main(int argc, char* argv[])
 	srand(static_cast<unsigned int>(std::time(0)));
 
 	test_helpers::HttpTestServer server;
+
+	// TODO: Remove
+	newsboat::Tui tui;
 
 	return Catch::Session().run(argc, argv);
 }


### PR DESCRIPTION
I'm trying to get stfl replaced by ratatui, see also #232 
That is going relatively well. Input handling and rendering of lists/text seems to work (mostly) fine already.
Main things remaining:
- color/styling support (preparation work in https://github.com/newsboat/newsboat/pull/2894)
- editable line (cmdline and file/dir browsers) => https://github.com/newsboat/newsboat/pull/3389
- make sure we don't make changes in state from separate threads at the same time (could happen now by `reload-all` which updates the bottom-of-the-screen messages and the per-feed reload status)
    -> Might require breaking out of Crossterm's `read()` call, which might require some asynchronous code: https://github.com/crossterm-rs/crossterm/issues/397

I'm creating this PR to have a place to get some feedback and possibly discuss whether we want this (and if yes, in what way this can be merged)

Some ideas/questions/remarks:
- Do we want to have support for ratatui and stfl at the same time for a while? (as compile time option, or even a temporary config/cli option)
- I will try to split of part of the work into small improvements which also work with the old stfl implementation
- The commits in this PR are not all that useful so I plan to squash everything together into a single commit