### PR TITLE
Add ConfigContainer::get_configvalue_as_filepath()

### DIFF
--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "configactionhandler.h"
+#include "filepath.h"
 
 namespace newsboat {
 
@@ -67,6 +68,7 @@ public:
 
 	bool get_configvalue_as_bool(const std::string& key) const;
 	int get_configvalue_as_int(const std::string& key) const;
+	Filepath get_configvalue_as_filepath(const std::string& key) const;
 	std::string get_configvalue(const std::string& key) const;
 	void set_configvalue(const std::string& key, const std::string& value);
 	void reset_to_default(const std::string& key);

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -418,11 +418,7 @@ std::string ConfigContainer::get_configvalue(const std::string& key) const
 	auto it = config_data.find(key);
 	if (it != config_data.cend()) {
 		const auto& entry = it->second;
-		std::string value = entry.value();
-		if (entry.type() == ConfigDataType::PATH) {
-			value = utils::resolve_tilde(Filepath::from_locale_string(value)).to_locale_string();
-		}
-		return value;
+		return entry.value();
 	}
 
 	return {};
@@ -441,6 +437,20 @@ int ConfigContainer::get_configvalue_as_int(const std::string& key) const
 	}
 
 	return 0;
+}
+
+Filepath ConfigContainer::get_configvalue_as_filepath(const std::string& key) const
+{
+	std::lock_guard<std::recursive_mutex> guard(config_data_mtx);
+	auto it = config_data.find(key);
+	if (it != config_data.cend()) {
+		const auto& entry = it->second;
+		if (entry.type() == ConfigDataType::PATH) {
+			return utils::resolve_tilde(Filepath::from_locale_string(entry.value()));
+		}
+	}
+
+	return {};
 }
 
 bool ConfigContainer::get_configvalue_as_bool(const std::string& key) const

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -204,7 +204,7 @@ int Controller::run(const CliArgsParser& args)
 	}
 
 	// create cache object
-	std::string cachefilepath = cfg.get_configvalue("cache-file");
+	std::string cachefilepath = cfg.get_configvalue_as_filepath("cache-file");
 	if (cachefilepath.length() > 0 && !args.cache_file().has_value()) {
 		configpaths.set_cache_file(cachefilepath);
 	}
