### PR TITLE
Update curl-sys dependency and avoid harmless mismatch in test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.85+curl-8.18.0"
+version = "0.4.86+curl-8.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
+checksum = "3a1dd6a487cf4532ce0d801634b82aa2deb7c9c3ed930b9dadfce904df000745"
 dependencies = [
  "cc",
  "libc",

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1626,16 +1626,20 @@ TEST_CASE(
 	"on defined values and undefined values",
 	"[utils]")
 {
-	REQUIRE(utils::get_auth_method("any") == CURLAUTH_ANY);
+	// Starting with Curl 3.19, the curlauth "any" and "anysafe" values are masked to 32 bits
+	// (via https://github.com/curl/curl/pull/20416)
+	// To avoid mismatches between the curl version bundled on the rust side (curl-sys) and the
+	// system curl version, apply manual casting to uint32_t.
+	REQUIRE(utils::get_auth_method("any") == static_cast<std::uint32_t>(CURLAUTH_ANY));
 	REQUIRE(utils::get_auth_method("ntlm") == CURLAUTH_NTLM);
 	REQUIRE(utils::get_auth_method("basic") == CURLAUTH_BASIC);
 	REQUIRE(utils::get_auth_method("digest") == CURLAUTH_DIGEST);
 	REQUIRE(utils::get_auth_method("digest_ie") == CURLAUTH_DIGEST_IE);
 	REQUIRE(utils::get_auth_method("gssnegotiate") == CURLAUTH_GSSNEGOTIATE);
-	REQUIRE(utils::get_auth_method("anysafe") == CURLAUTH_ANYSAFE);
+	REQUIRE(utils::get_auth_method("anysafe") == static_cast<std::uint32_t>(CURLAUTH_ANYSAFE));
 
-	REQUIRE(utils::get_auth_method("") == CURLAUTH_ANY);
-	REQUIRE(utils::get_auth_method("test") == CURLAUTH_ANY);
+	REQUIRE(utils::get_auth_method("") == static_cast<std::uint32_t>(CURLAUTH_ANY));
+	REQUIRE(utils::get_auth_method("test") == static_cast<std::uint32_t>(CURLAUTH_ANY));
 }
 
 TEST_CASE(


### PR DESCRIPTION
One of our tests started failing on my machine after an update of the `curl` package to `8.19.0` (Arch Linux)
The authentication values "any" and "anysafe" originate from our Rust code (via curl-sys).
Those values were still 64-bit bitfields with (almost) all bits set, whereas the updated curl package only set the lower 32 bits (see Curl PR: https://github.com/curl/curl/pull/20416)
This caused a mismatch in our tests.
The mismatch is harmless because the Curl library casts the value to a 32-bit value anyway.

Change tested locally both with the new Curl version and with the rolled-back old version.