### PR TITLE
Draft: Compile in C++ 17 mode

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -237,14 +237,6 @@ task:
                 cxx_package: g++-14
                 cc: gcc-14
                 cxx: g++-14
-        - name: Rust stable, Clang 4.0 (Ubuntu 18.04)
-          container:
-            greedy: true
-            dockerfile: docker/ubuntu_18.04-build-tools.dockerfile
-            docker_arguments:
-                cxx_package: clang-4.0
-                cc: clang-4.0
-                cxx: clang++-4.0
         - name: Rust stable, Clang 5.0 (Ubuntu 18.04)
           container:
             greedy: true

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ DEFINES=-DLOCALEDIR='"$(localedir)"' -DCATCH_AMALGAMATED_CUSTOM_MAIN
 WARNFLAGS=-Werror -Wall -Wextra -Wunreachable-code
 INCLUDES=-Iinclude -Istfl -Ifilter -I. -Irss -I$(CARGO_TARGET_DIR)/cxxbridge/
 # Keep in sync with c++ version specified in FFI build.rs
-BARE_CXXFLAGS=-std=c++14 -O2 -ggdb $(INCLUDES)
+BARE_CXXFLAGS=-std=c++17 -O2 -ggdb $(INCLUDES)
 LDFLAGS+=-L.
 
 # Constants

--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ Newsboat can be compiled.
     UPDATE doc/newsboat.asciidoc IF YOU CHANGE THIS LIST
 -->
 - GNU Make 4.0 or newer
-- GCC 5.0 or newer, or Clang 3.6 or newer
+- C++ compiler that accepts `-std=c++17` option: GCC 5.0 or newer, or Clang 5 or
+  newer. If you have libicu 76 or newer, than C++17 support is required as
+  Newsboat indirectly depends on libicu headers via libxml2. Newsboat 2.40 (ETA
+  2025.06.22) is expected to require a compiler that _supports_ C++17
 - Stable [Rust](https://www.rust-lang.org/en-US/) and Cargo (Rust's package
     manager) (1.81.0 or newer; might work with older versions, but we don't
     check that)

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -69,7 +69,11 @@ Debian and derivatives, headers are in `-dev` packages, e.g. `libsqlite3-dev`.)
 
 // UPDATE README.md IF YOU CHANGE THIS LIST
 - GNU Make 4.0 or newer
-- GCC 5.0 or newer, or Clang 3.6 or newer
+- C{plus}{plus} compiler that accepts `-std=c{plus}{plus}17` option: GCC 5.0 or
+  newer, or Clang 5 or newer. If you have libicu 76 or newer, than
+  C{plus}{plus}17 support is required as Newsboat indirectly depends on libicu
+  headers via libxml2. Newsboat 2.40 (ETA 2025.06.22) is expected to require
+  a compiler that _supports_ C{plus}{plus}17
 - Stable https://www.rust-lang.org/en-US/[Rust] and Cargo (Rust's package
   manager) (1.81.0 or newer; might work with older versions, but we don't check
   that)

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -1,7 +1,7 @@
 fn add_cxxbridge(module: &str) {
     cxx_build::bridge(format!("src/{module}.rs"))
         // Keep in sync with c++ version specified in Makefile
-        .std("c++14")
+        .std("c++17")
         // Disable warnings in generated code, since we can't affect them directly. We have to do
         // this because these warnings are turned into errors when we pass `-D warnings` to Cargo
         // on CI.


### PR DESCRIPTION
Fixes #3031.

I'll update compiler requirements in the README and the docs once CI failed and I see which compilers to exclude.