### PR TITLE
ConfigContainer: Get rid of INVALID config type

### DIFF
--- a/include/configdata.h
+++ b/include/configdata.h
@@ -8,7 +8,7 @@
 
 namespace newsboat {
 
-enum class ConfigDataType { INVALID, BOOL, INT, STR, PATH, ENUM };
+enum class ConfigDataType { BOOL, INT, STR, PATH, ENUM };
 
 /// Data about a setting: its default and current values, its type, and its
 /// allowed values if it's an enum.
@@ -17,8 +17,7 @@ public:
 	/// Construct a value of type `t` and equal to `v`. If `multi_option` is
 	/// true and config file contains this option multiple times, the values
 	/// will be combined instead of rewritten.
-	ConfigData(const std::string& v = "",
-		ConfigDataType t = ConfigDataType::INVALID, bool multi_option = false);
+	ConfigData(const std::string& v, ConfigDataType t, bool multi_option = false);
 
 	/// Construct a value that can take any of given `values`, and currently
 	/// equal to `v` (which *must* be one of `values`).

--- a/src/configdata.cpp
+++ b/src/configdata.cpp
@@ -80,10 +80,6 @@ nonstd::expected<void, std::string> ConfigData::set_value(
 	case ConfigDataType::PATH:
 		value_ = std::move(new_value);
 		break;
-
-	case ConfigDataType::INVALID:
-		assert(0 && "unreachable");
-		break;
 	}
 
 

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -291,6 +291,24 @@ TEST_CASE(
 	}
 }
 
+// Added for https://github.com/newsboat/newsboat/issues/3104
+TEST_CASE("Resetting or toggling invalid config option does cause crash dump_config()",
+	"[ConfigContainer]")
+{
+	ConfigContainer cfg;
+	std::vector<std::string> dummy_output;
+
+	SECTION("reset_to_default()") {
+		cfg.reset_to_default("non-existent");
+		cfg.dump_config(dummy_output);
+	}
+
+	SECTION("toggle()") {
+		cfg.toggle("non-existent");
+		cfg.dump_config(dummy_output);
+	}
+}
+
 TEST_CASE(
 	"get_suggestions() returns all settings whose names begin "
 	"with a given string",


### PR DESCRIPTION
Fixes https://github.com/newsboat/newsboat/issues/3104