### PR TITLE
Fix edit-flags when used from new-style binding

### DIFF
--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -330,13 +330,13 @@ bool ItemViewFormAction::process_operation(Operation op,
 		switch (bindingType) {
 		case BindingType::Bind:
 			if (args.empty()) {
-				qna_responses = { args.front() };
-				this->finished_qna(QnaFinishAction::UpdateFlags);
-			} else {
 				std::vector<QnaPair> qna {
 					QnaPair(_("Flags: "), item->flags()),
 				};
 				this->start_qna(qna, QnaFinishAction::UpdateFlags);
+			} else {
+				qna_responses = { args.front() };
+				this->finished_qna(QnaFinishAction::UpdateFlags);
 			}
 			break;
 		case BindingType::Macro:


### PR DESCRIPTION
Condition was specified the wrong way around causing a crash when using `edit-flags` configured using `bind`.
`bind-key` (and the default keybinding for `edit-flags` -> `Ctrl+E`) were not effected, as they would hit the `::BindKey` arm of the switch statement.

Caused by me in [commit 39c66a321](https://github.com/newsboat/newsboat/commit/39c66a321fad85936d925ceb1e52f6aba99ee5e6#diff-05722ea839454b7bbe5203d23a4a58a8391d9f6e2c9a6ff93398b1a58e98dab0R335)