### PR TITLE
Port StflRichText to Rust

### DIFF
--- a/include/stflrichtext.h
+++ b/include/stflrichtext.h
@@ -1,8 +1,9 @@
 #ifndef NEWSBOAT_STFLSTRING_H_
 #define NEWSBOAT_STFLSTRING_H_
 
-#include <map>
 #include <string>
+
+#include "libnewsboat-ffi/src/stflrichtext.rs.h"
 
 namespace newsboat {
 
@@ -11,13 +12,12 @@ public:
 	static StflRichText from_plaintext(std::string);
 	static StflRichText from_quoted(std::string);
 
-	StflRichText(const StflRichText&) = default;
+	StflRichText(const StflRichText&);
 	StflRichText(StflRichText&&) = default;
-	StflRichText& operator=(const StflRichText&) = default;
+	StflRichText& operator=(const StflRichText&);
 	StflRichText& operator=(StflRichText&&) = default;
 	~StflRichText() = default;
 
-	friend StflRichText operator+(StflRichText left, const StflRichText& right);
 
 	void apply_style_tag(const std::string& tag, size_t start, size_t end);
 
@@ -25,16 +25,10 @@ public:
 	std::string stfl_quoted() const;
 
 private:
-	StflRichText(std::string&&,
-		std::map<size_t, std::string>&&); // Only constructable using the public static functions
-	static std::map<size_t, std::string> extract_style_tags(std::string&);
-	static void merge_style_tag(std::map<size_t, std::string>& tags, const std::string& tag,
-		size_t start, size_t end);
-	static std::string insert_style_tags(const std::string& str,
-		const std::map<size_t, std::string>& tags);
+	rust::Box<stflrichtext::bridged::StflRichText> rs_object;
 
-	std::string text; // plaintext string (without highlighting)
-	std::map<size_t, std::string> style_tags;
+	// Only constructable using the public static functions
+	StflRichText(rust::Box<stflrichtext::bridged::StflRichText>&&);
 };
 
 } // namespace newsboat

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -21,5 +21,6 @@ fn main() {
     add_cxxbridge("keymap");
     add_cxxbridge("logger");
     add_cxxbridge("scopemeasure");
+    add_cxxbridge("stflrichtext");
     add_cxxbridge("utils");
 }

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -22,6 +22,7 @@ pub mod keymap;
 pub mod logger;
 pub mod matchererror;
 pub mod scopemeasure;
+pub mod stflrichtext;
 pub mod utils;
 
 /// Runs a Rust function, and if it panics, calls abort(); otherwise returns what function

--- a/rust/libnewsboat-ffi/src/stflrichtext.rs
+++ b/rust/libnewsboat-ffi/src/stflrichtext.rs
@@ -1,0 +1,49 @@
+use cxx::CxxString;
+use libnewsboat::stflrichtext;
+
+// cxx doesn't allow to share types from other crates, so we have to wrap it
+// cf. https://github.com/dtolnay/cxx/issues/496
+struct StflRichText(stflrichtext::StflRichText);
+
+#[cxx::bridge(namespace = "newsboat::stflrichtext::bridged")]
+mod ffi {
+    extern "Rust" {
+        type StflRichText;
+
+        fn from_plaintext(text: &CxxString) -> Box<StflRichText>;
+        fn from_quoted(text: &CxxString) -> Box<StflRichText>;
+        fn copy(richtext: &StflRichText) -> Box<StflRichText>;
+
+        fn apply_style_tag(richtext: &mut StflRichText, tag: &str, start: usize, end: usize);
+        fn plaintext(richtext: &StflRichText) -> &str;
+        fn quoted(richtext: &StflRichText) -> String;
+    }
+}
+
+fn from_plaintext(text: &CxxString) -> Box<StflRichText> {
+    let text = text.to_string_lossy();
+    let richtext = stflrichtext::StflRichText::from_plaintext(&text);
+    Box::new(StflRichText(richtext))
+}
+
+fn from_quoted(text: &CxxString) -> Box<StflRichText> {
+    let text = text.to_string_lossy();
+    let richtext = stflrichtext::StflRichText::from_quoted(&text);
+    Box::new(StflRichText(richtext))
+}
+
+fn copy(richtext: &StflRichText) -> Box<StflRichText> {
+    Box::new(StflRichText(richtext.0.clone()))
+}
+
+fn apply_style_tag(richtext: &mut StflRichText, tag: &str, start: usize, end: usize) {
+    richtext.0.apply_style_tag(tag, start, end);
+}
+
+fn plaintext(richtext: &StflRichText) -> &str {
+    richtext.0.plaintext()
+}
+
+fn quoted(richtext: &StflRichText) -> String {
+    richtext.0.quoted()
+}

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -23,3 +23,4 @@ pub mod matchable;
 pub mod matcher;
 pub mod matchererror;
 pub mod scopemeasure;
