### PR TITLE
Apply `IWYU pragma: export` to avoid warnings from clangd LSP

### DIFF
--- a/include/cliargsparser.h
+++ b/include/cliargsparser.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_CLIARGSPARSER_H_
 #define NEWSBOAT_CLIARGSPARSER_H_
 
-#include "libnewsboat-ffi/src/cliargsparser.rs.h"
+#include "libnewsboat-ffi/src/cliargsparser.rs.h" // IWYU pragma: export
 
 #include <string>
 #include <vector>

--- a/include/configpaths.h
+++ b/include/configpaths.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_CONFIGPATHS_H_
 #define NEWSBOAT_CONFIGPATHS_H_
 
-#include "libnewsboat-ffi/src/configpaths.rs.h"
+#include "libnewsboat-ffi/src/configpaths.rs.h" // IWYU pragma: export
 
 #include <string>
 

--- a/include/fmtstrformatter.h
+++ b/include/fmtstrformatter.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_FORMATSTRING_H_
 #define NEWSBOAT_FORMATSTRING_H_
 
-#include "libnewsboat-ffi/src/fmtstrformatter.rs.h"
+#include "libnewsboat-ffi/src/fmtstrformatter.rs.h" // IWYU pragma: export
 
 #include <string>
 

--- a/include/fslock.h
+++ b/include/fslock.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_FSLOCK_H_
 #define NEWSBOAT_FSLOCK_H_
 
-#include "libnewsboat-ffi/src/fslock.rs.h"
+#include "libnewsboat-ffi/src/fslock.rs.h" // IWYU pragma: export
 
 #include <string>
 #include <sys/types.h>

--- a/include/history.h
+++ b/include/history.h
@@ -1,7 +1,7 @@
 #ifndef NEWSBOAT_HISTORY_H_
 #define NEWSBOAT_HISTORY_H_
 
-#include "libnewsboat-ffi/src/history.rs.h"
+#include "libnewsboat-ffi/src/history.rs.h" // IWYU pragma: export
 
 #include <string>
 

--- a/include/logger.h
+++ b/include/logger.h
@@ -3,7 +3,7 @@
 
 #include "strprintf.h"
 
-#include "libnewsboat-ffi/src/logger.rs.h"
+#include "libnewsboat-ffi/src/logger.rs.h" // IWYU pragma: export
 
 namespace newsboat {
 

--- a/include/scopemeasure.h
+++ b/include/scopemeasure.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "libnewsboat-ffi/src/scopemeasure.rs.h"
+#include "libnewsboat-ffi/src/scopemeasure.rs.h" // IWYU pragma: export
 
 namespace newsboat {
 

--- a/include/stflrichtext.h
+++ b/include/stflrichtext.h
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "libnewsboat-ffi/src/stflrichtext.rs.h"
+#include "libnewsboat-ffi/src/stflrichtext.rs.h" // IWYU pragma: export
 
 namespace newsboat {
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -13,7 +13,7 @@
 
 #include "configcontainer.h"
 
-#include "libnewsboat-ffi/src/utils.rs.h"
+#include "libnewsboat-ffi/src/utils.rs.h" // IWYU pragma: export
 
 namespace newsboat {
 

--- a/src/keycombination.cpp
+++ b/src/keycombination.cpp
@@ -1,8 +1,6 @@
 #include "keycombination.h"
 
-#include <algorithm>
 #include <cctype>
-#include <iterator>
 #include <tuple>
 
 #include "libnewsboat-ffi/src/keycombination.rs.h"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -40,7 +40,6 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 #include "curldatareceiver.h"
 #include "curlhandle.h"
 #include "links.h"
-#include "libnewsboat-ffi/src/utils.rs.h"
 #include "logger.h"
 #include "strprintf.h"
 


### PR DESCRIPTION
[Include What You Use docs for `pragma: export`](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#user-content-iwyu-pragma-export)