### PR TITLE
ListFormatter: lock lines with a mutex

### DIFF
--- a/include/listformatter.h
+++ b/include/listformatter.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <mutex>
 
 #include "regexmanager.h"
 #include "stflrichtext.h"
@@ -17,11 +18,13 @@ public:
 	void set_line(const unsigned int itempos, const StflRichText& text);
 	void clear()
 	{
+		std::lock_guard<std::mutex> guard(mutex);
 		lines.clear();
 	}
-	std::string format_list() const;
-	unsigned int get_lines_count() const
+	std::string format_list();
+	unsigned int get_lines_count()
 	{
+		std::lock_guard<std::mutex> guard(mutex);
 		return lines.size();
 	}
 
@@ -29,6 +32,7 @@ private:
 	std::vector<StflRichText> lines;
 	RegexManager* rxman;
 	std::string location;
+	std::mutex mutex;
 };
 
 } // namespace newsboat

--- a/src/listformatter.cpp
+++ b/src/listformatter.cpp
@@ -31,6 +31,7 @@ void ListFormatter::set_line(const unsigned int itempos,
 	const std::string formatted_text = utils::wstr2str(cleaned);
 	const StflRichText stflRichText = StflRichText::from_quoted(formatted_text);
 
+	std::lock_guard<std::mutex> guard(mutex);
 	if (itempos == UINT_MAX) {
 		lines.push_back(stflRichText);
 	} else {
@@ -38,9 +39,10 @@ void ListFormatter::set_line(const unsigned int itempos,
 	}
 }
 
-std::string ListFormatter::format_list() const
+std::string ListFormatter::format_list()
 {
 	std::string format_cache = "{list";
+	std::lock_guard<std::mutex> guard(mutex);
 	for (auto str : lines) {
 		if (rxman) {
 			rxman->quote_and_highlight(str, location);


### PR DESCRIPTION
Hello,

Tried to track down the issue in #2101 by compiling newsboat with ASAN and launching it with the following config:
```
auto-reload yes
reload-threads 32
```

It looks like the bug is caused by one of the `StflRichText` being referenced after being freed.
I'm pretty sure there are better ways to fix this. Especially given that this patch removes the `const` attributes to two methods