### PR TITLE
Propagate StflRichText in keymap hint generation

### DIFF
--- a/include/keymap.h
+++ b/include/keymap.h
@@ -11,6 +11,7 @@
 #include "configactionhandler.h"
 #include "dialog.h"
 #include "keycombination.h"
+#include "stflrichtext.h"
 
 enum class BindingType {
 	BindKey,
@@ -245,7 +246,8 @@ public:
 		const std::string& command_name, bool allow_description = true);
 	std::vector<MacroCmd> get_startup_operation_sequence();
 
-	std::string prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints, Dialog context);
+	StflRichText prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints,
+		Dialog context);
 
 private:
 	std::vector<HelpBindInfo> get_help_info_bindings(std::set<Operation>& unused_actions,

--- a/include/stflrichtext.h
+++ b/include/stflrichtext.h
@@ -9,8 +9,10 @@ namespace newsboat {
 
 class StflRichText {
 public:
-	static StflRichText from_plaintext(std::string);
-	static StflRichText from_quoted(std::string);
+	static StflRichText from_plaintext(const std::string& text);
+	static StflRichText from_plaintext_with_style(const std::string& text,
+		const std::string& style_tag);
+	static StflRichText from_quoted(const std::string& text);
 
 	StflRichText(const StflRichText&);
 	StflRichText(StflRichText&&) = default;
@@ -18,7 +20,7 @@ public:
 	StflRichText& operator=(StflRichText&&) = default;
 	~StflRichText() = default;
 
-
+	void append(const StflRichText& other);
 	void highlight_searchphrase(const std::string& search, bool case_insensitive = true);
 	void apply_style_tag(const std::string& tag, size_t start, size_t end);
 

--- a/rust/libnewsboat-ffi/src/stflrichtext.rs
+++ b/rust/libnewsboat-ffi/src/stflrichtext.rs
@@ -11,8 +11,10 @@ mod ffi {
         type StflRichText;
 
         fn from_plaintext(text: &CxxString) -> Box<StflRichText>;
+        fn from_plaintext_with_style(text: &CxxString, style_tag: &str) -> Box<StflRichText>;
         fn from_quoted(text: &CxxString) -> Box<StflRichText>;
         fn copy(richtext: &StflRichText) -> Box<StflRichText>;
+        fn append(richtext: &mut StflRichText, other: &StflRichText);
 
         fn highlight_searchphrase(
             richtext: &mut StflRichText,
@@ -31,6 +33,12 @@ fn from_plaintext(text: &CxxString) -> Box<StflRichText> {
     Box::new(StflRichText(richtext))
 }
 
+fn from_plaintext_with_style(text: &CxxString, style_tag: &str) -> Box<StflRichText> {
+    let text = text.to_string_lossy();
+    let richtext = stflrichtext::StflRichText::from_plaintext_with_style(&text, style_tag);
+    Box::new(StflRichText(richtext))
+}
+
 fn from_quoted(text: &CxxString) -> Box<StflRichText> {
     let text = text.to_string_lossy();
     let richtext = stflrichtext::StflRichText::from_quoted(&text);
@@ -39,6 +47,10 @@ fn from_quoted(text: &CxxString) -> Box<StflRichText> {
 
 fn copy(richtext: &StflRichText) -> Box<StflRichText> {
     Box::new(StflRichText(richtext.0.clone()))
+}
+
+fn append(richtext: &mut StflRichText, other: &StflRichText) {
+    richtext.0.append(&other.0);
 }
 
 fn highlight_searchphrase(richtext: &mut StflRichText, search: &str, case_insensitive: bool) {

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -1105,11 +1105,9 @@ StflRichText FeedListFormAction::format_line(const std::string& feedlist_format,
 	fmt.register_fmt('d', utils::utf8_to_locale(feed->description()));
 
 	const auto formattedLine = fmt.do_format(feedlist_format, width);
-	auto stflFormattedLine = StflRichText::from_plaintext(formattedLine);
-
-	if (unread_count > 0) {
-		stflFormattedLine.apply_style_tag("<unread>", 0, formattedLine.length());
-	}
+	auto stflFormattedLine = unread_count > 0
+		? StflRichText::from_plaintext_with_style(formattedLine, "<unread>")
+		: StflRichText::from_plaintext(formattedLine);
 
 	const int id = rxman.feed_matches(feed.get());
 	if (id != -1) {

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -62,7 +62,7 @@ void FormAction::report_unhandled_operation(Operation op)
 void FormAction::set_keymap_hints()
 {
 	set_value("help", v.get_keymap()->prepare_keymap_hint(this->get_keymap_hint(),
-			this->id()));
+			this->id()).stfl_quoted());
 }
 
 std::string FormAction::get_value(const std::string& name)

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1177,11 +1177,9 @@ StflRichText ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	fmt.register_fmt('L', item.first->length());
 
 	const auto formattedLine = fmt.do_format(itemlist_format, width);
-	auto stflFormattedLine = StflRichText::from_plaintext(formattedLine);
-
-	if (item.first->unread()) {
-		stflFormattedLine.apply_style_tag("<unread>", 0, formattedLine.length());
-	}
+	auto stflFormattedLine = item.first->unread() > 0
+		? StflRichText::from_plaintext_with_style(formattedLine, "<unread>")
+		: StflRichText::from_plaintext(formattedLine);
 
 	const int id = rxman.article_matches(item.first.get());
 	if (id != -1) {

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -1352,32 +1352,36 @@ unsigned short KeyMap::get_flag_from_context(Dialog context)
 }
 
 
-std::string KeyMap::prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints,
+StflRichText KeyMap::prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints,
 	Dialog context)
 {
-	std::string keymap_hint;
+	auto keymap_hint = StflRichText::from_plaintext("");
+	bool first_hint = true;
 	for (const auto& hint : hints) {
-		const std::vector<KeyCombination> bound_keys = get_keys(hint.op, context);
+		if (!first_hint) {
+			keymap_hint.append(StflRichText::from_plaintext(" "));
+		}
+		first_hint = false;
 
-		std::vector<std::string> key_stfl_strings;
+		const std::vector<KeyCombination> bound_keys = get_keys(hint.op, context);
+		const auto comma = StflRichText::from_plaintext_with_style(",", "<comma>");
+
 		if (bound_keys.empty()) {
-			std::string key_string = StflRichText::from_plaintext("<none>").stfl_quoted();
-			key_string = strprintf::fmt("<key>%s</>", key_string);
-			key_stfl_strings = {key_string};
+			keymap_hint.append(StflRichText::from_plaintext_with_style("<none>", "<key>"));
 		} else {
+			bool first_key = true;
 			for (const auto& key : bound_keys) {
-				std::string key_string = StflRichText::from_plaintext(
-						key.to_bindkey_string()).stfl_quoted();
-				key_string = strprintf::fmt("<key>%s</>", key_string);
-				key_stfl_strings.push_back(key_string);
+				if (!first_key) {
+					keymap_hint.append(comma);
+				}
+				first_key = false;
+				keymap_hint.append(StflRichText::from_plaintext_with_style(key.to_bindkey_string(),
+						"<key>"));
 			}
 		}
 
-		keymap_hint.append(utils::join(key_stfl_strings, "<comma>,</>"));
-		keymap_hint.append("<colon>:</>");
-		keymap_hint.append(strprintf::fmt("<desc>%s</>",
-				StflRichText::from_plaintext(hint.text).stfl_quoted()));
-		keymap_hint.append(" ");
+		keymap_hint.append(StflRichText::from_plaintext_with_style(":", "<colon>"));
+		keymap_hint.append(StflRichText::from_plaintext_with_style(hint.text, "<desc>"));
 	}
 	return keymap_hint;
 }

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -419,7 +419,7 @@ void PbView::set_help_keymap_hint()
 {
 	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Quit")}};
 	const auto keymap_hint = keys.prepare_keymap_hint(hints, Dialog::Podboat);
-	help_form.set("help", keymap_hint);
+	help_form.set("help", keymap_hint.stfl_quoted());
 }
 
 void PbView::set_dllist_keymap_hint()
@@ -436,7 +436,7 @@ void PbView::set_dllist_keymap_hint()
 	};
 
 	const auto keymap_hint = keys.prepare_keymap_hint(hints, Dialog::Podboat);
-	dllist_form.set("help", keymap_hint);
+	dllist_form.set("help", keymap_hint.stfl_quoted());
 }
 
 StflRichText PbView::format_line(const std::string& podlist_format,

--- a/src/stflrichtext.cpp
+++ b/src/stflrichtext.cpp
@@ -1,4 +1,5 @@
 #include "stflrichtext.h"
+#include "libnewsboat-ffi/src/stflrichtext.rs.h"
 
 namespace newsboat {
 
@@ -18,18 +19,31 @@ StflRichText& StflRichText::operator=(const StflRichText& other)
 	return *this;
 }
 
-StflRichText StflRichText::from_plaintext(std::string text)
+StflRichText StflRichText::from_plaintext(const std::string& text)
 {
 	auto rs_object = stflrichtext::bridged::from_plaintext(text);
 
 	return StflRichText(std::move(rs_object));
 }
 
-StflRichText StflRichText::from_quoted(std::string text)
+StflRichText StflRichText::from_plaintext_with_style(const std::string& text,
+	const std::string& style_tag)
+{
+	auto rs_object = stflrichtext::bridged::from_plaintext_with_style(text, style_tag);
+
+	return StflRichText(std::move(rs_object));
+}
+
+StflRichText StflRichText::from_quoted(const std::string& text)
 {
 	auto rs_object = stflrichtext::bridged::from_quoted(text);
 
 	return StflRichText(std::move(rs_object));
+}
+
+void StflRichText::append(const StflRichText& other)
+{
+	stflrichtext::bridged::append(*rs_object, *other.rs_object);
 }
 
 void StflRichText::highlight_searchphrase(const std::string& search, bool case_insensitive)

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -767,12 +767,12 @@ TEST_CASE("prepare_keymap_hint() returns a string describing keys to which given
 		{OP_SEARCH, "Go find me"}
 	};
 
-	REQUIRE(k.prepare_keymap_hint(hints, Dialog::FeedList) ==
-		"<key>q</><colon>:</><desc>Get out of <>this> dialog</> "
-		"<key>?</><comma>,</><key>w</><colon>:</><desc>HALP</> "
-		"<key>ENTER</><comma>,</><key><></><comma>,</><key>x</><colon>:</><desc>Open</> "
-		"<key>O</><colon>:</><desc>Reload current entry</> "
-		"<key><>none></><colon>:</><desc>Go find me</> ");
+	REQUIRE(k.prepare_keymap_hint(hints, Dialog::FeedList).stfl_quoted() ==
+		"<key>q<colon>:<desc>Get out of <>this> dialog</> "
+		"<key>?<comma>,<key>w<colon>:<desc>HALP</> "
+		"<key>ENTER<comma>,<key><><comma>,<key>x<colon>:<desc>Open</> "
+		"<key>O<colon>:<desc>Reload current entry</> "
+		"<key><>none><colon>:<desc>Go find me</>");
 }
 
 TEST_CASE("get_help_info() returns info about macros, bindings, and unbound actions",


### PR DESCRIPTION
Part of https://github.com/newsboat/newsboat/issues/806

StflRichText: Introduced constructor with style tag and an append method.