### PR TITLE
run_command: Avoid unsafe code and replace double fork

### DIFF
--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -424,6 +424,11 @@ pub fn run_command(cmd: &str, param: &str) {
             }
             0 => {
                 // Child process, continue and spawn the command.
+
+                // close our fds to avoid clobbering the screen
+                close(0);
+                close(1);
+                close(2);
             }
             _ => {
                 // Parent process, fork succeeded: reap child and return.


### PR DESCRIPTION
While looking into https://github.com/newsboat/newsboat/issues/3278, saw a bunch of AddressSanitizer memory leak messages when running `libnewsboat` tests.
It looks like these where coming from the top-level fork child.

I expect that child inherits the AddressSanitizer bookkeeping but does not contain a copy of all threads, so at exit it complains about memory leaks but also shows warnings like `==169035==Running thread 168756 was not suspended. False leaks are possible.`
The top-level fork child did not close its stdin/stdout/stderr, so those warnings were visible between the test output (but did not fail the tests because the main test process does not wait for it to finish and does not check its exit code)

We had the double fork construction to avoid zombie processes (processes which exited but for which the parent Newsboat process did not await the result, resulting in a lack of proper resource cleanup until Newsboat would exit)
I believe we can also avoid the zombie issues this with `Command::spawn()` if we just call `.wait()` on the result (doing so on a separate thread as we don't want to wait for it on the calling thread)