### PR TITLE
Add missing handling of feed titles from OPML

### DIFF
--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -149,6 +149,18 @@ void rec_find_rss_outlines(
 				if (std::find(urls.begin(), urls.end(), quoted_url) == urls.end()) {
 					LOG(Level::DEBUG, "opml::import: added url = %s", quoted_url);
 					std::vector<std::string> tags;
+
+					char* text_p = (char*)xmlGetProp(node, (const xmlChar*)"text");
+					if (!text_p) {
+						text_p = (char*)xmlGetProp(node, (const xmlChar*)"title");
+					}
+					if (text_p) {
+						if (text_p[0] != '\0') {
+							tags.push_back(std::string{"~"} + text_p);
+						}
+						xmlFree(text_p);
+					}
+
 					if (tag.length() > 0) {
 						LOG(Level::DEBUG,
 							"opml::import: appending tag %s to url %s",
@@ -156,6 +168,7 @@ void rec_find_rss_outlines(
 							quoted_url);
 						tags.push_back(tag);
 					}
+
 					urlcfg.add_url(quoted_url, tags);
 				} else {
 					LOG(Level::DEBUG,

--- a/src/opmlurlreader.cpp
+++ b/src/opmlurlreader.cpp
@@ -68,9 +68,25 @@ void OpmlUrlReader::handle_node(xmlNode* node, const std::string& tag)
 		if (rssurl && strlen(rssurl) > 0) {
 			std::string theurl(rssurl);
 			urls.push_back(theurl);
+
+			std::vector<std::string> tmptags;
+
+			char* rsstext = (char*)xmlGetProp(node, (const xmlChar*)"text");
+			if (!rsstext) {
+				rsstext = (char*)xmlGetProp(node, (const xmlChar*)"title");
+			}
+			if (rsstext) {
+				if (rsstext[0] != '\0') {
+					tmptags.push_back(std::string{"~"} + rsstext);
+				}
+				xmlFree(rsstext);
+			}
+
 			if (tag.length() > 0) {
-				std::vector<std::string> tmptags;
 				tmptags.push_back(tag);
+			}
+
+			if (tmptags.size() > 0) {
 				tags[theurl] = tmptags;
 			}
 		}

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -146,13 +146,13 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 			urlcfg));
 
 	const std::map<URL, Tags> opmlUrls {
-		{"https://example.com/feed.xml", {}},
-		{"https://example.com/mirrors/distrowatch.rss", {}},
-		{"https://example.com/feed.atom", {}},
-		{"https://example.com/feed.rss09", {}},
-		{"https://blogs.example.com/~john/posts.rss", {"Blogs"}},
-		{"https://blogs.example.com/~mike/.rss", {"Blogs/friends"}},
-		{"https://fred.example.com/writing/index.php?type=rss", {"eloquent"}},
+		{"https://example.com/feed.xml", {"~example.com website"}},
+		{"https://example.com/mirrors/distrowatch.rss", {"~Distrowatch mirror"}},
+		{"https://example.com/feed.atom", {"~example.com website (Atom feed)"}},
+		{"https://example.com/feed.rss09", {"~example.com website (RSS 0.9 feed)"}},
+		{"https://blogs.example.com/~john/posts.rss", {"~John's musings", "Blogs"}},
+		{"https://blogs.example.com/~mike/.rss", {"~Notes by Mike", "Blogs/friends"}},
+		{"https://fred.example.com/writing/index.php?type=rss", {"~Fred on everything", "eloquent"}},
 	};
 
 	std::map<URL, Tags> combinedUrls;
@@ -189,8 +189,8 @@ TEST_CASE("import() turns URLs that start with a pipe symbol (\"|\") "
 	using Tag = std::string;
 	using Tags = std::vector<Tag>;
 	const std::map<URL, Tags> opmlUrls {
-		{"exec:~/fetch_tweets.py", {}},
-		{"https://example.com/feed.atom", {"tagged"}},
+		{"exec:~/fetch_tweets.py", {"~Birdsite search"}},
+		{"https://example.com/feed.atom", {"~example.com website (Atom feed)", "tagged"}},
 	};
 
 	REQUIRE(urlcfg.get_urls().size() == opmlUrls.size());
@@ -224,8 +224,8 @@ TEST_CASE("import() turns \"filtercmd\" attribute into a `filter:` URL "
 	using Tag = std::string;
 	using Tags = std::vector<Tag>;
 	const std::map<URL, Tags> opmlUrls {
-		{"https://example.com/another_feed.atom", {"misc"}},
-		{"filter:~/.bin/keep_interesting.pl:https://example.com/firehose", {}},
+		{"https://example.com/another_feed.atom", {"~example.com website (Atom feed)", "misc"}},
+		{"filter:~/.bin/keep_interesting.pl:https://example.com/firehose", {"~Firehose"}},
 	};
 
 	REQUIRE(urlcfg.get_urls().size() == opmlUrls.size());
@@ -278,7 +278,7 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 			urlcfg));
 
 	const std::map<URL, Tags> opmlUrls {
-		{"https://example.com/another_feed.atom", {}},
+		{"https://example.com/another_feed.atom", {"~example.com website (Atom feed)"}},
 	};
 
 	std::map<URL, Tags> combinedUrls;

--- a/test/opmlurlreader.cpp
+++ b/test/opmlurlreader.cpp
@@ -41,13 +41,13 @@ TEST_CASE("OpmlUrlReader::reload() reads URLs and tags from an OPML file",
 	using Tag = std::string;
 	using Tags = std::vector<Tag>;
 	const std::map<URL, Tags> expected {
-		{"https://example.com/feed.xml", {}},
-		{"https://example.com/mirrors/distrowatch.rss", {}},
-		{"https://example.com/feed.atom", {}},
-		{"https://example.com/feed.rss09", {}},
-		{"https://blogs.example.com/~john/posts.rss", {"Blogs"}},
-		{"https://fred.example.com/writing/index.php?type=rss", {"eloquent"}},
-		{"https://blogs.example.com/~mike/.rss", {"Blogs/friends"}},
+		{"https://example.com/feed.xml", {"~example.com website"}},
+		{"https://example.com/mirrors/distrowatch.rss", {"~Distrowatch mirror"}},
+		{"https://example.com/feed.atom", {"~example.com website (Atom feed)"}},
+		{"https://example.com/feed.rss09", {"~example.com website (RSS 0.9 feed)"}},
+		{"https://blogs.example.com/~john/posts.rss", {"~John's musings", "Blogs"}},
+		{"https://fred.example.com/writing/index.php?type=rss", {"~Fred on everything", "eloquent"}},
+		{"https://blogs.example.com/~mike/.rss", {"~Notes by Mike", "Blogs/friends"}},
 	};
 
 	REQUIRE(reader.get_urls().size() == expected.size());
@@ -64,9 +64,11 @@ TEST_CASE("OpmlUrlReader::reload() reads URLs and tags from an OPML file",
 
 	std::set<Tag> expected_tags;
 	for (const auto& entry : expected) {
-		expected_tags.insert(
-			entry.second.cbegin(),
-			entry.second.cend());
+		for (const auto& tag : entry.second) {
+			if (tag[0] != '~') {
+				expected_tags.insert(tag);
+			}
+		}
 	}
 	std::set<Tag> tags;
 	const auto alltags = reader.get_alltags();
@@ -93,20 +95,20 @@ TEST_CASE("OpmlUrlReader::reload() loads URLs from multiple sources",
 	using Tag = std::string;
 	using Tags = std::vector<Tag>;
 	const std::map<URL, Tags> expected {
-		{"https://example.com/feed.xml", {}},
-		{"https://example.com/mirrors/distrowatch.rss", {}},
-		{"https://example.com/feed.atom", {}},
-		{"https://example.com/feed.rss09", {}},
-		{"https://blogs.example.com/~john/posts.rss", {"Blogs"}},
-		{"https://fred.example.com/writing/index.php?type=rss", {"eloquent"}},
-		{"https://blogs.example.com/~mike/.rss", {"Blogs/friends"}},
-		{"https://one.example.com/file.xml", {}},
-		{"https://to.example.com/elves/tidings.rss", {}},
-		{"https://third.example.com/~of/internet.rss", {"Rant boards/humans"}},
-		{"https://four.example.com/~john/posts.rss", {"Rant boards"}},
-		{"https://example.com/five.atom", {}},
-		{"https://freddie.example.com/ritin/index.pl?format=rss", {"eloquent"}},
-		{"https://example.com/feed2.rss09", {}},
+		{"https://example.com/feed.xml", {"~example.com website"}},
+		{"https://example.com/mirrors/distrowatch.rss", {"~Distrowatch mirror"}},
+		{"https://example.com/feed.atom", {"~example.com website (Atom feed)"}},
+		{"https://example.com/feed.rss09", {"~example.com website (RSS 0.9 feed)"}},
+		{"https://blogs.example.com/~john/posts.rss", {"~John's musings", "Blogs"}},
+		{"https://fred.example.com/writing/index.php?type=rss", {"~Fred on everything", "eloquent"}},
+		{"https://blogs.example.com/~mike/.rss", {"~Notes by Mike", "Blogs/friends"}},
+		{"https://one.example.com/file.xml", {"~To rule them all"}},
+		{"https://to.example.com/elves/tidings.rss", {"~Another file"}},
+		{"https://third.example.com/~of/internet.rss", {"~Really?", "Rant boards/humans"}},
+		{"https://four.example.com/~john/posts.rss", {"~and another", "Rant boards"}},
+		{"https://example.com/five.atom", {"~another title"}},
+		{"https://freddie.example.com/ritin/index.pl?format=rss", {"~freddie rite about fings", "eloquent"}},
+		{"https://example.com/feed2.rss09", {"~an outdated feed"}},
 	};
 
 	REQUIRE(reader.get_urls().size() == expected.size());
@@ -123,9 +125,11 @@ TEST_CASE("OpmlUrlReader::reload() loads URLs from multiple sources",
 
 	std::set<Tag> expected_tags;
 	for (const auto& entry : expected) {
-		expected_tags.insert(
-			entry.second.cbegin(),
-			entry.second.cend());
+		for (const auto& tag : entry.second) {
+			if (tag[0] != '~') {
+				expected_tags.insert(tag);
+			}
+		}
 	}
 	std::set<Tag> tags;
 	const auto alltags = reader.get_alltags();
@@ -156,20 +160,20 @@ TEST_CASE("OpmlUrlReader::reload() skips things that can't be parsed",
 	using Tag = std::string;
 	using Tags = std::vector<Tag>;
 	const std::map<URL, Tags> expected {
-		{"https://example.com/feed.xml", {}},
-		{"https://example.com/mirrors/distrowatch.rss", {}},
-		{"https://example.com/feed.atom", {}},
-		{"https://example.com/feed.rss09", {}},
-		{"https://blogs.example.com/~john/posts.rss", {"Blogs"}},
-		{"https://fred.example.com/writing/index.php?type=rss", {"eloquent"}},
-		{"https://blogs.example.com/~mike/.rss", {"Blogs/friends"}},
-		{"https://one.example.com/file.xml", {}},
-		{"https://to.example.com/elves/tidings.rss", {}},
-		{"https://third.example.com/~of/internet.rss", {"Rant boards/humans"}},
-		{"https://four.example.com/~john/posts.rss", {"Rant boards"}},
-		{"https://example.com/five.atom", {}},
-		{"https://freddie.example.com/ritin/index.pl?format=rss", {"eloquent"}},
-		{"https://example.com/feed2.rss09", {}},
+		{"https://example.com/feed.xml", {"~example.com website"}},
+		{"https://example.com/mirrors/distrowatch.rss", {"~Distrowatch mirror"}},
+		{"https://example.com/feed.atom", {"~example.com website (Atom feed)"}},
+		{"https://example.com/feed.rss09", {"~example.com website (RSS 0.9 feed)"}},
+		{"https://blogs.example.com/~john/posts.rss", {"~John's musings", "Blogs"}},
+		{"https://fred.example.com/writing/index.php?type=rss", {"~Fred on everything", "eloquent"}},
+		{"https://blogs.example.com/~mike/.rss", {"~Notes by Mike", "Blogs/friends"}},
+		{"https://one.example.com/file.xml", {"~To rule them all"}},
+		{"https://to.example.com/elves/tidings.rss", {"~Another file"}},
+		{"https://third.example.com/~of/internet.rss", {"~Really?", "Rant boards/humans"}},
+		{"https://four.example.com/~john/posts.rss", {"~and another", "Rant boards"}},
+		{"https://example.com/five.atom", {"~another title"}},
+		{"https://freddie.example.com/ritin/index.pl?format=rss", {"~freddie rite about fings", "eloquent"}},
+		{"https://example.com/feed2.rss09", {"~an outdated feed"}},
 	};
 
 	REQUIRE(reader.get_urls().size() == expected.size());
@@ -186,9 +190,11 @@ TEST_CASE("OpmlUrlReader::reload() skips things that can't be parsed",
 
 	std::set<Tag> expected_tags;
 	for (const auto& entry : expected) {
-		expected_tags.insert(
-			entry.second.cbegin(),
-			entry.second.cend());
+		for (const auto& tag : entry.second) {
+			if (tag[0] != '~') {
+				expected_tags.insert(tag);
+			}
+		}
 	}
 	std::set<Tag> tags;
 	const auto alltags = reader.get_alltags();


### PR DESCRIPTION
Fixes #3063

First checks `text` attribute, then `title` (since former is mandatory, and latter optional).