### PR TITLE
Fix OPML tests

### DIFF
--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -328,7 +328,9 @@ TEST_CASE("import() returns an error when the <opml> root element is missing", "
 
 	FileUrlReader urlcfg;
 	const auto error_message = opml::import(
-			"file://" + utils::getcwd() + "/data/opml-element-missing.opml",
+			"file:/"_path // `Filepath` will append an extra slash
+			.join(utils::getcwd())
+			.join("data/opml-element-missing.opml"_path),
 			urlcfg);
 
 	REQUIRE(error_message.has_value());
@@ -343,7 +345,9 @@ TEST_CASE("import() returns an error when the <body> element is missing", "[Opml
 
 	FileUrlReader urlcfg;
 	const auto error_message = opml::import(
-			"file://" + utils::getcwd() + "/data/body-element-missing.opml",
+			"file:/"_path // `Filepath` will append an extra slash
+			.join(utils::getcwd())
+			.join("data/body-element-missing.opml"_path),
 			urlcfg);
 
 	REQUIRE(error_message.has_value());


### PR DESCRIPTION
We recently switched to a separate type for filesystem paths, necessitating a mechanical revamp of much related code. Unfortunately, 4c0bc735d3c20b084d4463e68d80df6b244b4faa was made before that work got merged. CI didn't fail for the PR because it contained an older version of the code, and I missed the notification when CI failed after merging the PR into master.