### PR TITLE
Avoid crash on setting non-existent config option

### DIFF
--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "3rd-party/expected.hpp"
 #include "configactionhandler.h"
 
 namespace newsboat {
@@ -68,7 +69,8 @@ public:
 	bool get_configvalue_as_bool(const std::string& key) const;
 	int get_configvalue_as_int(const std::string& key) const;
 	std::string get_configvalue(const std::string& key) const;
-	void set_configvalue(const std::string& key, const std::string& value);
+	nonstd::expected<void, std::string> set_configvalue(const std::string& key,
+		const std::string& value);
 	void reset_to_default(const std::string& key);
 	void toggle(const std::string& key);
 	std::vector<std::string> get_suggestions(const std::string& fragment) const;

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -244,9 +244,16 @@ void FormAction::handle_set(const std::vector<std::string>& args)
 				args[0],
 				utils::quote_if_necessary(cfg->get_configvalue(args[0]))));
 	} else if (args.size() == 2) {
-		std::string result = ConfigParser::evaluate_backticks(args[1]);
-		utils::trim_end(result);
-		cfg->set_configvalue(args[0], result);
+		std::string value = ConfigParser::evaluate_backticks(args[1]);
+		utils::trim_end(value);
+		const auto& key = args[0];
+		const auto result = cfg->set_configvalue(key, value);
+		if (!result) {
+			v.get_statusline().show_error(strprintf::fmt(_("error setting '%s' to '%s': %s"),
+					key,
+					value,
+					result.error()));
+		}
 		// because some configuration value might have changed something UI-related
 		set_redraw(true);
 	} else {


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/2989