### PR TITLE
Add user-defined literal ""_path for constructing Filepath from string

### DIFF
--- a/config.h
+++ b/config.h
@@ -3,15 +3,17 @@
 
 #include "filepath.h"
 
+using newsboat::operator""_path;
+
 #define PACKAGE				"newsboat"
 #define PROGRAM_NAME			"Newsboat"
 
 #define PROGRAM_URL			"https://newsboat.org/"
 
-const newsboat::Filepath NEWSBEUTER_CONFIG_SUBDIR = newsboat::Filepath::from_locale_string(".newsbeuter");
-const newsboat::Filepath NEWSBEUTER_SUBDIR_XDG = newsboat::Filepath::from_locale_string("newsbeuter");
-const newsboat::Filepath NEWSBOAT_CONFIG_SUBDIR = newsboat::Filepath::from_locale_string(".newsboat");
-const newsboat::Filepath NEWSBOAT_SUBDIR_XDG = newsboat::Filepath::from_locale_string("newsboat");
+const newsboat::Filepath NEWSBEUTER_CONFIG_SUBDIR = ".newsbeuter"_path;
+const newsboat::Filepath NEWSBEUTER_SUBDIR_XDG = "newsbeuter"_path;
+const newsboat::Filepath NEWSBOAT_CONFIG_SUBDIR = ".newsboat"_path;
+const newsboat::Filepath NEWSBOAT_SUBDIR_XDG = "newsboat"_path;
 
 #include <libintl.h>
 #include <locale.h>

--- a/include/filepath.h
+++ b/include/filepath.h
@@ -103,6 +103,11 @@ private:
 	rust::Box<filepath::bridged::PathBuf> rs_object;
 };
 
+inline Filepath operator""_path(const char* filepath, size_t filepath_length)
+{
+	return newsboat::Filepath::from_locale_string(std::string(filepath, filepath_length));
+}
+
 } // namespace newsboat
 
 // Used in Catch2's INFO macro.

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -284,7 +284,7 @@ Cache::~Cache()
 
 std::unique_ptr<Cache> Cache::in_memory(ConfigContainer& c)
 {
-	return std::make_unique<Cache>(Filepath::from_locale_string(":memory:"), c);
+	return std::make_unique<Cache>(":memory:"_path, c);
 }
 
 void Cache::set_pragmas()

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -919,9 +919,9 @@ Filepath Controller::write_temporary_item(RssItem& item)
 	char* tmpdir = getenv("TMPDIR");
 	if (tmpdir != nullptr) {
 		filename_template = Filepath::from_locale_string(tmpdir);
-		filename_template.push(Filepath::from_locale_string("newsboat-article.XXXXXX"));
+		filename_template.push("newsboat-article.XXXXXX"_path);
 	} else {
-		filename_template = Filepath::from_locale_string("/tmp/newsboat-article.XXXXXX");
+		filename_template = "/tmp/newsboat-article.XXXXXX"_path;
 	}
 
 	auto template_string = filename_template.to_locale_string();

--- a/src/dirbrowserformaction.cpp
+++ b/src/dirbrowserformaction.cpp
@@ -212,8 +212,8 @@ std::vector<Filepath> get_sorted_dirlist()
 
 	std::sort(ret.begin(), ret.end());
 
