### PR TITLE
Update German translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: newsboat 0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/newsboat/newsboat/issues\n"
 "POT-Creation-Date: 2025-06-08 22:37+0300\n"
-"PO-Revision-Date: 2025-03-10 09:10+0100\n"
+"PO-Revision-Date: 2025-06-11 22:22+0200\n"
 "Last-Translator: Lysander Trischler <github@lyse.isobeef.org>\n"
 "Language-Team: Andreas Krennmair <ak@newsbeuter.org>, Simon Nagl "
 "<simonnagl@aim.com>, Lysander Trischler <github@lyse.isobeef.org>\n"
@@ -575,7 +575,7 @@ msgstr ""
 
 #: src/controller.cpp:593
 msgid "Press any key to continue"
-msgstr ""
+msgstr "Beliebige Taste drücken, um fortzufahren"
 
 #: src/controller.cpp:601
 msgid "failed: "
@@ -734,27 +734,25 @@ msgstr "Kein Feed ausgewählt!"
 #. "Sort by (f)irsttag/..." and "Reverse Sort by
 #. (f)irsttag/..." messages
 #: src/feedlistformaction.cpp:130 src/feedlistformaction.cpp:173
-#, fuzzy
 msgid "ftaulsn"
-msgstr "etauzn"
+msgstr "etauzsn"
 
 #: src/feedlistformaction.cpp:132
-#, fuzzy
 msgid ""
 "Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/(l)astupdated/"
 "late(s)tunread/(n)one?"
 msgstr ""
-"Sortieren nach (e)rstemtag/(t)itel/(a)rtikelzahl/(u)ngeleseneartikel/"
-"(z)uletztaktualisiert/(n)ichts?"
+"Sortieren nach (e)rstem Tag/(t)itel/Artikel(a)nzahl/Anzahl (u)ngelesener Artikel/"
+"(z)uletzt aktualisierte Artikel/neue(s)te ungelesene Artikel/(n)ichts?"
 
 #: src/feedlistformaction.cpp:175
-#, fuzzy
 msgid ""
 "Reverse Sort by (f)irsttag/(t)itle/(a)rticlecount/(u)nreadarticlecount/"
 "(l)astupdated/late(s)tunread/(n)one?"
 msgstr ""
-"Umgekehrt sortieren nach (e)rstemtag/(t)itel/(a)rtikelzahl/"
-"(u)ngeleseneartikel/(z)uletztaktualisiert/(n)ichts?"
+"Umgekehrt sortieren nach (e)rstem Tag/(t)itel/Artikel(a)nzahl/"
+"Anzahl (u)ngelesener Artikel/(z)uletzt aktualisierte Artikel/"
+"neue(s)te ungelesene Artikel/(n)ichts?"
 
 #: src/feedlistformaction.cpp:237 src/feedlistformaction.cpp:264
 #: src/feedlistformaction.cpp:594 src/itemlistformaction.cpp:183
@@ -853,9 +851,8 @@ msgid "Cannot open query feeds in the browser!"
 msgstr "Query-Feeds können nicht im Browser geöffnet werden!"
 
 #: src/feedlistformaction.cpp:571
-#, fuzzy
 msgid "Cannot open exec feeds in the browser!"
-msgstr "Query-Feeds können nicht im Browser geöffnet werden!"
+msgstr "Exec-Feeds können nicht im Browser geöffnet werden!"
 
 #: src/feedlistformaction.cpp:658 src/itemlistformaction.cpp:1399
 msgid "Clear filter"

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -142,7 +142,7 @@ REDO:
 		// That'll prevent this function from sorting anything, so users will
 		// complain, and we'll ask them to update the translation. A bit lame,
 		// but it's better than mishandling the answer.
-		const auto n_options = ((std::string) "ftaun").length();
+		const auto n_options = ((std::string) "ftaulsn").length();
 		if (input_options.length() < n_options) {
 			break;
 		}
@@ -185,7 +185,7 @@ REDO:
 		// That'll prevent this function from sorting anything, so users will
 		// complain, and we'll ask them to update the translation. A bit lame,
 		// but it's better than mishandling the answer.
-		const auto n_options = ((std::string) "ftaun").length();
+		const auto n_options = ((std::string) "ftaulsn").length();
 		if (input_options.length() < n_options) {
 			break;
 		}


### PR DESCRIPTION
I took inspiration from the [Dutch translations](https://github.com/newsboat/newsboat/pull/3091/files#diff-44a066469e7c75b3cdbbe18743cae1045124dcb86d20c65269ba4c323b04f61cR749) on the properly space-separated sort options instead of jamming it together like in the English source. That's much nicer, especially with longer words in German. Even though the German noun "Titel" ideally should have been title-cased ;-) as well, I left it unchanged to be backwards-compatible and not break a user's muscle memory.

I couldn't verify the attempted fix in the second commit right now, but I'm pretty sure it should work. I only noticed that when looking at the code. (I never use that sorting feature myself.)