### PR TITLE
Add support for enclosures from Miniflux

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -643,9 +643,6 @@ You can disable these feeds by setting the following configuration variable:
 
 _Supported since Newsboat 2.21._
 
-WARNING: As of 2021-10-06, Miniflux's API doesn't list enclosures, so Newsboat
-won't display podcasts, cover images etc.
-
 https://miniflux.app[Miniflux] is a "minimalist and opinionated feed reader"
 that is self-hostable.
 

--- a/src/minifluxapi.cpp
+++ b/src/minifluxapi.cpp
@@ -237,17 +237,12 @@ rsspp::Feed MinifluxApi::fetch_feed(const std::string& id, CurlHandle& cached_ha
 
 			if (!entry["enclosures"].is_null() && entry["enclosures"].is_array()) {
 				for (const auto& enclosure : entry["enclosures"]) {
-					rsspp::Enclosure enc;
-
-					if (!enclosure["url"].is_null()) {
+					if (!enclosure["url"].is_null() && !enclosure["mime_type"].is_null()) {
+						rsspp::Enclosure enc;
 						enc.url = enclosure["url"];
-					}
-
-					if (!enclosure["mime_type"].is_null()) {
 						enc.type = enclosure["mime_type"];
+						item.enclosures.push_back(enc);
 					}
-
-					item.enclosures.push_back(enc);
 				}
 			}
 

--- a/src/minifluxapi.cpp
+++ b/src/minifluxapi.cpp
@@ -235,6 +235,22 @@ rsspp::Feed MinifluxApi::fetch_feed(const std::string& id, CurlHandle& cached_ha
 				item.content_encoded = entry["content"];
 			}
 
+			if (!entry["enclosures"].is_null() && entry["enclosures"].is_array()) {
+				for (const auto& enclosure : entry["enclosures"]) {
+					rsspp::Enclosure enc;
+
+					if (!enclosure["url"].is_null()) {
+						enc.url = enclosure["url"];
+					}
+
+					if (!enclosure["mime_type"].is_null()) {
+						enc.type = enclosure["mime_type"];
+					}
+
+					item.enclosures.push_back(enc);
+				}
+			}
+
 			const int entry_id = entry["id"];
 			item.guid = std::to_string(entry_id);
 


### PR DESCRIPTION
The enclosures are retrieved from the `enclosures` field of the existing JSON response from `Get Feed Entries`.

The API JSON format for an enclosure is specified here: https://miniflux.app/docs/api.html#endpoint-get-enclosure

The relevant issue in Miniflux is miniflux/v2#1059 which was solved in miniflux/v2#2109.
