### PR TITLE
docs: fix default color configuration to match actual values

### DIFF
--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -380,15 +380,15 @@ Currently, the following elements are supported:
 
 The default color configuration of Newsboat looks like this:
 
-	color background          white   black
-	color listnormal          white   black
-	color listfocus           yellow  blue   bold
-	color listnormal_unread   white   black  bold
-	color listfocus_unread    yellow  blue   bold
-	color title               yellow  blue   bold
-	color info                yellow  blue   bold
-	color hint-key            yellow  blue   bold
-	color hint-keys-delimiter white   blue
-	color hint-separator      white   blue   bold
-	color hint-description    white   blue
-	color article             white   black
+	color background          default   default
+	color listnormal          default   default
+	color listfocus           yellow    blue     bold
+	color listnormal_unread   default   default  bold
+	color listfocus_unread    yellow    blue     bold
+	color title               yellow    blue     bold
+	color info                yellow    blue     bold
+	color hint-key            yellow    blue     bold
+	color hint-keys-delimiter white     blue
+	color hint-separator      white     blue     bold
+	color hint-description    white     blue
+	color article             default   default


### PR DESCRIPTION
## Problem

The documented default colors in `doc/chapter-configuration.asciidoc` don't match the actual defaults defined in `src/colormanager.cpp`.

Several elements are documented as `white`/`black` but the code uses `default`/`default` (meaning the terminal's native colors):

| Element | Documented | Actual |
|---------|-----------|--------|
| background | white/black | default/default |
| listnormal | white/black | default/default |
| listnormal_unread | white/black/bold | default/default/bold |
| article | white/black | default/default |

## Fix

Updated the documentation block to match `src/colormanager.cpp` lines 12-26.

Closes #3329