### PR TITLE
Resolve strprintf::fmt ambiguity on OpenBSD.

### DIFF
--- a/include/strprintf.h
+++ b/include/strprintf.h
@@ -55,7 +55,7 @@ std::string fmt(std::string_view format, const uint64_t argument,
 	return detail::fmt_impl(format, argument, std::forward<Args>(args)...);
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 template<typename... Args>
 std::string fmt(std::string_view format, const std::size_t argument,
 	Args&& ... args)


### PR DESCRIPTION
The fix provided for Apple platforms in commit 4139a0ba1ec87e442ef1408823b07fc739742f9d is also required on OpenBSD.

Compilation fails otherwise:

```
In file included from rss/parser.cpp:17:
include/logger.h:22:19: error: call to 'fmt' is ambiguous
   22 |                 log_internal(l, strprintf::fmt(format, std::forward<Args>(args)...));
      |                                 ^~~~~~~~~~~~~~
rss/parser.cpp:249:3: note: in instantiation of function template specialization 'newsboat::logger::log<unsigned long>' requested here
  249 |                 LOG(Level::DEBUG, "Parser::parse_buffer: parse xml in utf-8 encoding (length: %zu)",
      |                 ^
include/logger.h:37:21: note: expanded from macro 'LOG'
   37 |                 newsboat::logger::log(x, __VA_ARGS__); \
      |                                   ^
include/strprintf.h:33:13: note: candidate function [with Args = <>]
   33 | std::string fmt(std::string_view format, const int32_t argument, Args&& ... args)
      |             ^
include/strprintf.h:39:13: note: candidate function [with Args = <>]
   39 | std::string fmt(std::string_view format, const std::uint32_t argument,
      |             ^
include/strprintf.h:46:13: note: candidate function [with Args = <>]
   46 | std::string fmt(std::string_view format, const int64_t argument, Args&& ... args)
      |             ^
include/strprintf.h:52:13: note: candidate function [with Args = <>]
   52 | std::string fmt(std::string_view format, const uint64_t argument,
      |             ^
include/strprintf.h:81:13: note: candidate function [with Args = <>]
   81 | std::string fmt(std::string_view format, const float argument, Args&& ... args)
      |             ^
include/strprintf.h:90:13: note: candidate function [with Args = <>]
   90 | std::string fmt(std::string_view format, const double argument, Args&& ... args)
      |             ^
1 error generated.
```