### PR TITLE
CI: Upgrade FreeBSD 14.1 to 14.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,9 +9,9 @@ task:
           freebsd_instance:
             image: freebsd-13-4-release-amd64
             << : *freebsd_resource_settings
-        - name: FreeBSD 14.1
+        - name: FreeBSD 14.2
           freebsd_instance:
-            image: freebsd-14-1-release-amd64-ufs
+            image: freebsd-14-2-release-amd64-ufs
             <<: *freebsd_resource_settings
 
     cargo_cache: &cargo_cache


### PR DESCRIPTION
https://www.freebsd.org/news/newsflash/#2024-12-03:1