### PR TITLE
Remove implicit Filepath conversions from PodDlThread

### DIFF
--- a/include/filepath.h
+++ b/include/filepath.h
@@ -104,7 +104,7 @@ public:
 	//
 	// The difference from `set_extension()` is that `set_extension()` replaces
 	// the existing extension while `add_extension()` appends to it. For the
-	// path `foo.tar`, `set_extension("gz")` will turn the path into "tar.gz",
+	// path "foo.tar", `set_extension("gz")` will turn the path into "foo.gz",
 	// while `add_extension("gz")` will turn the path into "foo.tar.gz".
 	//
 	// \note `ext` is interpreted as bytes in locale string.

--- a/include/filepath.h
+++ b/include/filepath.h
@@ -94,8 +94,21 @@ public:
 	// Return `false` and do nothing if Filepath is empty, set extension and
 	// return `true` otherwise.
 	//
+	// See also `add_extension()`.
+	//
 	// \note `ext` is interpreted as bytes in locale encoding.
 	bool set_extension(const std::string& ext);
+
+	// Return `false` and do nothing if Filepath is empty, append extension and
+	// return `true` otherwise.
+	//
+	// The difference from `set_extension()` is that `set_extension()` replaces
+	// the existing extension while `add_extension()` appends to it. For the
+	// path `foo.tar`, `set_extension("gz")` will turn the path into "tar.gz",
+	// while `add_extension("gz")` will turn the path into "foo.tar.gz".
+	//
+	// \note `ext` is interpreted as bytes in locale string.
+	bool add_extension(const std::string& ext);
 
 	// Return `true` if Filepath start with `base`, `false` otherwise.
 	//

--- a/rust/libnewsboat-ffi/src/filepath.rs
+++ b/rust/libnewsboat-ffi/src/filepath.rs
@@ -1,4 +1,5 @@
 use cxx::{type_id, ExternType};
+use libnewsboat::filepath;
 use std::ffi::OsStr;
 use std::os::unix::ffi::OsStrExt;
 
@@ -26,6 +27,7 @@ mod bridged {
         fn clone(filepath: &PathBuf) -> Box<PathBuf>;
         fn is_absolute(filepath: &PathBuf) -> bool;
         fn set_extension(filepath: &mut PathBuf, extension: Vec<u8>) -> bool;
+        fn add_extension(filepath: &mut PathBuf, extension: Vec<u8>) -> bool;
         fn starts_with(filepath: &PathBuf, base: &PathBuf) -> bool;
         fn file_name(filepath: &PathBuf) -> Vec<u8>;
     }
