### PR TITLE
Set cookiejar option again to take effect during curl_easy_cleanup()

### DIFF
--- a/src/reloader.cpp
+++ b/src/reloader.cpp
@@ -263,8 +263,15 @@ void Reloader::reload_indexes_impl(std::vector<unsigned int> indexes, bool unatt
 				"Reloader::reload_indexes_impl: reloading feed #%u",
 				feed_index);
 			reload(feed_index, easyhandle, true, unattended);
+
 			// Reset any options set on the handle before next reload
 			curl_easy_reset(easyhandle.ptr());
+
+			// Restore cookiejar config to make sure option is active during curl_easy_cleanup()
+			const auto cookie_cache = cfg.get_configvalue("cookie-cache");
+			if (cookie_cache != "") {
+				curl_easy_setopt(easyhandle.ptr(), CURLOPT_COOKIEJAR, cookie_cache.c_str());
+			}
 		}
 	}, indexes.size());
 }


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2935

I see some other possible solutions but I would like to get this fix in as a stopgap solution for the coming release.

Possible alternatives (not really sue if they make sense for us, probably quite a bit more complex to use correctly)
- Using separate easy handles but [setting up sharing explicitly](https://everything.curl.dev/helpers/sharing.html#sharing-between-easy-handles)
- Use curl multi (to put multiple easy-handles in a pool which shares resources)
- ...?