### PR TITLE
docs(configuration): fix default colorscheme to match actual code defaults

### DIFF
--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -380,15 +380,16 @@ Currently, the following elements are supported:
 
 The default color configuration of Newsboat looks like this:
 
-	color background          white   black
-	color listnormal          white   black
-	color listfocus           yellow  blue   bold
-	color listnormal_unread   white   black  bold
-	color listfocus_unread    yellow  blue   bold
-	color title               yellow  blue   bold
-	color info                yellow  blue   bold
-	color hint-key            yellow  blue   bold
-	color hint-keys-delimiter white   blue
-	color hint-separator      white   blue   bold
-	color hint-description    white   blue
-	color article             white   black
+	color background          default   default
+	color listnormal          default   default
+	color listfocus           yellow    blue   bold
+	color listnormal_unread   default   default  bold
+	color listfocus_unread    yellow    blue   bold
+	color title               yellow    blue   bold
+	color info                yellow    blue   bold
+	color hint-key            yellow    blue   bold
+	color hint-keys-delimiter white     blue
+	color hint-separator      white     blue   bold
+	color hint-description    white     blue
+	color end-of-text-marker  blue      default  bold
+	color article             default   default


### PR DESCRIPTION
The documented default colors in chapter-configuration.asciidoc listed `white`/`black` for several elements, but the actual defaults in `src/colormanager.cpp` use `default` (which respects the terminal's color scheme). Updated the docs to match the code:

- `background`, `listnormal`, `listnormal_unread`, `article`: `white black` → `default default`
- Added missing `end-of-text-marker` entry (`blue default bold`)

Fixes #3329.