### PR TITLE
Don't show unbound actions in help line

### DIFF
--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -1360,32 +1360,34 @@ unsigned short KeyMap::get_flag_from_context(Dialog context)
 StflRichText KeyMap::prepare_keymap_hint(const std::vector<KeyMapHintEntry>& hints,
 	Dialog context)
 {
+	const auto comma = StflRichText::from_plaintext_with_style(",", "<comma>");
+	const auto colon = StflRichText::from_plaintext_with_style(":", "<colon>");
+
 	auto keymap_hint = StflRichText::from_plaintext("");
 	bool first_hint = true;
 	for (const auto& hint : hints) {
+		const std::vector<KeyCombination> bound_keys = get_keys(hint.op, context);
+		if (bound_keys.empty()) {
+			continue;
+		}
+
 		if (!first_hint) {
 			keymap_hint.append(StflRichText::from_plaintext(" "));
 		}
 		first_hint = false;
 
-		const std::vector<KeyCombination> bound_keys = get_keys(hint.op, context);
-		const auto comma = StflRichText::from_plaintext_with_style(",", "<comma>");
 
-		if (bound_keys.empty()) {
-			keymap_hint.append(StflRichText::from_plaintext_with_style("<none>", "<key>"));
-		} else {
-			bool first_key = true;
-			for (const auto& key : bound_keys) {
-				if (!first_key) {
-					keymap_hint.append(comma);
-				}
-				first_key = false;
-				keymap_hint.append(StflRichText::from_plaintext_with_style(key.to_bindkey_string(),
-						"<key>"));
+		bool first_key = true;
+		for (const auto& key : bound_keys) {
+			if (!first_key) {
+				keymap_hint.append(comma);
 			}
+			first_key = false;
+			keymap_hint.append(StflRichText::from_plaintext_with_style(key.to_bindkey_string(),
+					"<key>"));
 		}
 
-		keymap_hint.append(StflRichText::from_plaintext_with_style(":", "<colon>"));
+		keymap_hint.append(colon);
 		keymap_hint.append(StflRichText::from_plaintext_with_style(hint.text, "<desc>"));
 	}
 	return keymap_hint;

--- a/test/keymap.cpp
+++ b/test/keymap.cpp
@@ -756,8 +756,6 @@ TEST_CASE("prepare_keymap_hint() returns a string describing keys to which given
 	k.handle_action("bind-key", "< open");
 	k.handle_action("unbind-key", "r");
 	k.handle_action("bind-key", "O reload");
-	// This frees up OP_SEARCH
-	k.handle_action("unbind-key", "/");
 
 	const std::vector<KeyMapHintEntry> hints {
 		{OP_QUIT, "Get out of <this> dialog"},
@@ -772,7 +770,16 @@ TEST_CASE("prepare_keymap_hint() returns a string describing keys to which given
 		"<key>?<comma>,<key>w<colon>:<desc>HALP</> "
 		"<key>ENTER<comma>,<key><><comma>,<key>x<colon>:<desc>Open</> "
 		"<key>O<colon>:<desc>Reload current entry</> "
-		"<key><>none><colon>:<desc>Go find me</>");
+		"<key>/<colon>:<desc>Go find me</>");
+
+	// This makes OP_SEARCH unbound and thus hides it in the keymap hints
+	k.handle_action("unbind-key", "/");
+
+	REQUIRE(k.prepare_keymap_hint(hints, Dialog::FeedList).stfl_quoted() ==
+		"<key>q<colon>:<desc>Get out of <>this> dialog</> "
+		"<key>?<comma>,<key>w<colon>:<desc>HALP</> "
+		"<key>ENTER<comma>,<key><><comma>,<key>x<colon>:<desc>Open</> "
+		"<key>O<colon>:<desc>Reload current entry</>");
 }
 
 TEST_CASE("get_help_info() returns info about macros, bindings, and unbound actions",


### PR DESCRIPTION
Related to https://github.com/newsboat/newsboat/issues/3267
> > I also don't need some of the entries currently showing as &lt;none&gt;:Something.
> 
> Now that you mention it, I wonder why we even include unbound operations in the hints line. It really doesn't make any sense, since those operations can't be invoked by pressing a key =\