-	if (cwdtmp != Filepath::from_locale_string("/")) {
-		ret.emplace(ret.begin(), Filepath::from_locale_string(".."));
+	if (cwdtmp != "/"_path) {
+		ret.emplace(ret.begin(), ".."_path);
 	}
 
 	return ret;

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -227,8 +227,8 @@ std::vector<Filepath> get_sorted_filelist()
 
 	std::sort(ret.begin(), ret.end());
 
-	if (cwdtmp != Filepath::from_locale_string("/")) {
-		ret.emplace(ret.begin(), Filepath::from_locale_string(".."));
+	if (cwdtmp != "/"_path) {
+		ret.emplace(ret.begin(), ".."_path);
 	}
 
 	return ret;

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -154,7 +154,7 @@ void render_html(
 	bool raw)
 {
 	const auto renderer = cfg.get_configvalue_as_filepath("html-renderer");
-	if (renderer == Filepath::from_locale_string("internal")) {
+	if (renderer == "internal"_path) {
 		HtmlRenderer rnd(raw);
 		rnd.render(source, lines, thelinks, url);
 	} else {

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -51,7 +51,7 @@ bool PbController::setup_dirs_xdg(const newsboat::Filepath& home)
 		xdg_config_dir = Filepath::from_locale_string(env_xdg_config);
 	} else {
 		xdg_config_dir = home;
-		xdg_config_dir.push(Filepath::from_locale_string(".config"));
+		xdg_config_dir.push(".config"_path);
 	}
 
 	const char* env_xdg_data = ::getenv("XDG_DATA_HOME");
@@ -59,8 +59,8 @@ bool PbController::setup_dirs_xdg(const newsboat::Filepath& home)
 		xdg_data_dir = Filepath::from_locale_string(env_xdg_data);
 	} else {
 		xdg_data_dir = home;
-		xdg_data_dir.push(Filepath::from_locale_string(".local"));
-		xdg_data_dir.push(Filepath::from_locale_string("share"));
+		xdg_data_dir.push(".local"_path);
+		xdg_data_dir.push("share"_path);
 	}
 
 	xdg_config_dir.push(NEWSBOAT_SUBDIR_XDG);
@@ -100,7 +100,7 @@ bool PbController::setup_dirs_xdg(const newsboat::Filepath& home)
 	config_file = config_dir.join(config_file);
 
 	/* in data */
-	const Filepath LOCK_SUFFIX = Filepath::from_locale_string(".lock");
+	const Filepath LOCK_SUFFIX = ".lock"_path;
 	lock_file = xdg_data_dir.join(LOCK_SUFFIX);
 	queue_file = xdg_data_dir.join(queue_file);
 
@@ -108,10 +108,10 @@ bool PbController::setup_dirs_xdg(const newsboat::Filepath& home)
 }
 
 PbController::PbController()
-	: config_file(Filepath::from_locale_string("config"))
-	, queue_file(Filepath::from_locale_string("queue"))
+	: config_file("config"_path)
+	, queue_file("queue"_path)
 	, max_dls(1)
-	, lock_file(Filepath::from_locale_string("pb-lock.pid"))
+	, lock_file("pb-lock.pid"_path)
 	, keys(KM_PODBOAT)
 {
 	char* cfgdir;
@@ -275,7 +275,7 @@ void PbController::initialize(int argc, char* argv[])
 	cfgparser.register_handler("run-on-startup", null_cah);
 
 	try {
-		cfgparser.parse_file(Filepath::from_locale_string("/etc/newsboat/config"));
+		cfgparser.parse_file("/etc/newsboat/config"_path);
 		cfgparser.parse_file(config_file);
 	} catch (const ConfigException& ex) {
 		std::cout << ex.what() << std::endl;

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -355,7 +355,7 @@ Filepath View::get_filename_suggestion(const std::string& s)
 
 	Filepath retval;
 	if (suggestion.empty()) {
-		retval = Filepath::from_locale_string("article.txt");
+		retval = "article.txt"_path;
 	} else {
 		retval = Filepath::from_locale_string(suggestion);
 		retval.add_extension("txt");
@@ -552,8 +552,7 @@ void View::push_itemview(std::shared_ptr<RssFeed> f,
 	const std::string& guid,
 	const std::string& searchphrase)
 {
-	if (cfg->get_configvalue_as_filepath("pager") ==
-		Filepath::from_locale_string("internal")) {
+	if (cfg->get_configvalue_as_filepath("pager") == "internal"_path) {
 		auto fa = get_current_formaction();
 
 		std::shared_ptr<ItemListFormAction> itemlist =

--- a/test/cliargsparser.cpp
+++ b/test/cliargsparser.cpp
@@ -46,7 +46,7 @@ TEST_CASE(
 	"provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("blogroll.opml");
+	const auto filename = "blogroll.opml"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -72,7 +72,7 @@ TEST_CASE("Resolves tilde to homedir in -i/--import-from-opml",
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("feedlist.opml");
+	const auto filename = "feedlist.opml"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {
@@ -185,7 +185,7 @@ TEST_CASE(
 	"is provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("urlfile");
+	const auto filename = "urlfile"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -210,7 +210,7 @@ TEST_CASE("Resolves tilde to homedir in -u/--url-file", "[CliArgsParser]")
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("urlfile");
+	const auto filename = "urlfile"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {
@@ -233,7 +233,7 @@ TEST_CASE(
 	"if -c/--cache-file is provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("cache.db");
+	const auto filename = "cache.db"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -256,7 +256,7 @@ TEST_CASE(
 
 TEST_CASE("Supports combined short options", "[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("cache.db");
+	const auto filename = "cache.db"_path;
 
 	test_helpers::Opts opts = {"newsboat", "-vc", filename.to_locale_string()};
 	CliArgsParser args(opts.argc(), opts.argv());
@@ -271,7 +271,7 @@ TEST_CASE("Supports combined short options", "[CliArgsParser]")
 
 TEST_CASE("Supports combined short option and value", "[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("cache.db");
+	const auto filename = "cache.db"_path;
 
 	test_helpers::Opts opts = {"newsboat", "-c" + filename.to_locale_string()};
 	CliArgsParser args(opts.argc(), opts.argv());
@@ -286,7 +286,7 @@ TEST_CASE("Supports combined short option and value", "[CliArgsParser]")
 TEST_CASE("Supports `=` between short option and value",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("cache.db");
+	const auto filename = "cache.db"_path;
 
 	test_helpers::Opts opts = {"newsboat", "-c=" + filename.to_locale_string()};
 	CliArgsParser args(opts.argc(), opts.argv());
@@ -305,7 +305,7 @@ TEST_CASE("Resolves tilde to homedir in -c/--cache-file", "[CliArgsParser]")
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("mycache.db");
+	const auto filename = "mycache.db"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {
@@ -331,7 +331,7 @@ TEST_CASE(
 	"is provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("config file");
+	const auto filename = "config file"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -356,7 +356,7 @@ TEST_CASE("Resolves tilde to homedir in -C/--config-file", "[CliArgsParser]")
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("newsboat-config");
+	const auto filename = "newsboat-config"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {
@@ -380,7 +380,7 @@ TEST_CASE(
 	"is provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("queuefile");
+	const auto filename = "queuefile"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -401,7 +401,7 @@ TEST_CASE("Resolves tilde to homedir in --queue-file", "[CliArgsParser]")
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("queuefile");
+	const auto filename = "queuefile"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {
@@ -420,7 +420,7 @@ TEST_CASE(
 	"is provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("searchfile");
+	const auto filename = "searchfile"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -441,7 +441,7 @@ TEST_CASE("Resolves tilde to homedir in --search-history-file", "[CliArgsParser]
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("searchfile");
+	const auto filename = "searchfile"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {
@@ -460,7 +460,7 @@ TEST_CASE(
 	"is provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("cmdlinefile");
+	const auto filename = "cmdlinefile"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -481,7 +481,7 @@ TEST_CASE("Resolves tilde to homedir in --cmdline-history-file", "[CliArgsParser
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("cmdlinefile");
+	const auto filename = "cmdlinefile"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {
@@ -651,7 +651,7 @@ TEST_CASE(
 	"Sets `readinfofile` if -I/--import-from-file is provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("filename");
+	const auto filename = "filename"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -676,7 +676,7 @@ TEST_CASE("Resolves tilde to homedir in -I/--import-from-file",
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("read.txt");
+	const auto filename = "read.txt"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {
@@ -698,7 +698,7 @@ TEST_CASE(
 	"Sets `readinfofile` if -E/--export-to-file is provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("filename");
+	const auto filename = "filename"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -722,7 +722,7 @@ TEST_CASE("Resolves tilde to homedir in -E/--export-to-file", "[CliArgsParser]")
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("read.txt");
+	const auto filename = "read.txt"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {
@@ -745,8 +745,8 @@ TEST_CASE(
 	"-I/--import-from-file and -E/--export-to-file are provided",
 	"[CliArgsParser]")
 {
-	const auto importf = Filepath::from_locale_string("import.opml");
-	const auto exportf = Filepath::from_locale_string("export.opml");
+	const auto importf = "import.opml"_path;
+	const auto exportf = "export.opml"_path;
 
 	auto check = [](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -767,7 +767,7 @@ TEST_CASE(
 TEST_CASE("Sets `log_file` if -d/--log-file is provided",
 	"[CliArgsParser]")
 {
-	const auto filename = Filepath::from_locale_string("log file.txt");
+	const auto filename = "log file.txt"_path;
 
 	auto check = [&filename](test_helpers::Opts opts) {
 		CliArgsParser args(opts.argc(), opts.argv());
@@ -791,7 +791,7 @@ TEST_CASE("Resolves tilde to homedir in -d/--log-file", "[CliArgsParser]")
 	test_helpers::EnvVar home("HOME");
 	home.set(tmp.get_path().to_locale_string());
 
-	const auto filename = Filepath::from_locale_string("newsboat.log");
+	const auto filename = "newsboat.log"_path;
 	const std::string arg = std::string("~/") + filename.to_locale_string();
 
 	auto check = [&filename, &tmp](test_helpers::Opts opts) {

--- a/test/colormanager.cpp
+++ b/test/colormanager.cpp
@@ -98,7 +98,7 @@ TEST_CASE("register_commands() registers ColorManager with ConfigParser",
 
 	REQUIRE_NOTHROW(clr.register_commands(cfg));
 
-	cfg.parse_file(Filepath::from_locale_string("data/config-with-colors"));
+	cfg.parse_file("data/config-with-colors"_path);
 
 	clr.apply_colors(collector.setter());
 	REQUIRE(collector.style("background") == "fg=red,bg=green");

--- a/test/configcontainer.cpp
+++ b/test/configcontainer.cpp
@@ -18,8 +18,7 @@ TEST_CASE("Parses test config without exceptions", "[ConfigContainer]")
 	KeyMap k(KM_NEWSBOAT);
 	cfgparser.register_handler("macro", k);
 
-	REQUIRE_NOTHROW(cfgparser.parse_file(
-			Filepath::from_locale_string("data/test-config.txt")));
+	REQUIRE_NOTHROW(cfgparser.parse_file("data/test-config.txt"_path));
 
 	SECTION("bool value") {
 		REQUIRE(cfg.get_configvalue("show-read-feeds") == "no");
@@ -51,16 +50,15 @@ TEST_CASE(
 	ConfigParser cfgparser;
 	cfg.register_commands(cfgparser);
 
-	REQUIRE_NOTHROW(cfgparser.parse_file(
-			Filepath::from_locale_string("data/test-config-without-newline-at-the-end.txt")));
+	REQUIRE_NOTHROW(
+		cfgparser.parse_file("data/test-config-without-newline-at-the-end.txt"_path));
 
 	SECTION("first line") {
 		REQUIRE(cfg.get_configvalue("article-sort-order") == "date-asc");
 	}
 
 	SECTION("last line") {
-		REQUIRE(cfg.get_configvalue_as_filepath("download-path") ==
-			Filepath::from_locale_string("whatever"));
+		REQUIRE(cfg.get_configvalue_as_filepath("download-path") == "whatever"_path);
 	}
 }
 

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -182,8 +182,7 @@ TEST_CASE("evaluate_backticks replaces command in backticks with its output",
 		ConfigParser cfgparser;
 		KeyMap keys(KM_NEWSBOAT);
 		cfgparser.register_handler("bind-key", keys);
-		REQUIRE_NOTHROW(cfgparser.parse_file(
-				Filepath::from_locale_string("data/config-space-backticks")));
+		REQUIRE_NOTHROW(cfgparser.parse_file("data/config-space-backticks"_path));
 		MultiKeyBindingState binding_state{};
 		BindingType binding_type{};
 		const auto& cmds = keys.get_operation({KeyCombination("s")}, "feedlist", binding_state,
@@ -226,7 +225,7 @@ TEST_CASE("\"unbind-key -a\" removes all key bindings", "[ConfigParser]")
 	SECTION("In all contexts by default") {
 		KeyMap keys(KM_NEWSBOAT);
 		cfgparser.register_handler("unbind-key", keys);
-		cfgparser.parse_file(Filepath::from_locale_string("data/config-unbind-all"));
+		cfgparser.parse_file("data/config-unbind-all"_path);
 
 		for (int i = OP_QUIT; i < OP_NB_MAX; ++i) {
 			REQUIRE(keys.get_keys(static_cast<Operation>(i),
@@ -239,7 +238,7 @@ TEST_CASE("\"unbind-key -a\" removes all key bindings", "[ConfigParser]")
 	SECTION("For a specific context") {
 		KeyMap keys(KM_NEWSBOAT);
 		cfgparser.register_handler("unbind-key", keys);
-		cfgparser.parse_file(Filepath::from_locale_string("data/config-unbind-all-context"));
+		cfgparser.parse_file("data/config-unbind-all-context"_path);
 
 		INFO("it doesn't affect the help dialog");
 		KeyMap default_keys(KM_NEWSBOAT);
@@ -260,8 +259,7 @@ TEST_CASE("Concatenates lines that end with a backslash", "[ConfigParser]")
 	ConfigParser cfgparser;
 	KeyMap k(KM_NEWSBOAT);
 	cfgparser.register_handler("macro", k);
-	REQUIRE_NOTHROW(cfgparser.parse_file(
-			Filepath::from_locale_string("data/config-multi-line")));
+	REQUIRE_NOTHROW(cfgparser.parse_file("data/config-multi-line"_path));
 	auto p_macro = k.get_macro(KeyCombination("p"));
 	REQUIRE(!p_macro.empty());
 	REQUIRE(p_macro[0].op == newsboat::OP_OPEN);
@@ -282,31 +280,24 @@ TEST_CASE("`include` directive includes other config files", "[ConfigParser]")
 	// TODO: error messages should be more descriptive than "file couldn't be opened"
 	ConfigParser cfgparser;
 	SECTION("Errors if file is not found") {
-		REQUIRE_THROWS_AS(cfgparser.parse_file(
-				Filepath::from_locale_string("data/config-missing-include")),
+		REQUIRE_THROWS_AS(cfgparser.parse_file("data/config-missing-include"_path),
 			ConfigException);
 	}
 	SECTION("Errors on invalid UTF-8 in file") {
-		REQUIRE_THROWS_AS(cfgparser.parse_file(
-				Filepath::from_locale_string("data/config-invalid-utf-8")),
-			ConfigException);
+		REQUIRE_THROWS_AS(cfgparser.parse_file("data/config-invalid-utf-8"_path), ConfigException);
 	}
 	SECTION("Terminates on recursive include") {
-		REQUIRE_THROWS_AS(cfgparser.parse_file(
-				Filepath::from_locale_string("data/config-recursive-include")),
+		REQUIRE_THROWS_AS(cfgparser.parse_file("data/config-recursive-include"_path),
 			ConfigException);
 	}
 	SECTION("Successfully includes existing file") {
-		REQUIRE_NOTHROW(cfgparser.parse_file(
-				Filepath::from_locale_string("data/config-absolute-include")));
+		REQUIRE_NOTHROW(cfgparser.parse_file("data/config-absolute-include"_path));
 	}
 	SECTION("Success on relative includes") {
-		REQUIRE_NOTHROW(cfgparser.parse_file(
-				Filepath::from_locale_string("data/config-relative-include")));
+		REQUIRE_NOTHROW(cfgparser.parse_file("data/config-relative-include"_path));
 	}
 	SECTION("Diamond of death includes pass") {
-		REQUIRE_NOTHROW(cfgparser.parse_file(
-				Filepath::from_locale_string("data/diamond-of-death/A")));
+		REQUIRE_NOTHROW(cfgparser.parse_file("data/diamond-of-death/A"_path));
 	}
 	SECTION("File including itself only gets evaluated once") {
 		test_helpers::TempFile testfile;
@@ -315,7 +306,7 @@ TEST_CASE("`include` directive includes other config files", "[ConfigParser]")
 
 		// recursive includes don't fail
 		REQUIRE_NOTHROW(
-			cfgparser.parse_file(Filepath::from_locale_string("data/recursive-include-side-effect")));
+			cfgparser.parse_file("data/recursive-include-side-effect"_path));
 		// I think it will never get below here and fail? If it recurses, the above fails
 
 		int line_count = 0;

--- a/test/configpaths.cpp
+++ b/test/configpaths.cpp
@@ -18,7 +18,7 @@ TEST_CASE("ConfigPaths returns paths to Newsboat dotdir if no Newsboat dirs "
 	"[ConfigPaths]")
 {
 	test_helpers::TempDir tmp;
-	const auto newsboat_dir = tmp.get_path().join(Filepath::from_locale_string(".newsboat"));
+	const auto newsboat_dir = tmp.get_path().join(".newsboat"_path);
 	REQUIRE(0 == utils::mkdir_parents(newsboat_dir, 0700));
 
 	test_helpers::EnvVar home("HOME");
@@ -33,16 +33,13 @@ TEST_CASE("ConfigPaths returns paths to Newsboat dotdir if no Newsboat dirs "
 
 	ConfigPaths paths;
 	REQUIRE(paths.initialized());
-	REQUIRE(paths.url_file() == newsboat_dir.join(Filepath::from_locale_string("urls")));
-	REQUIRE(paths.cache_file() == newsboat_dir.join(Filepath::from_locale_string("cache.db")));
-	REQUIRE(paths.lock_file() == newsboat_dir.join(
-			Filepath::from_locale_string("cache.db.lock")));
-	REQUIRE(paths.config_file() == newsboat_dir.join(Filepath::from_locale_string("config")));
-	REQUIRE(paths.queue_file() == newsboat_dir.join(Filepath::from_locale_string("queue")));
-	REQUIRE(paths.search_history_file() == newsboat_dir.join(
-			Filepath::from_locale_string("history.search")));
-	REQUIRE(paths.cmdline_history_file() == newsboat_dir.join(
-			Filepath::from_locale_string("history.cmdline")));
+	REQUIRE(paths.url_file() == newsboat_dir.join("urls"_path));
+	REQUIRE(paths.cache_file() == newsboat_dir.join("cache.db"_path));
+	REQUIRE(paths.lock_file() == newsboat_dir.join("cache.db.lock"_path));
+	REQUIRE(paths.config_file() == newsboat_dir.join("config"_path));
+	REQUIRE(paths.queue_file() == newsboat_dir.join("queue"_path));
+	REQUIRE(paths.search_history_file() == newsboat_dir.join("history.search"_path));
+	REQUIRE(paths.cmdline_history_file() == newsboat_dir.join("history.cmdline"_path));
 }
 
 TEST_CASE("ConfigPaths returns paths to Newsboat XDG dirs if they exist and "
@@ -50,11 +47,9 @@ TEST_CASE("ConfigPaths returns paths to Newsboat XDG dirs if they exist and "
 	"[ConfigPaths]")
 {
 	test_helpers::TempDir tmp;
-	const auto config_dir = tmp.get_path().join(
-			Filepath::from_locale_string(".config/newsboat"));
+	const auto config_dir = tmp.get_path().join(".config/newsboat"_path);
 	REQUIRE(0 == utils::mkdir_parents(config_dir, 0700));
-	const auto data_dir = tmp.get_path().join(
-			Filepath::from_locale_string(".local/share/newsboat"));
+	const auto data_dir = tmp.get_path().join(".local/share/newsboat"_path);
 	REQUIRE(0 == utils::mkdir_parents(data_dir, 0700));
 
 	test_helpers::EnvVar home("HOME");
@@ -70,26 +65,22 @@ TEST_CASE("ConfigPaths returns paths to Newsboat XDG dirs if they exist and "
 	const auto check = [&]() {
 		ConfigPaths paths;
 		REQUIRE(paths.initialized());
-		REQUIRE(paths.config_file() == config_dir.join(Filepath::from_locale_string("config")));
-		REQUIRE(paths.url_file() == config_dir.join(Filepath::from_locale_string("urls")));
-		REQUIRE(paths.cache_file() == data_dir.join(Filepath::from_locale_string("cache.db")));
-		REQUIRE(paths.lock_file() == data_dir.join(Filepath::from_locale_string("cache.db.lock")));
-		REQUIRE(paths.queue_file() == data_dir.join(Filepath::from_locale_string("queue")));
-		REQUIRE(paths.search_history_file() == data_dir.join(
-				Filepath::from_locale_string("history.search")));
-		REQUIRE(paths.cmdline_history_file() == data_dir.join(
-				Filepath::from_locale_string("history.cmdline")));
+		REQUIRE(paths.config_file() == config_dir.join("config"_path));
+		REQUIRE(paths.url_file() == config_dir.join("urls"_path));
+		REQUIRE(paths.cache_file() == data_dir.join("cache.db"_path));
+		REQUIRE(paths.lock_file() == data_dir.join("cache.db.lock"_path));
+		REQUIRE(paths.queue_file() == data_dir.join("queue"_path));
+		REQUIRE(paths.search_history_file() == data_dir.join("history.search"_path));
+		REQUIRE(paths.cmdline_history_file() == data_dir.join("history.cmdline"_path));
 	};
 
 	SECTION("XDG_CONFIG_HOME is set") {
 		test_helpers::EnvVar xdg_config("XDG_CONFIG_HOME");
-		xdg_config.set(tmp.get_path().join(
-				Filepath::from_locale_string(".config")).to_locale_string());
+		xdg_config.set(tmp.get_path().join(".config"_path).to_locale_string());
 
 		SECTION("XDG_DATA_HOME is set") {
 			test_helpers::EnvVar xdg_data("XDG_DATA_HOME");
-			xdg_data.set(tmp.get_path().join(
-					Filepath::from_locale_string(".local/share")).to_locale_string());
+			xdg_data.set(tmp.get_path().join(".local/share"_path).to_locale_string());
 			check();
 		}
 
@@ -106,8 +97,7 @@ TEST_CASE("ConfigPaths returns paths to Newsboat XDG dirs if they exist and "
 
 		SECTION("XDG_DATA_HOME is set") {
 			test_helpers::EnvVar xdg_data("XDG_DATA_HOME");
-			xdg_data.set(tmp.get_path().join(
-					Filepath::from_locale_string(".local/share")).to_locale_string());
+			xdg_data.set(tmp.get_path().join(".local/share"_path).to_locale_string());
 			check();
 		}
 
@@ -132,11 +122,11 @@ TEST_CASE("ConfigPaths::process_args replaces paths with the ones supplied by "
 	test_helpers::EnvVar xdg_data("XDG_DATA_HOME");
 	xdg_data.unset();
 
-	const auto url_file = Filepath::from_locale_string("my urls file");
-	const auto cache_file = Filepath::from_locale_string("/path/to/cache file.db");
+	const auto url_file = "my urls file"_path;
+	const auto cache_file = "/path/to/cache file.db"_path;
 	auto lock_file = cache_file;
 	lock_file.add_extension("lock");
-	const auto config_file = Filepath::from_locale_string("this is a/config");
+	const auto config_file = "this is a/config"_path;
 	test_helpers::Opts opts({
 		"newsboat",
 		"-u", url_file.to_locale_string(),
@@ -172,13 +162,11 @@ TEST_CASE("ConfigPaths::set_cache_file changes paths to cache and lock files",
 	ConfigPaths paths;
 	REQUIRE(paths.initialized());
 
-	const auto newsboat_dir = tmp.get_path().join(Filepath::from_locale_string(".newsboat"));
-	REQUIRE(paths.cache_file() == newsboat_dir.join(Filepath::from_locale_string("cache.db")));
-	REQUIRE(paths.lock_file() == newsboat_dir.join(
-			Filepath::from_locale_string("cache.db.lock")));
+	const auto newsboat_dir = tmp.get_path().join(".newsboat"_path);
+	REQUIRE(paths.cache_file() == newsboat_dir.join("cache.db"_path));
+	REQUIRE(paths.lock_file() == newsboat_dir.join("cache.db.lock"_path));
 
-	const auto new_cache =
-		Filepath::from_locale_string("something/entirely different.sqlite3");
+	const auto new_cache = "something/entirely different.sqlite3"_path;
 	paths.set_cache_file(new_cache);
 	REQUIRE(paths.cache_file() == new_cache);
 	auto expected_lock_file = new_cache;
@@ -223,11 +211,9 @@ TEST_CASE("ConfigPaths::create_dirs() returns true if both config and data dirs 
 		}
 	};
 
-	const auto dotdir = tmp.get_path().join(Filepath::from_locale_string(".newsboat"));
-	const auto default_config_dir = tmp.get_path().join(
-			Filepath::from_locale_string(".config/newsboat"));
-	const auto default_data_dir = tmp.get_path().join(
-			Filepath::from_locale_string(".local/share/newsboat"));
+	const auto dotdir = tmp.get_path().join(".newsboat"_path);
+	const auto default_config_dir = tmp.get_path().join(".config/newsboat"_path);
+	const auto default_data_dir = tmp.get_path().join(".local/share/newsboat"_path);
 
 	SECTION("Using dotdir") {
 		SECTION("Dotdir didn't exist") {
@@ -277,7 +263,7 @@ TEST_CASE("ConfigPaths::create_dirs() returns true if both config and data dirs 
 			const auto config_home =
 				tmp.get_path().join(Filepath::from_locale_string("config" + std::to_string(rand())));
 			INFO("Config home is " << config_home);
-			const auto config_dir = config_home.join(Filepath::from_locale_string("newsboat"));
+			const auto config_dir = config_home.join("newsboat"_path);
 
 			test_helpers::EnvVar xdg_config_home("XDG_CONFIG_HOME");
 			xdg_config_home.set(config_home.to_locale_string());
@@ -317,7 +303,7 @@ TEST_CASE("ConfigPaths::create_dirs() returns true if both config and data dirs 
 			const auto data_home =
 				tmp.get_path().join(Filepath::from_locale_string("data" + std::to_string(rand())));
 			INFO("Data home is " << data_home);
-			const auto data_dir = data_home.join(Filepath::from_locale_string("newsboat"));
+			const auto data_dir = data_home.join("newsboat"_path);
 
 			test_helpers::EnvVar xdg_data_home("XDG_DATA_HOME");
 			xdg_data_home.set(data_home.to_locale_string());
@@ -351,12 +337,12 @@ TEST_CASE("ConfigPaths::create_dirs() returns true if both config and data dirs 
 			const auto config_home =
 				tmp.get_path().join(Filepath::from_locale_string("config" + std::to_string(rand())));
 			INFO("Config home is " << config_home);
-			const auto config_dir = config_home.join(Filepath::from_locale_string("newsboat"));
+			const auto config_dir = config_home.join("newsboat"_path);
 
 			const auto data_home =
 				tmp.get_path().join(Filepath::from_locale_string("data" + std::to_string(rand())));
 			INFO("Data home is " << data_home);
-			const auto data_dir = data_home.join(Filepath::from_locale_string("newsboat"));
+			const auto data_dir = data_home.join("newsboat"_path);
 
 			test_helpers::EnvVar xdg_config_home("XDG_CONFIG_HOME");
 			xdg_config_home.set(config_home.to_locale_string());
@@ -420,20 +406,14 @@ void mock_newsbeuter_dotdir(
 	const test_helpers::TempDir& tmp,
 	const FileSentries& sentries)
 {
-	const auto dotdir_path = tmp.get_path().join(Filepath::from_locale_string(".newsbeuter"));
+	const auto dotdir_path = tmp.get_path().join(".newsbeuter"_path);
 	REQUIRE(test_helpers::mkdir(dotdir_path, 0700) == 0);
-	REQUIRE(create_file(dotdir_path.join(Filepath::from_locale_string("config")),
-			sentries.config));
-	REQUIRE(create_file(dotdir_path.join(Filepath::from_locale_string("urls")),
-			sentries.urls));
-	REQUIRE(create_file(dotdir_path.join(Filepath::from_locale_string("cache.db")),
-			sentries.cache));
-	REQUIRE(create_file(dotdir_path.join(Filepath::from_locale_string("queue")),
-			sentries.queue));
-	REQUIRE(create_file(dotdir_path.join(Filepath::from_locale_string("history.search")),
-			sentries.search));
-	REQUIRE(create_file(dotdir_path.join(Filepath::from_locale_string("history.cmdline")),
-			sentries.cmdline));
+	REQUIRE(create_file(dotdir_path.join("config"_path), sentries.config));
+	REQUIRE(create_file(dotdir_path.join("urls"_path), sentries.urls));
+	REQUIRE(create_file(dotdir_path.join("cache.db"_path), sentries.cache));
+	REQUIRE(create_file(dotdir_path.join("queue"_path), sentries.queue));
+	REQUIRE(create_file(dotdir_path.join("history.search"_path), sentries.search));
+	REQUIRE(create_file(dotdir_path.join("history.cmdline"_path), sentries.cmdline));
 }
 
 void mock_newsbeuter_xdg_dirs(
@@ -442,30 +422,22 @@ void mock_newsbeuter_xdg_dirs(
 	const FileSentries& sentries)
 {
 	REQUIRE(utils::mkdir_parents(config_dir_path, 0700) == 0);
-	REQUIRE(create_file(config_dir_path.join(Filepath::from_locale_string("config")),
-			sentries.config));
-	REQUIRE(create_file(config_dir_path.join(Filepath::from_locale_string("urls")),
-			sentries.urls));
+	REQUIRE(create_file(config_dir_path.join("config"_path), sentries.config));
+	REQUIRE(create_file(config_dir_path.join("urls"_path), sentries.urls));
 
 	REQUIRE(utils::mkdir_parents(data_dir_path, 0700) == 0);
-	REQUIRE(create_file(data_dir_path.join(Filepath::from_locale_string("cache.db")),
-			sentries.cache));
-	REQUIRE(create_file(data_dir_path.join(Filepath::from_locale_string("queue")),
-			sentries.queue));
-	REQUIRE(create_file(data_dir_path.join(Filepath::from_locale_string("history.search")),
-			sentries.search));
-	REQUIRE(create_file(data_dir_path.join(Filepath::from_locale_string("history.cmdline")),
-			sentries.cmdline));
+	REQUIRE(create_file(data_dir_path.join("cache.db"_path), sentries.cache));
+	REQUIRE(create_file(data_dir_path.join("queue"_path), sentries.queue));
+	REQUIRE(create_file(data_dir_path.join("history.search"_path), sentries.search));
+	REQUIRE(create_file(data_dir_path.join("history.cmdline"_path), sentries.cmdline));
 }
 
 void mock_newsbeuter_xdg_dirs(
 	const test_helpers::TempDir& tmp,
 	const FileSentries& sentries)
 {
-	const auto config_dir_path = tmp.get_path().join(
-			Filepath::from_locale_string(".config/newsbeuter"));
-	const auto data_dir_path = tmp.get_path().join(
-			Filepath::from_locale_string(".local/share/newsbeuter"));
+	const auto config_dir_path = tmp.get_path().join(".config/newsbeuter"_path);
+	const auto data_dir_path = tmp.get_path().join(".local/share/newsbeuter"_path);
 	mock_newsbeuter_xdg_dirs(config_dir_path, data_dir_path, sentries);
 }
 
@@ -473,10 +445,10 @@ void mock_newsboat_dotdir(
 	const test_helpers::TempDir& tmp,
 	const FileSentries& sentries)
 {
-	const auto dotdir_path = tmp.get_path().join(Filepath::from_locale_string(".newsboat"));
+	const auto dotdir_path = tmp.get_path().join(".newsboat"_path);
 	REQUIRE(test_helpers::mkdir(dotdir_path, 0700) == 0);
 
-	const auto urls_file = dotdir_path.join(Filepath::from_locale_string("urls"));
+	const auto urls_file = dotdir_path.join("urls"_path);
 	REQUIRE(create_file(urls_file, sentries.urls));
 }
 
@@ -487,7 +459,7 @@ void mock_newsboat_xdg_dirs(
 {
 	REQUIRE(utils::mkdir_parents(config_dir_path, 0700) == 0);
 
-	const auto urls_file = config_dir_path.join(Filepath::from_locale_string("urls"));
+	const auto urls_file = config_dir_path.join("urls"_path);
 	REQUIRE(create_file(urls_file, sentries.urls));
 }
 
@@ -495,10 +467,8 @@ void mock_newsboat_xdg_dirs(
 	const test_helpers::TempDir& tmp,
 	const FileSentries& sentries)
 {
-	const auto config_dir_path = tmp.get_path().join(
-			Filepath::from_locale_string(".config/newsboat"));
-	const auto data_dir_path = tmp.get_path().join(
-			Filepath::from_locale_string(".local/share/newsboat"));
+	const auto config_dir_path = tmp.get_path().join(".config/newsboat"_path);
+	const auto data_dir_path = tmp.get_path().join(".local/share/newsboat"_path);
 	mock_newsboat_xdg_dirs(config_dir_path, data_dir_path, sentries);
 }
 
@@ -524,14 +494,13 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate if config paths "
 	const auto check = [&]() {
 		FileSentries boat_sentries;
 
-		const auto url_file = tmp.get_path().join(Filepath::from_locale_string("my urls file"));
+		const auto url_file = tmp.get_path().join("my urls file"_path);
 		REQUIRE(create_file(url_file, boat_sentries.urls));
 
-		const auto cache_file = tmp.get_path().join(Filepath::from_locale_string("new cache.db"));
+		const auto cache_file = tmp.get_path().join("new cache.db"_path);
 		REQUIRE(create_file(cache_file, boat_sentries.cache));
 
-		const auto config_file = tmp.get_path().join(
-				Filepath::from_locale_string("custom config file"));
+		const auto config_file = tmp.get_path().join("custom config file"_path);
 		REQUIRE(create_file(config_file, boat_sentries.config));
 
 		test_helpers::Opts opts({
@@ -605,59 +574,58 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate if urls file "
 
 		SECTION("Newsboat uses dotdir") {
 			mock_newsboat_dotdir(tmp, boat_sentries);
-			check(tmp.get_path().join(Filepath::from_locale_string(".newsboat/urls")));
+			check(tmp.get_path().join(".newsboat/urls"_path));
 		}
 
 		SECTION("Newsboat uses XDG") {
 			SECTION("Default XDG locations") {
 				mock_newsboat_xdg_dirs(tmp, boat_sentries);
-				check(tmp.get_path().join(Filepath::from_locale_string(".config/newsboat/urls")));
+				check(tmp.get_path().join(".config/newsboat/urls"_path));
 			}
 
 			SECTION("XDG_CONFIG_HOME redefined") {
-				const auto config_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+				const auto config_dir = tmp.get_path().join("xdg-conf"_path);
 				REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
 				xdg_config.set(config_dir.to_locale_string());
-				const auto newsboat_config_dir = config_dir.join(Filepath::from_locale_string("newsboat"));
+				const auto newsboat_config_dir = config_dir.join("newsboat"_path);
 				mock_newsboat_xdg_dirs(
 					newsboat_config_dir,
-					tmp.get_path().join(Filepath::from_locale_string(".local/share/newsboat")),
+					tmp.get_path().join(".local/share/newsboat"_path),
 					boat_sentries);
-				check(newsboat_config_dir.join(Filepath::from_locale_string("urls")));
+				check(newsboat_config_dir.join("urls"_path));
 			}
 
 			SECTION("XDG_DATA_HOME redefined") {
-				const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+				const auto data_dir = tmp.get_path().join("xdg-data"_path);
 				REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 				xdg_data.set(data_dir.to_locale_string());
-				const auto newsboat_config_dir =
-					tmp.get_path().join(Filepath::from_locale_string(".config/newsboat"));
-				const auto newsboat_data_dir = data_dir.join(Filepath::from_locale_string("newsboat"));
+				const auto newsboat_config_dir = tmp.get_path().join(".config/newsboat"_path);
+				const auto newsboat_data_dir = data_dir.join("newsboat"_path);
 				mock_newsboat_xdg_dirs(
 					newsboat_config_dir,
 					newsboat_data_dir,
 					boat_sentries);
-				check(newsboat_config_dir.join(Filepath::from_locale_string("urls")));
+				check(newsboat_config_dir.join("urls"_path));
 			}
 
 			SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
-				const auto config_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+				const auto config_dir = tmp.get_path().join("xdg-conf"_path);
 				REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
 				xdg_config.set(config_dir.to_locale_string());
 
-				const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+				const auto data_dir = tmp.get_path().join("xdg-data"_path);
 				REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 				xdg_data.set(data_dir.to_locale_string());
 
-				const auto newsboat_config_dir = config_dir.join(Filepath::from_locale_string("newsboat"));
-				const auto newsboat_data_dir = data_dir.join(Filepath::from_locale_string("newsboat"));
+				const auto newsboat_config_dir = config_dir.join("newsboat"_path);
+				const auto newsboat_data_dir = data_dir.join("newsboat"_path);
 
 				mock_newsboat_xdg_dirs(
 					newsboat_config_dir,
 					newsboat_data_dir,
 					boat_sentries);
 
-				check(newsboat_config_dir.join(Filepath::from_locale_string("urls")));
+				check(newsboat_config_dir.join("urls"_path));
 			}
 		}
 	}
@@ -668,90 +636,90 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate if urls file "
 
 			SECTION("Newsboat uses dotdir") {
 				mock_newsboat_dotdir(tmp, boat_sentries);
-				check(tmp.get_path().join(Filepath::from_locale_string(".newsboat/urls")));
+				check(tmp.get_path().join(".newsboat/urls"_path));
 			}
 
 			SECTION("Newsboat uses XDG") {
 				mock_newsboat_xdg_dirs(tmp, boat_sentries);
-				check(tmp.get_path().join(Filepath::from_locale_string(".config/newsboat/urls")));
+				check(tmp.get_path().join(".config/newsboat/urls"_path));
 			}
 		}
 
 		SECTION("XDG_CONFIG_HOME redefined") {
-			const auto config_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+			const auto config_dir = tmp.get_path().join("xdg-conf"_path);
 			REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
 			xdg_config.set(config_dir.to_locale_string());
 			mock_newsbeuter_xdg_dirs(
-				config_dir.join(Filepath::from_locale_string("newsbeuter")),
-				tmp.get_path().join(Filepath::from_locale_string(".local/share/newsbeuter")),
+				config_dir.join("newsbeuter"_path),
+				tmp.get_path().join(".local/share/newsbeuter"_path),
 				beuter_sentries);
 
 			SECTION("Newsboat uses dotdir") {
 				mock_newsboat_dotdir(tmp, boat_sentries);
-				check(tmp.get_path().join(Filepath::from_locale_string(".newsboat/urls")));
+				check(tmp.get_path().join(".newsboat/urls"_path));
 			}
 
 			SECTION("Newsboat uses XDG") {
-				const auto newsboat_config_dir = config_dir.join(Filepath::from_locale_string("newsboat"));
+				const auto newsboat_config_dir = config_dir.join("newsboat"_path);
 				mock_newsboat_xdg_dirs(
 					newsboat_config_dir,
-					tmp.get_path().join(Filepath::from_locale_string(".local/share/newsboat")),
+					tmp.get_path().join(".local/share/newsboat"_path),
 					boat_sentries);
-				check(newsboat_config_dir.join(Filepath::from_locale_string("urls")));
+				check(newsboat_config_dir.join("urls"_path));
 			}
 		}
 
 		SECTION("XDG_DATA_HOME redefined") {
-			const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+			const auto data_dir = tmp.get_path().join("xdg-data"_path);
 			REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 			xdg_data.set(data_dir.to_locale_string());
 			mock_newsbeuter_xdg_dirs(
-				tmp.get_path().join(Filepath::from_locale_string(".config/newsbeuter")),
+				tmp.get_path().join(".config/newsbeuter"_path),
 				data_dir,
 				beuter_sentries);
 
 			SECTION("Newsboat uses dotdir") {
 				mock_newsboat_dotdir(tmp, boat_sentries);
-				check(tmp.get_path().join(Filepath::from_locale_string(".newsboat/urls")));
+				check(tmp.get_path().join(".newsboat/urls"_path));
 			}
 
 			SECTION("Newsboat uses XDG") {
 				const auto newsboat_config_dir =
-					tmp.get_path().join(Filepath::from_locale_string(".config/newsboat"));
+					tmp.get_path().join(".config/newsboat"_path);
 				mock_newsboat_xdg_dirs(
 					newsboat_config_dir,
-					data_dir.join(Filepath::from_locale_string("newsboat")),
+					data_dir.join("newsboat"_path),
 					boat_sentries);
-				check(newsboat_config_dir.join(Filepath::from_locale_string("urls")));
+				check(newsboat_config_dir.join("urls"_path));
 			}
 		}
 
 		SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
-			const auto config_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+			const auto config_dir = tmp.get_path().join("xdg-conf"_path);
 			REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
 			xdg_config.set(config_dir.to_locale_string());
 
-			const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+			const auto data_dir = tmp.get_path().join("xdg-data"_path);
 			REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 			xdg_data.set(data_dir.to_locale_string());
 
 			mock_newsbeuter_xdg_dirs(
-				config_dir.join(Filepath::from_locale_string("newsbeuter")),
-				data_dir.join(Filepath::from_locale_string("newsbeuter")),
+				config_dir.join("newsbeuter"_path),
+				data_dir.join("newsbeuter"_path),
 				beuter_sentries);
 
 			SECTION("Newsboat uses dotdir") {
 				mock_newsboat_dotdir(tmp, boat_sentries);
-				check(tmp.get_path().join(Filepath::from_locale_string(".newsboat/urls")));
+				check(tmp.get_path().join(".newsboat/urls"_path));
 			}
 
 			SECTION("Newsboat uses XDG") {
-				const auto newsboat_config_dir = config_dir.join(Filepath::from_locale_string("newsboat"));
+				const auto newsboat_config_dir = config_dir.join("newsboat"_path);
 				mock_newsboat_xdg_dirs(
 					newsboat_config_dir,
-					data_dir.join(Filepath::from_locale_string("newsboat")),
+					data_dir.join("newsboat"_path),
 					boat_sentries);
-				check(newsboat_config_dir.join(Filepath::from_locale_string("urls")));
+				check(newsboat_config_dir.join("urls"_path));
 			}
 		}
 	}
@@ -784,22 +752,16 @@ TEST_CASE("try_migrate_from_newsbeuter() migrates Newsbeuter dotdir from "
 	// Files should be migrated, so should return true.
 	REQUIRE(paths.try_migrate_from_newsbeuter());
 
-	const auto dotdir = tmp.get_path().join(Filepath::from_locale_string(".newsboat"));
+	const auto dotdir = tmp.get_path().join(".newsboat"_path);
 
-	REQUIRE(test_helpers::file_contents(dotdir.join(
-				Filepath::from_locale_string("config"))).at(0) == sentries.config);
-	REQUIRE(test_helpers::file_contents(dotdir.join(Filepath::from_locale_string("urls"))).at(
-			0) == sentries.urls);
-	REQUIRE(test_helpers::file_contents(dotdir.join(
-				Filepath::from_locale_string("cache.db"))).at(0) == sentries.cache);
-	REQUIRE(test_helpers::file_contents(dotdir.join(Filepath::from_locale_string("queue"))).at(
-			0) == sentries.queue);
-	REQUIRE(test_helpers::file_contents(dotdir.join(
-				Filepath::from_locale_string("history.search"))).at(
-			0) == sentries.search);
-	REQUIRE(test_helpers::file_contents(dotdir.join(
-				Filepath::from_locale_string("history.cmdline"))).at(
-			0) == sentries.cmdline);
+	REQUIRE(test_helpers::file_contents(dotdir.join("config"_path)).at(0) == sentries.config);
+	REQUIRE(test_helpers::file_contents(dotdir.join("urls"_path)).at(0) == sentries.urls);
+	REQUIRE(test_helpers::file_contents(dotdir.join("cache.db"_path)).at(0) == sentries.cache);
+	REQUIRE(test_helpers::file_contents(dotdir.join("queue"_path)).at(0) == sentries.queue);
+	REQUIRE(test_helpers::file_contents(dotdir.join("history.search"_path)).at(0)
+		== sentries.search);
+	REQUIRE(test_helpers::file_contents(dotdir.join("history.cmdline"_path)).at(0)
+		== sentries.cmdline);
 }
 
 TEST_CASE("try_migrate_from_newsbeuter() migrates Newsbeuter XDG dirs from "
@@ -829,74 +791,68 @@ TEST_CASE("try_migrate_from_newsbeuter() migrates Newsbeuter XDG dirs from "
 		// Files should be migrated, so should return true.
 		REQUIRE(paths.try_migrate_from_newsbeuter());
 
-		REQUIRE(test_helpers::file_contents(config_dir.join(
-					Filepath::from_locale_string("config"))).at(0) == sentries.config);
-		REQUIRE(test_helpers::file_contents(config_dir.join(
-					Filepath::from_locale_string("urls"))).at(0) == sentries.urls);
+		REQUIRE(test_helpers::file_contents(config_dir.join("config"_path)).at(0)
+			== sentries.config);
+		REQUIRE(test_helpers::file_contents(config_dir.join("urls"_path)).at(0) == sentries.urls);
 
-		REQUIRE(test_helpers::file_contents(data_dir.join(
-					Filepath::from_locale_string("cache.db"))).at(0) == sentries.cache);
-		REQUIRE(test_helpers::file_contents(data_dir.join(
-					Filepath::from_locale_string("queue"))).at(0) == sentries.queue);
-		REQUIRE(test_helpers::file_contents(data_dir.join(
-					Filepath::from_locale_string("history.search"))).at(
-				0) == sentries.search);
-		REQUIRE(test_helpers::file_contents(data_dir.join(
-					Filepath::from_locale_string("history.cmdline"))).at(
-				0) == sentries.cmdline);
+		REQUIRE(test_helpers::file_contents(data_dir.join("cache.db"_path)).at(0)
+			== sentries.cache);
+		REQUIRE(test_helpers::file_contents(data_dir.join("queue"_path)).at(0) == sentries.queue);
+		REQUIRE(test_helpers::file_contents(data_dir.join("history.search"_path)).at(0)
+			== sentries.search);
+		REQUIRE(test_helpers::file_contents(data_dir.join("history.cmdline"_path)).at(0)
+			== sentries.cmdline);
 	};
 
 	SECTION("Default XDG locations") {
 		mock_newsbeuter_xdg_dirs(tmp, sentries);
-		const auto config_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".config/newsboat"));
-		const auto data_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".local/share/newsboat"));
+		const auto config_dir = tmp.get_path().join(".config/newsboat"_path);
+		const auto data_dir = tmp.get_path().join(".local/share/newsboat"_path);
 		check(config_dir, data_dir);
 	}
 
 	SECTION("XDG_CONFIG_HOME redefined") {
-		const auto config_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_dir = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
 		xdg_config.set(config_dir.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			config_dir.join(Filepath::from_locale_string("newsbeuter")),
-			tmp.get_path().join(Filepath::from_locale_string(".local/share/newsbeuter")),
+			config_dir.join("newsbeuter"_path),
+			tmp.get_path().join(".local/share/newsbeuter"_path),
 			sentries);
 
-		check(config_dir.join(Filepath::from_locale_string("newsboat")),
-			tmp.get_path().join(Filepath::from_locale_string(".local/share/newsboat")));
+		check(config_dir.join("newsboat"_path),
+			tmp.get_path().join(".local/share/newsboat"_path));
 	}
 
 	SECTION("XDG_DATA_HOME redefined") {
-		const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_dir = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 		xdg_data.set(data_dir.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			tmp.get_path().join(Filepath::from_locale_string(".config/newsbeuter")),
-			data_dir.join(Filepath::from_locale_string("newsbeuter")),
+			tmp.get_path().join(".config/newsbeuter"_path),
+			data_dir.join("newsbeuter"_path),
 			sentries);
 
-		check(tmp.get_path().join(Filepath::from_locale_string(".config/newsboat")),
-			data_dir.join(Filepath::from_locale_string("newsboat")));
+		check(tmp.get_path().join(".config/newsboat"_path),
+			data_dir.join("newsboat"_path));
 	}
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
-		const auto config_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_dir = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
 		xdg_config.set(config_dir.to_locale_string());
 
-		const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_dir = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 		xdg_data.set(data_dir.to_locale_string());
 
 		mock_newsbeuter_xdg_dirs(
-			config_dir.join(Filepath::from_locale_string("newsbeuter")),
-			data_dir.join(Filepath::from_locale_string("newsbeuter")),
+			config_dir.join("newsbeuter"_path),
+			data_dir.join("newsbeuter"_path),
 			sentries);
 
-		check(config_dir.join(Filepath::from_locale_string("newsboat")),
-			data_dir.join(Filepath::from_locale_string("newsboat")));
+		check(config_dir.join("newsboat"_path),
+			data_dir.join("newsboat"_path));
 	}
 }
 
@@ -910,19 +866,15 @@ void verify_xdg_not_migrated(
 	// Shouldn't migrate anything, so should return false.
 	REQUIRE_FALSE(paths.try_migrate_from_newsbeuter());
 
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(config_dir.join(
-				Filepath::from_locale_string("config"))));
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(config_dir.join(
-				Filepath::from_locale_string("urls"))));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(config_dir.join("config"_path)));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(config_dir.join("urls"_path)));
 
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(data_dir.join(
-				Filepath::from_locale_string("cache.db"))));
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(data_dir.join(
-				Filepath::from_locale_string("queue"))));
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(data_dir.join(
-				Filepath::from_locale_string("history.search"))));
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(data_dir.join(
-				Filepath::from_locale_string("history.cmdline"))));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(data_dir.join("cache.db"_path)));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(data_dir.join("queue"_path)));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(
+			data_dir.join("history.search"_path)));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(
+			data_dir.join("history.cmdline"_path)));
 }
 
 TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
@@ -947,64 +899,59 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 	SECTION("Default XDG locations") {
 		mock_newsbeuter_xdg_dirs(tmp, sentries);
 
-		const auto config_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".config/newsboat"));
+		const auto config_dir = tmp.get_path().join(".config/newsboat"_path);
 		REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
 
-		const auto data_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".local/share/newsboat"));
+		const auto data_dir = tmp.get_path().join(".local/share/newsboat"_path);
 		verify_xdg_not_migrated(config_dir, data_dir);
 	}
 
 	SECTION("XDG_CONFIG_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_home = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_home, 0700) == 0);
 		xdg_config.set(config_home.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			config_home.join(Filepath::from_locale_string("newsbeuter")),
-			tmp.get_path().join(Filepath::from_locale_string(".local/share/newsbeuter")),
+			config_home.join("newsbeuter"_path),
+			tmp.get_path().join(".local/share/newsbeuter"_path),
 			sentries);
 
-		const auto config_dir = config_home.join(Filepath::from_locale_string("newsboat"));
+		const auto config_dir = config_home.join("newsboat"_path);
 		REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
 		verify_xdg_not_migrated(config_dir,
-			tmp.get_path().join(Filepath::from_locale_string(".local/share/newsboat")));
+			tmp.get_path().join(".local/share/newsboat"_path));
 	}
 
 	SECTION("XDG_DATA_HOME redefined") {
-		const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_dir = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 		xdg_data.set(data_dir.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			tmp.get_path().join(Filepath::from_locale_string(".config/newsbeuter")),
-			data_dir.join(Filepath::from_locale_string("newsbeuter")),
+			tmp.get_path().join(".config/newsbeuter"_path),
+			data_dir.join("newsbeuter"_path),
 			sentries);
 
-		const auto config_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".config/newsboat"));
+		const auto config_dir = tmp.get_path().join(".config/newsboat"_path);
 		REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
-		verify_xdg_not_migrated(config_dir,
-			data_dir.join(Filepath::from_locale_string("newsboat")));
+		verify_xdg_not_migrated(config_dir, data_dir.join("newsboat"_path));
 	}
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_home = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_home, 0700) == 0);
 		xdg_config.set(config_home.to_locale_string());
 
-		const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_dir = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 		xdg_data.set(data_dir.to_locale_string());
 
 		mock_newsbeuter_xdg_dirs(
-			config_home.join(Filepath::from_locale_string("newsbeuter")),
-			data_dir.join(Filepath::from_locale_string("newsbeuter")),
+			config_home.join("newsbeuter"_path),
+			data_dir.join("newsbeuter"_path),
 			sentries);
 
-		const auto config_dir = config_home.join(Filepath::from_locale_string("newsboat"));
+		const auto config_dir = config_home.join("newsboat"_path);
 		REQUIRE(test_helpers::mkdir(config_dir, 0700) == 0);
-		verify_xdg_not_migrated(config_dir,
-			data_dir.join(Filepath::from_locale_string("newsboat")));
+		verify_xdg_not_migrated(config_dir, data_dir.join("newsboat"_path));
 	}
 }
 
@@ -1030,63 +977,57 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 	SECTION("Default XDG locations") {
 		mock_newsbeuter_xdg_dirs(tmp, sentries);
 
-		const auto config_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".config/newsboat"));
-		const auto data_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".local/share/newsboat"));
+		const auto config_dir = tmp.get_path().join(".config/newsboat"_path);
+		const auto data_dir = tmp.get_path().join(".local/share/newsboat"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 		verify_xdg_not_migrated(config_dir, data_dir);
 	}
 
 	SECTION("XDG_CONFIG_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_home = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_home, 0700) == 0);
 		xdg_config.set(config_home.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			config_home.join(Filepath::from_locale_string("newsbeuter")),
-			tmp.get_path().join(Filepath::from_locale_string(".local/share/newsbeuter")),
+			config_home.join("newsbeuter"_path),
+			tmp.get_path().join(".local/share/newsbeuter"_path),
 			sentries);
 
-		const auto data_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".local/share/newsboat"));
+		const auto data_dir = tmp.get_path().join(".local/share/newsboat"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
-		verify_xdg_not_migrated(config_home.join(Filepath::from_locale_string("newsboat")),
-			data_dir);
+		verify_xdg_not_migrated(config_home.join("newsboat"_path), data_dir);
 	}
 
 	SECTION("XDG_DATA_HOME redefined") {
-		const auto data_home = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_home = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_home, 0700) == 0);
 		xdg_data.set(data_home.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			tmp.get_path().join(Filepath::from_locale_string(".config/newsbeuter")),
-			data_home.join(Filepath::from_locale_string("newsbeuter")),
+			tmp.get_path().join(".config/newsbeuter"_path),
+			data_home.join("newsbeuter"_path),
 			sentries);
 
-		const auto data_dir = data_home.join(Filepath::from_locale_string("newsboat"));
+		const auto data_dir = data_home.join("newsboat"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
-		verify_xdg_not_migrated(tmp.get_path().join(
-				Filepath::from_locale_string(".config/newsboat")), data_dir);
+		verify_xdg_not_migrated(tmp.get_path().join(".config/newsboat"_path), data_dir);
 	}
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_home = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_home, 0700) == 0);
 		xdg_config.set(config_home.to_locale_string());
 
-		const auto data_home = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_home = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_home, 0700) == 0);
 		xdg_data.set(data_home.to_locale_string());
 
 		mock_newsbeuter_xdg_dirs(
-			config_home.join(Filepath::from_locale_string("newsbeuter")),
-			data_home.join(Filepath::from_locale_string("newsbeuter")),
+			config_home.join("newsbeuter"_path),
+			data_home.join("newsbeuter"_path),
 			sentries);
 
-		const auto data_dir = data_home.join(Filepath::from_locale_string("newsboat"));
+		const auto data_dir = data_home.join("newsboat"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
-		verify_xdg_not_migrated(config_home.join(Filepath::from_locale_string("newsboat")),
-			data_dir);
+		verify_xdg_not_migrated(config_home.join("newsboat"_path), data_dir);
 	}
 }
 
@@ -1114,22 +1055,21 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 
 		// Making XDG .config unwriteable makes it impossible to create
 		// a directory there
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string(".config"));
+		const auto config_home = tmp.get_path().join(".config"_path);
 		test_helpers::Chmod config_home_chmod(config_home, S_IRUSR | S_IXUSR);
 
-		const auto config_dir = config_home.join(Filepath::from_locale_string("newsboat"));
-		const auto data_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".local/share/newsboat"));
+		const auto config_dir = config_home.join("newsboat"_path);
+		const auto data_dir = tmp.get_path().join(".local/share/newsboat"_path);
 		verify_xdg_not_migrated(config_dir, data_dir);
 	}
 
 	SECTION("XDG_CONFIG_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_home = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_home, 0700) == 0);
 		xdg_config.set(config_home.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			config_home.join(Filepath::from_locale_string("newsbeuter")),
-			tmp.get_path().join(Filepath::from_locale_string(".local/share/newsbeuter")),
+			config_home.join("newsbeuter"_path),
+			tmp.get_path().join(".local/share/newsbeuter"_path),
 			sentries);
 
 		// Making XDG .config unwriteable makes it impossible to create
@@ -1137,50 +1077,46 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 		test_helpers::Chmod config_home_chmod(config_home, S_IRUSR | S_IXUSR);
 
 		verify_xdg_not_migrated(
-			config_home.join(Filepath::from_locale_string("newsboat")),
-			tmp.get_path().join(Filepath::from_locale_string(".local/share/newsboat")));
+			config_home.join("newsboat"_path),
+			tmp.get_path().join(".local/share/newsboat"_path));
 	}
 
 	SECTION("XDG_DATA_HOME redefined") {
-		const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_dir = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 		xdg_data.set(data_dir.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			tmp.get_path().join(Filepath::from_locale_string(".config/newsbeuter")),
-			data_dir.join(Filepath::from_locale_string("newsbeuter")),
+			tmp.get_path().join(".config/newsbeuter"_path),
+			data_dir.join("newsbeuter"_path),
 			sentries);
 
 		// Making XDG .config unwriteable makes it impossible to create
 		// a directory there
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string(".config"));
+		const auto config_home = tmp.get_path().join(".config"_path);
 		test_helpers::Chmod config_home_chmod(config_home, S_IRUSR | S_IXUSR);
 
-		verify_xdg_not_migrated(
-			config_home.join(Filepath::from_locale_string("newsboat")),
-			data_dir.join(Filepath::from_locale_string("newsboat")));
+		verify_xdg_not_migrated(config_home.join("newsboat"_path), data_dir.join("newsboat"_path));
 	}
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_home = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_home, 0700) == 0);
 		xdg_config.set(config_home.to_locale_string());
 
-		const auto data_dir = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_dir = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_dir, 0700) == 0);
 		xdg_data.set(data_dir.to_locale_string());
 
 		mock_newsbeuter_xdg_dirs(
-			config_home.join(Filepath::from_locale_string("newsbeuter")),
-			data_dir.join(Filepath::from_locale_string("newsbeuter")),
+			config_home.join("newsbeuter"_path),
+			data_dir.join("newsbeuter"_path),
 			sentries);
 
 		// Making XDG .config unwriteable makes it impossible to create
 		// a directory there
 		test_helpers::Chmod config_home_chmod(config_home, S_IRUSR | S_IXUSR);
 
-		verify_xdg_not_migrated(
-			config_home.join(Filepath::from_locale_string("newsboat")),
-			data_dir.join(Filepath::from_locale_string("newsboat")));
+		verify_xdg_not_migrated(config_home.join("newsboat"_path), data_dir.join("newsboat"_path));
 	}
 }
 
@@ -1208,41 +1144,39 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 
 		// Making XDG .local/share unwriteable makes it impossible to create
 		// a directory there
-		const auto data_home = tmp.get_path().join(Filepath::from_locale_string(".local/share"));
+		const auto data_home = tmp.get_path().join(".local/share"_path);
 		test_helpers::Chmod data_home_chmod(data_home, S_IRUSR | S_IXUSR);
 
-		const auto config_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".config/newsboat"));
-		const auto data_dir = data_home.join(Filepath::from_locale_string("newsboat"));
+		const auto config_dir = tmp.get_path().join(".config/newsboat"_path);
+		const auto data_dir = data_home.join("newsboat"_path);
 		verify_xdg_not_migrated(config_dir, data_dir);
 	}
 
 	SECTION("XDG_CONFIG_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_home = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_home, 0700) == 0);
 		xdg_config.set(config_home.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			config_home.join(Filepath::from_locale_string("newsbeuter")),
-			tmp.get_path().join(Filepath::from_locale_string(".local/share/newsbeuter")),
+			config_home.join("newsbeuter"_path),
+			tmp.get_path().join(".local/share/newsbeuter"_path),
 			sentries);
 
 		// Making XDG .local/share unwriteable makes it impossible to create
 		// a directory there
-		const auto data_home = tmp.get_path().join(Filepath::from_locale_string(".local/share"));
+		const auto data_home = tmp.get_path().join(".local/share"_path);
 		test_helpers::Chmod data_home_chmod(data_home, S_IRUSR | S_IXUSR);
 
-		verify_xdg_not_migrated(
-			config_home.join(Filepath::from_locale_string("newsboat")),
-			data_home.join(Filepath::from_locale_string("newsboat")));
+		verify_xdg_not_migrated(config_home.join("newsboat"_path),
+			data_home.join("newsboat"_path));
 	}
 
 	SECTION("XDG_DATA_HOME redefined") {
-		const auto data_home = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_home = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_home, 0700) == 0);
 		xdg_data.set(data_home.to_locale_string());
 		mock_newsbeuter_xdg_dirs(
-			tmp.get_path().join(Filepath::from_locale_string(".config/newsbeuter")),
-			data_home.join(Filepath::from_locale_string("newsbeuter")),
+			tmp.get_path().join(".config/newsbeuter"_path),
+			data_home.join("newsbeuter"_path),
 			sentries);
 
 		// Making XDG .local/share unwriteable makes it impossible to create
@@ -1250,31 +1184,30 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat XDG "
 		test_helpers::Chmod data_home_chmod(data_home, S_IRUSR | S_IXUSR);
 
 		verify_xdg_not_migrated(
-			tmp.get_path().join(Filepath::from_locale_string(".config/newsboat")),
-			data_home.join(Filepath::from_locale_string("newsboat")));
+			tmp.get_path().join(".config/newsboat"_path),
+			data_home.join("newsboat"_path));
 	}
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-conf"));
+		const auto config_home = tmp.get_path().join("xdg-conf"_path);
 		REQUIRE(test_helpers::mkdir(config_home, 0700) == 0);
 		xdg_config.set(config_home.to_locale_string());
 
-		const auto data_home = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_home = tmp.get_path().join("xdg-data"_path);
 		REQUIRE(test_helpers::mkdir(data_home, 0700) == 0);
 		xdg_data.set(data_home.to_locale_string());
 
 		mock_newsbeuter_xdg_dirs(
-			config_home.join(Filepath::from_locale_string("newsbeuter")),
-			data_home.join(Filepath::from_locale_string("newsbeuter")),
+			config_home.join("newsbeuter"_path),
+			data_home.join("newsbeuter"_path),
 			sentries);
 
 		// Making XDG .local/share unwriteable makes it impossible to create
 		// a directory there
 		test_helpers::Chmod data_home_chmod(data_home, S_IRUSR | S_IXUSR);
 
-		verify_xdg_not_migrated(
-			config_home.join(Filepath::from_locale_string("newsboat")),
-			data_home.join(Filepath::from_locale_string("newsboat")));
+		verify_xdg_not_migrated(config_home.join("newsboat"_path),
+			data_home.join("newsboat"_path));
 	}
 }
 
@@ -1286,19 +1219,15 @@ void verify_dotdir_not_migrated(const Filepath& dotdir)
 	// Shouldn't migrate anything, so should return false.
 	REQUIRE_FALSE(paths.try_migrate_from_newsbeuter());
 
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join(
-				Filepath::from_locale_string("config"))));
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join(
-				Filepath::from_locale_string("urls"))));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join("config"_path)));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join("urls"_path)));
 
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join(
-				Filepath::from_locale_string("cache.db"))));
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join(
-				Filepath::from_locale_string("queue"))));
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join(
-				Filepath::from_locale_string("history.search"))));
-	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join(
-				Filepath::from_locale_string("history.cmdline"))));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join("cache.db"_path)));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(dotdir.join("queue"_path)));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(
+			dotdir.join("history.search"_path)));
+	REQUIRE_FALSE(test_helpers::file_available_for_reading(
+			dotdir.join("history.cmdline"_path)));
 }
 
 TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
