### PR TITLE
Allow specifying initial input text with cmdline operation

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -50,7 +50,7 @@ enqueue||kbd:[E]||Add the podcast download URL of the current article (if any is
 edit-urls||kbd:[Shift+E]||Edit the list of subscribed URLs. Newsboat will start the editor configured through the <<VISUAL,`VISUAL`>> environment variable (if unset, <<EDITOR,`EDITOR`>> is used; fallback: `vi`). When editing is finished, Newsboat will reload the URLs file.
 reload-urls||kbd:[Ctrl+R]||Reload the URLs configuration file.
 redraw||kbd:[Ctrl+L]||Redraw the screen.
-cmdline||kbd:[:]||Open the command line.
+cmdline||kbd:[:]||Open the command line with optional string already filled in. Example configuration: `bind c everywhere cmdline "source ~/.newsboat/config"`
 set-filter||kbd:[Shift+F]||Set a filter.
 select-filter||kbd:[F]||Select a predefined filter.
 clear-filter||kbd:[Ctrl+F]||Clear currently set filter.

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -114,7 +114,22 @@ bool FormAction::process_op(Operation op,
 		Stfl::reset();
 		break;
 	case OP_CMDLINE:
-		start_cmdline();
+		switch (args.size()) {
+		case 0:
+			start_cmdline();
+			break;
+		case 1:
+			start_cmdline(args[0]);
+			break;
+		default:
+			std::vector<std::string> quoted_args;
+			for (const auto& arg : args) {
+				quoted_args.push_back(utils::quote(arg));
+			}
+			const std::string args_str = utils::join(quoted_args, " ");
+			v.get_statusline().show_error(strprintf::fmt(_
+					(R"(Too many arguments to "cmdline" command: %s)"), args_str));
+		}
 		break;
 	case OP_SET:
 		switch (bindingType) {


### PR DESCRIPTION
Simple idea based on a question from user `mugalu_` on IRC:
> mugalu_: I'm pretty this is the case but I just wanted to verify that you can't creating a binding to 'cmdline'
> mugalu_: AND pass it a custom string like in `bind ^X^X everywhere cmdline 'source ~/.newsboat/config'`
> mugalu_: I thought I had it working for a second but seems i fooled myself. not a big deal

This opens the command line with the provided argument already filled in.
With a config like `bind ^X^X everywhere  cmdline "source ~/.newsboat/config"`, pressing `Ctrl-X`, `Ctrl-X`, `Enter` will start the command line and then execute the command `source ~/.newsboat/config`

I've added some restrictions to only allow 0 or 1 argument (should be enough as double-quote surrounded strings can already contain whitespace and, with backslash, double quotes)
Two reasons for this restriction:
- Catches some configuration issues, e.g. using single quotes instead of double quotes, as happened in mugalu_'s original message. With this implementation it shows error:
    `Too many arguments to "cmdline" command: "'source" "~/.newsboat/config'"`
- Allow future extensions (e.g. to add a flag to the `cmdline` operation to execute directly instead of requiring Enter)

Related issue: https://github.com/newsboat/newsboat/issues/1336 (if we decide to document these optional operation flags in a structured way)