### PR TITLE
Report error if OPML file is missing <opml> or <body>

### DIFF
--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -214,9 +214,16 @@ std::optional<std::string> opml::import(
 	std::optional<std::string> error_message;
 
 	xmlNode* root = xmlDocGetRootElement(doc);
+	if (strcmp((const char*)root->name, "opml") != 0) {
+		xmlFreeDoc(doc);
+		return _("the <opml> root element is missing");
+	}
+
+	bool foundBody = false;
 	for (xmlNode* node = root->children; node != nullptr;
 		node = node->next) {
 		if (strcmp((const char*)node->name, "body") == 0) {
+			foundBody = true;
 			LOG(Level::DEBUG, "opml::import: found body");
 			rec_find_rss_outlines(urlcfg, node->children, "");
 
@@ -228,6 +235,10 @@ std::optional<std::string> opml::import(
 	}
 
 	xmlFreeDoc(doc);
+
+	if (!foundBody) {
+		return _("the <body> element in the <opml> root element is missing");
+	}
 
 	return error_message;
 }

--- a/test/data/body-element-missing.opml
+++ b/test/data/body-element-missing.opml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+    <head>
+        <title>The body element is missing</title>
+    </head>
+</opml>

--- a/test/data/opml-element-missing.opml
+++ b/test/data/opml-element-missing.opml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<not-opml version="1.0">
+    <head>
+        <title>Invalid OPML</title>
+    </head>
+
+    <body>
+        <outline title="misc">
+            <outline xmlUrl="https://example.com/another_feed.atom" type="rss" title="example.com website (Atom feed)" />
+        </outline>
+        <outline type="rss" title="Firehose" xmlUrl="https://example.com/firehose" filtercmd="~/.bin/keep_interesting.pl" />
+    </body>
+</not-opml>

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -6,6 +6,7 @@
 #include "cache.h"
 #include "fileurlreader.h"
 #include "rssfeed.h"
+#include "test_helpers/envvar.h"
 #include "test_helpers/misc.h"
 #include "test_helpers/tempfile.h"
 
@@ -310,6 +311,38 @@ TEST_CASE("import() tags from category attribute", "[Opml]")
 	REQUIRE(urls.size() == 1);
 	REQUIRE(urlcfg.get_tags(urls[0]) == tags);
 }
+
+TEST_CASE("import() returns an error when the <opml> root element is missing", "[Opml]")
+{
+	// we want to check the original English error message, not a localized one
+	test_helpers::LcCtypeEnvVar lc_ctype;
+	lc_ctype.set("C");
+
+	FileUrlReader urlcfg;
+	const auto error_message = opml::import(
+			"file://" + utils::getcwd() + "/data/opml-element-missing.opml",
+			urlcfg);
+
+	REQUIRE(error_message.has_value());
+	REQUIRE(error_message.value() == "the <opml> root element is missing");
+}
+
+TEST_CASE("import() returns an error when the <body> element is missing", "[Opml]")
+{
+	// we want to check the original English error message, not a localized one
+	test_helpers::LcCtypeEnvVar lc_ctype;
+	lc_ctype.set("C");
+
+	FileUrlReader urlcfg;
+	const auto error_message = opml::import(
+			"file://" + utils::getcwd() + "/data/body-element-missing.opml",
+			urlcfg);
+
+	REQUIRE(error_message.has_value());
+	REQUIRE(error_message.value() ==
+		"the <body> element in the <opml> root element is missing");
+}
+
 // falls back to "url" if "xmlUrl" is absent
 
 // skips an entry if xmlUrl/url is absent


### PR DESCRIPTION
User kd4ihw_home reported an issue in our IRC channel. Newsboat showed a success message that the OPML file was successfully imported. However, the urls file wasn't touched at all, no URLs had been added.

It turned out that the OPML file was actually invalid. The exact problem with the OPML file wasn't confirmed, but the <body> element in the <opml> root element must have been missing, so no data were processed. The provided strace output did not include any write attempt to the urls file, supporting this theory.

Now, we show a dedicated error message if there is no <body> element. For good measure we now also abort right away if the root element is not an <opml> element. This should improve the user experience and avoid debugging effort.

Here's it in action:

```
$ LC_ALL=C ./newsboat -i test/data/opml-element-missing.opml
An error occurred while parsing test/data/opml-element-missing.opml: the <opml> root element is missing
$ echo $?
1

$ LC_ALL=C ./newsboat -i test/data/body-element-missing.opml 
An error occurred while parsing test/data/body-element-missing.opml: the <body> element in the <opml> root element is missing
$ echo $?
1

$ LC_ALL=C ./newsboat -i test/data/example.opml              
Import of test/data/example.opml finished.
$ echo $?
0
```

Maybe somebody has suggestions on how to improve these new error messages, I'm happy to hear about them. :-)