### PR TITLE
Clang tidy fix target & config improvement

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,8 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,modernize-make-unique'
+Checks:
+  - 'clang-analyzer-*'
+  - 'clang-diagnostic-*'
+  - 'modernize-make-unique'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle:     none

--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,12 @@ compile_flags.txt: Makefile
 PHONY/clang-tidy-%: compile_flags.txt xlicense.h $(STFL_HDRS) $(NEWSBOATLIB_OUTPUT)
 	$(CLANG_TIDY) $(@:PHONY/clang-tidy-%=%)
 
+PHONY/fix-clang-tidy-%: compile_flags.txt xlicense.h $(STFL_HDRS) $(NEWSBOATLIB_OUTPUT)
+	-$(CLANG_TIDY) --fix $(@:PHONY/fix-clang-tidy-%=%)
+
 clang-tidy: $(addprefix PHONY/clang-tidy-,$(LIB_SRCS) $(NEWSBOAT_SRCS) $(RSSPPLIB_SRCS) $(PODBOAT_SRCS) $(TEST_SRCS) newsboat.cpp podboat.cpp)
+
+fix-clang-tidy: $(addprefix PHONY/fix-clang-tidy-,$(LIB_SRCS) $(NEWSBOAT_SRCS) $(RSSPPLIB_SRCS) $(PODBOAT_SRCS) $(TEST_SRCS) newsboat.cpp podboat.cpp)
 
 install-newsboat: $(NEWSBOAT)
 	$(MKDIR) $(DESTDIR)$(prefix)/bin


### PR DESCRIPTION
This makes it bit nicer to add & test new clang-tidy rules for the code base.

The fix-target can apply any automatic fixes, and having the rules defined as a proper list makes it easier to add (less likely to conflict).