### PR TITLE
CI: drop some compilers, move macOS job to GitHub Actions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -263,42 +263,6 @@ task:
     before_cache_script: *before_cache_script
 
 task:
-    skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'docker/*', 'docker/**/*', '.github/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
-    name: macOS Sonoma
-    macos_instance:
-        image: ghcr.io/cirruslabs/macos-runner:sonoma
-    cargo_cache: *cargo_cache
-    env:
-        HOMEBREW_PREFIX: /opt/homebrew
-        PATH: /opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/opt/gettext/bin:$PATH
-        PKG_CONFIG_PATH: /opt/homebrew/opt/libxml2/lib/pkgconfig:/opt/homebrew/lib/pkgconfig
-        DYLD_LIBRARY_PATH: /opt/homebrew/lib
-        LDFLAGS: -L/opt/homebrew/opt/gettext/lib -L/opt/homebrew/lib
-        CFLAGS: -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/include
-        CXXFLAGS: -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/include
-        GETTEXT_DIR: /opt/homebrew/opt/gettext
-        RUSTFLAGS: '-D warnings'
-        JOBS: 5
-    after_cache_script: *after_cache_script
-    install_deps_script:
-        - brew install make rust sqlite libxml2 curl json-c ncurses openssl gettext asciidoctor pkg-config
-        - sudo ln -sf /opt/homebrew/opt/ncurses/bin/ncurses6-config /usr/local/bin/ncurses5.4-config
-    install_stfl_script: |
-        git clone https://github.com/newsboat/stfl.git /tmp/stfl
-        cd /tmp/stfl
-        sed -i '' 's/ncursesw/ncurses/g' Makefile stfl_internals.h
-        sed -i '' 's|<ncurses/ncurses.h>|<ncurses.h>|g' stfl_internals.h
-        sed -i '' 's/-Wl,-soname,$(SONAME)/-Wl/g' Makefile
-        CFLAGS="-I/opt/homebrew/opt/ncurses/include -D_XOPEN_SOURCE_EXTENDED=1" LDFLAGS="-L/opt/homebrew/opt/ncurses/lib" LDLIBS="-lncurses -liconv" make
-        sudo make prefix=/opt/homebrew install
-    build_script: *build_script
-    test_script: *test_script
-    fake_install_script: *fake_install_script
-    clippy_script: *clippy_script
-    before_cache_script: *before_cache_script
-
-
-task:
     name: UB Sanitizer (Clang 18, Ubuntu 24.04)
     skip: "changesIncludeOnly('contrib/*', 'contrib/**/*', 'doc/*', 'doc/**/*', 'docker/remote-testing/*', 'docker/remote-testing/**/*', 'po/*', 'po/**/*', 'snap/*', 'snap/**/*')"
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,80 @@
+name: macOS Sonoma
+
+on:
+  push:
+    paths-ignore: &ignored_paths
+      - contrib/*
+      - contrib/**/*
+      - doc/*
+      - doc/**/*
+      - docker/*
+      - docker/**/*
+      - .github/**/*
+      - po/*
+      - po/**/*
+      - snap/*
+      - snap/**/*
+  pull_request:
+    paths_ignore: *ignored_paths
+
+jobs:
+  build_and_test_macos:
+    name: macOS Sonoma
+    runs-on: macos-14
+    env:
+      # Disable progress bar in Cargo. This cuts down on output, avoiding log length limits.
+      TERM: dumb
+      TARGET: aarch64-apple-darwin
+      JOBS: 3
+      HOMEBREW_PREFIX: /opt/homebrew
+      PKG_CONFIG_PATH: /opt/homebrew/opt/libxml2/lib/pkgconfig:/opt/homebrew/lib/pkgconfig
+      DYLD_LIBRARY_PATH: /opt/homebrew/lib
+      LDFLAGS: -L/opt/homebrew/opt/gettext/lib -L/opt/homebrew/lib
+      CFLAGS: -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/include
+      CXXFLAGS: -I/opt/homebrew/opt/gettext/include -I/opt/homebrew/include
+      RUSTFLAGS: '-D warnings'
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          key: ${{ hashFiles('Cargo.lock') }}
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git
+
+      - name: Install dependencies
+        run: |
+          brew install make rust sqlite libxml2 curl json-c ncurses openssl gettext asciidoctor pkg-config
+          sudo ln -sf /opt/homebrew/opt/ncurses/bin/ncurses6-config /usr/local/bin/ncurses5.4-config
+          echo "GETTEXT_DIR=/opt/homebrew/opt/gettext" >> $GITHUB_ENV
+          echo "PATH=/opt/homebrew/opt/make/libexec/gnubin:/opt/homebrew/opt/gettext/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Compile and install STFL
+        run: |
+          git clone https://github.com/newsboat/stfl.git /tmp/stfl
+          cd /tmp/stfl
+          sed -i '' 's/ncursesw/ncurses/g' Makefile stfl_internals.h
+          sed -i '' 's|<ncurses/ncurses.h>|<ncurses.h>|g' stfl_internals.h
+          sed -i '' 's/-Wl,-soname,$(SONAME)/-Wl/g' Makefile
+          CFLAGS="-I/opt/homebrew/opt/ncurses/include -D_XOPEN_SOURCE_EXTENDED=1" LDFLAGS="-L/opt/homebrew/opt/ncurses/lib" LDLIBS="-lncurses -liconv" make
+          sudo make prefix=/opt/homebrew install
+
+      - name: Build
+        run: make -j${JOBS} --keep-going all test
+
+      - name: Test
+        run: RUST_TEST_THREADS=${JOBS} RUST_BACKTRACE=1 make -j${JOBS} NEWSBOAT_RUN_IGNORED_TESTS=1 ci-check
+
+      - name: Fake install
+        run: |
+          mkdir fakeroot
+          make DESTDIR=fakeroot install
+          make DESTDIR=fakeroot uninstall
+          test $(find fakeroot -type f -print | wc -l) -eq 0
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings -A unknown-lints


### PR DESCRIPTION
We now run only four versions of GCC and Clang each: the minimum supported one and the three latest ones. My initial approach was to keep the compilers that are available in the currently supported Debian releases, but that only lets us drop a few jobs, too few to noticeably reduce the load on Cirrus. Thus I'm taking a risk dropping more compilers.

Fixes #3262.