### PR TITLE
Experiment with lock to avoid crashes when interacting during reload

### DIFF
--- a/include/view.h
+++ b/include/view.h
@@ -175,7 +175,13 @@ protected:
 	const ColorManager& colorman;
 
 private:
+
 	bool try_prepare_query_feed(std::shared_ptr<RssFeed> feed);
+
+public:
+	std::mutex general_state_mutex;
+private:
+	std::unique_lock<std::mutex> general_state_lock;
 };
 
 } // namespace newsboat


### PR DESCRIPTION
Initial attempt at fixing a bunch of crashes related to UI interactions during feed reloads.

The main thread is used for drawing the UI, waiting for user input, and then executing operations based on that user input.
In parallel, there might be several threads running to download feeds, parse them, and update feeds with the newly retrieved articles (both in the sqlite cache and the in-memory feed representations).
There have been several issues reported mentioning crashes when interacting with newsboat while it is reloading feeds (see below).
I expect these are caused by the simultaneous access (without proper locking/synchronization) of internal state (like the list of feeds) 

In this PR, I try to avoid these issues by guaranteeing that only one thread at a time can read/update the internal state:
- main thread: Keep the mutex locked while handling user input but unlock as soon as we start waiting for new input
- Reloader thread: Keep the mutex unlocked while downloading and parsing a feed but lock it as soon as the new feed data is being written to the in-memory feeds and the cache

I've been testing these changes locally for a few weeks now.
They seem to work well (no hangs and no crashes when actively trying to scroll a lot during reloads).
However, I only use a small subset of newsboat's features so I might still be missing something.
If anyone wants to test these changes, that would be great!

Hopefully:
- Resolves https://github.com/newsboat/newsboat/issues/3180
- Resolves https://github.com/newsboat/newsboat/issues/3075
- Resolves https://github.com/newsboat/newsboat/issues/3052
- Resolves https://github.com/newsboat/newsboat/issues/2592
- Resolves https://github.com/newsboat/newsboat/issues/2101
- Resolves https://github.com/newsboat/newsboat/issues/1723