### PR TITLE
fix: add null check in rss09xparser

### DIFF
--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -28,7 +28,7 @@ void Rss09xParser::parse_feed(Feed& f, xmlNode* rootNode)
 		channel = channel->next;
 	}
 
-	if (!channel || channel->name) {
+	if (!channel || !channel->name) {
 		throw Exception(_("no RSS channel found"));
 	}
 

--- a/rss/rss09xparser.cpp
+++ b/rss/rss09xparser.cpp
@@ -24,11 +24,11 @@ void Rss09xParser::parse_feed(Feed& f, xmlNode* rootNode)
 	globalbase = get_prop(rootNode, "base", XML_URI);
 
 	xmlNode* channel = rootNode->children;
-	while (channel && strcmp((const char*)channel->name, "channel") != 0) {
+	while (channel && channel->name && strcmp((const char*)channel->name, "channel") != 0) {
 		channel = channel->next;
 	}
 
-	if (!channel) {
+	if (!channel || channel->name) {
 		throw Exception(_("no RSS channel found"));
 	}
 

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -633,7 +633,7 @@ TEST_CASE("parse_url() assumes utf-8 if no encoding specified and replaces inval
 }
 
 TEST_CASE("Exit with abort (fixtures)",
-	"[rsspp::Parser][issueXXXX]")
+	"[rsspp::Parser][issue3108]")
 {
 	using test_helpers::ExceptionWithMsg;
 

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -631,3 +631,14 @@ TEST_CASE("parse_url() assumes utf-8 if no encoding specified and replaces inval
 	REQUIRE(parsed_feed.items.size() == 1);
 	REQUIRE(parsed_feed.title == expected_title);
 }
+
+TEST_CASE("Exit with abort (fixtures)",
+	"[rsspp::Parser][issueXXXX]")
+{
+	using test_helpers::ExceptionWithMsg;
+
+	rsspp::Parser p;
+	REQUIRE_THROWS_MATCHES(p.parse_buffer("<rss version=\"0.92\"><![CDATA[]]>"),
+		rsspp::Exception,
+		ExceptionWithMsg<rsspp::Exception>("no RSS channel found"));
+}

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -632,7 +632,7 @@ TEST_CASE("parse_url() assumes utf-8 if no encoding specified and replaces inval
 	REQUIRE(parsed_feed.title == expected_title);
 }
 
-TEST_CASE("Exit with abort (fixtures)",
+TEST_CASE("Throws if no \"channel\" element is found",
 	"[rsspp::Parser][issue3108]")
 {
 	using test_helpers::ExceptionWithMsg;


### PR DESCRIPTION
Fixed possible null pointer derefence:
```console
AddressSanitizer:DEADLYSIGNAL
=================================================================
==407==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x55a62d83f800 bp 0x7ffe84d27e50 sp 0x7ffe84d275f0 T0)
==407==The signal is caused by a READ memory access.
==407==Hint: address points to the zero page.
    #0 0x55a62d83f800 in strcmp (/fuzz/rss_asan+0x38d800) (BuildId: 60fb1f3ae69daa2ec9150edf40877fd4aa57c418)
    #1 0x55a62e3f21d2 in rsspp::Rss09xParser::parse_feed(rsspp::Feed&, _xmlNode*) /src/rss/rss09xparser.cpp:27:20
    #2 0x55a62e3ec10a in rsspp::Parser::parse_xmlnode(_xmlNode*) /src/rss/parser.cpp:373:13
    #3 0x55a62e3ea6a5 in rsspp::Parser::parse_buffer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::optional<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>) /src/rss/parser.cpp:268:11
```

Testcase output:
```console
-------------------------------------------------------------------------------
Throws exception if file can't be parsed (fix NPD)
-------------------------------------------------------------------------------
test/rsspp_parser.cpp:636
...............................................................................

test/rsspp_parser.cpp:636: FAILED:
due to a fatal error condition:
  SIGSEGV - Segmentation violation signal
```