### PR TITLE
Add "monochrome" colorscheme

### DIFF
--- a/contrib/colorschemes/monochrome
+++ b/contrib/colorschemes/monochrome
@@ -1,0 +1,11 @@
+color listnormal         default default dim
+color listnormal_unread  default default 
+color listfocus_unread   default default reverse
+color listfocus          default default reverse
+color background         default default
+color article            default default
+color end-of-text-marker default default
+color info               default default
+color hint-separator     default default
+color hint-description   default default underline
+color title              default default bold reverse

--- a/contrib/colorschemes/monochrome
+++ b/contrib/colorschemes/monochrome
@@ -1,5 +1,5 @@
 color listnormal         default default dim
-color listnormal_unread  default default 
+color listnormal_unread  default default
 color listfocus_unread   default default reverse
 color listfocus          default default reverse
 color background         default default


### PR DESCRIPTION
Adding beautiful monochrome readable color scheme that morph into any terminal default style.
![1](https://github.com/user-attachments/assets/db2fb20f-4558-42f5-9064-cb4f2dadc9c0)
![2](https://github.com/user-attachments/assets/da35fb11-6a49-4659-b766-cbf3a73a3fc1)

