### PR TITLE
Keybindings: Allow escaping `<` and `>` using `<LT>` and `<GT>`

### DIFF
--- a/rust/libnewsboat/src/keycombination.rs
+++ b/rust/libnewsboat/src/keycombination.rs
@@ -83,7 +83,12 @@ fn alphabetic(input: &str) -> IResult<&str, char> {
 }
 
 fn regular_bindkey(input: &str) -> IResult<&str, KeyCombination> {
-    Ok(("", KeyCombination::new(input.to_owned())))
+    let key_combination = match input {
+        "<" => KeyCombination::new("LT".to_owned()),
+        ">" => KeyCombination::new("GT".to_owned()),
+        key => KeyCombination::new(key.to_owned()),
+    };
+    Ok(("", key_combination))
 }
 
 fn control_bindkey(input: &str) -> IResult<&str, KeyCombination> {
@@ -199,8 +204,8 @@ mod tests {
         assert_eq!(bindkey("a"), KeyCombination::new("a".to_owned()));
         assert_eq!(bindkey("ENTER"), KeyCombination::new("ENTER".to_owned()));
         assert_eq!(bindkey("^"), KeyCombination::new("^".to_owned()));
-        assert_eq!(bindkey("<"), KeyCombination::new("<".to_owned()));
-        assert_eq!(bindkey(">"), KeyCombination::new(">".to_owned()));
+        assert_eq!(bindkey("<"), KeyCombination::new("LT".to_owned()));
+        assert_eq!(bindkey(">"), KeyCombination::new("GT".to_owned()));
     }
 
     #[test]
@@ -234,6 +239,14 @@ mod tests {
             bindkey("^z"),
             KeyCombination::new("z".to_owned()).with_control()
         );
+    }
+
+    #[test]
+    fn t_bindkey_single_special_key() {
+        assert_eq!(bindkey("="), KeyCombination::new("=".to_owned()));
+        assert_eq!(bindkey("<"), KeyCombination::new("LT".to_owned()));
+        assert_eq!(bindkey(">"), KeyCombination::new("GT".to_owned()));
+        assert_eq!(bindkey("-"), KeyCombination::new("-".to_owned()));
     }
 
     #[test]

--- a/src/keycombination.cpp
+++ b/src/keycombination.cpp
@@ -62,7 +62,13 @@ std::string KeyCombination::to_bindkey_string() const
 	} else if (shift == ShiftState::Shift && key.length() == 1) {
 		return strprintf::fmt("%c", static_cast<char>(std::toupper(key[0])));
 	} else {
-		return key;
+		if (key == "LT") {
+			return "<";
+		} else if (key == "GT") {
+			return ">";
+		} else {
+			return key;
+		}
 	}
 }
 

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -1050,6 +1050,10 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 			}
 		}
 		const auto key_sequence = KeyCombination::from_bind(std::string(binding.key_sequence));
+		LOG(Level::DEBUG, "New binding with key sequence:");
+		for (const auto& key : key_sequence) {
+			LOG(Level::DEBUG, "- %s (%s)", key.to_bind_string(), key.get_key());
+		}
 		const auto description = std::string(binding.description);
 		const auto cmds = convert_operations(binding.operations);
 		for (const auto& context : bind_contexts) {

--- a/test/keycombination.cpp
+++ b/test/keycombination.cpp
@@ -21,8 +21,8 @@ TEST_CASE("KeyCombination parses bind-key key combinations", "[KeyCombination]")
 	check("^a", "a", false, true, false);
 	check("^A", "a", false, true, false);
 
-	check("<", "<", false, false, false);
-	check(">", ">", false, false, false);
+	check("<", "LT", false, false, false);
+	check(">", "GT", false, false, false);
 	check("ENTER", "ENTER", false, false, false);
 }
 

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -715,7 +715,7 @@ TEST_CASE("prepare_keymap_hint() returns a string describing keys to which given
 	REQUIRE(k.prepare_keymap_hint(hints, "feedlist") ==
 		"<key>q</><colon>:</><desc>Get out of <>this> dialog</> "
 		"<key>?</><comma>,</><key>w</><colon>:</><desc>HALP</> "
-		"<key><></><comma>,</><key>ENTER</><comma>,</><key>x</><colon>:</><desc>Open</> "
+		"<key>ENTER</><comma>,</><key><></><comma>,</><key>x</><colon>:</><desc>Open</> "
 		"<key>O</><colon>:</><desc>Reload current entry</> "
 		"<key><>none></><colon>:</><desc>Go find me</> ");
 }


### PR DESCRIPTION
Part of https://github.com/newsboat/newsboat/pull/2364