### PR TITLE
Use std::string_view in handle_action and log/stringformatting

### DIFF
--- a/include/colormanager.h
+++ b/include/colormanager.h
@@ -22,7 +22,7 @@ class ColorManager : public ConfigActionHandler {
 public:
 	~ColorManager() override = default;
 	void register_commands(ConfigParser& cfgparser);
-	void handle_action(const std::string& action,
+	void handle_action(std::string_view action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;
 	void apply_colors(std::function<void(const std::string&, const std::string&)>

--- a/include/configactionhandler.h
+++ b/include/configactionhandler.h
@@ -2,6 +2,7 @@
 #define NEWSBOAT_CONFIGACTIONHANDLER_H_
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace newsboat {
@@ -9,8 +10,7 @@ namespace newsboat {
 class ConfigActionHandler {
 public:
 	// Derived classes can override this function to handle the `params` string without the default tokenization
-	virtual void handle_action(const std::string& action,
-		const std::string& params);
+	virtual void handle_action(std::string_view action, std::string_view params);
 
 	virtual void dump_config(std::vector<std::string>& config_output) const = 0;
 	ConfigActionHandler() {}
@@ -18,7 +18,7 @@ public:
 
 private:
 	// Derived classes should override either of the handle_action() overloads
-	virtual void handle_action(const std::string& action,
+	virtual void handle_action(std::string_view action,
 		const std::vector<std::string>& params);
 };
 

--- a/include/configcontainer.h
+++ b/include/configcontainer.h
@@ -64,7 +64,7 @@ public:
 	ConfigContainer();
 	~ConfigContainer() override;
 	void register_commands(ConfigParser& cfgparser);
-	void handle_action(const std::string& action,
+	void handle_action(std::string_view action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;
 

--- a/include/configparser.h
+++ b/include/configparser.h
@@ -23,7 +23,7 @@ public:
 	~ConfigParser() override;
 	void register_handler(const std::string& cmd,
 		ConfigActionHandler& handler);
-	void handle_action(const std::string& action,
+	void handle_action(std::string_view action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>&) const override
 	{

--- a/include/filtercontainer.h
+++ b/include/filtercontainer.h
@@ -21,7 +21,7 @@ class FilterContainer : public ConfigActionHandler {
 public:
 	FilterContainer() = default;
 	~FilterContainer() override;
-	void handle_action(const std::string& action,
+	void handle_action(std::string_view action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;
 	std::vector<FilterNameExprPair>& get_filters()

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -236,14 +236,14 @@ public:
 	std::vector<MacroCmd> get_macro(const KeyCombination& key_combination);
 	char get_key(const std::string& keycode);
 	std::vector<KeyCombination> get_keys(Operation op, Dialog context);
-	void handle_action(const std::string& action,
-		const std::string& params) override;
+	void handle_action(std::string_view action,
+		std::string_view params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;
 	HelpInfo get_help_info(Dialog context);
 	std::vector<KeyMapDesc> get_keymap_descriptions(Dialog context);
 
-	ParsedOperations parse_operation_sequence(const std::string& line,
-		const std::string& command_name, bool allow_description = true);
+	ParsedOperations parse_operation_sequence(std::string_view line,
+		std::string_view command_name, bool allow_description = true);
 	std::vector<MacroCmd> get_startup_operation_sequence();
 
 	StflRichText prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints,

--- a/include/logger.h
+++ b/include/logger.h
@@ -2,7 +2,7 @@
 #define NEWSBOAT_LOGGER_H_
 
 #include <cstdint>
-#include <string>
+#include <string_view>
 #include <utility>
 
 #include "strprintf.h"
@@ -16,7 +16,7 @@ using Level = logger::Level;
 namespace logger {
 
 template<typename... Args>
-void log(Level l, const std::string& format, Args&& ... args)
+void log(Level l, std::string_view format, Args&& ... args)
 {
 	if (l == Level::USERERROR || static_cast<int64_t>(l) <= get_loglevel()) {
 		log_internal(l, strprintf::fmt(format, std::forward<Args>(args)...));

--- a/include/nullconfigactionhandler.h
+++ b/include/nullconfigactionhandler.h
@@ -9,7 +9,7 @@ class NullConfigActionHandler : public ConfigActionHandler {
 public:
 	NullConfigActionHandler() {}
 	~NullConfigActionHandler() override {}
-	void handle_action(const std::string&,
+	void handle_action(std::string_view,
 		const std::vector<std::string>&) override
 	{
 	}

--- a/include/regexmanager.h
+++ b/include/regexmanager.h
@@ -20,7 +20,7 @@ namespace newsboat {
 
 class RegexManager : public ConfigActionHandler {
 public:
-	void handle_action(const std::string& action,
+	void handle_action(std::string_view action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;
 	void quote_and_highlight(StflRichText& stflString, Dialog location) const;
@@ -37,7 +37,7 @@ private:
 	std::vector<std::pair<std::shared_ptr<Matcher>, int>> matchers_feed;
 
 	void handle_highlight_action(const std::vector<std::string>& params);
-	void handle_highlight_item_action(const std::string& action,
+	void handle_highlight_item_action(std::string_view action,
 		const std::vector<std::string>& params);
 };
 

--- a/include/rssignores.h
+++ b/include/rssignores.h
@@ -17,7 +17,7 @@ class RssIgnores : public ConfigActionHandler {
 public:
 	RssIgnores() {}
 	~RssIgnores() override {}
-	void handle_action(const std::string& action,
+	void handle_action(std::string_view action,
 		const std::vector<std::string>& params) override;
 	void dump_config(std::vector<std::string>& config_output) const override;
 	bool matches(RssItem* item);

--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -14,42 +14,42 @@ namespace newsboat {
 namespace strprintf {
 namespace detail {
 template<typename T, typename... Args>
-std::string fmt_impl(const std::string& format, const T& argument,
+std::string fmt_impl(std::string_view format, const T& argument,
 	Args&& ... args);
 }
 
 std::pair<std::string, std::string> split_format(
-	const std::string& printf_format);
+	std::string_view printf_format);
 
-std::string fmt(const std::string& format);
+std::string fmt(std::string_view format);
 
 template<typename... Args>
-std::string fmt(const std::string& format, const char* argument, Args&& ... args)
+std::string fmt(std::string_view format, const char* argument, Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format, const int32_t argument, Args&& ... args)
+std::string fmt(std::string_view format, const int32_t argument, Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format, const std::uint32_t argument,
+std::string fmt(std::string_view format, const std::uint32_t argument,
 	Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format, const int64_t argument, Args&& ... args)
+std::string fmt(std::string_view format, const int64_t argument, Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format, const uint64_t argument,
+std::string fmt(std::string_view format, const uint64_t argument,
 	Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
@@ -57,7 +57,7 @@ std::string fmt(const std::string& format, const uint64_t argument,
 
 #ifdef __APPLE__
 template<typename... Args>
-std::string fmt(const std::string& format, const std::size_t argument,
+std::string fmt(std::string_view format, const std::size_t argument,
 	Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
@@ -65,20 +65,20 @@ std::string fmt(const std::string& format, const std::size_t argument,
 #endif
 
 template<typename... Args>
-std::string fmt(const std::string& format, const void* argument, Args&& ... args)
+std::string fmt(std::string_view format, const void* argument, Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format, const std::nullptr_t argument,
+std::string fmt(std::string_view format, const std::nullptr_t argument,
 	Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format, const float argument, Args&& ... args)
+std::string fmt(std::string_view format, const float argument, Args&& ... args)
 {
 	// Variadic functions (like snprintf) do not accept `float`, so let's
 	// convert that.
@@ -87,13 +87,13 @@ std::string fmt(const std::string& format, const float argument, Args&& ... args
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format, const double argument, Args&& ... args)
+std::string fmt(std::string_view format, const double argument, Args&& ... args)
 {
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format,
+std::string fmt(std::string_view format,
 	const std::string& argument,
 	Args&& ... args)
 {
@@ -101,7 +101,15 @@ std::string fmt(const std::string& format,
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format,
+std::string fmt(std::string_view format,
+	std::string_view argument,
+	Args&& ... args)
+{
+	return fmt(format, argument.data(), std::forward<Args>(args)...);
+}
+
+template<typename... Args>
+std::string fmt(std::string_view format,
 	const std::string* argument,
 	Args&& ... args)
 {
@@ -109,7 +117,7 @@ std::string fmt(const std::string& format,
 }
 
 template<typename... Args>
-std::string fmt(const std::string& format,
+std::string fmt(std::string_view format,
 	const Filepath& argument,
 	Args&& ... args)
 {
@@ -118,7 +126,7 @@ std::string fmt(const std::string& format,
 
 namespace detail {
 template<typename T, typename... Args>
-std::string fmt_impl(const std::string& format, const T& argument, Args&& ... args)
+std::string fmt_impl(std::string_view format, const T& argument, Args&& ... args)
 {
 	std::string local_format, remaining_format;
 	std::tie(local_format, remaining_format) = split_format(format);

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,6 +6,7 @@
 #include <libxml/parser.h>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -39,8 +40,8 @@ std::vector<std::string> tokenize_spaced(const std::string& str,
 	std::string delimiters = " \r\n\t");
 std::vector<std::string> tokenize_nl(const std::string& str,
 	std::string delimiters = "\r\n");
-std::vector<std::string> tokenize_quoted(const std::string& str,
-	std::string delimiters = " \r\n\t");
+std::vector<std::string> tokenize_quoted(std::string_view str,
+	std::string_view delimiters = " \r\n\t");
 std::optional<std::string> extract_token_quoted(std::string& str,
 	std::string delimiters = " \r\n\t");
 

--- a/src/colormanager.cpp
+++ b/src/colormanager.cpp
@@ -57,7 +57,7 @@ void ColorManager::register_commands(ConfigParser& cfgparser)
 	cfgparser.register_handler("color", *this);
 }
 
-void ColorManager::handle_action(const std::string& action,
+void ColorManager::handle_action(std::string_view action,
 	const std::vector<std::string>& params)
 {
 	LOG(Level::DEBUG,

--- a/src/configactionhandler.cpp
+++ b/src/configactionhandler.cpp
@@ -4,14 +4,14 @@
 
 namespace newsboat {
 
-void ConfigActionHandler::handle_action(const std::string& action,
-	const std::string& params)
+void ConfigActionHandler::handle_action(std::string_view action,
+	std::string_view params)
 {
 	const std::vector<std::string> tokens = utils::tokenize_quoted(params);
 	handle_action(action, tokens);
 }
 
-void ConfigActionHandler::handle_action(const std::string&,
+void ConfigActionHandler::handle_action(std::string_view,
 	const std::vector<std::string>&)
 {
 }

--- a/src/configcontainer.cpp
+++ b/src/configcontainer.cpp
@@ -373,11 +373,11 @@ void ConfigContainer::register_commands(ConfigParser& cfgparser)
 	}
 }
 
-void ConfigContainer::handle_action(const std::string& action,
+void ConfigContainer::handle_action(std::string_view action,
 	const std::vector<std::string>& params)
 {
 	std::lock_guard<std::recursive_mutex> guard(config_data_mtx);
-	auto entry = config_data.find(action);
+	auto entry = config_data.find(std::string(action));
 
 	if (entry == config_data.end()) {
 		LOG(Level::WARN,

--- a/src/configparser.cpp
+++ b/src/configparser.cpp
@@ -21,7 +21,7 @@ ConfigParser::ConfigParser()
 
 ConfigParser::~ConfigParser() {}
 
-void ConfigParser::handle_action(const std::string& action,
+void ConfigParser::handle_action(std::string_view action,
 	const std::vector<std::string>& params)
 {
 	/*

--- a/src/filtercontainer.cpp
+++ b/src/filtercontainer.cpp
@@ -13,7 +13,7 @@ namespace newsboat {
 
 FilterContainer::~FilterContainer() {}
 
-void FilterContainer::handle_action(const std::string& action,
+void FilterContainer::handle_action(std::string_view action,
 	const std::vector<std::string>& params)
 {
 	/*

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -1119,7 +1119,7 @@ std::string KeyMap::getopname(Operation op) const
 	return "<none>";
 }
 
-void KeyMap::handle_action(const std::string& action, const std::string& params)
+void KeyMap::handle_action(std::string_view action, std::string_view params)
 {
 	/*
 	 * The keymap acts as ConfigActionHandler so that all the key-related
@@ -1176,7 +1176,9 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 		}
 	} else if (action == "bind") {
 		bool parsing_failed = false;
-		const auto binding = keymap::bridged::tokenize_binding(params, parsing_failed);
+		const auto binding = keymap::bridged::tokenize_binding(
+				rust::Str(params.data(), params.size()),
+				parsing_failed);
 		if (parsing_failed) {
 			throw ConfigHandlerException(strprintf::fmt(_("failed to parse binding")));
 		}
@@ -1212,7 +1214,7 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 			apply_bind(context_keymaps[context], key_sequence, cmds, description, BindingType::Bind);
 		}
 	} else if (action == "macro") {
-		std::string remaining_params = params;
+		std::string remaining_params{params};
 		const auto token = utils::extract_token_quoted(remaining_params);
 		const auto parsed = parse_operation_sequence(remaining_params, action);
 		const std::vector<MacroCmd> cmds = parsed.operations;
@@ -1268,13 +1270,16 @@ void KeyMap::apply_bindkey(Mapping& target, const KeyCombination& key_combinatio
 	BindingType::BindKey);
 }
 
-ParsedOperations KeyMap::parse_operation_sequence(const std::string& line,
-	const std::string& command_name, bool allow_description)
+ParsedOperations KeyMap::parse_operation_sequence(std::string_view line,
+	std::string_view command_name, bool allow_description)
 {
 	rust::String description;
 	bool parsing_failed = false;
-	const auto operations = keymap::bridged::tokenize_operation_sequence(line, description,
-			allow_description, parsing_failed);
+	const auto operations = keymap::bridged::tokenize_operation_sequence(
+			rust::Str(line.data(), line.size()),
+			description,
+			allow_description,
+			parsing_failed);
 	if (parsing_failed) {
 		throw ConfigHandlerException(strprintf::fmt(_("failed to parse operation sequence for %s"),
 				command_name));

--- a/src/regexmanager.cpp
+++ b/src/regexmanager.cpp
@@ -18,7 +18,7 @@ void RegexManager::dump_config(std::vector<std::string>& config_output) const
 	}
 }
 
-void RegexManager::handle_action(const std::string& action,
+void RegexManager::handle_action(std::string_view action,
 	const std::vector<std::string>& params)
 {
 	if (action == "highlight") {
@@ -29,7 +29,7 @@ void RegexManager::handle_action(const std::string& action,
 		throw ConfigHandlerException(
 			ActionHandlerStatus::INVALID_COMMAND);
 	}
-	std::string line = action;
+	std::string line{action};
 	for (const auto& param : params) {
 		line.append(" ");
 		line.append(utils::quote(param));
@@ -165,7 +165,7 @@ void RegexManager::handle_highlight_action(const std::vector<std::string>&
 	}
 }
 
-void RegexManager::handle_highlight_item_action(const std::string& action,
+void RegexManager::handle_highlight_item_action(std::string_view action,
 	const std::vector<std::string>& params)
 {
 	if (params.size() < 3) {

--- a/src/rssignores.cpp
+++ b/src/rssignores.cpp
@@ -18,7 +18,7 @@ namespace newsboat {
 
 const std::string RssIgnores::REGEX_PREFIX = "regex:";
 
-void RssIgnores::handle_action(const std::string& action,
+void RssIgnores::handle_action(std::string_view action,
 	const std::vector<std::string>& params)
 {
 	if (action == "ignore-article") {

--- a/src/strprintf.cpp
+++ b/src/strprintf.cpp
@@ -2,7 +2,7 @@
 
 using namespace newsboat;
 
-std::string strprintf::fmt(const std::string& format)
+std::string strprintf::fmt(std::string_view format)
 {
 	char buffer[1024];
 	std::string result;
@@ -17,12 +17,12 @@ std::string strprintf::fmt(const std::string& format)
 	// percent signs, if any. So we don't need additional
 	// parameters.
 	unsigned int len = 1 +
-		snprintf(buffer, sizeof(buffer), format.c_str(), "");
+		snprintf(buffer, sizeof(buffer), format.data(), "");
 	if (len <= sizeof(buffer)) {
 		result = buffer;
 	} else {
 		std::vector<char> buf(len);
-		snprintf(buf.data(), len, format.c_str(), "");
+		snprintf(buf.data(), len, format.data(), "");
 		result = buf.data();
 	}
 	return result;
@@ -37,7 +37,7 @@ std::string strprintf::fmt(const std::string& format)
  * "a 100%% rel%iable e%xamp%le"  =>  { "a 100%% rel%iable e", "%xamp%le" }
  */
 std::pair<std::string, std::string> strprintf::split_format(
-	const std::string& printf_format)
+	std::string_view printf_format)
 {
 	std::string first_format, rest;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -53,10 +53,12 @@ std::string utils::strip_comments(const std::string& line)
 	return std::string(utils::bridged::strip_comments(line));
 }
 
-std::vector<std::string> utils::tokenize_quoted(const std::string& str,
-	std::string delimiters)
+std::vector<std::string> utils::tokenize_quoted(std::string_view str,
+	std::string_view delimiters)
 {
-	const auto tokens = utils::bridged::tokenize_quoted(str, delimiters);
+	const auto tokens = utils::bridged::tokenize_quoted(
+			rust::Str(str.data(), str.size()),
+			rust::Str(delimiters.data(), delimiters.size()));
 
 	std::vector<std::string> result;
 	for (const auto& token : tokens) {

--- a/test/configparser.cpp
+++ b/test/configparser.cpp
@@ -18,7 +18,7 @@ namespace {
 
 class ConfigHandlerHistoryDummy : public ConfigActionHandler {
 public:
-	void handle_action(const std::string& action,
+	void handle_action(std::string_view action,
 		const std::vector<std::string>& params) override
 	{
 		history.emplace_back(action, params);


### PR DESCRIPTION
This might reduce a bunch of `std::string` allocations, especially in logging where it is common that the first argument is constant data (using std::string caused an allocation where std::string_view just references the constant data)
I don't expect a big performance/readability impact but still think it might be worth it for a cleaner mapping to Rust's `&str` and thus slightly easier porting work.

This only converts a small part of the `const std::string&` occurrences to `std::string_view`.
I might convert all of those (where it makes sense) in some follow up PRs but there is no hurry in finishing this.