@@ -1322,7 +1251,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if empty "
 
 	mock_newsbeuter_dotdir(tmp, sentries);
 
-	const auto dotdir = tmp.get_path().join(Filepath::from_locale_string(".newsboat"));
+	const auto dotdir = tmp.get_path().join(".newsboat"_path);
 	REQUIRE(test_helpers::mkdir(dotdir, 0700) == 0);
 
 	verify_dotdir_not_migrated(dotdir);
@@ -1353,7 +1282,7 @@ TEST_CASE("try_migrate_from_newsbeuter() doesn't migrate files if Newsboat "
 	// a directory there
 	test_helpers::Chmod dotdir_chmod(tmp.get_path(), S_IRUSR | S_IXUSR);
 
-	verify_dotdir_not_migrated(tmp.get_path().join(Filepath::from_locale_string(".newsboat")));
+	verify_dotdir_not_migrated(tmp.get_path().join(".newsboat"_path));
 }
 
 void verify_create_dirs_returns_false(const test_helpers::TempDir& tmp)
@@ -1404,29 +1333,27 @@ TEST_CASE("create_dirs() returns false if XDG config dir exists but data dir "
 	xdg_data.unset();
 
 	SECTION("Default XDG locations") {
-		const auto config_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".config/newsboat"));
+		const auto config_dir = tmp.get_path().join(".config/newsboat"_path);
 		REQUIRE(utils::mkdir_parents(config_dir, 0700) == 0);
 
 		verify_create_dirs_returns_false(tmp);
 	}
 
 	SECTION("XDG_CONFIG_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-cfg"));
