### PR TITLE
Docs: use proper markup for key presses

### DIFF
--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -134,7 +134,7 @@ Lowercase keys, uppercase keys and special characters are written literally.
 
 Key combinations with kbd:[Ctrl] are written using the caret `^`.
 For instance kbd:[Ctrl+R] equals to `^R`.
-Please be aware that all Ctrl-related key combinations need to be written in uppercase.
+Please be aware that all kbd:[Ctrl]-related key combinations need to be written in uppercase.
 
 The following identifiers for special keys are supported:
 

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -744,7 +744,7 @@ the URL view. The actual bookmarking is performed by a program that you specify
 via the <<bookmark-cmd,`bookmark-cmd`>> setting; Newsboat merely supplies the
 data.
 
-To bookmark the currently selected item, press `^B` (invoking the
+To bookmark the currently selected item, press kbd:[Ctrl+B] (invoking the
 <<bookmark,`bookmark`>> operation), and Newsboat will ask you for:
 
 1. the URL to bookmark (already preset with the URL of the current selection);
@@ -813,9 +813,9 @@ following examples:
 The possibilities for combining such queries is endless, sky (actually:
 the available memory) is the limit.
 
-To filter your feeds, press "F" in the feed list, enter your filter expression,
-and press "Enter".  To clear the filter, press "Ctrl-F". To filter the articles in the article list,
-press "F", enter your expression, and press "Enter". Clearing the filter works the same as before.
+To filter your feeds, press kbd:[Shift+F] in the feed list, enter your filter expression,
+and press kbd:[Enter].  To clear the filter, press kbd:[Ctrl+F]. To filter the articles in the article list,
+press kbd:[Shift+F], enter your expression, and press kbd:[Enter]. Clearing the filter works the same as before.
 Be aware that only certain attributes work in both dialogs. The table below lists all available
 attributes and their context, i.e. an attribute that belongs to a feed can only be matched
 in the feed list, while an attribute that belongs to an article can only be matched in the
@@ -978,9 +978,9 @@ To support custom categorization of articles by the user, it is possible to
 flag an article. A valid flag is any character from _A_ to _Z_ and from _a_ to
 _z_. Every article can be flagged with up to 52 different flags, i.e. every
 letter from the Roman alphabet in upper and lower case. Flagging is easy: just
-select an article in the article list, or enter the article view, and press "Ctrl-E".
-This will start the flag editor. By pressing "Enter", the new flags are saved.
-You can cancel by pressing the "Esc" key.
+select an article in the article list, or enter the article view, and press :kbd:[Ctrl+E].
+This will start the flag editor. By pressing kbd:[Enter], the new flags are saved.
+You can cancel by pressing the kbd:[Esc] key.
 
 The flags of an article can be used in every filter expression. The flags of an
 article are always ordered, and when new flags are added, ordering is
@@ -1300,34 +1300,34 @@ list, and the user can jump to another, previously opened dialog from
 everywhere. This allows a user to open more than one article list, more than one
 article view, etc., and switch between them without closing them.
 
-The main dialog for this feature can be reached by pressing the "v" key. This
+The main dialog for this feature can be reached by pressing the kbd:[V] key. This
 opens the list of open dialogs. From there, the user can switch to another
-dialog by selecting the appropriate entry and pressing "Enter", or can close
-open dialogs by selecting them and pressing "Ctrl-X".
+dialog by selecting the appropriate entry and pressing kbd:[Enter], or can close
+open dialogs by selecting them and pressing kbd:[Ctrl+X].
 
 === Macro Support
 
 Bindings created with <<bind-key,`bind-key`>> can only execute a single operation, like
 <<open,`open`>> or <<quit,`quit`>>. To execute multiple operations, one has to define a so-called
-"macro". To invoke the macro, the user presses the macro prefix ("," by
+"macro". To invoke the macro, the user presses the macro prefix (kbd:[,] by
 default) and then the macro's key. It's easier to explain with some examples:
 
   macro k open; reload; quit  -- "enter feed to reload it"
   macro o open-in-browser; toggle-article-read "read"
 
-Here, we define two macros. Now when the user types ",k", Newsboat will enter
+Here, we define two macros. Now when the user types kbd:[,]kbd:[K], Newsboat will enter
 the current feed, reload it, and go back to the feedlist. If the user types
-",o", Newsboat will open current article in the external browser, and also mark
+kbd:[,]kbd:[O], Newsboat will open current article in the external browser, and also mark
 it read. Note that macros can have a description which will be displayed in the
-help dialog when the user presses "?".
+help dialog when the user presses kbd:[?].
 
 Macros can invoke any of <<_newsboat_operations,Newsboat's operations>>. Keep
 in mind that some operations only make sense in certain situations, e.g.
 `reload` doesn't make sense while viewing an article. If you try to execute an
 operation that is not supported by the current dialog, it will be ignored.
 
-The macro prefix can be changed from the default "," to another key, e.g. "+"
-(if you don't unbind the default "," you're left with two macro prefixes):
+The macro prefix can be changed from the default kbd:[,] to another key, e.g. kbd:[+]
+(if you don't unbind the default kbd:[,] you're left with two macro prefixes):
 
   bind-key + macro-prefix
   unbind-key ,
@@ -1374,27 +1374,27 @@ To open any link with your browser, the versatile
 <<open-in-browser,`open-in-browser`>> operation can be used. Its behavior is
 specific to each dialog.
 
-The default keybinding for `open-in-browser` is "o". An alternative operation,
+The default keybinding for `open-in-browser` is kbd:[O]. An alternative operation,
 <<open-in-browser-and-mark-read,`open-in-browser-and-mark-read`>> also marks the
 article as read when in the article list, but doesn't work in the feed list.
-The default keybinding is "O".
+The default keybinding is kbd:[Shift+O].
 
 Articles usually contain links which point to different resources and websites.
 Newsboat detects those links and creates a list which can be seen at the bottom
 of the article view. To easily scroll through the list and choose a link to
-open, one can go to the URL view with the "u" key.
+open, one can go to the URL view with the kbd:[U] key.
 
 Those links can also be opened directly from the article view.
 Relevant operations are <<one,`one`>> to <<zero,`zero`>>
 (digits written as words) and <<goto-url,`goto-url`>>.
-Keys "1" to "0" can be used to open URL 1 to 10. To open URLs above 10,
-start with the "#" key, then type the URL's number, and press "Enter". To use
-goto-url inside a macro, simply append the URL's number (e.g. `goto-url 11`).
+Keys kbd:[1] to kbd:[0] can be used to open URL 1 to 10. To open URLs above 10,
+start with the kbd:[#] key, then type the URL's number, and press kbd:[Enter]. To use
+`goto-url` inside a macro, simply append the URL's number (e.g. `goto-url 11`).
 
 ==== Switching Browser for Different Tasks
 
 To manually change the browser from Newsboat internal command line, type
-`:set browser` followed by the command, and press "Enter".
+`:set browser` followed by the command, and press kbd:[Enter].
 The variable is only set temporarily (useful for testing), so next
 time Newsboat is launched, `browser` will reset to the command specified in your
 config file:
@@ -1614,7 +1614,7 @@ changes the subject and then let itself mark the article again as unread.
 		   >   update rss_item set unread = 1 where rowid == new.rowid;
 		   > end;
 
-4. Leave `sqlite3` with "Ctrl-D" or `.quit`.
+4. Leave `sqlite3` with kbd:[Ctrl+D] or `.quit`.
 
 That's it. Newsboat (well, its db) now marks articles as unread when their
 title changes. And nicely enough this works all inside Newsboat, no need to


### PR DESCRIPTION
Back in the days, we put the key strokes in double quotes. However, this convention was changed to AsciiDoc's `kbd:` syntax later. Apparently, we missed some key strokes during the migration. So, this commit changes the remaining ones to the proper syntax.

Lowercase keys in the old syntax are now converted to uppercase. The old uppercase keys still remain uppercase, but get an explicit Shift prefix.