### PR TITLE
Avoid using deprecated fields of xmlBuffer

### DIFF
--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -29,8 +29,8 @@ TEST_CASE("opml::generate creates an XML document with feed URLs in OPML format"
 		xmlFreeDoc(opml);
 
 		const std::string opmlText(
-			reinterpret_cast<char*>(buffer->content),
-			buffer->use);
+			reinterpret_cast<const char*>(xmlBufferContent(buffer)),
+			xmlBufferLength(buffer));
 
 		xmlBufferFree(buffer);
 		buffer = nullptr;


### PR DESCRIPTION
Fields were marked deprecated in [libxml commit b34dc1e4](https://gitlab.gnome.org/GNOME/libxml2/-/commit/b34dc1e4a3afecad13b21d5ef38dc26851371abc)