### PR TITLE
Remove unused parts of TextFormatter

### DIFF
--- a/include/textformatter.h
+++ b/include/textformatter.h
@@ -32,11 +32,10 @@ enum class LineType {
 
 class TextFormatter {
 public:
-	TextFormatter() = default;
+	TextFormatter(
+		const std::vector<std::pair<LineType, std::string>>& text);
 	~TextFormatter() = default;
-	void add_line(LineType type, std::string line);
-	void add_lines(
-		const std::vector<std::pair<LineType, std::string>>& lines);
+
 	std::pair<std::string, std::size_t> format_text_to_list(
 		RegexManager* r = nullptr,
 		std::optional<Dialog> location = {},
@@ -44,11 +43,6 @@ public:
 		const size_t total_width = 0);
 	std::string format_text_plain(const size_t width = 80,
 		const size_t total_width = 0);
-
-	void clear()
-	{
-		lines.clear();
-	}
 
 private:
 	std::vector<std::pair<LineType, std::string>> lines;

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -253,8 +253,7 @@ std::string item_renderer::to_plain_text(
 
 	render_links_summary(lines, links);
 
-	TextFormatter txtfmt;
-	txtfmt.add_lines(lines);
+	TextFormatter txtfmt(lines);
 
 	unsigned int width = cfg.get_configvalue_as_int("text-width");
 	if (width == 0) {
@@ -290,8 +289,7 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 
 	render_links_summary(lines, links);
 
-	TextFormatter txtfmt;
-	txtfmt.add_lines(lines);
+	TextFormatter txtfmt(lines);
 
 	return txtfmt.format_text_to_list(rxman, location, text_width, window_width);
 }
@@ -332,8 +330,7 @@ std::pair<std::string, size_t> item_renderer::source_to_stfl_list(
 	render_source(lines, StflRichText::from_plaintext(utils::utf8_to_locale(
 				item.description().text)).stfl_quoted());
 
-	TextFormatter txtfmt;
-	txtfmt.add_lines(lines);
+	TextFormatter txtfmt(lines);
 
 	return txtfmt.format_text_to_list(rxman, location, text_width, window_width);
 }

--- a/src/textformatter.cpp
+++ b/src/textformatter.cpp
@@ -13,24 +13,14 @@
 
 namespace newsboat {
 
-void TextFormatter::add_line(LineType type, std::string line)
+TextFormatter::TextFormatter(
+	const std::vector<std::pair<LineType, std::string>>& text)
 {
-	LOG(Level::DEBUG,
-		"TextFormatter::add_line: `%s' (line type %u)",
-		line,
-		static_cast<unsigned int>(type));
-
-	auto clean_line = utils::wstr2str(
-			utils::clean_nonprintable_characters(utils::str2wstr(line)));
-	lines.push_back(std::make_pair(type, clean_line));
-}
-
-void TextFormatter::add_lines(
-	const std::vector<std::pair<LineType, std::string>>& lines)
-{
-	for (const auto& line : lines) {
-		add_line(line.first,
-			utils::replace_all(line.second, "\t", "        "));
+	for (const auto& [type, line] : text) {
+		const auto tabs_replaced_line = utils::replace_all(line, "\t", "        ");
+		const auto clean_line = utils::wstr2str(
+				utils::clean_nonprintable_characters(utils::str2wstr(tabs_replaced_line)));
+		lines.push_back(std::make_pair(type, clean_line));
 	}
 }
 

--- a/test/textformatter.cpp
+++ b/test/textformatter.cpp
@@ -9,9 +9,7 @@ using namespace newsboat;
 TEST_CASE("lines marked as `wrappable` are wrapped to fit width",
 	"[TextFormatter]")
 {
-	TextFormatter fmt;
-
-	fmt.add_lines({std::make_pair(LineType::wrappable,
+	TextFormatter fmt({std::make_pair(LineType::wrappable,
 				"this one is going to be wrapped"),
 			std::make_pair(LineType::softwrappable,
 				"this one is going to be wrapped at the window "
@@ -58,9 +56,7 @@ TEST_CASE("lines marked as `wrappable` are wrapped to fit width",
 
 TEST_CASE("line wrapping works for non-space-separated text", "[TextFormatter]")
 {
-	TextFormatter fmt;
-
-	fmt.add_lines({std::make_pair(LineType::wrappable,
+	TextFormatter fmt({std::make_pair(LineType::wrappable,
 				"    つれづれなるままに、ひぐらしすずりにむかいて、")});
 
 	SECTION("preserve indent and doesn't return broken UTF-8") {
@@ -89,9 +85,7 @@ TEST_CASE("line wrapping works for non-space-separated text", "[TextFormatter]")
 TEST_CASE("regex manager is used by format_text_to_list if one is passed",
 	"[TextFormatter]")
 {
-	TextFormatter fmt;
-
-	fmt.add_line(LineType::wrappable, "Highlight me please!");
+	TextFormatter fmt({{LineType::wrappable, "Highlight me please!"}});
 
 	RegexManager rxmgr;
 	// the choice of green text on red background does not reflect my
@@ -114,9 +108,7 @@ TEST_CASE("regex manager is used by format_text_to_list if one is passed",
 TEST_CASE("<hr> is rendered as a string of dashes framed with newlines",
 	"[TextFormatter]")
 {
-	TextFormatter fmt;
-
-	fmt.add_line(LineType::hr, "");
+	TextFormatter fmt({{LineType::hr, ""}});
 
 	SECTION("width = 3") {
 		const std::string expected =
@@ -150,10 +142,9 @@ TEST_CASE("<hr> is rendered as a string of dashes framed with newlines",
 TEST_CASE("wrappable sequences longer then format width are forced-wrapped",
 	"[TextFormatter]")
 {
-	TextFormatter fmt;
-	fmt.add_line(LineType::wrappable, "0123456789101112");
-	fmt.add_line(LineType::softwrappable, "0123456789101112");
-	fmt.add_line(LineType::nonwrappable, "0123456789101112");
+	TextFormatter fmt({{LineType::wrappable, "0123456789101112"},
+		{LineType::softwrappable, "0123456789101112"},
+		{LineType::nonwrappable, "0123456789101112"}});
 
 	const std::string expected =
 		"01234\n"
@@ -169,10 +160,9 @@ TEST_CASE("wrappable sequences longer then format width are forced-wrapped",
 TEST_CASE("Lines marked as non-wrappable are always returned verbatim",
 	"[TextFormatter]")
 {
-	TextFormatter fmt;
-	fmt.add_line(LineType::wrappable, " 0123456789101112");
-	fmt.add_line(LineType::softwrappable, " 0123456789101112");
-	fmt.add_line(LineType::nonwrappable, " 0123456789101112");
+	TextFormatter fmt({{LineType::wrappable, " 0123456789101112"},
+		{LineType::softwrappable, " 0123456789101112"},
+		{LineType::nonwrappable, " 0123456789101112"}});
 
 	const std::string expected =
 		" \n"
@@ -198,8 +188,7 @@ TEST_CASE("Lines marked as non-wrappable are always returned verbatim",
 TEST_CASE("Ignore whitespace that's going to be wrapped onto the next line",
 	"[TextFormatter]")
 {
-	TextFormatter fmt;
-	fmt.add_line(LineType::wrappable, "just a test");
+	TextFormatter fmt({{LineType::wrappable, "just a test"}});
 
 	const std::string expected =
 		"just\n"
@@ -213,8 +202,7 @@ TEST_CASE(
 	"total_width != 0",
 	"[TextFormatter]")
 {
-	TextFormatter fmt;
-	fmt.add_line(LineType::softwrappable, "just a test");
+	TextFormatter fmt({{LineType::softwrappable, "just a test"}});
 	const size_t wrap_width = 100;
 	RegexManager* rxman = nullptr;
 
@@ -258,13 +246,12 @@ TEST_CASE("Lines consisting entirely of spaces are replaced "
 	// Limit for softwrapable lines
 	const size_t total_width = 4;
 
-	TextFormatter fmt;
 	// All of these lines are longer than the wrap limits. If these lines were
 	// wrapped, the result would have more than 4 lines.
-	fmt.add_line(LineType::wrappable, "    ");
-	fmt.add_line(LineType::wrappable, "          ");
-	fmt.add_line(LineType::softwrappable, "      ");
-	fmt.add_line(LineType::softwrappable, "  ");
+	TextFormatter fmt({{LineType::wrappable, "    "},
+		{LineType::wrappable, "          "},
+		{LineType::softwrappable, "      "},
+		{LineType::softwrappable, "  "}});
 
 	const std::string expected_text =
 		"{list"


### PR DESCRIPTION
`clear()` was unused.
`add_line()` was only used in one location (in TextFormatter itself) -> manually inlined
`add_lines()` was always called directly after constructing a `TextFormatter` instance -> content moved into constructor