### PR TITLE
Add test to check cookie-cache functionality

### DIFF
--- a/test/feedretriever.cpp
+++ b/test/feedretriever.cpp
@@ -9,6 +9,7 @@
 #include "strprintf.h"
 #include "test_helpers/httptestserver.h"
 #include "test_helpers/misc.h"
+#include "test_helpers/tempfile.h"
 #include <cstdint>
 #include <vector>
 
@@ -139,5 +140,52 @@ TEST_CASE("Feed retriever throws on HTTP error status codes", "[FeedRetriever]")
 
 		REQUIRE_THROWS_AS(feedRetriever.retrieve(url), rsspp::Exception);
 		REQUIRE(testServer.num_hits(mockRegistration) == 1);
+	}
+}
+
+TEST_CASE("Feed retriever remembers cookie between requests if cookie-cache is set",
+	"[FeedRetriever]")
+{
+	auto feed_xml = test_helpers::read_binary_file("data/atom10_1.xml");
+
+	ConfigContainer cfg;
+
+	GIVEN("a configured cookie-cache and a test HTTP server") {
+		test_helpers::TempFile cookie_cache_file;
+		cfg.set_configvalue("cookie-cache", cookie_cache_file.get_path());
+		Cache rsscache(":memory:", &cfg);
+
+		auto& testServer = test_helpers::HttpTestServer::get_instance();
+		const auto address = testServer.get_address();
+		const auto url = strprintf::fmt("http://%s/feed", address);
+
+		WHEN("a HTTP request comes back with a Set-Cookie header") {
+			// Make sure mockRegistration is removed before registering a potentially conflicting next mock endpoint
+			{
+				auto mockRegistration = testServer.add_endpoint("/feed", {}, 200, {
+					{"content-type", "text/xml"},
+					{"Set-Cookie", "abc=def"},
+				}, feed_xml);
+
+				CurlHandle easyHandle;
+				FeedRetriever feedRetriever(cfg, rsscache, easyHandle);
+				const auto feed = feedRetriever.retrieve(url);
+				REQUIRE(testServer.num_hits(mockRegistration) == 1);
+			}
+
+			THEN("the next HTTP request includes the previously received cookie") {
+				auto mockRegistration = testServer.add_endpoint("/feed", {
+					{"Cookie", "abc=def"},
+				}, 200, {
+					{"content-type", "text/xml"},
+				}, feed_xml);
+
+				// Make sure to use a different handle because otherwise Curl keeps cookies alive in memory
+				CurlHandle easyHandle;
+				FeedRetriever feedRetriever(cfg, rsscache, easyHandle);
+				const auto feed = feedRetriever.retrieve(url);
+				REQUIRE(testServer.num_hits(mockRegistration) == 1);
+			}
+		}
 	}
 }


### PR DESCRIPTION
A user reported an issue with Curl cookiejar usage on IRC.
I've not been able to reproduce the issue yet.
While testing, thought it might be nice to have test for some basic cookie-cache functionality.

This PR adds a test which verifies the work done in https://github.com/newsboat/newsboat/pull/50

Relevant Curl documentation:
- Writing cookies: https://curl.se/libcurl/c/CURLOPT_COOKIEJAR.html
- Reading cookies: https://curl.se/libcurl/c/CURLOPT_COOKIEFILE.html