### PR TITLE
Clarify "Operation %s not handled in %s" message

### DIFF
--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -55,7 +55,8 @@ FormAction::FormAction(View& vv, std::string formstr, ConfigContainer* cfg)
 
 void FormAction::report_unhandled_operation(Operation op)
 {
-	set_status(strprintf::fmt(_("Operation %s not handled in %s"), KeyMap::get_op_name(op),
+	set_status(strprintf::fmt(_(R"(Operation "%s" not handled in dialog "%s")"),
+			KeyMap::get_op_name(op),
 			dialog_name(id())));
 }
 


### PR DESCRIPTION
Resolves https://github.com/newsboat/newsboat/issues/3171

In addition to the suggested quoting around the dialog name, I've also added quoting around the operation name (to avoid potentially confusing sentences in case of some operation name)