### PR TITLE
Migrate to source-based code coverage

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -23,7 +23,7 @@ jobs:
       # This prevents our tests from hogging too much of the CPU and failing
       # due to races.
       RUST_TEST_THREADS: 2
-      LLVM_PROFILE_FILE: '%h_%m.profraw'
+      LLVM_PROFILE_FILE: '/tmp/newsboat-profiles/%h_%m.profraw'
 
     steps:
       - name: Install dependencies
@@ -67,7 +67,7 @@ jobs:
         run: make --jobs=3 NEWSBOAT_RUN_IGNORED_TESTS=1 ci-check
 
       - name: Calculate test coverage
-        run: grcov . --source-dir . --binary-path . --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
+        run: grcov /tmp/newsboat-profiles/ --source-dir . --binary-path . --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
 
       - name: Submit coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -8,24 +8,22 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      # We use Rust Nightly, which builds upon LLVM 18. To ensure best
-      # compatibility, we use a matching C++ compiler.
+      # We use Rust 1.81, which builds upon LLVM 18. We have to use a matching
+      # C++ compiler, otherwise grcov won't be able to produce the coverage
+      # report.
       CC: clang-18
       CXX: clang++-18
       # Enable test coverage.
       PROFILE: 1
-      # These flags are necessary for grcov to correctly calculate coverage.
-      CARGO_INCREMENTAL: 0
-      # We add `-A warnings` because we aren't interested in warnings from Rust
-      # Nightly -- GitHub turns them into annotations, which is annoying.
-      RUSTFLAGS: '-A warnings -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
-      RUSTDOCFLAGS: '-Cpanic=abort'
+      CXXFLAGS: '-O0 -fprofile-instr-generate -fcoverage-mapping'
+      RUSTFLAGS: '-Clink-dead-code -Cinstrument-coverage'
       # Some of our tests use ncurses, which require a terminal of some sort.
       # We pretend ours is a simple one.
       TERM: 'dumb'
       # This prevents our tests from hogging too much of the CPU and failing
       # due to races.
       RUST_TEST_THREADS: 2
+      LLVM_PROFILE_FILE: '%h_%m.profraw'
 
     steps:
       - name: Install dependencies
@@ -42,7 +40,12 @@ jobs:
           sudo locale-gen
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        # The last version based on LLVM 18. We have to match LLVM versions
+        # used to compile Rust and C++, otherwise they might generate
+        # incompatible coverage reports
+        uses: dtolnay/rust-toolchain@1.81
+        with:
+          components: llvm-tools-preview
 
       - uses: actions/checkout@v4
 
@@ -63,16 +66,8 @@ jobs:
       - name: Run tests
         run: make --jobs=3 NEWSBOAT_RUN_IGNORED_TESTS=1 ci-check
 
-        # gcov tool from gcc doesn't understand profiling info that LLVM
-        # produces, so we trick grcov into using llvm-cov instead. We can't
-        # simply point grcov at llvm-cov, because the latter only behaves like
-        # gcc's gcov when invoked by that name.
-      - name: Prepare to use llvm-cov-18 as gcov
-        run: ln -s $(which llvm-cov-18) gcov
-
       - name: Calculate test coverage
-        # Note that we override the path to gcov tool.
-        run: GCOV=$(pwd)/gcov grcov . --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
+        run: grcov . --source-dir . --binary-path . --ignore-not-existing --ignore='/*' --ignore='3rd-party/*' --ignore='doc/*' --ignore='test/*' --ignore='target/*' --ignore='newsboat.cpp' --ignore='podboat.cpp' -t lcov -o coverage.lcov
 
       - name: Submit coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ doc/podboat-cmds-linked.asciidoc
 *.dSYM
 /.deps/
 /compile_flags.txt
+*.profraw

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ clean: clean-newsboat clean-podboat clean-libboat clean-libfilter clean-doc clea
 
 profclean:
 	find . -name '*.gc*' -type f -print0 | xargs -0 $(RM) --
+	find . -name '*.profraw' -type f -print0 | xargs -0 $(RM) --
 	$(RM) app*.info
 
 distclean: clean profclean


### PR DESCRIPTION
We used to rely on `-Zprofile`, but it was recently removed from Rust Nightly: https://github.com/rust-lang/rust/pull/131829 This commit switches to a stable alternative; cf. https://github.com/mozilla/grcov/issues/1240

This change is accompanied by a change in the build environment: instead of using Clang 18 with Rust Nightly, we now use Clang 18 with Rust 1.81. That's the last Rust version based on LLVM 18. Previously we tried to match LLVM versions between C++ and Rust to avoid weird coverage results. Now, it's *required* to match them, otherwise no coverage is gathered at all.

Fixes #2912.

This doesn't seem controversial, and the issue blocks all PRs, so I'll merge in three days if there are no reviews.