### PR TITLE
Speed up cache loading during startup

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -50,6 +50,9 @@ public:
 	void externalize_rssfeed(RssFeed& feed, bool reset_unread);
 	std::shared_ptr<RssFeed> internalize_rssfeed(std::string rssurl,
 		RssIgnores* ign);
+	std::vector<std::shared_ptr<RssFeed>> internalize_all_feeds(
+			const std::vector<std::string>& urls,
+			RssIgnores* ign);
 	void update_rssitem_unread_and_enqueued(RssItem& item,
 		const std::string& feedurl);
 	/// If requested, removes unreachable data stored in cache.

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -455,17 +455,18 @@ int Controller::run(const CliArgsParser& args)
 	{
 		ScopeMeasure m1("Load articles from cache");
 
+		bool ignore_disp = (cfg.get_configvalue("ignore-mode") == "display");
+		const auto& urls = urlcfg->get_urls();
+		auto loaded_feeds = rsscache->internalize_all_feeds(urls, ignore_disp ? &ign : nullptr);
+
 		unsigned int i = 0;
-		for (const auto& url : urlcfg->get_urls()) {
+		for (size_t idx = 0; idx < loaded_feeds.size(); ++idx) {
+			auto feed = loaded_feeds[idx];
+			const auto& url = urls[idx];
+
 			try {
-				bool ignore_disp =
-					(cfg.get_configvalue("ignore-mode") ==
-					 "display");
-				std::shared_ptr<RssFeed> feed =
-					rsscache->internalize_rssfeed(
-							url, ignore_disp ? &ign : nullptr);
 				feed->set_tags(urlcfg->get_tags(url));
-				feed->set_order(i);
+				feed->set_order(i++);
 				feedcontainer.add_feed(feed);
 			} catch (const DbException& e) {
 				std::cerr << _("Error while loading feeds from "
@@ -481,7 +482,6 @@ int Controller::run(const CliArgsParser& args)
 					<< std::endl;
 				return EXIT_FAILURE;
 			}
-			i++;
 		}
 	}
 


### PR DESCRIPTION
I just want to open this PR to have it out of my system, but do not stress about responding/deciding right away. I intend to polish #3219 first.

I've tried to decrease Newsboat's startup time and one idea that I had was to decrease the number of SQL queries to the cache that we currently do. I do it be loading all feeds and (non-deleted) items once in `controller::run()`. I benchmarked this for two cases:

- with my personal cache of around 200MiB
- with fake cache generated (~37MiB) and ran with `.py` script from #3210 

Both scenarios were done with cold cache (`vmtouch -e <cache_file>` between runs). I observe around 33% speedup for real scenario and ~11x speedup for the fake one. I haven't investigated the high win for fake case, but I suspect the win is also fake. :) I've used `ScopeMeasure` to count the time.

```
+--------------------+---------------+--------------+
|                    | BEFORE Change | WITH Change  |
+--------------------+---------------+--------------+
| Fake Cache (1)     |  4.135372 s   |  0.384310 s  |
| Fake Cache (2)     |  4.136365 s   |  0.386113 s  |
| Fake Cache (3)     |  4.161611 s   |  0.386548 s  |
| Fake Cache (Avg)   |  4.144449 s   |  0.385657 s  |
|--------------------|---------------|--------------|
| Real Cache (1)     |  3.014429 s   |  2.047725 s  |
| Real Cache (2)     |  3.080632 s   |  2.087318 s  |
| Real Cache (3)     |  3.094218 s   |  2.040778 s  |
| Real Cache (Avg)   |  3.063093 s   |  2.058607 s  |
+--------------------+---------------+--------------+
```

The code change feels a bit copy-pasty, but I'm open to polishing it further if we intend to merge this. Let me know what you think.