@@ -71,6 +73,10 @@ fn is_absolute(filepath: &PathBuf) -> bool {
 
 fn set_extension(filepath: &mut PathBuf, extension: Vec<u8>) -> bool {
     filepath.0.set_extension(OsStr::from_bytes(&extension))
+}
+
+fn add_extension(filepath: &mut PathBuf, extension: Vec<u8>) -> bool {
+    filepath::add_extension(&mut filepath.0, extension)
 }
 
 fn starts_with(filepath: &PathBuf, base: &PathBuf) -> bool {

--- a/rust/libnewsboat/src/filepath.rs
+++ b/rust/libnewsboat/src/filepath.rs
@@ -1,0 +1,53 @@
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
+use std::path::PathBuf;
+
+/// Append `extension` to the filename.
+///
+/// Return `true` if successful, `false` if `filepath` is empty.
+pub fn add_extension(filepath: &mut PathBuf, extension: Vec<u8>) -> bool {
+    if extension.is_empty() {
+        true
+    } else {
+        let extension = OsStr::from_bytes(&extension);
+
+        match filepath.extension() {
+            None => filepath.set_extension(extension),
+            Some(ext) => {
+                let mut ext = ext.to_os_string();
+                ext.push(OsStr::new("."));
+                ext.push(extension);
+                filepath.set_extension(ext)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::Path;
+
+    #[test]
+    fn t_examples_from_rust_lang_docs() {
+        // Copied from https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.add_extension
+
+        let mut p = PathBuf::from("/feel/the");
+
+        add_extension(&mut p, "formatted".as_bytes().to_vec());
+        assert_eq!(Path::new("/feel/the.formatted"), p.as_path());
+
+        add_extension(&mut p, "dark.side".as_bytes().to_vec());
+        assert_eq!(Path::new("/feel/the.formatted.dark.side"), p.as_path());
+
+        p.set_extension("cookie");
+        assert_eq!(Path::new("/feel/the.formatted.dark.cookie"), p.as_path());
+
+        p.set_extension("");
+        assert_eq!(Path::new("/feel/the.formatted.dark"), p.as_path());
+
+        add_extension(&mut p, "".as_bytes().to_vec());
+        assert_eq!(Path::new("/feel/the.formatted.dark"), p.as_path());
+    }
+}

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -12,6 +12,7 @@ pub mod utils;
 pub mod charencoding;
 pub mod cliargsparser;
 pub mod configpaths;
+pub mod filepath;
 pub mod filterparser;
 pub mod fmtstrformatter;
 pub mod fslock;

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -17,7 +17,7 @@
 
 namespace newsboat {
 
-const std::string ConfigContainer::PARTIAL_FILE_SUFFIX = ".part";
+const std::string ConfigContainer::PARTIAL_FILE_SUFFIX = "part";
 
 ConfigContainer::ConfigContainer()
 // create the config options and set their resp. default value and type

--- a/src/filepath.cpp
+++ b/src/filepath.cpp
@@ -105,6 +105,11 @@ bool Filepath::set_extension(const std::string& ext)
 	return filepath::bridged::set_extension(*rs_object, string_to_vec(ext));
 }
 
+bool Filepath::add_extension(const std::string& ext)
+{
+	return filepath::bridged::add_extension(*rs_object, string_to_vec(ext));
+}
+
 bool Filepath::starts_with(const Filepath& base) const
 {
 	return filepath::bridged::starts_with(*rs_object, *base.rs_object);

--- a/src/poddlthread.cpp
+++ b/src/poddlthread.cpp
@@ -1,5 +1,3 @@
-#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
-
 #include "poddlthread.h"
 
 #include <cstring>
@@ -74,8 +72,8 @@ void PodDlThread::run()
 	}
 
 	struct stat sb;
-	Filepath filename =
-		dl->filename().join(newsboat::ConfigContainer::PARTIAL_FILE_SUFFIX);
+	Filepath filename = dl->filename();
+	filename.add_extension(newsboat::ConfigContainer::PARTIAL_FILE_SUFFIX);
 
 	if (stat(filename.to_locale_string().c_str(), &sb) == -1) {
 		LOG(Level::INFO,
@@ -88,9 +86,9 @@ void PodDlThread::run()
 		std::vector<char> directory(filename.to_locale_string().begin(),
 			filename.to_locale_string().end());
 		directory.push_back('\0');
-		utils::mkdir_parents(dirname(&directory[0]));
+		utils::mkdir_parents(Filepath::from_locale_string(dirname(&directory[0])));
 
-		f->open(filename, std::fstream::out);
+		f->open(filename.to_locale_string(), std::fstream::out);
 		dl->set_offset(0);
 		resumed_download = false;
 	} else {
@@ -102,7 +100,7 @@ void PodDlThread::run()
 			static_cast<int64_t>(sb.st_size));
 		curl_easy_setopt(handle.ptr(), CURLOPT_RESUME_FROM, sb.st_size);
 		dl->set_offset(sb.st_size);
-		f->open(filename, std::fstream::out | std::fstream::app);
+		f->open(filename.to_locale_string(), std::fstream::out | std::fstream::app);
 		resumed_download = true;
 	}
 

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -1,5 +1,3 @@
-#define ENABLE_IMPLICIT_FILEPATH_CONVERSIONS
-
 #include "queueloader.h"
 
 #include <cerrno>
@@ -104,7 +102,7 @@ std::optional<QueueLoader::CategorizedDownloads> QueueLoader::categorize_downloa
 
 void QueueLoader::update_from_queue_file(CategorizedDownloads& downloads) const
 {
-	std::fstream f(queuefile, std::fstream::in);
+	std::fstream f(queuefile.to_locale_string(), std::fstream::in);
 	if (!f.is_open()) {
 		return;
 	}
@@ -165,11 +163,11 @@ void QueueLoader::update_from_queue_file(CategorizedDownloads& downloads) const
 			"QueueLoader::reload: found `%s' nowhere -> storing to new vector",
 			line);
 		Download d(cb_require_view_update);
-		std::string fn;
+		Filepath fn;
 		if (fields.size() == 1) {
 			fn = get_filename(fields[0]);
 		} else {
-			fn = fields[1];
+			fn = Filepath::from_locale_string(fields[1]);
 		}
 		d.set_filename(fn);
 
@@ -188,18 +186,20 @@ void QueueLoader::update_from_queue_file(CategorizedDownloads& downloads) const
 			}
 		}
 
-		if (access(fn.c_str(), F_OK) == 0) {
+		auto partial_fn = fn;
+		partial_fn.add_extension(ConfigContainer::PARTIAL_FILE_SUFFIX);
+
+		if (access(fn.to_locale_string().c_str(), F_OK) == 0) {
 			LOG(Level::INFO,
 				"QueueLoader::reload: found `%s' on file system -> mark as already downloaded",
 				fn);
 			if (d.status() == DlStatus::QUEUED || d.status() == DlStatus::MISSING) {
 				d.set_status(DlStatus::READY);
 			}
-		} else if (access((fn + ConfigContainer::PARTIAL_FILE_SUFFIX).c_str(),
-				F_OK) == 0) {
+		} else if (access(partial_fn.to_locale_string().c_str(), F_OK) == 0) {
 			LOG(Level::INFO,
 				"QueueLoader::reload: found `%s' on file system -> mark as partially downloaded",
-				fn + ConfigContainer::PARTIAL_FILE_SUFFIX);
+				partial_fn);
 			d.set_status(DlStatus::FAILED);
 		} else {
 			if (d.status() != DlStatus::QUEUED) {
@@ -214,13 +214,13 @@ void QueueLoader::update_from_queue_file(CategorizedDownloads& downloads) const
 
 void QueueLoader::write_queue_file(const CategorizedDownloads& downloads) const
 {
-	std::fstream f(queuefile, std::fstream::out);
+	std::fstream f(queuefile.to_locale_string(), std::fstream::out);
 	if (!f.is_open()) {
 		return;
 	}
 
 	for (const auto& dl : downloads.to_keep) {
-		f << dl.url() << " " << utils::quote(dl.filename());
+		f << dl.url() << " " << utils::quote(dl.filename().to_locale_string());
 		switch (dl.status()) {
 		case DlStatus::READY:
 			f << " downloaded";
@@ -276,9 +276,11 @@ newsboat::Filepath QueueLoader::get_filename(const std::string& str) const
 	char* base = basename(buf);
 	if (!base || strlen(base) == 0) {
 		time_t t = time(nullptr);
-		fn.push(utils::mt_strf_localtime("%Y-%b-%d-%H%M%S.unknown", t));
+		const auto filename = utils::mt_strf_localtime("%Y-%b-%d-%H%M%S.unknown", t);
+		fn.push(Filepath::from_locale_string(filename));
 	} else {
-		fn.push(utils::replace_all(base, "'", "%27"));
+		const auto filename = utils::replace_all(base, "'", "%27");
+		fn.push(Filepath::from_locale_string(filename));
 	}
 	return fn;
 }

--- a/test/filepath.cpp
+++ b/test/filepath.cpp
@@ -114,6 +114,28 @@ TEST_CASE("Can set extension for non-empty path", "[Filepath]")
 	}
 }
 
+TEST_CASE("add_extension passes tests from Rust docs", "[Filepath]")
+{
+	// Copied from https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.add_extension
+
+	auto path = Filepath::from_locale_string("/feel/the");
+
+	REQUIRE(path.add_extension("formatted"));
+	REQUIRE(Filepath::from_locale_string("/feel/the.formatted") == path);
+
+	REQUIRE(path.add_extension("dark.side"));
+	REQUIRE(Filepath::from_locale_string("/feel/the.formatted.dark.side") == path);
+
+	REQUIRE(path.set_extension("cookie"));
+	REQUIRE(Filepath::from_locale_string("/feel/the.formatted.dark.cookie") == path);
+
+	REQUIRE(path.set_extension(""));
+	REQUIRE(Filepath::from_locale_string("/feel/the.formatted.dark") == path);
+
+	REQUIRE(path.add_extension(""));
+	REQUIRE(Filepath::from_locale_string("/feel/the.formatted.dark") == path);
+}
+
 TEST_CASE("Can check if path is absolute", "[Filepath]")
 {
 	Filepath path;


### PR DESCRIPTION
Yet another step towards #2326.

The complication here was that `PodDlThread` adds ".part" extension to the temporary files it creates. Rust doesn't have a stable API for that: [`PathBuf::add_extension()` is unstable](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.add_extension). I ended up re-implementing the method in stable Rust.

The other changes are trivial conversions to strings before passing them into standard APIs.