### PR TITLE
CI: bump Rust to 1.92.0

### DIFF
--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat. Contains GCC 8
-# and Rust 1.91.0 by default.
+# and Rust 1.92.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-8
-# - rust_version -- Rust version to install. Default: 1.91.0
+# - rust_version -- Rust version to install. Default: 1.92.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-8
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -97,7 +97,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.91.0
+ARG rust_version=1.92.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_18.04-i686.dockerfile
+++ b/docker/ubuntu_18.04-i686.dockerfile
@@ -86,7 +86,7 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \
     && $HOME/rustup.sh -y \
         --default-host i686-unknown-linux-gnu \
-        --default-toolchain 1.91.0 \
+        --default-toolchain 1.92.0 \
     && chmod a+w $HOME/.cargo
 
 ENV HOME /home/builder

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 9 and Rust 1.91.0 by default.
+# compilers. Contains GCC 9 and Rust 1.92.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-9
-# - rust_version -- Rust version to install. Default: 1.91.0
+# - rust_version -- Rust version to install. Default: 1.92.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-9
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -97,7 +97,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.91.0
+ARG rust_version=1.92.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_22.04-build-tools.dockerfile
+++ b/docker/ubuntu_22.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 12 and Rust 1.91.0 by default.
+# compilers. Contains GCC 12 and Rust 1.92.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-12
-# - rust_version -- Rust version to install. Default: 1.91.0
+# - rust_version -- Rust version to install. Default: 1.92.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-12
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -98,7 +98,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.91.0
+ARG rust_version=1.92.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_24.04-build-tools.dockerfile
+++ b/docker/ubuntu_24.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 14 and Rust 1.91.0 by default.
+# compilers. Contains GCC 14 and Rust 1.92.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-14
-# - rust_version -- Rust version to install. Default: 1.91.0
+# - rust_version -- Rust version to install. Default: 1.92.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-14
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -99,7 +99,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.91.0
+ARG rust_version=1.92.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \

--- a/docker/ubuntu_25.04-build-tools.dockerfile
+++ b/docker/ubuntu_25.04-build-tools.dockerfile
@@ -1,10 +1,10 @@
 # All the programs and libraries necessary to build Newsboat with newer
-# compilers. Contains GCC 15 and Rust 1.91.0 by default.
+# compilers. Contains GCC 15 and Rust 1.92.0 by default.
 #
 # Configurable via build-args:
 #
 # - cxx_package -- additional Ubuntu packages to install. Default: g++-15
-# - rust_version -- Rust version to install. Default: 1.91.0
+# - rust_version -- Rust version to install. Default: 1.92.0
 # - cc -- C compiler to use. This gets copied into CC environment variable.
 #       Default: gcc-15
 # - cxx -- C++ compiler to use. This gets copied into CXX environment variable.
@@ -99,7 +99,7 @@ ENV LC_ALL en_US.UTF-8
 USER builder
 WORKDIR /home/builder/src
 
-ARG rust_version=1.91.0
+ARG rust_version=1.92.0
 
 RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
     && chmod +x $HOME/rustup.sh \


### PR DESCRIPTION
This PR is made on top of https://github.com/newsboat/newsboat/pull/3237 because that other PR contains a fix for a warning produced by Rust 1.92.0.