### PR TITLE
CI: reinstate macOS build by building stfl from source

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,48 +74,6 @@ task:
         - mv $HOME/.cargo/git/db/ $HOME/cargo-cache/git/ || true
 
 task:
-    skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'docker/*', 'docker/**/*', '.github/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
-    name: macOS Sonoma
-    macos_instance:
-        image: ghcr.io/cirruslabs/macos-runner:sonoma
-    cargo_cache: *cargo_cache
-    env:
-        HOMEBREW_PREFIX: /opt/homebrew
-        PATH: /opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/opt/gettext/bin:$PATH
-        PKG_CONFIG_PATH: /opt/homebrew/opt/libxml2/lib/pkgconfig:/opt/homebrew/lib/pkgconfig
-        DYLD_LIBRARY_PATH: /opt/homebrew/lib
-        LDFLAGS: -L/opt/homebrew/opt/gettext/lib -L/opt/homebrew/lib
-        CFLAGS: -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/include
-        CXXFLAGS: -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/include
-        GETTEXT_DIR: /opt/homebrew/opt/gettext
-        RUSTFLAGS: '-D warnings'
-        JOBS: 5
-    after_cache_script: *after_cache_script
-    install_deps_script:
-        - brew install make rust sqlite libxml2 curl json-c ncurses openssl gettext asciidoctor pkg-config
-        - sudo ln -sf /opt/homebrew/opt/ncurses/bin/ncurses6-config /usr/local/bin/ncurses5.4-config
-    install_stfl_script: |
-        git clone https://github.com/newsboat/stfl.git /tmp/stfl
-        cd /tmp/stfl
-        sed -i '' 's/ncursesw/ncurses/g' Makefile stfl_internals.h
-        sed -i '' 's|<ncurses/ncurses.h>|<ncurses.h>|g' stfl_internals.h
-        sed -i '' 's/-Wl,-soname,$(SONAME)/-Wl/g' Makefile
-        CFLAGS="-I/opt/homebrew/opt/ncurses/include -D_XOPEN_SOURCE_EXTENDED=1" LDFLAGS="-L/opt/homebrew/opt/ncurses/lib" LDLIBS="-lncurses -liconv" make
-        sudo make prefix=/opt/homebrew install
-    build_script: |
-        make --jobs=${JOBS} --keep-going all test
-    test_script: |
-        RUST_TEST_THREADS=${JOBS} RUST_BACKTRACE=1 make -j${JOBS} NEWSBOAT_RUN_IGNORED_TESTS=1 ci-check
-    fake_install_script: |
-        mkdir fakeroot
-        make DESTDIR=fakeroot install
-        make DESTDIR=fakeroot uninstall
-        test $(find fakeroot -type f -print | wc -l) -eq 0
-    clippy_script: |
-        cargo clippy --all-targets --all-features -- -D warnings -A unknown-lints
-    before_cache_script: *before_cache_script
-
-task:
     name: Linux i686 (Ubuntu 18.04)
     skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'docker/remote-testing/*', 'docker/remote-testing/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
     container:
@@ -423,6 +381,42 @@ task:
     build_script: make -j${JOBS} test
     test_script: cd test && ./test --order=rand --rng-seed=time
     before_cache_script: *before_cache_script
+
+task:
+    skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'docker/*', 'docker/**/*', '.github/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
+    name: macOS Sonoma
+    macos_instance:
+        image: ghcr.io/cirruslabs/macos-runner:sonoma
+    cargo_cache: *cargo_cache
+    env:
+        HOMEBREW_PREFIX: /opt/homebrew
+        PATH: /opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/opt/gettext/bin:$PATH
+        PKG_CONFIG_PATH: /opt/homebrew/opt/libxml2/lib/pkgconfig:/opt/homebrew/lib/pkgconfig
+        DYLD_LIBRARY_PATH: /opt/homebrew/lib
+        LDFLAGS: -L/opt/homebrew/opt/gettext/lib -L/opt/homebrew/lib
+        CFLAGS: -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/include
+        CXXFLAGS: -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/include
+        GETTEXT_DIR: /opt/homebrew/opt/gettext
+        RUSTFLAGS: '-D warnings'
+        JOBS: 5
+    after_cache_script: *after_cache_script
+    install_deps_script:
+        - brew install make rust sqlite libxml2 curl json-c ncurses openssl gettext asciidoctor pkg-config
+        - sudo ln -sf /opt/homebrew/opt/ncurses/bin/ncurses6-config /usr/local/bin/ncurses5.4-config
+    install_stfl_script: |
+        git clone https://github.com/newsboat/stfl.git /tmp/stfl
+        cd /tmp/stfl
+        sed -i '' 's/ncursesw/ncurses/g' Makefile stfl_internals.h
+        sed -i '' 's|<ncurses/ncurses.h>|<ncurses.h>|g' stfl_internals.h
+        sed -i '' 's/-Wl,-soname,$(SONAME)/-Wl/g' Makefile
+        CFLAGS="-I/opt/homebrew/opt/ncurses/include -D_XOPEN_SOURCE_EXTENDED=1" LDFLAGS="-L/opt/homebrew/opt/ncurses/lib" LDLIBS="-lncurses -liconv" make
+        sudo make prefix=/opt/homebrew install
+    build_script: *build_script
+    test_script: *test_script
+    fake_install_script: *fake_install_script
+    clippy_script: *clippy_script
+    before_cache_script: *before_cache_script
+
 
 task:
     name: UB Sanitizer (Clang 18, Ubuntu 24.04)


### PR DESCRIPTION
This fixes #2280 by reinstating the macOS CI that was removed in PR #2281 when Homebrew disabled the `libstfl` formula. The solution builds libstfl from source using the newsboat/stfl fork.