### PR TITLE
Fix typo in spelling of "available"

### DIFF
--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -1155,7 +1155,7 @@ void FeedListFormAction::apply_filter(const std::string& filtertext)
 			do_redraw = true;
 		} else {
 			v.get_statusline().show_error(strprintf::fmt(
-					_("Error: Some filter attributes are not availabe in feedlist: %s"),
+					_("Error: Some filter attributes are not available in feedlist: %s"),
 					utils::join(unavailable_attributes, ", ")));
 		}
 	}

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1699,7 +1699,7 @@ void ItemListFormAction::apply_filter(const std::string& filtertext)
 			invalidate_list();
 		} else {
 			v.get_statusline().show_error(strprintf::fmt(
-					_("Error: Some filter attributes are not availabe in itemlist: %s"),
+					_("Error: Some filter attributes are not available in itemlist: %s"),
 					utils::join(unavailable_attributes, ", ")));
 		}
 	}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -858,7 +858,7 @@ static unsigned long openssl_mth_id_function(void)
 #endif
 
 /*
- * GnuTLS 2.11.0+ uses the system availabe locking procedures and discourages
+ * GnuTLS 2.11.0+ uses the system available locking procedures and discourages
  * setting thread locks manually. See the changelog:
  * https://gitlab.com/gnutls/gnutls/-/blob/master/NEWS?ref_type=heads#L4521
  * Mind the "<=" typo in the suggestion.


### PR DESCRIPTION
I noticed in a recent commit (e20b308) there was a spelling mistake on the word "available". I've fixed this, and also found another area where the same typo was made in a comment which I've fixed as well.