### PR TITLE
Resolve warnings generated by clippy (nightly)

### DIFF
--- a/rust/libnewsboat/src/keymap.rs
+++ b/rust/libnewsboat/src/keymap.rs
@@ -116,9 +116,10 @@ fn binding(input: &str) -> IResult<&str, Binding> {
     ))
 }
 
-/// Split a semicolon-separated list of operations into a vector. Each operation is represented by
-/// a non-empty sub-vector, where the first element is the name of the operation, and the rest of
-/// the elements are operation's arguments.
+/// Split a semicolon-separated list of operations into a vector.
+///
+/// Each operation is represented by a non-empty sub-vector, where the first element is the name of
+/// the operation, and the rest of the elements are operation's arguments.
 ///
 /// Tokens can be double-quoted. Such tokens can contain spaces and C-like escaped sequences: `\n`
 /// for newline, `\r` for carriage return, `\t` for tab, `\"` for double quote, `\\` for backslash.

--- a/rust/libnewsboat/tests/configpaths_helpers/mod.rs
+++ b/rust/libnewsboat/tests/configpaths_helpers/mod.rs
@@ -178,7 +178,7 @@ impl<'a> Chmod<'a> {
     }
 }
 
-impl<'a> Drop for Chmod<'a> {
+impl Drop for Chmod<'_> {
     fn drop(&mut self) {
         fs::set_permissions(self.path, fs::Permissions::from_mode(self.original_mode))
             .unwrap_or_else(|_| {

--- a/rust/libnewsboat/tests/fslock.rs
+++ b/rust/libnewsboat/tests/fslock.rs
@@ -80,6 +80,7 @@ fn t_fails_if_lock_was_already_created() {
     // notify child to exit and drop lock
     let stdin = child.stdin.as_mut().unwrap();
     stdin.write_all(b"\n").unwrap();
+    child.wait().unwrap();
 }
 
 #[test]

--- a/rust/strprintf/src/format_specifiers_32bit.rs
+++ b/rust/strprintf/src/format_specifiers_32bit.rs
@@ -3,7 +3,7 @@
 // 2. the names are copied from C, and should be kept verbatim, capitalization and all.
 #![allow(non_upper_case_globals)]
 
-/// `printf` format specifiers for 32-bit platforms.
+//! `printf` format specifiers for 32-bit platforms.
 
 /// `printf`'s format conversion specifier to output an `i32` (equivalent to `PRIi32`).
 pub const PRId32: &str = "d";

--- a/rust/strprintf/src/format_specifiers_64bit.rs
+++ b/rust/strprintf/src/format_specifiers_64bit.rs
@@ -3,7 +3,7 @@
 // 2. the names are copied from C, and should be kept verbatim, capitalization and all.
 #![allow(non_upper_case_globals)]
 
-/// `printf` format specifiers for 64-bit platforms.
+//! `printf` format specifiers for 64-bit platforms.
 
 /// `printf`'s format conversion specifier to output an `i32` (equivalent to `PRIi32`).
 pub const PRId32: &str = "d";

--- a/rust/strprintf/src/traits.rs
+++ b/rust/strprintf/src/traits.rs
@@ -86,14 +86,14 @@ impl Printfable for f64 {
     }
 }
 
-impl<'a> Printfable for &'a str {
+impl Printfable for &str {
     type Holder = CString;
     fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         CString::new(self).ok()
     }
 }
 
-impl<'a> Printfable for &'a String {
+impl Printfable for &String {
     type Holder = CString;
     fn into_c_repr_holder(self) -> Option<<Self as Printfable>::Holder> {
         CString::new(self.as_str()).ok()


### PR DESCRIPTION
Ran into this while experimenting a bit with Cargo's `+nightly` option.
Fixing them now to avoid work when updating our current stable rust compiler version.