+		const auto config_home = tmp.get_path().join("xdg-cfg"_path);
 		xdg_config.set(config_home.to_locale_string());
 
-		const auto config_dir = config_home.join(Filepath::from_locale_string("newsboat"));
+		const auto config_dir = config_home.join("newsboat"_path);
 		REQUIRE(utils::mkdir_parents(config_dir, 0700) == 0);
 
 		verify_create_dirs_returns_false(tmp);
 	}
 
 	SECTION("XDG_DATA_HOME redefined") {
-		const auto config_dir = tmp.get_path().join(
-				Filepath::from_locale_string(".config/newsboat"));
+		const auto config_dir = tmp.get_path().join(".config/newsboat"_path);
 		REQUIRE(utils::mkdir_parents(config_dir, 0700) == 0);
 
-		const auto data_home = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_home = tmp.get_path().join("xdg-data"_path);
 		xdg_data.set(data_home.to_locale_string());
 		// It's important to set the variable, but *not* create the directory
 		// - it's the pre-condition of the test that the data dir doesn't exist
@@ -1435,13 +1362,13 @@ TEST_CASE("create_dirs() returns false if XDG config dir exists but data dir "
 	}
 
 	SECTION("Both XDG_CONFIG_HOME and XDG_DATA_HOME redefined") {
-		const auto config_home = tmp.get_path().join(Filepath::from_locale_string("xdg-cfg"));
+		const auto config_home = tmp.get_path().join("xdg-cfg"_path);
 		xdg_config.set(config_home.to_locale_string());
 
-		const auto config_dir = config_home.join(Filepath::from_locale_string("newsboat"));
+		const auto config_dir = config_home.join("newsboat"_path);
 		REQUIRE(utils::mkdir_parents(config_dir, 0700) == 0);
 
-		const auto data_home = tmp.get_path().join(Filepath::from_locale_string("xdg-data"));
+		const auto data_home = tmp.get_path().join("xdg-data"_path);
 		xdg_data.set(data_home.to_locale_string());
 		// It's important to set the variable, but *not* create the directory
 		// - it's the pre-condition of the test that the data dir doesn't exist

--- a/test/controller.cpp
+++ b/test/controller.cpp
@@ -16,11 +16,11 @@ using namespace newsboat;
 
 TEST_CASE("write_item correctly parses path", "[Controller]")
 {
-	const auto name = Filepath::from_locale_string("myitem");
+	const auto name = "myitem"_path;
 	test_helpers::TempDir tmp;
-	const auto home_dir = tmp.get_path().join(Filepath::from_locale_string("home"));
+	const auto home_dir = tmp.get_path().join("home"_path);
 	REQUIRE(0 == utils::mkdir_parents(home_dir, 0700));
-	const auto save_path = tmp.get_path().join(Filepath::from_locale_string("save"));
+	const auto save_path = tmp.get_path().join("save"_path);
 	REQUIRE(0 == utils::mkdir_parents(save_path, 0700));
 
 	test_helpers::EnvVar home("HOME");
@@ -39,7 +39,7 @@ TEST_CASE("write_item correctly parses path", "[Controller]")
 	item.set_description(description, "text/plain");
 
 	c.write_item(item, tmp.get_path().join(name));
-	c.write_item(item, Filepath::from_locale_string("~").join(name));
+	c.write_item(item, "~"_path.join(name));
 	c.write_item(item, name);
 
 	REQUIRE(test_helpers::file_available_for_reading(tmp.get_path().join(name)));

--- a/test/download.cpp
+++ b/test/download.cpp
@@ -7,6 +7,8 @@
 
 using namespace podboat;
 
+using newsboat::operator""_path;
+
 TEST_CASE("Require-view-update callback gets called when download progress or status changes",
 	"[Download]")
 {
@@ -66,14 +68,14 @@ TEST_CASE("filename() returns download's target filename", "[Download]")
 
 
 	SECTION("filename returns same string which is set via set_filename") {
-		const auto path = newsboat::Filepath::from_locale_string("abc");
+		const auto path = "abc"_path;
 		d.set_filename(path);
 		REQUIRE(d.filename() == path);
 	}
 
 	SECTION("filename will return the latest configured filename") {
-		d.set_filename(newsboat::Filepath::from_locale_string("abc"));
-		const auto path = newsboat::Filepath::from_locale_string("def");
+		d.set_filename("abc"_path);
+		const auto path = "def"_path;
 		d.set_filename(path);
 
 		REQUIRE(d.filename() == path);
@@ -133,15 +135,15 @@ TEST_CASE("basename() returns all text after last slash in the filename",
 	}
 
 	SECTION("basename() returns full filename if it does not contain slashes") {
-		const auto filename = newsboat::Filepath::from_locale_string("lorem_ipsum.txt");
+		const auto filename = "lorem_ipsum.txt"_path;
 		d.set_filename(filename);
 
 		REQUIRE(d.basename() == filename);
 	}
 
 	SECTION("basename() returns only text after the last slash in the filename") {
-		const auto basename = newsboat::Filepath::from_locale_string("lorem_ipsum.txt");
-		const auto path = newsboat::Filepath::from_locale_string("/test/path/");
+		const auto basename = "lorem_ipsum.txt"_path;
+		const auto path = "/test/path/"_path;
 		const auto filename = path.join(basename);
 		d.set_filename(filename);
 

--- a/test/feedretriever.cpp
+++ b/test/feedretriever.cpp
@@ -17,8 +17,7 @@ using namespace newsboat;
 
 TEST_CASE("Feed retriever retrieves feed successfully", "[FeedRetriever]")
 {
-	auto feed_xml = test_helpers::read_binary_file(
-			Filepath::from_locale_string("data/atom10_1.xml"));
+	auto feed_xml = test_helpers::read_binary_file("data/atom10_1.xml"_path);
 
 	ConfigContainer cfg;
 	auto rsscache = Cache::in_memory(cfg);
@@ -147,8 +146,7 @@ TEST_CASE("Feed retriever throws on HTTP error status codes", "[FeedRetriever]")
 TEST_CASE("Feed retriever remembers cookie between requests if cookie-cache is set",
 	"[FeedRetriever]")
 {
-	auto feed_xml = test_helpers::read_binary_file(
-			Filepath::from_locale_string("data/atom10_1.xml"));
+	auto feed_xml = test_helpers::read_binary_file("data/atom10_1.xml"_path);
 
 	ConfigContainer cfg;
 

--- a/test/filepath.cpp
+++ b/test/filepath.cpp
@@ -7,7 +7,7 @@ using namespace newsboat;
 TEST_CASE("Can be constructed from a string and converted back into a string",
 	"[Filepath]")
 {
-	const auto example = Filepath::from_locale_string("/etc/hosts");
+	const auto example = "/etc/hosts"_path;
 	REQUIRE(example.to_locale_string() == "/etc/hosts");
 }
 
@@ -32,52 +32,52 @@ TEST_CASE("Can be displayed even if it contains non-Unicode characters", "[Filep
 
 TEST_CASE("push() adds a new component to the path", "[Filepath]")
 {
-	auto dir = Filepath::from_locale_string("/tmp");
+	auto dir = "/tmp"_path;
 
-	dir.push(Filepath::from_locale_string("newsboat"));
-	REQUIRE(dir == Filepath::from_locale_string("/tmp/newsboat"));
+	dir.push("newsboat"_path);
+	REQUIRE(dir == "/tmp/newsboat"_path);
 
-	dir.push(Filepath::from_locale_string(".local/share/cache/cache.db"));
-	REQUIRE(dir == Filepath::from_locale_string("/tmp/newsboat/.local/share/cache/cache.db"));
+	dir.push(".local/share/cache/cache.db"_path);
+	REQUIRE(dir == "/tmp/newsboat/.local/share/cache/cache.db"_path);
 }
 
 TEST_CASE("push() still adds a separator to non-empty path if new component is empty",
 	"[Filepath]")
 {
-	auto dir = Filepath::from_locale_string("/root");
-	dir.push(Filepath::from_locale_string(""));
+	auto dir = "/root"_path;
+	dir.push(""_path);
 	REQUIRE(dir.display() == "/root/");
 }
 
 TEST_CASE("Can be extended with join()", "[Filepath]")
 {
-	const auto tmp = Filepath::from_locale_string("/tmp");
+	const auto tmp = "/tmp"_path;
 
 	const auto subdir =
 		tmp
-		.join(Filepath::from_locale_string("newsboat"))
-		.join(Filepath::from_locale_string("tests"));
-	REQUIRE(subdir == Filepath::from_locale_string("/tmp/newsboat/tests"));
+		.join("newsboat"_path)
+		.join("tests"_path);
+	REQUIRE(subdir == "/tmp/newsboat/tests"_path);
 }
 
 TEST_CASE("join() still adds a separator to non-empty path if new component is empty",
 	"[Filepath]")
 {
-	const auto path = Filepath::from_locale_string("relative path");
+	const auto path = "relative path"_path;
 	const auto path_with_trailing_slash = path.join(Filepath{});
 	REQUIRE(path_with_trailing_slash.display() == "relative path/");
 }
 
 TEST_CASE("Can be copied", "[Filepath]")
 {
-	auto original = Filepath::from_locale_string("/etc/hosts");
+	auto original = "/etc/hosts"_path;
 
 	const auto check = [&original](const Filepath& copy) {
 		REQUIRE(original == copy);
 		REQUIRE(original.display() == "/etc/hosts");
 
 		// Demonstrate that changing the original object doesn't modify the copy
-		original.push(Filepath::from_locale_string(" a bit more"));
+		original.push(" a bit more"_path);
 		REQUIRE(original.display() == "/etc/hosts/ a bit more");
 		REQUIRE(copy.display() == "/etc/hosts");
 	};
@@ -101,16 +101,16 @@ TEST_CASE("Can't set extension for an empty path", "[Filepath]")
 
 TEST_CASE("Can set extension for non-empty path", "[Filepath]")
 {
-	auto path = Filepath::from_locale_string("file");
+	auto path = "file"_path;
 
 	SECTION("extension is UTF-8") {
 		REQUIRE(path.set_extension("exe"));
-		REQUIRE(path == Filepath::from_locale_string("file.exe"));
+		REQUIRE(path == "file.exe"_path);
 	}
 
 	SECTION("extension is not a valid UTF-8 string") {
 		REQUIRE(path.set_extension("\x80"));
-		REQUIRE(path == Filepath::from_locale_string("file.\x80"));
+		REQUIRE(path == "file.\x80"_path);
 	}
 }
 
@@ -118,22 +118,22 @@ TEST_CASE("add_extension passes tests from Rust docs", "[Filepath]")
 {
 	// Copied from https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.add_extension
 
-	auto path = Filepath::from_locale_string("/feel/the");
+	auto path = "/feel/the"_path;
 
 	REQUIRE(path.add_extension("formatted"));
-	REQUIRE(Filepath::from_locale_string("/feel/the.formatted") == path);
+	REQUIRE("/feel/the.formatted"_path == path);
 
 	REQUIRE(path.add_extension("dark.side"));
-	REQUIRE(Filepath::from_locale_string("/feel/the.formatted.dark.side") == path);
+	REQUIRE("/feel/the.formatted.dark.side"_path == path);
 
 	REQUIRE(path.set_extension("cookie"));
-	REQUIRE(Filepath::from_locale_string("/feel/the.formatted.dark.cookie") == path);
+	REQUIRE("/feel/the.formatted.dark.cookie"_path == path);
 
 	REQUIRE(path.set_extension(""));
-	REQUIRE(Filepath::from_locale_string("/feel/the.formatted.dark") == path);
+	REQUIRE("/feel/the.formatted.dark"_path == path);
 
 	REQUIRE(path.add_extension(""));
-	REQUIRE(Filepath::from_locale_string("/feel/the.formatted.dark") == path);
+	REQUIRE("/feel/the.formatted.dark"_path == path);
 }
 
 TEST_CASE("Can check if path is absolute", "[Filepath]")
@@ -144,21 +144,21 @@ TEST_CASE("Can check if path is absolute", "[Filepath]")
 	}
 
 	SECTION("path that starts with a slash is absolute") {
-		path.push(Filepath::from_locale_string("/etc"));
+		path.push("/etc"_path);
 		REQUIRE(path.display() == "/etc");
 		REQUIRE(path.is_absolute());
 
-		path.push(Filepath::from_locale_string("ca-certificates"));
+		path.push("ca-certificates"_path);
 		REQUIRE(path.display() == "/etc/ca-certificates");
 		REQUIRE(path.is_absolute());
 	}
 
 	SECTION("path that doesn't start with a slash is not absolute") {
-		path.push(Filepath::from_locale_string("vmlinuz"));
+		path.push("vmlinuz"_path);
 		REQUIRE(path.display() == "vmlinuz");
 		REQUIRE_FALSE(path.is_absolute());
 
-		path.push(Filepath::from_locale_string("undefined"));
+		path.push("undefined"_path);
 		REQUIRE(path.display() == "vmlinuz/undefined");
 		REQUIRE_FALSE(path.is_absolute());
 	}
@@ -174,32 +174,32 @@ TEST_CASE("Can check if path starts with a given base path", "[Filepath]")
 		}
 
 		SECTION("Base path is not empty") {
-			REQUIRE_FALSE(path.starts_with(Filepath::from_locale_string("/etc")));
+			REQUIRE_FALSE(path.starts_with("/etc"_path));
 		}
 	}
 
 	SECTION("Non-empty path that doesn't start with the base") {
-		const auto path = Filepath::from_locale_string("/etcetera");
-		const auto base = Filepath::from_locale_string("/etc");
+		const auto path = "/etcetera"_path;
+		const auto base = "/etc"_path;
 		REQUIRE_FALSE(path.starts_with(base));
 	}
 
 	SECTION("Non-empty path that starts with the base") {
-		const auto path = Filepath::from_locale_string("/usr/local/bin/newsboat");
-		const auto base = Filepath::from_locale_string("/usr/local");
+		const auto path = "/usr/local/bin/newsboat"_path;
+		const auto base = "/usr/local"_path;
 		REQUIRE(path.starts_with(base));
 	}
 
 	SECTION("Base is not a valid UTF-8 string") {
-		const auto path = Filepath::from_locale_string("/test\x81\x82/foobar");
+		const auto path = "/test\x81\x82/foobar"_path;
 
 		SECTION("Path doesn't start with base") {
-			const auto base = Filepath::from_locale_string("baz\x80quux");
+			const auto base = "baz\x80quux"_path;
 			REQUIRE_FALSE(path.starts_with(base));
 		}
 
 		SECTION("Path starts with base") {
-			const auto base = Filepath::from_locale_string("/test\x81\x82/");
+			const auto base = "/test\x81\x82/"_path;
 			REQUIRE(path.starts_with(base));
 		}
 	}
@@ -214,28 +214,27 @@ TEST_CASE("Can extract the final component of the path (file or directory name)"
 	}
 
 	SECTION("The final component of a path with single level is the path itself") {
-		const auto path = Filepath::from_locale_string("hello");
+		const auto path = "hello"_path;
 		REQUIRE(path.file_name().value() == path);
 	}
 
 	SECTION("Multi-level path") {
-		const auto path = Filepath::from_locale_string("/dev/pts/0");
-		REQUIRE(path.file_name().value() == Filepath::from_locale_string("0"));
+		const auto path = "/dev/pts/0"_path;
+		REQUIRE(path.file_name().value() == "0"_path);
 	}
 
 	SECTION("Final component is not a valid UTF-8 string") {
-		const auto path = Filepath::from_locale_string("/whatever/one\x80two");
-		REQUIRE(path.file_name().value() == Filepath::from_locale_string("one\x80two"));
+		const auto path = "/whatever/one\x80two"_path;
+		REQUIRE(path.file_name().value() == "one\x80two"_path);
 	}
 }
 
 TEST_CASE("Can be ordered lexicographically", "[Filepath]")
 {
-	const auto root = Filepath::from_locale_string("/");
-	const auto var_log = Filepath::from_locale_string("/var/log");
-	const auto home_minoru = Filepath::from_locale_string("/home/minoru");
-	const auto home_minoru_src_newsboat =
-		Filepath::from_locale_string("/home/minoru/src/newsboat");
+	const auto root = "/"_path;
+	const auto var_log = "/var/log"_path;
+	const auto home_minoru = "/home/minoru"_path;
+	const auto home_minoru_src_newsboat = "/home/minoru/src/newsboat"_path;
 
 	SECTION("operator<") {
 		SECTION("Path to directory is less than the path to its subdirectory") {
@@ -318,4 +317,11 @@ TEST_CASE("Can be ordered lexicographically", "[Filepath]")
 			REQUIRE_FALSE(home_minoru >= home_minoru_src_newsboat);
 		}
 	}
+}
+
+TEST_CASE("Can be constructed from a literal with user-defined literal syntax",
+	"[Filepath]")
+{
+	const auto example = "/etc/hosts"_path;
+	REQUIRE(example.to_locale_string() == "/etc/hosts");
 }

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -13,7 +13,7 @@ using namespace newsboat;
 TEST_CASE("URL reader remembers the file name from which it read the URLs",
 	"[FileUrlReader]")
 {
-	const auto url = Filepath::from_locale_string("data/test-urls.txt");
+	const auto url = "data/test-urls.txt"_path;
 
 	FileUrlReader u(url);
 	REQUIRE(u.get_source() == url.display());
@@ -23,7 +23,7 @@ TEST_CASE("URL reader remembers the file name from which it read the URLs",
 
 TEST_CASE("URL reader extracts all URLs from the file", "[FileUrlReader]")
 {
-	FileUrlReader u(Filepath::from_locale_string("data/test-urls.txt"));
+	FileUrlReader u("data/test-urls.txt"_path);
 	u.reload();
 
 	REQUIRE(u.get_urls().size() == 3);
@@ -34,7 +34,7 @@ TEST_CASE("URL reader extracts all URLs from the file", "[FileUrlReader]")
 
 TEST_CASE("URL reader extracts feeds' tags", "[FileUrlReader]")
 {
-	FileUrlReader u(Filepath::from_locale_string("data/test-urls.txt"));
+	FileUrlReader u("data/test-urls.txt"_path);
 	u.reload();
 
 	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml").size() == 3);
@@ -52,7 +52,7 @@ TEST_CASE("URL reader extracts feeds' tags", "[FileUrlReader]")
 
 TEST_CASE("URL reader keeps track of unique tags", "[FileUrlReader]")
 {
-	FileUrlReader u(Filepath::from_locale_string("data/test-urls.txt"));
+	FileUrlReader u("data/test-urls.txt"_path);
 	u.reload();
 
 	REQUIRE(u.get_alltags().size() == 3);
@@ -61,7 +61,7 @@ TEST_CASE("URL reader keeps track of unique tags", "[FileUrlReader]")
 TEST_CASE("URL reader writes files that it can understand later",
 	"[FileUrlReader]")
 {
-	const auto testDataPath = Filepath::from_locale_string("data/test-urls.txt");
+	const auto testDataPath = "data/test-urls.txt"_path;
 	test_helpers::TempFile urlsFile;
 
 	test_helpers::copy_file(testDataPath, urlsFile.get_path());
@@ -91,7 +91,7 @@ TEST_CASE("URL reader writes files that it can understand later",
 
 TEST_CASE("Preserves URLs as-is", "[FileUrlReader][issue926]")
 {
-	const auto testDataPath = Filepath::from_locale_string("data/926-urls");
+	const auto testDataPath = "data/926-urls"_path;
 
 	FileUrlReader u(testDataPath);
 	u.reload();
@@ -104,7 +104,7 @@ TEST_CASE("Preserves URLs as-is", "[FileUrlReader][issue926]")
 TEST_CASE("URL reader returns error structure if file cannot be opened",
 	"[FileUrlReader]")
 {
-	const auto testDataPath = Filepath::from_locale_string("data/test-urls.txt");
+	const auto testDataPath = "data/test-urls.txt"_path;
 
 	test_helpers::TempFile urlsFile;
 	FileUrlReader u(urlsFile.get_path());
@@ -191,7 +191,7 @@ TEST_CASE("FileUrlReader::get_alltags() returns all unique tags across all feeds
 	"excluding the title tags",
 	"[FileUrlReader]")
 {
-	FileUrlReader u(Filepath::from_locale_string("data/test-urls.txt"));
+	FileUrlReader u("data/test-urls.txt"_path);
 	u.reload();
 
 	const auto tags = u.get_alltags();

--- a/test/fslock.cpp
+++ b/test/fslock.cpp
@@ -76,9 +76,8 @@ TEST_CASE("try_lock() returns an error if lock-file permissions or location are 
 
 	GIVEN("An invalid lock location") {
 		const test_helpers::TempDir test_directory;
-		const auto non_existing_dir = test_directory.get_path().join(
-				Filepath::from_locale_string("does-not-exist"));
-		const auto lock_location = non_existing_dir.join(Filepath::from_locale_string("lockfile"));
+		const auto non_existing_dir = test_directory.get_path().join("does-not-exist"_path);
+		const auto lock_location = non_existing_dir.join("lockfile"_path);
 
 		THEN("try_lock() will fail and return pid == 0") {
 			FsLock lock;

--- a/test/history.cpp
+++ b/test/history.cpp
@@ -48,7 +48,7 @@ TEST_CASE("History can be iterated on in any direction", "[History]")
 TEST_CASE("History can be saved and loaded from file", "[History]")
 {
 	test_helpers::TempDir tmp;
-	const auto filepath = tmp.get_path().join(Filepath::from_locale_string("history.cmdline"));
+	const auto filepath = tmp.get_path().join("history.cmdline"_path);
 
 	History h;
 	h.add_line("testline");
@@ -79,7 +79,7 @@ TEST_CASE("Only the most recent lines are saved when limiting history",
 	"[History]")
 {
 	test_helpers::TempDir tmp;
-	const auto filepath = tmp.get_path().join(Filepath::from_locale_string("history.cmdline"));
+	const auto filepath = tmp.get_path().join("history.cmdline"_path);
 	const int max_lines = 3;
 
 	History h;

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -114,7 +114,7 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 {
 	test_helpers::TempFile urlsFile;
 
-	test_helpers::copy_file(Filepath::from_locale_string("data/test-urls.txt"),
+	test_helpers::copy_file("data/test-urls.txt"_path,
 		urlsFile.get_path());
 
 	using URL = std::string;
@@ -142,9 +142,9 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 	}
 
 	const auto path =
-		Filepath::from_locale_string("file:/") // `Filepath` will append an extra slash
+		"file:/"_path // `Filepath` will append an extra slash
 		.join(utils::getcwd())
-		.join(Filepath::from_locale_string("data/example.opml"));
+		.join("data/example.opml"_path);
 	REQUIRE_NOTHROW(opml::import(path, urlcfg));
 
 	const std::map<URL, Tags> opmlUrls {
@@ -183,9 +183,9 @@ TEST_CASE("import() turns URLs that start with a pipe symbol (\"|\") "
 	urlcfg.reload();
 
 	const auto path =
-		Filepath::from_locale_string("file:/") // `Filepath` will append an extra slash
+		"file:/"_path // `Filepath` will append an extra slash
 		.join(utils::getcwd())
-		.join(Filepath::from_locale_string("data/piped.opml"));
+		.join("data/piped.opml"_path);
 	REQUIRE_NOTHROW(opml::import(path, urlcfg));
 
 	using URL = std::string;
@@ -219,9 +219,9 @@ TEST_CASE("import() turns \"filtercmd\" attribute into a `filter:` URL "
 	urlcfg.reload();
 
 	const auto path =
-		Filepath::from_locale_string("file:/") // `Filepath` will append an extra slash
+		"file:/"_path // `Filepath` will append an extra slash
 		.join(utils::getcwd())
-		.join(Filepath::from_locale_string("data/filtered.opml"));
+		.join("data/filtered.opml"_path);
 	REQUIRE_NOTHROW(opml::import(path, urlcfg));
 
 	using URL = std::string;
@@ -250,7 +250,7 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 {
 	test_helpers::TempFile urlsFile;
 
-	test_helpers::copy_file(Filepath::from_locale_string("data/test-urls.txt"),
+	test_helpers::copy_file("data/test-urls.txt"_path,
 		urlsFile.get_path());
 
 	using URL = std::string;
@@ -278,9 +278,9 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 	}
 
 	const auto path =
-		Filepath::from_locale_string("file:/") // `Filepath` will append an extra slash
+		"file:/"_path // `Filepath` will append an extra slash
 		.join(utils::getcwd())
-		.join(Filepath::from_locale_string("data/test-urls+.opml"));
+		.join("data/test-urls+.opml"_path);
 	REQUIRE_NOTHROW(opml::import(path, urlcfg));
 
 	const std::map<URL, Tags> opmlUrls {
@@ -308,9 +308,9 @@ TEST_CASE("import() tags from category attribute", "[Opml]")
 {
 	FileUrlReader urlcfg;
 	const auto path =
-		Filepath::from_locale_string("file:/") // `Filepath` will append an extra slash
+		"file:/"_path // `Filepath` will append an extra slash
 		.join(utils::getcwd())
-		.join(Filepath::from_locale_string("data/category.opml"));
+		.join("data/category.opml"_path);
 	REQUIRE_NOTHROW(opml::import(path, urlcfg));
 
 	const std::vector<std::string> tags{"tag one", "tag_two", "tag/three"};

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Passes the callback to Download objects", "[QueueLoader]")
 	};
 
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/nonempty-queue-file"),
+	test_helpers::copy_file("data/nonempty-queue-file"_path,
 		queueFile.get_path());
 
 	ConfigContainer cfg;
@@ -111,7 +111,7 @@ TEST_CASE("reload() appends downloads from the array to the queue file",
 	"[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/sentry-queue-file"),
+	test_helpers::copy_file("data/sentry-queue-file"_path,
 		queueFile.get_path());
 
 	ConfigContainer cfg;
@@ -129,11 +129,11 @@ TEST_CASE("reload() appends downloads from the array to the queue file",
 		"https://example.com/sample"
 	};
 	const auto filenames = std::vector<Filepath> {
-		Filepath::from_locale_string("first.mp4"),
-		Filepath::from_locale_string("another.mp3"),
-		Filepath::from_locale_string("a different one.ogg"),
-		Filepath::from_locale_string("episode 0024.ogg"),
-		Filepath::from_locale_string("another one.mp3")
+		"first.mp4"_path,
+		"another.mp3"_path,
+		"a different one.ogg"_path,
+		"episode 0024.ogg"_path,
+		"another one.mp3"_path
 	};
 	const auto statuses = std::vector<DlStatus> {
 		DlStatus::QUEUED,
@@ -174,7 +174,7 @@ TEST_CASE("reload() adds downloads from the queue file to the array",
 	"[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/nonempty-queue-file"),
+	test_helpers::copy_file("data/nonempty-queue-file"_path,
 		queueFile.get_path());
 
 	ConfigContainer cfg;
@@ -192,35 +192,32 @@ TEST_CASE("reload() adds downloads from the queue file to the array",
 	REQUIRE(downloads.size() == 6);
 
 	REQUIRE(downloads[1].url() == "https://example.com/podcast/episode-001.ogg");
-	REQUIRE(downloads[1].filename() == Filepath::from_locale_string("nonexistent-file.ogg"));
+	REQUIRE(downloads[1].filename() == "nonexistent-file.ogg"_path);
 	REQUIRE(downloads[1].status() == DlStatus::QUEUED);
 
 	REQUIRE(downloads[2].url() ==
 		"https://wwww.example.com/another-podcast/episode-421.mp3");
-	REQUIRE(downloads[2].filename() ==
-		Filepath::from_locale_string("data/podcast-standin.mp3"));
+	REQUIRE(downloads[2].filename() == "data/podcast-standin.mp3"_path);
 	REQUIRE(downloads[2].status() == DlStatus::READY);
 
 	REQUIRE(downloads[3].url() == "https://pods.example.com/that_one/");
-	REQUIRE(downloads[3].filename() ==
-		Filepath::from_locale_string("data/podcast-standin.mp4"));
+	REQUIRE(downloads[3].filename() == "data/podcast-standin.mp4"_path);
 	REQUIRE(downloads[3].status() == DlStatus::PLAYED);
 
 	REQUIRE(downloads[4].url() == "https://pods.example.com/this%20one/audio.ogg");
-	REQUIRE(downloads[4].filename() ==
-		Filepath::from_locale_string("data/podcast-standin.ogg"));
+	REQUIRE(downloads[4].filename() == "data/podcast-standin.ogg"_path);
 	REQUIRE(downloads[4].status() == DlStatus::FINISHED);
 
 	REQUIRE(downloads[5].url() == "https://pods.example.com/partial.ogg");
 	// Note that this file doesn't exist, but data/partial.ogg.part does.
-	REQUIRE(downloads[5].filename() == Filepath::from_locale_string("data/partial.ogg"));
+	REQUIRE(downloads[5].filename() == "data/partial.ogg"_path);
 	REQUIRE(downloads[5].status() == DlStatus::FAILED);
 }
 
 TEST_CASE("reload() merges downloads in the queue file and the array", "[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/queue-file-for-merging"),
+	test_helpers::copy_file("data/queue-file-for-merging"_path,
 		queueFile.get_path());
 
 	ConfigContainer cfg;
@@ -233,18 +230,18 @@ TEST_CASE("reload() merges downloads in the queue file and the array", "[QueueLo
 	// because of its status.
 	downloads.emplace_back(empty_callback);
 	downloads.back().set_url("https://example.com/podcast/episode-001.ogg");
-	downloads.back().set_filename(Filepath::from_locale_string("nonexistent-file.ogg"));
+	downloads.back().set_filename("nonexistent-file.ogg"_path);
 	downloads.back().set_status(DlStatus::DELETED);
 	// This download exists in the queue file already, and it will be kept in
 	// the array.
 	downloads.emplace_back(empty_callback);
 	downloads.back().set_url("https://example.com/podcast/episode-002.ogg");
-	downloads.back().set_filename(Filepath::from_locale_string("a different episode.ogg"));
+	downloads.back().set_filename("a different episode.ogg"_path);
 	downloads.back().set_status(DlStatus::QUEUED);
 	// This download doesn't exist in the queue file.
 	downloads.emplace_back(empty_callback);
 	downloads.back().set_url("https://example.com/another.mp3");
-	downloads.back().set_filename(Filepath::from_locale_string("another.mp3"));
+	downloads.back().set_filename("another.mp3"_path);
 	downloads.back().set_status(DlStatus::QUEUED);
 
 	queue_loader.reload(downloads);
@@ -253,18 +250,16 @@ TEST_CASE("reload() merges downloads in the queue file and the array", "[QueueLo
 
 	// This download was present in both the file and the array, and was kept.
 	REQUIRE(downloads[0].url() == "https://example.com/podcast/episode-002.ogg");
-	REQUIRE(downloads[0].filename() ==
-		Filepath::from_locale_string("a different episode.ogg"));
+	REQUIRE(downloads[0].filename() == "a different episode.ogg"_path);
 	REQUIRE(downloads[0].status() == DlStatus::QUEUED);
 
 	REQUIRE(downloads[1].url() == "https://example.com/another.mp3");
-	REQUIRE(downloads[1].filename() == Filepath::from_locale_string("another.mp3"));
+	REQUIRE(downloads[1].filename() == "another.mp3"_path);
 	REQUIRE(downloads[1].status() == DlStatus::QUEUED);
 
 	// This download was read from the queue file
 	REQUIRE(downloads[2].url() == "https://example.com/this_doesnt_exist_in_code.mp3");
-	REQUIRE(downloads[2].filename() ==
-		Filepath::from_locale_string("data/podcast-standin.mp3"));
+	REQUIRE(downloads[2].filename() == "data/podcast-standin.mp3"_path);
 	REQUIRE(downloads[2].status() == DlStatus::READY);
 }
 
@@ -272,7 +267,7 @@ TEST_CASE("Overrides status in the queue with `MISSING` if file if the podcast i
 	"[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/queue-with-missing-files"),
+	test_helpers::copy_file("data/queue-with-missing-files"_path,
 		queueFile.get_path());
 
 	ConfigContainer cfg;
@@ -294,8 +289,7 @@ TEST_CASE(
 	"[QueueFile]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(
-		Filepath::from_locale_string("data/queue-with-unmarked-downloaded-file"),
+	test_helpers::copy_file("data/queue-with-unmarked-downloaded-file"_path,
 		queueFile.get_path());
 
 	ConfigContainer cfg;
@@ -307,8 +301,7 @@ TEST_CASE(
 
 	REQUIRE(downloads.size() == 1);
 	REQUIRE(downloads[0].url() == "https://example.com/this-got-downloaded-earlier.mp3");
-	REQUIRE(downloads[0].filename() ==
-		Filepath::from_locale_string("data/podcast-standin.ogg"));
+	REQUIRE(downloads[0].filename() == "data/podcast-standin.ogg"_path);
 	REQUIRE(downloads[0].status() == DlStatus::READY);
 }
 
@@ -316,7 +309,7 @@ TEST_CASE("Generates filename if it's absent from the queue file",
 	"[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/queue-without-filenames"),
+	test_helpers::copy_file("data/queue-without-filenames"_path,
 		queueFile.get_path());
 
 	ConfigContainer cfg;
@@ -328,12 +321,12 @@ TEST_CASE("Generates filename if it's absent from the queue file",
 	SECTION("`download-path` set without a trailing slash") {
 		cfg.set_configvalue("download-path", "/some/bogus value");
 		// QueueLoader should append a slash if a setting doesn't contain it.
-		download_path = Filepath::from_locale_string("/some/bogus value/");
+		download_path = "/some/bogus value/"_path;
 	}
 	SECTION("`download-path` set with a trailing slash") {
 		cfg.set_configvalue("download-path",
 			"/yet another/fictional path for downloads/");
-		download_path = Filepath::from_locale_string("/yet another/fictional path for downloads/");
+		download_path = "/yet another/fictional path for downloads/"_path;
 	}
 
 	auto empty_callback = []() {};
@@ -343,12 +336,10 @@ TEST_CASE("Generates filename if it's absent from the queue file",
 	queue_loader.reload(downloads);
 
 	REQUIRE(downloads.size() == 5);
-	REQUIRE(downloads[0].filename() == download_path.join(
-			Filepath::from_locale_string("filename.mp3")));
-	REQUIRE(downloads[1].filename() == download_path.join(
-			Filepath::from_locale_string("hello_world.ogg")));
-	REQUIRE(downloads[2].filename() == download_path.join(
-			Filepath::from_locale_string("here%27s_one_with_a_quote.mp4")));
+	REQUIRE(downloads[0].filename() == download_path.join("filename.mp3"_path));
+	REQUIRE(downloads[1].filename() == download_path.join("hello_world.ogg"_path));
+	REQUIRE(downloads[2].filename() ==
+		download_path.join("here%27s_one_with_a_quote.mp4"_path));
 	// These two downloads should have filenames based on current time, so we
 	// only check their prefixes.
 	downloads[3].filename().starts_with(download_path);
@@ -368,11 +359,11 @@ TEST_CASE("reload() removes files corresponding to \"DELETED\" downloads "
 	QueueLoader queue_loader(queueFile.get_path(), cfg, empty_callback);
 
 	test_helpers::TempFile fileToBeDeleted;
-	test_helpers::copy_file(Filepath::from_locale_string("data/empty-file"),
+	test_helpers::copy_file("data/empty-file"_path,
 		fileToBeDeleted.get_path());
 
 	test_helpers::TempFile fileToBePreserved;
-	test_helpers::copy_file(Filepath::from_locale_string("data/empty-file"),
+	test_helpers::copy_file("data/empty-file"_path,
 		fileToBePreserved.get_path());
 
 	std::vector<Download> downloads;
@@ -422,15 +413,15 @@ TEST_CASE("reload() removes files corresponding to \"FINISHED\" downloads "
 	QueueLoader queue_loader(queueFile.get_path(), cfg, empty_callback);
 
 	test_helpers::TempFile fileInDeletedStatte;
-	test_helpers::copy_file(Filepath::from_locale_string("data/empty-file"),
+	test_helpers::copy_file("data/empty-file"_path,
 		fileInDeletedStatte.get_path());
 
 	test_helpers::TempFile fileInFinishedState;
-	test_helpers::copy_file(Filepath::from_locale_string("data/empty-file"),
+	test_helpers::copy_file("data/empty-file"_path,
 		fileInFinishedState.get_path());
 
 	test_helpers::TempFile fileToBePreserved;
-	test_helpers::copy_file(Filepath::from_locale_string("data/empty-file"),
+	test_helpers::copy_file("data/empty-file"_path,
 		fileToBePreserved.get_path());
 
 	std::vector<Download> downloads;
@@ -478,7 +469,7 @@ TEST_CASE("reload() does nothing if one of the downloads in the vector "
 	"[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/nonempty-queue-file"),
+	test_helpers::copy_file("data/nonempty-queue-file"_path,
 		queueFile.get_path());
 
 	auto empty_callback = []() {};
@@ -487,12 +478,12 @@ TEST_CASE("reload() does nothing if one of the downloads in the vector "
 
 	std::vector<Download> downloads;
 	downloads.emplace_back(empty_callback);
-	downloads.back().set_filename(Filepath::from_locale_string("whatever1"));
+	downloads.back().set_filename("whatever1"_path);
 	downloads.back().set_url("https://nonempty.example.com/1");
 	downloads.back().set_status(DlStatus::DOWNLOADING);
 
 	downloads.emplace_back(empty_callback);
-	downloads.back().set_filename(Filepath::from_locale_string("whatever2"));
+	downloads.back().set_filename("whatever2"_path);
 	downloads.back().set_url("https://nonempty.example.com/2");
 	downloads.back().set_status(DlStatus::FINISHED);
 
@@ -505,12 +496,12 @@ TEST_CASE("reload() does nothing if one of the downloads in the vector "
 	}
 
 	REQUIRE(test_helpers::file_contents(queueFile.get_path()) ==
-		test_helpers::file_contents(Filepath::from_locale_string("data/nonempty-queue-file")));
+		test_helpers::file_contents("data/nonempty-queue-file"_path));
 	REQUIRE(downloads.size() == 2);
-	REQUIRE(downloads[0].filename() == Filepath::from_locale_string("whatever1"));
+	REQUIRE(downloads[0].filename() == "whatever1"_path);
 	REQUIRE(downloads[0].url() == "https://nonempty.example.com/1");
 	REQUIRE(downloads[0].status() == DlStatus::DOWNLOADING);
-	REQUIRE(downloads[1].filename() == Filepath::from_locale_string("whatever2"));
+	REQUIRE(downloads[1].filename() == "whatever2"_path);
 	REQUIRE(downloads[1].url() == "https://nonempty.example.com/2");
 	REQUIRE(downloads[1].status() == DlStatus::FINISHED);
 }
@@ -518,7 +509,7 @@ TEST_CASE("reload() does nothing if one of the downloads in the vector "
 TEST_CASE("reload() skips empty lines in the queue file", "[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/queue-file-with-empty-lines"),
+	test_helpers::copy_file("data/queue-file-with-empty-lines"_path,
 		queueFile.get_path());
 
 	auto empty_callback = []() {};
@@ -527,7 +518,7 @@ TEST_CASE("reload() skips empty lines in the queue file", "[QueueLoader]")
 
 	std::vector<Download> downloads;
 	downloads.emplace_back(empty_callback);
-	downloads.back().set_filename(Filepath::from_locale_string("newest.mp3"));
+	downloads.back().set_filename("newest.mp3"_path);
 	downloads.back().set_url("https://example.com/newest_episode.mp3");
 	downloads.back().set_status(DlStatus::READY);
 
@@ -541,27 +532,27 @@ TEST_CASE("reload() skips empty lines in the queue file", "[QueueLoader]")
 
 	REQUIRE(downloads.size() == 6);
 
-	REQUIRE(downloads[0].filename() == Filepath::from_locale_string("newest.mp3"));
+	REQUIRE(downloads[0].filename() == "newest.mp3"_path);
 	REQUIRE(downloads[0].url() == "https://example.com/newest_episode.mp3");
 	REQUIRE(downloads[0].status() == DlStatus::READY);
 
-	REQUIRE(downloads[1].filename() == Filepath::from_locale_string("first.mp3"));
+	REQUIRE(downloads[1].filename() == "first.mp3"_path);
 	REQUIRE(downloads[1].url() == "https://example.com/episode01.mp3");
 	REQUIRE(downloads[1].status() == DlStatus::QUEUED);
 
-	REQUIRE(downloads[2].filename() == Filepath::from_locale_string("second.mp3"));
+	REQUIRE(downloads[2].filename() == "second.mp3"_path);
 	REQUIRE(downloads[2].url() == "https://example.com/episode02.mp3");
 	REQUIRE(downloads[2].status() == DlStatus::QUEUED);
 
-	REQUIRE(downloads[3].filename() == Filepath::from_locale_string("third.mp3"));
+	REQUIRE(downloads[3].filename() == "third.mp3"_path);
 	REQUIRE(downloads[3].url() == "https://example.com/episode03.mp3");
 	REQUIRE(downloads[3].status() == DlStatus::QUEUED);
 
-	REQUIRE(downloads[4].filename() == Filepath::from_locale_string("fourth.mp3"));
+	REQUIRE(downloads[4].filename() == "fourth.mp3"_path);
 	REQUIRE(downloads[4].url() == "https://example.com/episode04.mp3");
 	REQUIRE(downloads[4].status() == DlStatus::QUEUED);
 
-	REQUIRE(downloads[5].filename() == Filepath::from_locale_string("fifth.mp3"));
+	REQUIRE(downloads[5].filename() == "fifth.mp3"_path);
 	REQUIRE(downloads[5].url() == "https://example.com/episode05.mp3");
 	REQUIRE(downloads[5].status() == DlStatus::QUEUED);
 }
@@ -569,7 +560,7 @@ TEST_CASE("reload() skips empty lines in the queue file", "[QueueLoader]")
 TEST_CASE("reload() removes empty lines from the queue file", "[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/queue-file-with-empty-lines"),
+	test_helpers::copy_file("data/queue-file-with-empty-lines"_path,
 		queueFile.get_path());
 
 	auto empty_callback = []() {};
@@ -588,14 +579,14 @@ TEST_CASE("reload() removes empty lines from the queue file", "[QueueLoader]")
 
 	REQUIRE(test_helpers::file_contents(queueFile.get_path()) ==
 		test_helpers::file_contents(
-			Filepath::from_locale_string("data/queue-file-with-empty-lines-removed")));
+			"data/queue-file-with-empty-lines-removed"_path));
 }
 
 TEST_CASE("No exceptions are thrown if reload() can't read the queue file",
 	"[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/empty-file"),
+	test_helpers::copy_file("data/empty-file"_path,
 		queueFile.get_path());
 	// Make the file write-only.
 	test_helpers::Chmod queueFileMode(queueFile.get_path(), 0200);
@@ -613,7 +604,7 @@ TEST_CASE("No exceptions are thrown if reload() can't write the queue file",
 	"[QueueLoader]")
 {
 	test_helpers::TempFile queueFile;
-	test_helpers::copy_file(Filepath::from_locale_string("data/empty-file"),
+	test_helpers::copy_file("data/empty-file"_path,
 		queueFile.get_path());
 	// Make the file read-only.
 	test_helpers::Chmod queueFileMode(queueFile.get_path(), 0400);

--- a/test/queuemanager.cpp
+++ b/test/queuemanager.cpp
@@ -226,7 +226,7 @@ SCENARIO("enqueue_url() errors if the queue file can't be opened for writing",
 		test_helpers::TempFile queue_file;
 		QueueManager manager(&cfg, queue_file.get_path());
 
-		test_helpers::copy_file(Filepath::from_locale_string("data/empty-file"),
+		test_helpers::copy_file("data/empty-file"_path,
 			queue_file.get_path());
 		// The file is read-only
 		test_helpers::Chmod uneditable_queue_file(queue_file.get_path(), 0444);
@@ -560,7 +560,7 @@ SCENARIO("autoenqueue() errors if the queue file can't be opened for writing",
 		test_helpers::TempFile queue_file;
 		QueueManager manager(&cfg, queue_file.get_path());
 
-		test_helpers::copy_file(Filepath::from_locale_string("data/empty-file"),
+		test_helpers::copy_file("data/empty-file"_path,
 			queue_file.get_path());
 		// The file is read-only
 		test_helpers::Chmod uneditable_queue_file(queue_file.get_path(), 0444);

--- a/test/remoteapi.cpp
+++ b/test/remoteapi.cpp
@@ -61,7 +61,7 @@ TEST_CASE("get_credentials() returns the users name and password",
 	ConfigContainer cfg;
 	ConfigParser cfgparser;
 	cfg.register_commands(cfgparser);
-	cfgparser.parse_file(Filepath::from_locale_string("data/test-config-credentials.txt"));
+	cfgparser.parse_file("data/test-config-credentials.txt"_path);
 	auto api = std::make_unique<test_api>(cfg);
 	REQUIRE(api->get_user("ttrss", "") == "ttrss-user");
 	REQUIRE(api->get_pass("ttrss", "") == "my-birthday");
@@ -84,15 +84,15 @@ TEST_CASE("get_credentials() returns the users name and password",
 
 TEST_CASE("read_password() returns the first line of the file", "[RemoteApi]")
 {
-	REQUIRE(RemoteApi::read_password(Filepath::from_locale_string("/dev/null")) == "");
-	REQUIRE_NOTHROW(RemoteApi::read_password(
-			Filepath::from_locale_string("a-passwordfile-that-is-guaranteed-to-not-exist.txt")));
-	REQUIRE(RemoteApi::read_password(
-			Filepath::from_locale_string("a-passwordfile-that-is-guaranteed-to-not-exist.txt")) == "");
-	REQUIRE(RemoteApi::read_password(
-			Filepath::from_locale_string("data/single-line-string.txt")) == "single line with spaces");
-	REQUIRE(RemoteApi::read_password(
-			Filepath::from_locale_string("data/multi-line-string.txt")) == "string with spaces");
+	REQUIRE(RemoteApi::read_password("/dev/null"_path) == "");
+	REQUIRE_NOTHROW(
+		RemoteApi::read_password("a-passwordfile-that-is-guaranteed-to-not-exist.txt"_path));
+	REQUIRE(RemoteApi::read_password("a-passwordfile-that-is-guaranteed-to-not-exist.txt"_path)
+		== "");
+	REQUIRE(RemoteApi::read_password("data/single-line-string.txt"_path) ==
+		"single line with spaces");
+	REQUIRE(RemoteApi::read_password("data/multi-line-string.txt"_path) ==
+		"string with spaces");
 }
 
 TEST_CASE("eval_password() returns the first line of command's output",

--- a/test/rsspp_parser.cpp
+++ b/test/rsspp_parser.cpp
@@ -11,14 +11,15 @@
 #include "test_helpers/misc.h"
 #include "utils.h"
 
+using newsboat::operator""_path;
+
 TEST_CASE("Throws exception if file doesn't exist", "[rsspp::Parser]")
 {
 	using test_helpers::ExceptionWithMsg;
 
 	rsspp::Parser p;
 
-	REQUIRE_THROWS_MATCHES(p.parse_file(
-			newsboat::Filepath::from_locale_string("data/non-existent.xml")),
+	REQUIRE_THROWS_MATCHES(p.parse_file("data/non-existent.xml"_path),
 		rsspp::Exception,
 		ExceptionWithMsg<rsspp::Exception>("could not parse file"));
 }
@@ -29,8 +30,7 @@ TEST_CASE("Throws exception if file can't be parsed", "[rsspp::Parser]")
 
 	rsspp::Parser p;
 
-	REQUIRE_THROWS_MATCHES(p.parse_file(
-			newsboat::Filepath::from_locale_string("data/empty.xml")),
+	REQUIRE_THROWS_MATCHES(p.parse_file("data/empty.xml"_path),
 		rsspp::Exception,
 		ExceptionWithMsg<rsspp::Exception>("could not parse file"));
 }
@@ -40,8 +40,7 @@ TEST_CASE("Extracts data from RSS 0.91", "[rsspp::Parser]")
 	rsspp::Parser p;
 	rsspp::Feed f;
 
-	REQUIRE_NOTHROW(f = p.parse_file(
-				newsboat::Filepath::from_locale_string("data/rss091_1.xml")));
+	REQUIRE_NOTHROW(f = p.parse_file("data/rss091_1.xml"_path));
 
 	REQUIRE(f.rss_version == rsspp::Feed::RSS_0_91);
 	REQUIRE(f.title == "Example Channel");
@@ -88,22 +87,19 @@ TEST_CASE("Doesn't crash or garble data if an item in RSS 0.9x contains "
 	};
 
 	SECTION("RSS 0.91") {
-		REQUIRE_NOTHROW(f = p.parse_file(
-					newsboat::Filepath::from_locale_string("data/rss_091_with_empty_author.xml")));
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_091_with_empty_author.xml"_path));
 		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_91);
 		check();
 	}
 
 	SECTION("RSS 0.92") {
-		REQUIRE_NOTHROW(f = p.parse_file(
-					newsboat::Filepath::from_locale_string("data/rss_092_with_empty_author.xml")));
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_092_with_empty_author.xml"_path));
 		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_92);
 		check();
 	}
 
 	SECTION("RSS 0.94") {
-		REQUIRE_NOTHROW(f = p.parse_file(
-					newsboat::Filepath::from_locale_string("data/rss_094_with_empty_author.xml")));
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_094_with_empty_author.xml"_path));
 		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_94);
 		check();
 	}
@@ -145,22 +141,19 @@ TEST_CASE("Doesn't crash or garble data if an item in RSS 0.9x contains "
 	};
 
 	SECTION("RSS 0.91") {
-		REQUIRE_NOTHROW(f = p.parse_file(
-					newsboat::Filepath::from_locale_string("data/rss_091_with_bracket_author.xml")));
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_091_with_bracket_author.xml"_path));
 		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_91);
 		check();
 	}
 
 	SECTION("RSS 0.92") {
-		REQUIRE_NOTHROW(f = p.parse_file(
-					newsboat::Filepath::from_locale_string("data/rss_092_with_bracket_author.xml")));
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_092_with_bracket_author.xml"_path));
 		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_92);
 		check();
 	}
 
 	SECTION("RSS 0.94") {
-		REQUIRE_NOTHROW(f = p.parse_file(
-					newsboat::Filepath::from_locale_string("data/rss_094_with_bracket_author.xml")));
+		REQUIRE_NOTHROW(f = p.parse_file("data/rss_094_with_bracket_author.xml"_path));
 		REQUIRE(f.rss_version == rsspp::Feed::RSS_0_94);
 		check();
 	}
@@ -171,8 +164,7 @@ TEST_CASE("Extracts data from RSS 0.92", "[rsspp::Parser]")
 	rsspp::Parser p;
 	rsspp::Feed f;
 
-	REQUIRE_NOTHROW(f = p.parse_file(
-				newsboat::Filepath::from_locale_string("data/rss092_1.xml")));
+	REQUIRE_NOTHROW(f = p.parse_file("data/rss092_1.xml"_path));
 
 	REQUIRE(f.rss_version == rsspp::Feed::RSS_0_92);
 	REQUIRE(f.title == "Example Channel");
@@ -204,8 +196,7 @@ TEST_CASE("Extracts data fro RSS 2.0", "[rsspp::Parser]")
 	rsspp::Parser p;
 	rsspp::Feed f;
 
-	REQUIRE_NOTHROW(f = p.parse_file(
-				newsboat::Filepath::from_locale_string("data/rss20_1.xml")));
+	REQUIRE_NOTHROW(f = p.parse_file("data/rss20_1.xml"_path));
 
 	REQUIRE(f.title == "my weblog");
 	REQUIRE(f.link == "http://example.com/blog/");
@@ -230,8 +221,7 @@ TEST_CASE("Extracts data from RSS 1.0", "[rsspp::Parser]")
 	rsspp::Parser p;
 	rsspp::Feed f;
 
-	REQUIRE_NOTHROW(f = p.parse_file(
-				newsboat::Filepath::from_locale_string("data/rss10_1.xml")));
+	REQUIRE_NOTHROW(f = p.parse_file("data/rss10_1.xml"_path));
 
 	REQUIRE(f.rss_version == rsspp::Feed::RSS_1_0);
 
@@ -253,8 +243,7 @@ TEST_CASE("Extracts data from Atom 1.0", "[rsspp::Parser]")
 	rsspp::Parser p;
 	rsspp::Feed f;
 
-	REQUIRE_NOTHROW(f = p.parse_file(
-				newsboat::Filepath::from_locale_string("data/atom10_1.xml")));
+	REQUIRE_NOTHROW(f = p.parse_file("data/atom10_1.xml"_path));
 
 	REQUIRE(f.rss_version == rsspp::Feed::ATOM_1_0);
 
@@ -297,8 +286,7 @@ TEST_CASE("Extracts data from media:... tags in atom feed", "[rsspp::Parser]")
 	rsspp::Parser p;
 	rsspp::Feed f;
 
-	REQUIRE_NOTHROW(f = p.parse_file(
-				newsboat::Filepath::from_locale_string("data/atom10_2.xml")));
+	REQUIRE_NOTHROW(f = p.parse_file("data/atom10_2.xml"_path));
 
 	REQUIRE(f.rss_version == rsspp::Feed::ATOM_1_0);
 
@@ -359,8 +347,7 @@ TEST_CASE("Extracts data from media:... tags in  RSS 2.0 feeds",
 	rsspp::Parser p;
 	rsspp::Feed f;
 
-	REQUIRE_NOTHROW(f = p.parse_file(
-				newsboat::Filepath::from_locale_string("data/rss20_2.xml")));
+	REQUIRE_NOTHROW(f = p.parse_file("data/rss20_2.xml"_path));
 
 	REQUIRE(f.title == "my weblog");
 	REQUIRE(f.link == "http://example.com/blog/");
@@ -394,8 +381,7 @@ TEST_CASE("Multiple links in item", "[rsspp::Parser]")
 	rsspp::Parser p;
 	rsspp::Feed f;
 
-	REQUIRE_NOTHROW(f = p.parse_file(
-				newsboat::Filepath::from_locale_string("data/multiple_item_links.atom")));
+	REQUIRE_NOTHROW(f = p.parse_file("data/multiple_item_links.atom"_path));
 
 	REQUIRE(f.items.size() == 1u);
 
@@ -408,8 +394,7 @@ TEST_CASE("Feed authors and source authors in atom feed", "[rsspp::Parser]")
 	rsspp::Parser p;
 	rsspp::Feed f;
 
-	REQUIRE_NOTHROW(f = p.parse_file(
-				newsboat::Filepath::from_locale_string("data/atom10_feed_authors.xml")));
+	REQUIRE_NOTHROW(f = p.parse_file("data/atom10_feed_authors.xml"_path));
 
 	REQUIRE(f.rss_version == rsspp::Feed::ATOM_1_0);
 
@@ -461,8 +446,7 @@ TEST_CASE("parse_url() extracts etag and lastmodified data", "[rsspp::Parser]")
 {
 	using namespace newsboat;
 
-	auto feed_xml = test_helpers::read_binary_file(
-			newsboat::Filepath::from_locale_string("data/atom10_1.xml"));
+	auto feed_xml = test_helpers::read_binary_file("data/atom10_1.xml"_path);
 
 	auto& test_server = test_helpers::HttpTestServer::get_instance();
 	auto mock_registration = test_server.add_endpoint("/feed", {}, 200, {

--- a/test/strprintf.cpp
+++ b/test/strprintf.cpp
@@ -236,6 +236,6 @@ TEST_CASE("strprintf::fmt() works fine with 2MB format string", "[strprintf]")
 
 TEST_CASE("strprintf::fmt() formats Filepath", "[strprintf]")
 {
-	const auto input = Filepath::from_locale_string("/run/shm/");
+	const auto input = "/run/shm/"_path;
 	REQUIRE(strprintf::fmt("%s", input) == "/run/shm/");
 }

--- a/test/test_helpers/maintempdir.cpp
+++ b/test/test_helpers/maintempdir.cpp
@@ -6,6 +6,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+using newsboat::operator""_path;
+
 test_helpers::MainTempDir::tempfileexception::tempfileexception(
 	const newsboat::Filepath& filepath,
 	const std::string& error)
@@ -25,10 +27,10 @@ test_helpers::MainTempDir::MainTempDir()
 	if (tmpdir_p) {
 		tempdir = newsboat::Filepath::from_locale_string(tmpdir_p);
 	} else {
-		tempdir = newsboat::Filepath::from_locale_string("/tmp");
+		tempdir = "/tmp"_path;
 	}
 
-	tempdir.push(newsboat::Filepath::from_locale_string("newsboat-tests"));
+	tempdir.push("newsboat-tests"_path);
 
 	const auto tempdir_str = tempdir.to_locale_string();
 	int status = mkdir(tempdir_str.c_str(), S_IRWXU);

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -693,47 +693,29 @@ TEST_CASE("resolve_tilde() replaces ~ with the path to the home directory",
 {
 	test_helpers::EnvVar envVar("HOME");
 	envVar.set("test");
-	REQUIRE(utils::resolve_tilde(Filepath::from_locale_string("~")) ==
-		Filepath::from_locale_string("test/"));
-	REQUIRE(utils::resolve_tilde(Filepath::from_locale_string("~/")) ==
-		Filepath::from_locale_string("test/"));
-	REQUIRE(utils::resolve_tilde(Filepath::from_locale_string("~/dir")) ==
-		Filepath::from_locale_string("test/dir"));
-	const auto path_with_tilde_at_the_end = Filepath::from_locale_string("/home/~");
+	REQUIRE(utils::resolve_tilde("~"_path) == "test/"_path);
+	REQUIRE(utils::resolve_tilde("~/"_path) == "test/"_path);
+	REQUIRE(utils::resolve_tilde("~/dir"_path) == "test/dir"_path);
+	const auto path_with_tilde_at_the_end = "/home/~"_path;
 	REQUIRE(utils::resolve_tilde(path_with_tilde_at_the_end) == path_with_tilde_at_the_end);
-	REQUIRE(
-		utils::resolve_tilde(Filepath::from_locale_string("~/foo/bar")) ==
-		Filepath::from_locale_string("test/foo/bar")
-	);
-	const auto path_without_tilde = Filepath::from_locale_string("/foo/bar");
+	REQUIRE(utils::resolve_tilde("~/foo/bar"_path) == "test/foo/bar"_path);
+	const auto path_without_tilde = "/foo/bar"_path;
 	REQUIRE(utils::resolve_tilde(path_without_tilde) == path_without_tilde);
 }
 
 TEST_CASE("resolve_relative() returns an absolute file path relative to another",
 	"[utils]")
 {
-	const auto foobar = Filepath::from_locale_string("/foo/bar");
-	const auto config = Filepath::from_locale_string("/config");
+	const auto foobar = "/foo/bar"_path;
+	const auto config = "/config"_path;
 
 	SECTION("Nothing - absolute path") {
-		REQUIRE(
-			utils::resolve_relative(foobar, Filepath::from_locale_string("/baz"))
-			==
-			Filepath::from_locale_string("/baz"));
-		REQUIRE(
-			utils::resolve_relative(config, Filepath::from_locale_string("/config/baz"))
-			==
-			Filepath::from_locale_string("/config/baz"));
+		REQUIRE(utils::resolve_relative(foobar, "/baz"_path) == "/baz"_path);
+		REQUIRE(utils::resolve_relative(config, "/config/baz"_path) == "/config/baz"_path);
 	}
 	SECTION("Reference path") {
-		REQUIRE(
-			utils::resolve_relative(foobar, Filepath::from_locale_string("baz"))
-			==
-			Filepath::from_locale_string("/foo/baz"));
-		REQUIRE(
-			utils::resolve_relative(config, Filepath::from_locale_string("baz"))
-			==
-			Filepath::from_locale_string("/baz"));
+		REQUIRE(utils::resolve_relative(foobar, "baz"_path) == "/foo/baz"_path);
+		REQUIRE(utils::resolve_relative(config, "baz"_path) == "/baz"_path);
 	}
 }
 
@@ -1617,13 +1599,13 @@ TEST_CASE(
 
 	// If BROWSER is not set, default browser is lynx(1)
 	browserEnv.unset();
-	REQUIRE(utils::get_default_browser() == Filepath::from_locale_string("lynx"));
+	REQUIRE(utils::get_default_browser() == "lynx"_path);
 
 	browserEnv.set("firefox");
-	REQUIRE(utils::get_default_browser() == Filepath::from_locale_string("firefox"));
+	REQUIRE(utils::get_default_browser() == "firefox"_path);
 
 	browserEnv.set("opera");
-	REQUIRE(utils::get_default_browser() == Filepath::from_locale_string("opera"));
+	REQUIRE(utils::get_default_browser() == "opera"_path);
 }
 
 TEST_CASE(

--- a/test/view.cpp
+++ b/test/view.cpp
@@ -28,17 +28,12 @@ TEST_CASE("get_filename_suggestion() normalizes filenames for saving articles", 
 	c.set_view(&v);
 
 	// Default case is exclusively ASCII characters. Should never fail.
-	REQUIRE(v.get_filename_suggestion(example_en) ==
-		Filepath::from_locale_string("Comparing_Visual.txt"));
-	REQUIRE(v.get_filename_suggestion(example_ru) !=
-		Filepath::from_locale_string("Инженеры_из_MIT.txt"));
-	REQUIRE(v.get_filename_suggestion(example_fr) !=
-		Filepath::from_locale_string("Les_mathématiques.txt"));
+	REQUIRE(v.get_filename_suggestion(example_en) == "Comparing_Visual.txt"_path);
+	REQUIRE(v.get_filename_suggestion(example_ru) != "Инженеры_из_MIT.txt"_path);
+	REQUIRE(v.get_filename_suggestion(example_fr) != "Les_mathématiques.txt"_path);
 
 	cfg.toggle("restrict-filename");
 
-	REQUIRE(v.get_filename_suggestion(example_ru) ==
-		Filepath::from_locale_string("Инженеры из MIT.txt"));
-	REQUIRE(v.get_filename_suggestion(example_fr) ==
-		Filepath::from_locale_string("Les mathématiques.txt"));
+	REQUIRE(v.get_filename_suggestion(example_ru) == "Инженеры из MIT.txt"_path);
+	REQUIRE(v.get_filename_suggestion(example_fr) == "Les mathématiques.txt"_path);
 }


### PR DESCRIPTION
This implements the suggestion from https://github.com/newsboat/newsboat/pull/3120#discussion_r2232843746, and cleans up some of the code quite nicely IMHO.

Cf. https://github.com/newsboat/newsboat/issues/2326.

I believe this is going to be the final PR before the rebase onto current master and the mega-PR to finally get this into the main branch.