### PR TITLE
Quote URLs (if necessary) when writing to file

### DIFF
--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -72,7 +72,7 @@ std::optional<std::string> FileUrlReader::write_config()
 	}
 
 	for (const auto& url : urls) {
-		f << url;
+		f << utils::quote_if_necessary(url);
 		if (tags[url].size() > 0) {
 			for (const auto& tag : tags[url]) {
 				f << " \"" << tag << "\"";

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -89,6 +89,30 @@ TEST_CASE("URL reader writes files that it can understand later",
 	}
 }
 
+TEST_CASE("write_config quotes exec: and filter: urls", "[FileUrlReader]")
+{
+	test_helpers::TempFile urlsFile;
+	FileUrlReader u(urlsFile.get_path());
+
+	GIVEN("a url reader with an exec: and filter: feed") {
+		u.add_url(R"(exec:cat header body footer)", {"tag1", "tag 2"});
+		u.add_url(R"(filter:sed "s/foo/bar":https://example.com/feed.xml)", {"tag1", "tag 2"});
+
+		WHEN("the urls are saved to disk") {
+			u.write_config();
+
+			THEN("the exec: and filter: feeds are properly quoted") {
+				const auto content = test_helpers::file_contents(urlsFile.get_path());
+				// Looks like there is an extra newline at the end so allowing more than 2 lines
+				REQUIRE(content.size() >= 2);
+				REQUIRE(content[0] == R"("exec:cat header body footer" "tag1" "tag 2")");
+				REQUIRE(content[1] ==
+					R"("filter:sed \"s/foo/bar\":https://example.com/feed.xml" "tag1" "tag 2")");
+			}
+		}
+	}
+}
+
 TEST_CASE("Preserves URLs as-is", "[FileUrlReader][issue926]")
 {
 	const auto testDataPath = "data/926-urls"_path;


### PR DESCRIPTION
Related to https://github.com/newsboat/newsboat/issues/3115

It might be nice to just append new URLs. From the linked issue:
> Please also note that the tags of the already present feed have been all surrounded with double quotes. Newlines and comments are gone, too. Knowing about Newsboat's configuration parsing and ignoring newlines and comments, this is kinda expected, but still surprising. Naively thinking, the urls file could be opened in append mode and the new URLs just added this way without affecting the already existing part of the file. But maybe there's more to it, not sure.

I guess we need to parse the `urls` file to avoid adding duplicate entries.
It might be possible to determine which URLs from the OPML file are not yet in the file and append those without changing the existing content.
However, for now, I just want to make sure we don't actively break the `urls` file when importing from OPML.