@@ -268,11 +268,9 @@ int Controller::run(const CliArgsParser& args)
 		api = new TtRssApi(cfg);
 		urlcfg = new TtRssUrlReader(configpaths.url_file(), api);
 	} else if (type == "newsblur") {
-		const auto cookies = cfg.get_configvalue("cookie-cache");
-		if (cookies.empty()) {
-			std::cout << strprintf::fmt(
-					_("ERROR: You must set `cookie-cache` to use "
-						"NewsBlur.\n"));
+		const auto cookies = cfg.get_configvalue_as_filepath("cookie-cache");
+		if (cookies == Filepath{}) {
+			std::cout << strprintf::fmt(_("ERROR: You must set `cookie-cache` to use NewsBlur.\n"));
 			return EXIT_FAILURE;
 		}
 
@@ -292,7 +290,7 @@ int Controller::run(const CliArgsParser& args)
 	} else if (type == "feedbin") {
 		const std::string user = cfg.get_configvalue("feedbin-login");
 		const std::string pass = cfg.get_configvalue("feedbin-password");
-		const std::string pass_file = cfg.get_configvalue("feedbin-passwordfile");
+		const std::string pass_file = cfg.get_configvalue_as_filepath("feedbin-passwordfile");
 		const std::string pass_eval = cfg.get_configvalue("feedbin-passwordeval");
 		const bool creds_set = !user.empty() &&
 			(!pass.empty() || !pass_file.empty() || !pass_eval.empty());
@@ -316,7 +314,7 @@ int Controller::run(const CliArgsParser& args)
 
 		const std::string user = cfg.get_configvalue("freshrss-login");
 		const std::string pass = cfg.get_configvalue("freshrss-password");
-		const std::string pass_file = cfg.get_configvalue("freshrss-passwordfile");
+		const std::string pass_file = cfg.get_configvalue_as_filepath("freshrss-passwordfile");
 		const std::string pass_eval = cfg.get_configvalue("freshrss-passwordeval");
 		const bool creds_set = !user.empty() &&
 			(!pass.empty() || !pass_file.empty() || !pass_eval.empty());
@@ -343,10 +341,10 @@ int Controller::run(const CliArgsParser& args)
 
 		const std::string user = cfg.get_configvalue("miniflux-login");
 		const std::string pass = cfg.get_configvalue("miniflux-password");
-		const std::string pass_file = cfg.get_configvalue("miniflux-passwordfile");
+		const std::string pass_file = cfg.get_configvalue_as_filepath("miniflux-passwordfile");
 		const std::string pass_eval = cfg.get_configvalue("miniflux-passwordeval");
 		const std::string token = cfg.get_configvalue("miniflux-token");
-		const std::string token_file = cfg.get_configvalue("miniflux-tokenfile");
+		const std::string token_file = cfg.get_configvalue_as_filepath("miniflux-tokenfile");
 		const std::string token_eval = cfg.get_configvalue("miniflux-tokeneval");
 		const bool creds_set = !token.empty()
 			|| !token_file.empty()
@@ -953,19 +951,10 @@ Filepath Controller::write_temporary_item(RssItem& item)
 
 void Controller::write_item(RssItem& item, const Filepath& filename)
 {
-	const std::string save_path = cfg.get_configvalue("save-path");
-	Filepath spath = save_path.back() == '/' ? save_path : save_path + "/";
+	Filepath save_path = cfg.get_configvalue_as_filepath("save-path");
+	save_path.push(utils::resolve_tilde(filename));
 
-	Filepath path;
-	if (filename.starts_with("/")) {
-		path.push(filename);
-	} else if (filename.starts_with("~")) {
-		path = utils::resolve_tilde(filename);
-	} else {
-		path = spath.join(filename);
-	}
-
-	std::fstream f(path, std::fstream::out);
+	std::fstream f(save_path, std::fstream::out);
 	if (!f.is_open()) {
 		throw Exception(errno);
 	}
@@ -1011,15 +1000,12 @@ void Controller::update_config()
 {
 	v->apply_colors_to_all_formactions();
 
-	if (cfg.get_configvalue("error-log").length() > 0) {
+	const auto error_log_path = cfg.get_configvalue_as_filepath("error-log");
+	if (error_log_path != Filepath{}) {
 		try {
-			const auto filepath = Filepath::from_locale_string(cfg.get_configvalue("error-log"));
-			logger::set_user_error_logfile(filepath);
+			logger::set_user_error_logfile(error_log_path);
 		} catch (const Exception& e) {
-			const std::string msg =
-				strprintf::fmt("Couldn't open %s: %s",
-					cfg.get_configvalue("error-log"),
-					e.what());
+			const std::string msg = strprintf::fmt("Couldn't open %s: %s", error_log_path, e.what());
 			v->get_statusline().show_error(msg);
 			std::cerr << msg << std::endl;
 		}

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -266,20 +266,21 @@ void DirBrowserFormAction::init()
 
 	file_prompt_line.set_text(_("Directory: "));
 
-	const std::string save_path = cfg->get_configvalue("save-path");
+	const auto save_path = cfg->get_configvalue_as_filepath("save-path");
 
-	LOG(Level::DEBUG,
-		"view::dirbrowser: save-path is '%s'",
-		save_path);
+	LOG(Level::DEBUG, "view::dirbrowser: save-path is '%s'", save_path);
 
-	const int status = ::chdir(save_path.c_str());
+	const int status = ::chdir(save_path.to_locale_string().c_str());
 	LOG(Level::DEBUG, "view::dirbrowser: chdir(%s) = %i", save_path, status);
 
-	set_value("filenametext", save_path);
+	set_value("filenametext", save_path.to_locale_string());
 
 	// Set position to 0 and back to ensure that the text is visible
 	draw_form();
-	set_value("filenametext_pos", std::to_string(save_path.length()));
+	// TODO: #2326 use length by graphemes
+	// See: https://github.com/newsboat/newsboat/pull/2561#discussion_r1357376071
+	set_value("filenametext_pos",
+		std::to_string(save_path.to_locale_string().length()));
 }
 
 std::vector<KeyMapHintEntry> DirBrowserFormAction::get_keymap_hint() const

--- a/src/feedretriever.cpp
+++ b/src/feedretriever.cpp
@@ -198,12 +198,13 @@ rsspp::Feed FeedRetriever::download_http(const std::string& uri)
 		if (!ign || !ign->matches_lastmodified(uri)) {
 			ch.fetch_lastmodified(uri, lm, etag);
 		}
-		f = p.parse_url(uri,
+		f = p.parse_url(
+				uri,
 				easyhandle,
 				lm,
 				etag,
 				api,
-				cfg.get_configvalue("cookie-cache"));
+				cfg.get_configvalue_as_filepath("cookie-cache").to_locale_string());
 		LOG(Level::DEBUG,
 			"FeedRetriever::download_http: lm = %" PRId64 " etag = %s",
 			// On GCC, `time_t` is `long int`, which is at least 32 bits

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -280,13 +280,11 @@ void FileBrowserFormAction::init()
 
 	file_prompt_line.set_text(_("File: "));
 
-	const std::string save_path = cfg->get_configvalue("save-path");
+	const auto save_path = cfg->get_configvalue_as_filepath("save-path");
 
-	LOG(Level::DEBUG,
-		"view::filebrowser: save-path is '%s'",
-		save_path);
+	LOG(Level::DEBUG, "view::filebrowser: save-path is '%s'", save_path);
 
-	const int status = ::chdir(save_path.c_str());
+	const int status = ::chdir(save_path.to_locale_string().c_str());
 	LOG(Level::DEBUG, "view::filebrowser: chdir(%s) = %i", save_path, status);
 
 	set_value("filenametext", default_filename.to_locale_string());

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -279,23 +279,15 @@ bool ItemListFormAction::process_operation(Operation op,
 	case OP_SHOWURLS:
 		if (!visible_items.empty()) {
 			if (itempos < visible_items.size()) {
-				std::string urlviewer = cfg->get_configvalue(
-						"external-url-viewer");
-				if (urlviewer == "") {
+				const auto urlviewer = cfg->get_configvalue_as_filepath("external-url-viewer");
+				if (urlviewer == Filepath{}) {
 					Links links;
-					std::vector<std::pair<LineType,
-					    std::string>>
-					    lines;
+					std::vector<std::pair<LineType, std::string>> lines;
 					HtmlRenderer rnd;
 					std::string baseurl =
-						visible_items[itempos]
-						.first
-						->get_base() !=
-						""
-						? visible_items[itempos]
-						.first->get_base()
-						: visible_items[itempos]
-						.first->feedurl();
+						visible_items[itempos].first->get_base() != ""
+						? visible_items[itempos].first->get_base()
+						: visible_items[itempos].first->feedurl();
 					rnd.render(
 						utils::utf8_to_locale(visible_items[itempos].first->description().text),
 						lines,
@@ -309,7 +301,7 @@ bool ItemListFormAction::process_operation(Operation op,
 					}
 				} else {
 					qna_responses.clear();
-					qna_responses.push_back(urlviewer);
+					qna_responses.push_back(urlviewer.to_locale_string());
 					this->finished_qna(OP_PIPE_TO);
 				}
 			}

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -153,15 +153,16 @@ void render_html(
 	const std::string& url,
 	bool raw)
 {
-	const std::string renderer = cfg.get_configvalue("html-renderer");
-	if (renderer == "internal") {
+	const auto renderer = cfg.get_configvalue_as_filepath("html-renderer");
+	if (renderer == Filepath::from_locale_string("internal")) {
 		HtmlRenderer rnd(raw);
 		rnd.render(source, lines, thelinks, url);
 	} else {
 		const char* argv[4];
 		argv[0] = "/bin/sh";
 		argv[1] = "-c";
-		argv[2] = renderer.c_str();
+		const std::string renderer_locale_string = renderer.to_locale_string();
+		argv[2] = renderer_locale_string.c_str();
 		argv[3] = nullptr;
 		LOG(Level::DEBUG,
 			"item_renderer::render_html: source = %s",

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -354,10 +354,9 @@ bool ItemViewFormAction::process_operation(Operation op,
 		}
 		break;
 	case OP_SHOWURLS: {
-		std::string urlviewer =
-			cfg->get_configvalue("external-url-viewer");
+		const auto urlviewer = cfg->get_configvalue_as_filepath("external-url-viewer");
 		LOG(Level::DEBUG, "ItemViewFormAction::process_operation: showing URLs");
-		if (urlviewer == "") {
+		if (urlviewer == Filepath{}) {
 			if (links.size() > 0) {
 				v.push_urlview(links, feed);
 			} else {
@@ -365,7 +364,7 @@ bool ItemViewFormAction::process_operation(Operation op,
 			}
 		} else {
 			qna_responses.clear();
-			qna_responses.push_back(urlviewer);
+			qna_responses.push_back(urlviewer.to_locale_string());
 			this->finished_qna(OP_PIPE_TO);
 		}
 	}

--- a/src/newsblurapi.cpp
+++ b/src/newsblurapi.cpp
@@ -36,7 +36,7 @@ NewsBlurApi::NewsBlurApi(ConfigContainer& c)
 			(NEWSBLUR_ITEMS_PER_PAGE + 1)) /
 		NEWSBLUR_ITEMS_PER_PAGE;
 
-	if (cfg.get_configvalue("cookie-cache").empty()) {
+	if (cfg.get_configvalue_as_filepath("cookie-cache") == Filepath{}) {
 		LOG(Level::CRITICAL,
 			"NewsBlurApi::NewsBlurApi: No cookie-cache has been "
 			"configured the login won't work.");
@@ -58,11 +58,9 @@ bool NewsBlurApi::authenticate()
 	bool result = json_object_get_boolean(status);
 
 	LOG(Level::INFO,
-		"NewsBlurApi::authenticate: authentication resulted in %u, "
-		"cached "
-		"in %s",
+		"NewsBlurApi::authenticate: authentication resulted in %u, cached in %s",
 		result,
-		cfg.get_configvalue("cookie-cache"));
+		cfg.get_configvalue_as_filepath("cookie-cache"));
 
 	return result;
 }

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -481,11 +481,11 @@ void PbController::decrease_parallel_downloads()
 void PbController::play_file(const newsboat::Filepath& file)
 {
 	std::string cmdline;
-	std::string player = cfg.get_configvalue("player");
-	if (player == "") {
+	const auto player = cfg.get_configvalue_as_filepath("player");
+	if (player == Filepath{}) {
 		return;
 	}
-	cmdline.append(player);
+	cmdline.append(player.to_locale_string());
 	cmdline.append(" '");
 	cmdline.append(utils::replace_all(file, "'", "'\\''"));
 	cmdline.append("'");

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -269,19 +269,16 @@ const
 
 newsboat::Filepath QueueLoader::get_filename(const std::string& str) const
 {
-	std::string fn = cfg.get_configvalue("download-path");
+	auto fn = cfg.get_configvalue_as_filepath("download-path");
 
-	if (fn[fn.length() - 1] != NEWSBEUTER_PATH_SEP) {
-		fn.push_back(NEWSBEUTER_PATH_SEP);
-	}
 	char buf[1024];
 	snprintf(buf, sizeof(buf), "%s", str.c_str());
 	char* base = basename(buf);
 	if (!base || strlen(base) == 0) {
 		time_t t = time(nullptr);
-		fn.append(utils::mt_strf_localtime("%Y-%b-%d-%H%M%S.unknown", t));
+		fn.push(utils::mt_strf_localtime("%Y-%b-%d-%H%M%S.unknown", t));
 	} else {
-		fn.append(utils::replace_all(base, "'", "%27"));
+		fn.push(utils::replace_all(base, "'", "%27"));
 	}
 	return fn;
 }

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -64,21 +64,15 @@ std::string get_hostname_from_url(const std::string& url)
 	return hostname;
 }
 
-Filepath QueueManager::generate_enqueue_filename(
-	RssItem& item,
-	RssFeed& feed)
+Filepath QueueManager::generate_enqueue_filename(RssItem& item, RssFeed& feed)
 {
 	const std::string& url = item.enclosure_url();
 	const std::string& title = utils::utf8_to_locale(item.title());
 	const time_t pubDate = item.pubDate_timestamp();
 
-	std::string dlformat = cfg->get_configvalue("download-path");
-	if (dlformat[dlformat.length() - 1] != NEWSBEUTER_PATH_SEP) {
-		dlformat.push_back(NEWSBEUTER_PATH_SEP);
-	}
-
-	const std::string filemask = cfg->get_configvalue("download-filename-format");
-	dlformat.append(filemask);
+	const Filepath dlformat =
+		cfg->get_configvalue_as_filepath("download-path")
+		.join(Filepath::from_locale_string(cfg->get_configvalue("download-filename-format")));
 
 	const std::string base = utils::get_basename(url);
 	std::string extension;

--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -298,12 +298,12 @@ void Reloader::notify(const std::string& msg)
 		LOG(Level::DEBUG, "reloader:notify: notifying beep");
 		::beep();
 	}
-	if (cfg.get_configvalue("notify-program").length() > 0) {
-		std::string prog = cfg.get_configvalue("notify-program");
+	const auto notify_program = cfg.get_configvalue_as_filepath("notify-program");
+	if (notify_program != Filepath{}) {
 		LOG(Level::DEBUG,
 			"reloader:notify: notifying external program `%s'",
-			prog);
-		utils::run_command(prog, msg);
+			notify_program);
+		utils::run_command(notify_program.to_locale_string(), msg);
 	}
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -597,15 +597,14 @@ void utils::set_common_curl_options(CurlHandle& handle, ConfigContainer& cfg)
 		cfg.get_configvalue_as_int("download-timeout");
 	curl_easy_setopt(handle.ptr(), CURLOPT_TIMEOUT, dl_timeout);
 
-	const std::string cookie_cache =
-		cfg.get_configvalue("cookie-cache");
-	if (cookie_cache != "") {
+	const Filepath cookie_cache = cfg.get_configvalue_as_filepath("cookie-cache");
+	if (cookie_cache != Filepath{}) {
 		curl_easy_setopt(handle.ptr(),
 			CURLOPT_COOKIEFILE,
-			cookie_cache.c_str());
+			cookie_cache.to_locale_string().c_str());
 		curl_easy_setopt(handle.ptr(),
 			CURLOPT_COOKIEJAR,
-			cookie_cache.c_str());
+			cookie_cache.to_locale_string().c_str());
 	}
 
 	curl_easy_setopt(handle.ptr(),

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -343,7 +343,7 @@ void View::drop_queued_input()
 void View::open_in_pager(const Filepath& filename)
 {
 	std::string cmdline;
-	std::string pager = cfg->get_configvalue("pager");
+	const auto pager = cfg->get_configvalue_as_filepath("pager").to_locale_string();
 	if (pager.find("%f") != std::string::npos) {
 		FmtStrFormatter fmt;
 		fmt.register_fmt('f', filename);
@@ -372,7 +372,7 @@ nonstd::optional<std::uint8_t> View::open_in_browser(const std::string& url,
 	bool interactive)
 {
 	std::string cmdline;
-	const std::string browser = cfg->get_configvalue("browser");
+	const std::string browser = cfg->get_configvalue_as_filepath("browser");
 	const std::string escaped_url = "'" + utils::replace_all(url, "'", "%27") + "'";
 	const std::string escaped_feedurl = "'" + utils::replace_all(feedurl, "'",
 			"%27") + "'";
@@ -522,7 +522,8 @@ void View::push_itemview(std::shared_ptr<RssFeed> f,
 	const std::string& guid,
 	const std::string& searchphrase)
 {
-	if (cfg->get_configvalue("pager") == "internal") {
+	if (cfg->get_configvalue_as_filepath("pager") ==
+		Filepath::from_locale_string("internal")) {
 		auto fa = get_current_formaction();
 
 		std::shared_ptr<ItemListFormAction> itemlist =

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Parses test config without exceptions", "[ConfigContainer]")
 	}
 
 	SECTION("string value") {
-		REQUIRE(cfg.get_configvalue("browser") == "firefox");
+		REQUIRE(cfg.get_configvalue("article-sort-order") == "date-asc");
 	}
 
 	SECTION("integer value") {
@@ -38,9 +38,8 @@ TEST_CASE("Parses test config without exceptions", "[ConfigContainer]")
 	SECTION("Tilde got expanded into path to user's home directory") {
 		char* home = ::getenv("HOME");
 		REQUIRE(home != nullptr);
-		std::string cachefilecomp = home;
-		cachefilecomp.append("/foo");
-		REQUIRE(cfg.get_configvalue("cache-file") == cachefilecomp);
+		const Filepath expected = Filepath::from_locale_string(std::string(home) + "/foo");
+		REQUIRE(cfg.get_configvalue_as_filepath("cache-file") == expected);
 	}
 }
 
@@ -56,11 +55,12 @@ TEST_CASE(
 			Filepath::from_locale_string("data/test-config-without-newline-at-the-end.txt")));
 
 	SECTION("first line") {
-		REQUIRE(cfg.get_configvalue("browser") == "firefox");
+		REQUIRE(cfg.get_configvalue("article-sort-order") == "date-asc");
 	}
 
 	SECTION("last line") {
-		REQUIRE(cfg.get_configvalue("download-path") == "whatever");
+		REQUIRE(cfg.get_configvalue_as_filepath("download-path") ==
+			Filepath::from_locale_string("whatever"));
 	}
 }
 
@@ -197,6 +197,14 @@ TEST_CASE("get_configvalue_as_int() returns zero if value can't be parsed as int
 	REQUIRE(cfg.get_configvalue_as_int(key) == 0);
 }
 
+TEST_CASE("get_configvalue_as_filepath() returns null path if setting doesn't exist",
+	"[ConfigContainer]")
+{
+	ConfigContainer cfg;
+
+	REQUIRE(cfg.get_configvalue_as_filepath("foobar") == Filepath{});
+}
+
 TEST_CASE("toggle() inverts the value of a boolean setting",
 	"[ConfigContainer]")
 {
@@ -239,7 +247,7 @@ TEST_CASE("toggle() does nothing if setting is non-boolean",
 
 TEST_CASE(
 	"dump_config turns current state into text and saves it "
-	"into the supplyed vector",
+	"into the supplied vector",
 	"[ConfigContainer]")
 {
 	ConfigContainer cfg;

--- a/test/controller.cpp
+++ b/test/controller.cpp
@@ -35,7 +35,6 @@ TEST_CASE("write_item correctly parses path", "[Controller]")
 	cfg->set_configvalue("save-path", save_path);
 	auto rsscache = Cache::in_memory(*cfg);
 
-
 	RssItem item(rsscache.get());
 	item.set_title("title");
 	const auto description = "First line.\nSecond one.\nAnd finally the third";

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -309,19 +309,19 @@ TEST_CASE("Generates filename if it's absent from the queue file",
 
 	ConfigContainer cfg;
 
-	std::string download_path;
+	Filepath download_path;
 	SECTION("No `download-path` set") {
-		download_path = cfg.get_configvalue("download-path");
+		download_path = cfg.get_configvalue_as_filepath("download-path");
 	}
 	SECTION("`download-path` set without a trailing slash") {
 		cfg.set_configvalue("download-path", "/some/bogus value");
 		// QueueLoader should append a slash if a setting doesn't contain it.
-		download_path = "/some/bogus value/";
+		download_path = Filepath::from_locale_string("/some/bogus value/");
 	}
 	SECTION("`download-path` set with a trailing slash") {
 		cfg.set_configvalue("download-path",
 			"/yet another/fictional path for downloads/");
-		download_path = "/yet another/fictional path for downloads/";
+		download_path = Filepath::from_locale_string("/yet another/fictional path for downloads/");
 	}
 
 	auto empty_callback = []() {};
@@ -331,10 +331,9 @@ TEST_CASE("Generates filename if it's absent from the queue file",
 	queue_loader.reload(downloads);
 
 	REQUIRE(downloads.size() == 5);
-	REQUIRE(downloads[0].filename() == download_path + "filename.mp3");
-	REQUIRE(downloads[1].filename() == download_path + "hello_world.ogg");
-	REQUIRE(downloads[2].filename() == download_path +
-		"here%27s_one_with_a_quote.mp4");
+	REQUIRE(downloads[0].filename() == download_path.join("filename.mp3"));
+	REQUIRE(downloads[1].filename() == download_path.join("hello_world.ogg"));
+	REQUIRE(downloads[2].filename() == download_path.join("here%27s_one_with_a_quote.mp4"));
 	// These two downloads should have filenames based on current time, so we
 	// only check their prefixes.
 	REQUIRE(test_helpers::starts_with(download_path, downloads[3].filename()));


### PR DESCRIPTION
This method fetches ConfigData::PATH settings and resolves tilde in them. Thus get_configvalue() no longer needs special handling for PATHs.

This commit also migrates all relevant calls to the new method.

Most of the changes were mechanical. A few required judgment calls; `QueueManager::generate_enqueue_filename()` implements support for formats inside a filepath, which I believe can lead to bugs because `FmtStrFormatter` will attempt to format a `Filepath`, which has unknown encoding. But the existing C++ code seem to work, so I ported it to Filepath as closely as possible.

This is yet another step towards #2326.