### PR TITLE
Fix ocnewsapi build failure with libc++ compressed_pair on macOS 26 SDK

### DIFF
--- a/src/ocnewsapi.cpp
+++ b/src/ocnewsapi.cpp
@@ -17,7 +17,7 @@
 
 namespace newsboat {
 
-typedef std::unique_ptr<json_object, decltype(*json_object_put)> JsonUptr;
+typedef std::unique_ptr<json_object, decltype(&json_object_put)> JsonUptr;
 
 OcNewsApi::OcNewsApi(ConfigContainer& c)
 	: RemoteApi(c)


### PR DESCRIPTION
decltype(*json_object_put) yields the raw function type int(json_object*), causing unique_ptr to store a function reference as its deleter. The macOS 26 SDK's libc++ compressed_pair.h performs sizeof on the deleter type, which is ill-formed for function types, resulting in a build error.

Change to decltype(&json_object_put) to get the function pointer type int(*)(json_object*), which is valid for sizeof.