+pub mod stflrichtext;

--- a/rust/libnewsboat/src/stflrichtext.rs
+++ b/rust/libnewsboat/src/stflrichtext.rs
@@ -1,0 +1,144 @@
+use std::collections::BTreeMap;
+
+use crate::utils;
+
+#[derive(Clone)]
+pub struct StflRichText {
+    text: String,
+    style_tags: BTreeMap<usize, String>,
+}
+
+impl StflRichText {
+    pub fn from_plaintext(text: &str) -> Self {
+        let quoted_text = utils::quote_for_stfl(text);
+        Self::from_quoted(&quoted_text)
+    }
+
+    pub fn from_quoted(text: &str) -> Self {
+        let (text, style_tags) = Self::extract_style_tags(text);
+        Self { text, style_tags }
+    }
+
+    pub fn plaintext(&self) -> &str {
+        &self.text
+    }
+
+    pub fn quoted(&self) -> String {
+        self.insert_style_tags()
+    }
+
+    pub fn apply_style_tag(&mut self, tag: &str, start: usize, end: usize) {
+        self.merge_style_tag(tag, start, end);
+    }
+
+    fn extract_style_tags(text: &str) -> (String, BTreeMap<usize, String>) {
+        let mut result = text.to_owned();
+        let mut tags = BTreeMap::new();
+
+        let mut pos = 0;
+        while pos < result.len() {
+            let remainder = &result[pos..];
+            let tag_start = remainder.find(['<', '>']);
+            let Some(tag_start) = tag_start else {
+                break;
+            };
+            if remainder[tag_start..].starts_with('>') {
+                // Keep unmatched '>' (stfl way of encoding a literal '>')
+                pos += tag_start + 1;
+                continue;
+            }
+            let remainder_in_tag = &remainder[tag_start + 1..];
+            let tag_end = remainder_in_tag.find(['<', '>']).map(|i| i + tag_start + 1);
+            let Some(tag_end) = tag_end else {
+                break;
+            };
+            if remainder[tag_end..].starts_with('<') {
+                // First '<' bracket is unmatched, ignoring it
+                pos += tag_start + 1;
+                continue;
+            }
+            if tag_end - tag_start == 1 {
+                // Convert "<>" into "<" (stfl way of encoding a literal '<')
+                result.remove(pos + tag_end);
+                pos += tag_start + 1;
+                continue;
+            }
+            tags.insert(
+                pos + tag_start,
+                remainder[tag_start..tag_end + 1].to_owned(),
+            );
+            result.replace_range(pos + tag_start..pos + tag_end + 1, "");
+            pos += tag_start;
+        }
+
+        (result, tags)
+    }
+
+    fn merge_style_tag(&mut self, tag: &str, start: usize, end: usize) {
+        if end <= start {
+            return;
+        }
+
+        // Find the latest tag occurring before `end`.
+        // It is important that looping executes in ascending order of location.
+        let mut latest_tag = "</>";
+        for (&pos, tag) in self.style_tags.iter() {
+            if pos > end {
+                break;
+            }
+            latest_tag = tag;
+        }
+        let previous_tag = latest_tag.to_owned();
+        self.style_tags.insert(start, tag.into());
+        self.style_tags.insert(end, previous_tag);
+
+        // Remove any old tags between the start and end marker
+        self.style_tags.retain(|&k, _v| k <= start || k >= end);
+    }
+
+    fn insert_style_tags(&self) -> String {
+        let mut result = self.text.clone();
+        let mut tags = self.style_tags.clone();
+
+        // Expand "<" into "<>" (reverse of what happened in extract_style_tags()
+        let mut pos = 0;
+        while pos < result.len() {
+            let bracket = result[pos..].find('<').map(|i| i + pos);
+            let Some(bracket) = bracket else {
+                break;
+            };
+            pos = bracket + 1;
+            // Add to strings in the `tags` map so we don't have to shift all the positions in that map
+            // (would be necessary if inserting directly into `str`)
+            tags.insert(pos, '>'.into());
+        }
+
+        // Insert tags right-to-left (starting at the end of the string)
+        // This avoids recalculation of tag insertion points due to tags shifting all positions to
+        // the right
+        for (&pos, tag) in tags.iter().rev() {
+            result.insert_str(pos, tag);
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StflRichText;
+
+    proptest::proptest! {
+        #[test]
+        fn t_from_plaintext_does_not_crash_on_any_utf8_inputs(ref input in "\\PC*") {
+            // Result explicitly ignored because we just want to make sure this call doesn't panic.
+            let _ = StflRichText::from_plaintext(input);
+        }
+
+        #[test]
+        fn t_from_quoted_does_not_crash_on_any_utf8_inputs(ref input in "\\PC*") {
+            // Result explicitly ignored because we just want to make sure this call doesn't panic.
+            let _ = StflRichText::from_quoted(input);
+        }
+    }
+}

--- a/src/stflrichtext.cpp
+++ b/src/stflrichtext.cpp
@@ -1,153 +1,50 @@
 #include "stflrichtext.h"
 
-#include <utility>
-
-#include "utils.h"
-
 namespace newsboat {
 
-StflRichText::StflRichText(std::string&& text, std::map<size_t, std::string>&& style_tags)
-	: text(std::move(text))
-	, style_tags(std::move(style_tags))
+StflRichText::StflRichText(rust::Box<stflrichtext::bridged::StflRichText>&& rs_object)
+	: rs_object(std::move(rs_object))
 {
 }
 
-StflRichText operator+(StflRichText left, const StflRichText& right)
+StflRichText::StflRichText(const StflRichText& other)
+	: rs_object(stflrichtext::bridged::copy(*other.rs_object))
 {
-	auto text = left.text + right.text;
-	auto tags = left.style_tags;
+}
 
-	for (const auto& tag_position : right.style_tags) {
-		tags[tag_position.first + left.text.size()] = tag_position.second;
-	}
-
-	return StflRichText(std::move(text), std::move(tags));
+StflRichText& StflRichText::operator=(const StflRichText& other)
+{
+	this->rs_object = stflrichtext::bridged::copy(*other.rs_object);
+	return *this;
 }
 
 StflRichText StflRichText::from_plaintext(std::string text)
 {
-	text = utils::quote_for_stfl(text);
+	auto rs_object = stflrichtext::bridged::from_plaintext(text);
 
-	return from_quoted(text);
+	return StflRichText(std::move(rs_object));
 }
 
 StflRichText StflRichText::from_quoted(std::string text)
 {
-	auto style_tags = extract_style_tags(text);
+	auto rs_object = stflrichtext::bridged::from_quoted(text);
 
-	return StflRichText(std::move(text), std::move(style_tags));
+	return StflRichText(std::move(rs_object));
 }
 
 void StflRichText::apply_style_tag(const std::string& tag, size_t start, size_t end)
 {
-	merge_style_tag(style_tags, tag, start, end);
+	stflrichtext::bridged::apply_style_tag(*rs_object, tag, start, end);
 }
 
 std::string StflRichText::plaintext() const
 {
-	return text;
+	return std::string(stflrichtext::bridged::plaintext(*rs_object));
 }
 
 std::string StflRichText::stfl_quoted() const
 {
-	return insert_style_tags(text, style_tags);
-}
-
-std::map<size_t, std::string> StflRichText::extract_style_tags(std::string& str)
-{
-	std::map<size_t, std::string> tags;
-
-	size_t pos = 0;
-	while (pos < str.size()) {
-		auto tag_start = str.find_first_of("<>", pos);
-		if (tag_start == std::string::npos) {
-			break;
-		}
-		if (str[tag_start] == '>') {
-			// Keep unmatched '>' (stfl way of encoding a literal '>')
-			pos = tag_start + 1;
-			continue;
-		}
-		auto tag_end = str.find_first_of("<>", tag_start + 1);
-		if (tag_end == std::string::npos) {
-			break;
-		}
-		if (str[tag_end] == '<') {
-			// First '<' bracket is unmatched, ignoring it
-			pos = tag_start + 1;
-			continue;
-		}
-		if (tag_end - tag_start == 1) {
-			// Convert "<>" into "<" (stfl way of encoding a literal '<')
-			str.erase(tag_end, 1);
-			pos = tag_start + 1;
-			continue;
-		}
-		tags[tag_start] = str.substr(tag_start, tag_end - tag_start + 1);
-		str.erase(tag_start, tag_end - tag_start + 1);
-		pos = tag_start;
-	}
-	return tags;
-}
-
-void StflRichText::merge_style_tag(std::map<size_t, std::string>& tags,
-	const std::string& tag, size_t start, size_t end)
-{
-	if (end <= start) {
-		return;
-	}
-
-	// Find the latest tag occurring before `end`.
-	// It is important that looping executes in ascending order of location.
-	std::string latest_tag = "</>";
-	for (const auto& location_tag : tags) {
-		size_t location = location_tag.first;
-		if (location > end) {
-			break;
-		}
-		latest_tag = location_tag.second;
-	}
-	tags[start] = tag;
-	tags[end] = latest_tag;
-
-	// Remove any old tags between the start and end marker
-	for (auto it = tags.begin(); it != tags.end(); ) {
-		if (it->first > start && it->first < end) {
-			it = tags.erase(it);
-		} else {
-			++it;
-		}
-	}
-}
-
-std::string StflRichText::insert_style_tags(const std::string& text,
-	const std::map<size_t, std::string>& style_tags)
-{
-	auto str = text;
-	auto tags = style_tags;
-
-	// Expand "<" into "<>" (reverse of what happened in extract_style_tags()
-	size_t pos = 0;
-	while (pos < str.size()) {
-		auto bracket = str.find_first_of("<", pos);
-		if (bracket == std::string::npos) {
-			break;
-		}
-		pos = bracket + 1;
-		// Add to strings in the `tags` map so we don't have to shift all the positions in that map
-		// (would be necessary if inserting directly into `str`)
-		tags[pos] = ">" + tags[pos];
-	}
-
-	for (auto it = tags.rbegin(); it != tags.rend(); ++it) {
-		if (it->first > str.length()) {
-			// Ignore tags outside of string
-			continue;
-		}
-		str.insert(it->first, it->second);
-	}
-
-	return str;
+	return std::string(stflrichtext::bridged::quoted(*rs_object));
 }
 
 }


### PR DESCRIPTION
Part of https://github.com/newsboat/newsboat/pull/2892

For now, I've left all of the tests on the C++ side, given that those cover the combination of the Rust implementation together with the FFI.
My expectation is that we can get rid of the StflRichText relatively soon after moving away from STFL (and thus can keep the C++ glue+tests alive until that time)

I plan to keep this open for review until the end of the weekend.