### PR TITLE
Fix the build on Apple Silicon macOS

### DIFF
--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -55,12 +55,14 @@ std::string fmt(const std::string& format, const uint64_t argument,
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
 
+#ifdef __APPLE__
 template<typename... Args>
 std::string fmt(const std::string& format, const std::size_t argument,
 	Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
+#endif
 
 template<typename... Args>
 std::string fmt(const std::string& format, const void* argument, Args&& ... args)


### PR DESCRIPTION
I tried to fix the build on Apple Silicon macOS by resolving the ambiguity of the `strprintf::fmt()` call for `size_t` type definition.
Also fixed the test failures introduced in #3112, to be able to run `make test` in this PR.

Context: on Apple Silicon, the version 2.41 currently doesn't build with the following error:
```
In file included from rss/parser.cpp:16:
include/logger.h:22:19: error: call to 'fmt' is ambiguous
   22 |                 log_internal(l, strprintf::fmt(format, std::forward<Args>(args)...));
      |                                 ^~~~~~~~~~~~~~
rss/parser.cpp:252:3: note: in instantiation of function template specialization 'newsboat::logger::log<unsigned long>' requested here
  252 |                 LOG(Level::DEBUG, "Parser::parse_buffer: parse xml in utf-8 encoding (length: %zu)",
      |                 ^
include/logger.h:37:21: note: expanded from macro 'LOG'
   37 |                 newsboat::logger::log(x, __VA_ARGS__); \
      |                                   ^
include/strprintf.h:33:13: note: candidate function [with Args = <>]
   33 | std::string fmt(const std::string& format, const int32_t argument, Args&& ... args)
      |             ^
include/strprintf.h:39:13: note: candidate function [with Args = <>]
   39 | std::string fmt(const std::string& format, const std::uint32_t argument,
      |             ^
include/strprintf.h:46:13: note: candidate function [with Args = <>]
   46 | std::string fmt(const std::string& format, const int64_t argument, Args&& ... args)
      |             ^
include/strprintf.h:52:13: note: candidate function [with Args = <>]
   52 | std::string fmt(const std::string& format, const uint64_t argument,
      |             ^
include/strprintf.h:72:13: note: candidate function [with Args = <>]
   72 | std::string fmt(const std::string& format, const float argument, Args&& ... args)
      |             ^
include/strprintf.h:81:13: note: candidate function [with Args = <>]
   81 | std::string fmt(const std::string& format, const double argument, Args&& ... args)
      |             ^
```