### PR TITLE
Remove workaround for .gitignore-related issue in grcov

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -63,10 +63,6 @@ jobs:
         if: steps.cargo_cache.outputs.cache-hit != 'true'
         run: cargo install grcov
 
-      - name: Remove .gitignore
-        # Workaround for https://github.com/mozilla/grcov/issues/1333
-        run: rm .gitignore
-
       - name: Run tests
         run: make --jobs=3 NEWSBOAT_RUN_IGNORED_TESTS=1 ci-check
 


### PR DESCRIPTION
The issue got fixed upstream so we no longer need this workaround.