### PR TITLE
Highlight search phrase case insensitively

### DIFF
--- a/include/stflrichtext.h
+++ b/include/stflrichtext.h
@@ -19,6 +19,7 @@ public:
 	~StflRichText() = default;
 
 
+	void highlight_searchphrase(const std::string& search, bool case_insensitive = true);
 	void apply_style_tag(const std::string& tag, size_t start, size_t end);
 
 	std::string plaintext() const;

--- a/rust/libnewsboat-ffi/src/stflrichtext.rs
+++ b/rust/libnewsboat-ffi/src/stflrichtext.rs
@@ -14,6 +14,11 @@ mod ffi {
         fn from_quoted(text: &CxxString) -> Box<StflRichText>;
         fn copy(richtext: &StflRichText) -> Box<StflRichText>;
 
+        fn highlight_searchphrase(
+            richtext: &mut StflRichText,
+            search: &str,
+            case_insensitive: bool,
+        );
         fn apply_style_tag(richtext: &mut StflRichText, tag: &str, start: usize, end: usize);
         fn plaintext(richtext: &StflRichText) -> &str;
         fn quoted(richtext: &StflRichText) -> String;
@@ -34,6 +39,10 @@ fn from_quoted(text: &CxxString) -> Box<StflRichText> {
 
 fn copy(richtext: &StflRichText) -> Box<StflRichText> {
     Box::new(StflRichText(richtext.0.clone()))
+}
+
+fn highlight_searchphrase(richtext: &mut StflRichText, search: &str, case_insensitive: bool) {
+    richtext.0.highlight_searchphrase(search, case_insensitive);
 }
 
 fn apply_style_tag(richtext: &mut StflRichText, tag: &str, start: usize, end: usize) {

--- a/rust/libnewsboat/src/stflrichtext.rs
+++ b/rust/libnewsboat/src/stflrichtext.rs
@@ -31,6 +31,20 @@ impl StflRichText {
         self.merge_style_tag(tag, start, end);
     }
 
+    pub fn highlight_searchphrase(&mut self, search: &str, case_insensitive: bool) {
+        let literal_pattern = regex::escape(search);
+
+        if let Ok(re) = regex::RegexBuilder::new(&literal_pattern)
+            .case_insensitive(case_insensitive)
+            .build()
+        {
+            let text = self.text.clone();
+            for found in re.find_iter(&text) {
+                self.apply_style_tag("<hl>", found.start(), found.end());
+            }
+        }
+    }
+
     fn extract_style_tags(text: &str) -> (String, BTreeMap<usize, String>) {
         let mut result = text.to_owned();
         let mut tags = BTreeMap::new();

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -103,12 +103,12 @@ void HelpFormAction::prepare()
 				|| strcasestr(desc.desc.c_str(), searchphrase.c_str()) != nullptr;
 		};
 
-		std::string highlighted_searchphrase = strprintf::fmt("<hl>%s</>", searchphrase);
 		const auto apply_highlights = [&](const std::string& line) {
+			auto text = StflRichText::from_plaintext(line);
 			if (apply_search && searchphrase.length() > 0) {
-				return utils::replace_all(line, searchphrase, highlighted_searchphrase);
+				text.highlight_searchphrase(searchphrase);
 			}
-			return line;
+			return text;
 		};
 
 		for (const auto& desc : bound_descriptions) {
@@ -117,9 +117,7 @@ void HelpFormAction::prepare()
 						desc.key.to_bindkey_string(),
 						desc.cmd,
 						desc.desc);
-				line = utils::quote_for_stfl(line);
-				line = apply_highlights(line);
-				listfmt.add_line(StflRichText::from_quoted(line));
+				listfmt.add_line(apply_highlights(line));
 			}
 		}
 
@@ -134,9 +132,7 @@ void HelpFormAction::prepare()
 							desc.key.to_bindkey_string(),
 							desc.cmd,
 							desc.desc);
-					line = utils::quote_for_stfl(line);
-					line = apply_highlights(line);
-					listfmt.add_line(StflRichText::from_quoted(line));
+					listfmt.add_line(apply_highlights(line));
 				}
 			}
 		}
@@ -149,9 +145,7 @@ void HelpFormAction::prepare()
 			for (const auto& desc : unbound_descriptions) {
 				if (should_be_visible(desc)) {
 					std::string line = strprintf::fmt("%-39s %s", desc.cmd, desc.desc);
-					line = utils::quote_for_stfl(line);
-					line = apply_highlights(line);
-					listfmt.add_line(StflRichText::from_quoted(line));
+					listfmt.add_line(apply_highlights(line));
 				}
 			}
 		}
@@ -169,9 +163,7 @@ void HelpFormAction::prepare()
 				if (should_be_visible({ macro.first, "", description, "", 0 })) {
 					// "macro-prefix" is not translated because it refers to an operation name
 					std::string line = strprintf::fmt("<macro-prefix>%s  %s", key, description);
-					line = utils::quote_for_stfl(line);
-					line = apply_highlights(line);
-					listfmt.add_line(StflRichText::from_quoted(line));
+					listfmt.add_line(apply_highlights(line));
 				}
 			}
 		}

--- a/src/helpformaction.cpp
+++ b/src/helpformaction.cpp
@@ -166,11 +166,13 @@ void HelpFormAction::prepare()
 				const std::string key = macro.first.to_bindkey_string();
 				const std::string description = macro.second.description;
 
-				// "macro-prefix" is not translated because it refers to an operation name
-				std::string line = strprintf::fmt("<macro-prefix>%s  %s", key, description);
-				line = utils::quote_for_stfl(line);
-				line = apply_highlights(line);
-				listfmt.add_line(StflRichText::from_quoted(line));
+				if (should_be_visible({ macro.first, "", description, "", 0 })) {
+					// "macro-prefix" is not translated because it refers to an operation name
+					std::string line = strprintf::fmt("<macro-prefix>%s  %s", key, description);
+					line = utils::quote_for_stfl(line);
+					line = apply_highlights(line);
+					listfmt.add_line(StflRichText::from_quoted(line));
+				}
 			}
 		}
 

--- a/src/stflrichtext.cpp
+++ b/src/stflrichtext.cpp
@@ -32,6 +32,11 @@ StflRichText StflRichText::from_quoted(std::string text)
 	return StflRichText(std::move(rs_object));
 }
 
+void StflRichText::highlight_searchphrase(const std::string& search, bool case_insensitive)
+{
+	stflrichtext::bridged::highlight_searchphrase(*rs_object, search, case_insensitive);
+}
+
 void StflRichText::apply_style_tag(const std::string& tag, size_t start, size_t end)
 {
 	stflrichtext::bridged::apply_style_tag(*rs_object, tag, start, end);


### PR DESCRIPTION
I think case-insensitive regex search & replace is suitable for this.

There could still be some discrepancy between the case matching of this and `strcasestr`, which is used as the precondition check.

The added function is quite specific. It might also be beneficial to construct the regex once outside the `apply_highlights` lambda, but don't know if it's worth the bridging effort.

Fixes #2998 