### PR TITLE
Ignore PanicInfo deprecation until MSRV supports replacement

### DIFF
--- a/rust/libnewsboat/src/human_panic.rs
+++ b/rust/libnewsboat/src/human_panic.rs
@@ -69,19 +69,24 @@
 //! beginning of the program.
 use backtrace::Backtrace;
 use std::io::{self, stderr, BufWriter, Write};
-use std::panic::{self, PanicInfo};
+use std::panic;
+
+#[allow(deprecated)] // Change to PanicHookInfo when our MSRV has increased to 1.81.0 or later
+use std::panic::PanicInfo;
 
 /// Sets up a panic hook with a user-friendly message.
 ///
 /// See module description for details.
 pub fn setup() {
     if ::std::env::var("RUST_BACKTRACE").is_err() {
+        #[allow(deprecated)]
         panic::set_hook(Box::new(move |panic_info: &PanicInfo| {
             print_panic_msg(panic_info).expect("An error occurred while preparing a crash report");
         }));
     }
 }
 
+#[allow(deprecated)]
 fn print_panic_msg(panic_info: &PanicInfo) -> io::Result<()> {
     // Locking the handle to make sure all the messages are printed out in one chunk.
     let stderr = stderr();
@@ -125,6 +130,7 @@ fn print_panic_msg(panic_info: &PanicInfo) -> io::Result<()> {
     Ok(())
 }
 
+#[allow(deprecated)]
 fn get_error_message(panic_info: &PanicInfo) -> String {
     let payload = panic_info.payload().downcast_ref::<&str>();
     if let Some(payload) = payload {
@@ -134,6 +140,7 @@ fn get_error_message(panic_info: &PanicInfo) -> String {
     }
 }
 
+#[allow(deprecated)]
 fn get_location(panic_info: &PanicInfo) -> String {
     match panic_info.location() {
         Some(location) => format!("Crash location: {}:{}", location.file(), location.line()),


### PR DESCRIPTION
The replacement ([PanicHookInfo](https://doc.rust-lang.org/nightly/std/panic/struct.PanicHookInfo.html)) was only added in 1.81.0, and thus not yet supported in our MSRV 1.79.0.