### PR TITLE
Add operation to open urls file at current feed

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -47,7 +47,7 @@ cmd-seven||kbd:[7]||Start cmdline with 7.
 cmd-eight||kbd:[8]||Start cmdline with 8.
 cmd-nine||kbd:[9]||Start cmdline with 9.
 enqueue||kbd:[E]||Add the podcast download URL of the current article (if any is found) to the podcast download queue. See the <<_podcast_support>> section for more information.
-edit-urls||kbd:[Shift+E]||Edit the list of subscribed URLs. Newsboat will start the editor configured through the <<VISUAL,`VISUAL`>> environment variable (if unset, <<EDITOR,`EDITOR`>> is used; fallback: `vi`). When editing is finished, Newsboat will reload the URLs file.
+edit-urls||kbd:[Shift+E]||Edit the list of subscribed URLs. If a command is specified, Newsboat will replace the placeholders and then run the command. Newsboat supports the following placeholders in the command: `%f` (path to urls file), `%L` (line number of the current feed (or feed of the currently selected article) in the urls file, or 0 if the feed URL originates outside of the urls file). If no command is specified, Newsboat will start the editor configured through the <<VISUAL,`VISUAL`>> environment variable (if unset, <<EDITOR,`EDITOR`>> is used; fallback: `vi`). When editing is finished, Newsboat will reload the URLs file. Example config: `bind E feedlist,articlelist,searchresultslist edit-urls "vim +%L %f"`
 reload-urls||kbd:[Ctrl+R]||Reload the URLs configuration file.
 redraw||kbd:[Ctrl+L]||Redraw the screen.
 cmdline||kbd:[:]||Open the command line with optional string already filled in. Example configuration: `bind c everywhere cmdline "source ~/.newsboat/config"`

--- a/include/controller.h
+++ b/include/controller.h
@@ -57,6 +57,8 @@ public:
 
 	void reload_urls_file();
 	void edit_urls_file();
+	void edit_urls_file(const std::string& cmdline);
+	Filepath get_urls_file();
 
 	FeedContainer* get_feedcontainer()
 	{

--- a/include/feedorigin.h
+++ b/include/feedorigin.h
@@ -1,0 +1,19 @@
+#ifndef NEWSBOAT_FEEDORIGIN_H_
+#define NEWSBOAT_FEEDORIGIN_H_
+
+#include <optional>
+
+namespace newsboat {
+
+struct FileOrigin {
+	std::size_t line_number;
+};
+
+struct FeedOrigin {
+	std::optional<FileOrigin> file_origin;
+};
+
+} // namespace newsboat
+
+#endif /* NEWSBOAT_FEEDORIGIN_H_ */
+

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -135,6 +135,8 @@ protected:
 	void report_unhandled_operation(Operation op);
 	void set_keymap_hints();
 
+	void edit_urls(const std::vector<std::string>& args, std::shared_ptr<RssFeed> feed);
+
 	/// The name of the "main" STFL widget, i.e. the one that should be focused
 	/// by default.
 	virtual std::string main_widget() const = 0;

--- a/include/rssfeed.h
+++ b/include/rssfeed.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "config.h"
+#include "feedorigin.h"
 #include "matchable.h"
 #include "rssitem.h"
 #include "utils.h"
@@ -20,8 +21,20 @@ class Cache;
 
 class RssFeed : public Matchable {
 public:
+
 	explicit RssFeed(Cache* c, const std::string& rssurl);
 	~RssFeed() override = default;
+
+	void set_origin(const FeedOrigin& origin)
+	{
+		origin_ = origin;
+	}
+
+	const FeedOrigin& get_origin()
+	{
+		return origin_;
+	}
+
 	const std::string& title_raw() const
 	{
 		return title_;
@@ -192,6 +205,7 @@ public:
 	mutable std::mutex item_mutex;
 
 private:
+	FeedOrigin origin_;
 	std::string title_;
 	std::string description_;
 	std::string link_;

--- a/include/urlreader.h
+++ b/include/urlreader.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "feedorigin.h"
 #include "filepath.h"
 #include "utils.h"
 
@@ -30,8 +31,8 @@ public:
 	/// Tiny RSS").
 	virtual std::string get_source() const = 0;
 
-	/// \brief A list of feed URLs.
-	const std::vector<std::string>& get_urls() const;
+	/// \brief A list of feed URLs with their origin
+	const std::vector<std::pair<std::string, FeedOrigin>>& get_urls() const;
 
 	/// \brief Tags of feed that has url `url`.
 	std::vector<std::string>& get_tags(const std::string& url);
@@ -42,7 +43,7 @@ public:
 protected:
 	void load_query_urls_from_file(Filepath file);
 
-	std::vector<std::string> urls;
+	std::vector<std::pair<std::string, FeedOrigin>> urls;
 	std::map<std::string, std::vector<std::string>> tags;
 };
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -453,7 +453,7 @@ int Controller::run(const CliArgsParser& args)
 	std::cout.flush();
 
 	unsigned int i = 0;
-	for (const auto& url : urlcfg->get_urls()) {
+	for (const auto& [url, origin] : urlcfg->get_urls()) {
 		try {
 			bool ignore_disp =
 				(cfg.get_configvalue("ignore-mode") ==
@@ -461,6 +461,7 @@ int Controller::run(const CliArgsParser& args)
 			std::shared_ptr<RssFeed> feed =
 				rsscache->internalize_rssfeed(
 					url, ignore_disp ? &ign : nullptr);
+			feed->set_origin(origin);
 			feed->set_tags(urlcfg->get_tags(url));
 			feed->set_order(i);
 			feedcontainer.add_feed(feed);
@@ -706,6 +707,7 @@ void Controller::replace_feed(RssFeed& oldfeed, RssFeed& newfeed, unsigned int p
 	bool ignore_disp = (cfg.get_configvalue("ignore-mode") == "display");
 	std::shared_ptr<RssFeed> feed = rsscache->internalize_rssfeed(
 			oldfeed.rssurl(), ignore_disp ? &ign : nullptr);
+	feed->set_origin(oldfeed.get_origin());
 	LOG(Level::DEBUG,
 		"Controller::replace_feed: after internalize_rssfeed");
 
@@ -827,9 +829,10 @@ void Controller::reload_urls_file()
 	std::vector<std::shared_ptr<RssFeed>> new_feeds;
 	unsigned int i = 0;
 
-	for (const auto& url : urlcfg->get_urls()) {
+	for (const auto& [url, origin] : urlcfg->get_urls()) {
 		const auto feed = feedcontainer.get_feed_by_url(url);
 		if (feed) {
+			feed->set_origin(origin);
 			feed->set_tags(urlcfg->get_tags(url));
 			feed->set_order(i);
 			new_feeds.push_back(feed);
@@ -841,6 +844,7 @@ void Controller::reload_urls_file()
 				std::shared_ptr<RssFeed> new_feed =
 					rsscache->internalize_rssfeed(url,
 						ignore_disp ? &ign : nullptr);
+				new_feed->set_origin(origin);
 				new_feed->set_tags(urlcfg->get_tags(url));
 				new_feed->set_order(i);
 				new_feeds.push_back(new_feed);
@@ -877,7 +881,12 @@ void Controller::edit_urls_file()
 	std::string cmdline = strprintf::fmt("%s \"%s\"",
 			editor,
 			utils::replace_all(configpaths.url_file().to_locale_string(), "\"", "\\\""));
+	edit_urls_file(cmdline);
 
+}
+
+void Controller::edit_urls_file(const std::string& cmdline)
+{
 	v->push_empty_formaction();
 	Stfl::reset();
 	utils::run_interactively(cmdline, "Controller::edit_urls_file");
@@ -886,6 +895,11 @@ void Controller::edit_urls_file()
 	v->pop_current_formaction();
 
 	reload_urls_file();
+}
+
+Filepath Controller::get_urls_file()
+{
+	return configpaths.url_file();
 }
 
 int Controller::execute_commands(const std::vector<std::string>& cmds)

--- a/src/feedhqurlreader.cpp
+++ b/src/feedhqurlreader.cpp
@@ -30,7 +30,7 @@ FeedHqUrlReader::~FeedHqUrlReader() {}
 #define ADD_URL(url, caption)                 \
 	do {                                  \
 		tmptags.clear();              \
-		urls.push_back((url));        \
+		urls.push_back({(url), FeedOrigin{}});        \
 		tmptags.push_back((caption)); \
 		tags[(url)] = tmptags;        \
 	} while (0)
@@ -57,7 +57,7 @@ std::optional<utils::ReadTextFileError> FeedHqUrlReader::reload()
 		std::vector<std::string> url_tags = tagged.second;
 
 		LOG(Level::DEBUG, "added %s to URL list", url);
-		urls.push_back(url);
+		urls.push_back({url, FeedOrigin{}});
 		tags[tagged.first] = url_tags;
 		for (const auto& tag : url_tags) {
 			LOG(Level::DEBUG, "%s: added tag %s", url, tag);

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -12,6 +12,7 @@
 #include "dbexception.h"
 #include "feedcontainer.h"
 #include "fmtstrformatter.h"
+#include "keymap.h"
 #include "listformatter.h"
 #include "logger.h"
 #include "reloader.h"
@@ -499,7 +500,7 @@ REDO:
 		}
 		break;
 	case OP_EDIT_URLS:
-		v.get_ctrl().edit_urls_file();
+		edit_urls(args, v.get_ctrl().get_feedcontainer()->get_feed(pos));
 		break;
 	case OP_QUIT:
 		if (tag != "") {

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 
 #include "config.h"
+#include "feedorigin.h"
 #include "strprintf.h"
 #include "utils.h"
 
@@ -22,7 +23,7 @@ std::string FileUrlReader::get_source() const
 void FileUrlReader::add_url(const std::string& url,
 	const std::vector<std::string>& url_tags)
 {
-	urls.push_back(url);
+	urls.push_back({url, FeedOrigin{}});
 	tags[url] = url_tags;
 }
 
@@ -37,7 +38,10 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 	}
 	std::vector<std::string> lines = result.value();
 
+	std::size_t line_number = 0;
 	for (const std::string& line : lines) {
+		line_number++;
+
 		// skip empty lines and comments
 		if (line.empty() || line[0] == '#') {
 			continue;
@@ -49,7 +53,7 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 		}
 
 		std::string url = tokens[0];
-		urls.push_back(url);
+		urls.push_back({url, FeedOrigin{FileOrigin{line_number}}});
 
 		tokens.erase(tokens.begin());
 		if (!tokens.empty()) {
@@ -71,7 +75,9 @@ std::optional<std::string> FileUrlReader::write_config()
 				error_message);
 	}
 
-	for (const auto& url : urls) {
+	std::size_t line_number = 0;
+	for (auto& [url, origin] : urls) {
+		line_number++;
 		f << utils::quote_if_necessary(url);
 		if (tags[url].size() > 0) {
 			for (const auto& tag : tags[url]) {
@@ -79,6 +85,10 @@ std::optional<std::string> FileUrlReader::write_config()
 			}
 		}
 		f << std::endl;
+
+		// Update origin as writing to urls file might remove comments and empty lines,
+		// resulting in URLs ending up at different line numbers
+		origin = FeedOrigin{FileOrigin{line_number}};
 	}
 
 	return {};

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -7,7 +7,9 @@
 #include "config.h"
 #include "configexception.h"
 #include "controller.h"
+#include "fmtstrformatter.h"
 #include "logger.h"
+#include "rssfeed.h"
 #include "strprintf.h"
 #include "textviewwidget.h"
 #include "utils.h"
@@ -64,6 +66,41 @@ void FormAction::set_keymap_hints()
 {
 	set_value("help", v.get_keymap()->prepare_keymap_hint(this->get_keymap_hint(),
 			this->id()).stfl_quoted());
+}
+
+void FormAction::edit_urls(const std::vector<std::string>& args,
+	std::shared_ptr<RssFeed> feed)
+{
+	switch (args.size()) {
+	case 0:
+		v.get_ctrl().edit_urls_file();
+		break;
+	case 1: {
+		std::size_t line_number = 0;
+		if (feed) {
+			const auto file_origin = feed->get_origin().file_origin;
+			if (file_origin.has_value()) {
+				line_number = file_origin->line_number;
+			}
+		}
+		Filepath file = v.get_ctrl().get_urls_file();
+		std::string quoted_file_arg = strprintf::fmt(R"("%s")",
+				utils::replace_all(file.to_locale_string(), "\"", "\\\""));
+
+		FmtStrFormatter fmt;
+		fmt.register_fmt('f', quoted_file_arg);
+		fmt.register_fmt('L', std::to_string(line_number));
+		const auto cmdline = fmt.do_format(args[0]);
+
+		LOG(Level::DEBUG, "edit urls command: %s", cmdline);
+		v.get_ctrl().edit_urls_file(cmdline);
+		break;
+	}
+	default:
+		v.get_statusline().show_error(strprintf::fmt(_("Too many arguments for %s"),
+				KeyMap::get_op_name(OP_EDIT_URLS)));
+		break;
+	}
 }
 
 std::string FormAction::get_value(const std::string& name)

--- a/src/freshrssurlreader.cpp
+++ b/src/freshrssurlreader.cpp
@@ -28,7 +28,7 @@ std::optional<utils::ReadTextFileError> FreshRssUrlReader::reload()
 		std::vector<std::string> tmptags;
 		const std::string star_url = cfg->get_configvalue("freshrss-url") +
 			"/reader/api/0/stream/contents/user/-/state/com.google/starred";
-		urls.push_back(star_url);
+		urls.push_back({star_url, FeedOrigin{}});
 		tmptags.push_back(std::string("~") + _("Starred items"));
 		tags[star_url] = tmptags;
 	}
@@ -41,7 +41,7 @@ std::optional<utils::ReadTextFileError> FreshRssUrlReader::reload()
 		std::vector<std::string> url_tags = tagged.second;
 
 		LOG(Level::DEBUG, "added %s to URL list", url);
-		urls.push_back(url);
+		urls.push_back({url, FeedOrigin{}});
 		tags[tagged.first] = url_tags;
 		for (const auto& tag : url_tags) {
 			LOG(Level::DEBUG, "%s: added tag %s", url, tag);

--- a/src/inoreaderurlreader.cpp
+++ b/src/inoreaderurlreader.cpp
@@ -32,7 +32,7 @@ InoreaderUrlReader::~InoreaderUrlReader() {}
 #define ADD_URL(url, caption)                 \
 	do {                                  \
 		tmptags.clear();              \
-		urls.push_back((url));        \
+		urls.push_back({(url), FeedOrigin{}});        \
 		tmptags.push_back((caption)); \
 		tags[(url)] = tmptags;        \
 	} while (0)
@@ -58,7 +58,7 @@ std::optional<utils::ReadTextFileError> InoreaderUrlReader::reload()
 	std::vector<TaggedFeedUrl> feedurls = api->get_subscribed_urls();
 	for (const auto& url : feedurls) {
 		LOG(Level::DEBUG, "added %s to URL list", url.first);
-		urls.push_back(url.first);
+		urls.push_back({url.first, FeedOrigin{}});
 		tags[url.first] = url.second;
 		for (const auto& tag : url.second) {
 			LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -690,7 +690,11 @@ bool ItemListFormAction::process_operation(Operation op,
 		}
 		break;
 	case OP_EDIT_URLS:
-		v.get_ctrl().edit_urls_file();
+		if (visible_items.empty()) {
+			edit_urls(args, feed);
+		} else {
+			edit_urls(args, visible_items[itempos].first->get_feedptr());
+		}
 		break;
 	case OP_SELECTFILTER:
 		if (filter_container.size() > 0) {

--- a/src/minifluxurlreader.cpp
+++ b/src/minifluxurlreader.cpp
@@ -27,7 +27,7 @@ std::optional<utils::ReadTextFileError> MinifluxUrlReader::reload()
 	if (cfg->get_configvalue_as_bool("miniflux-show-special-feeds")) {
 		std::vector<std::string> tmptags;
 		const std::string star_url = "starred";
-		urls.push_back(star_url);
+		urls.push_back({star_url, FeedOrigin{}});
 		std::string star_tag = std::string("~") + _("Starred items");
 		tmptags.push_back(star_tag);
 		tags[star_url] = tmptags;
@@ -39,7 +39,7 @@ std::optional<utils::ReadTextFileError> MinifluxUrlReader::reload()
 
 	for (const auto& url : feedurls) {
 		LOG(Level::INFO, "added %s to URL list", url.first);
-		urls.push_back(url.first);
+		urls.push_back({url.first, FeedOrigin{}});
 		tags[url.first] = url.second;
 		for (const auto& tag : url.second) {
 			LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);

--- a/src/oldreaderurlreader.cpp
+++ b/src/oldreaderurlreader.cpp
@@ -31,7 +31,7 @@ OldReaderUrlReader::~OldReaderUrlReader() {}
 #define ADD_URL(url, caption)                 \
 	do {                                  \
 		tmptags.clear();              \
-		urls.push_back((url));        \
+		urls.push_back({(url), FeedOrigin{}});        \
 		tmptags.push_back((caption)); \
 		tags[(url)] = tmptags;        \
 	} while (0)
@@ -55,7 +55,7 @@ std::optional<utils::ReadTextFileError> OldReaderUrlReader::reload()
 	std::vector<TaggedFeedUrl> feedurls = api->get_subscribed_urls();
 	for (const auto& url : feedurls) {
 		LOG(Level::DEBUG, "added %s to URL list", url.first);
-		urls.push_back(url.first);
+		urls.push_back({url.first, FeedOrigin{}});
 		tags[url.first] = url.second;
 		for (const auto& tag : url.second) {
 			LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);

--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -146,7 +146,10 @@ void rec_find_rss_outlines(
 					static_cast<uint64_t>(urlcfg.get_urls().size()));
 
 				auto& urls = urlcfg.get_urls();
-				if (std::find(urls.begin(), urls.end(), quoted_url) == urls.end()) {
+				const auto is_same_url = [&quoted_url](auto& url) {
+					return url.first == quoted_url;
+				};
+				if (std::find_if(urls.begin(), urls.end(), is_same_url) == urls.end()) {
 					LOG(Level::DEBUG, "opml::import: added url = %s", quoted_url);
 					std::vector<std::string> tags;
 

--- a/src/opmlurlreader.cpp
+++ b/src/opmlurlreader.cpp
@@ -67,7 +67,7 @@ void OpmlUrlReader::handle_node(xmlNode* node, const std::string& tag)
 			(char*)xmlGetProp(node, (const xmlChar*)"xmlUrl");
 		if (rssurl && strlen(rssurl) > 0) {
 			std::string theurl(rssurl);
-			urls.push_back(theurl);
+			urls.push_back({theurl, FeedOrigin{}});
 
 			std::vector<std::string> tmptags;
 

--- a/src/remoteapiurlreader.cpp
+++ b/src/remoteapiurlreader.cpp
@@ -25,7 +25,7 @@ std::optional<utils::ReadTextFileError> RemoteApiUrlReader::reload()
 
 	for (const auto& url : feedurls) {
 		LOG(Level::INFO, "added %s to URL list", url.first);
-		urls.push_back(url.first);
+		urls.push_back({url.first, FeedOrigin{}});
 		tags[url.first] = url.second;
 		for (const auto& tag : url.second) {
 			LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);

--- a/src/urlreader.cpp
+++ b/src/urlreader.cpp
@@ -7,7 +7,7 @@
 
 namespace newsboat {
 
-const std::vector<std::string>& UrlReader::get_urls() const
+const std::vector<std::pair<std::string, FeedOrigin>>& UrlReader::get_urls() const
 {
 	return urls;
 }
@@ -42,9 +42,9 @@ void UrlReader::load_query_urls_from_file(Filepath file)
 	}
 
 	const auto& other_urls = file_url_reader.get_urls();
-	for (const auto& url : other_urls) {
+	for (const auto& [url, origin] : other_urls) {
 		if (utils::is_query_url(url)) {
-			urls.push_back(url);
+			urls.push_back({url, origin});
 			tags[url] = file_url_reader.get_tags(url);
 		}
 	}

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -27,9 +27,21 @@ TEST_CASE("URL reader extracts all URLs from the file", "[FileUrlReader]")
 	u.reload();
 
 	REQUIRE(u.get_urls().size() == 3);
-	REQUIRE(u.get_urls()[0] == "http://test1.url.cc/feed.xml");
-	REQUIRE(u.get_urls()[1] == "http://anotherfeed.com/");
-	REQUIRE(u.get_urls()[2] == "http://onemorefeed.at/feed/");
+	REQUIRE(u.get_urls()[0].first == "http://test1.url.cc/feed.xml");
+	REQUIRE(u.get_urls()[1].first == "http://anotherfeed.com/");
+	REQUIRE(u.get_urls()[2].first == "http://onemorefeed.at/feed/");
+}
+
+TEST_CASE("URL reader stores origin for each feed", "[FileUrlReader]")
+{
+	const auto path = "data/test-urls.txt"_path;
+	FileUrlReader u(path);
+	u.reload();
+
+	REQUIRE(u.get_urls().size() == 3);
+	REQUIRE(u.get_urls()[0].second.file_origin->line_number == 1);
+	REQUIRE(u.get_urls()[1].second.file_origin->line_number == 2);
+	REQUIRE(u.get_urls()[2].second.file_origin->line_number == 4);
 }
 
 TEST_CASE("URL reader extracts feeds' tags", "[FileUrlReader]")
@@ -83,9 +95,49 @@ TEST_CASE("URL reader writes files that it can understand later",
 	REQUIRE_FALSE(u2.get_urls().empty());
 	REQUIRE_FALSE(u2.get_alltags().empty());
 	REQUIRE(u.get_alltags() == u2.get_alltags());
-	REQUIRE(u.get_urls() == u2.get_urls());
-	for (const auto& url : u.get_urls()) {
+
+	auto u_urls = u.get_urls();
+	auto u2_urls = u2.get_urls();
+	REQUIRE(u_urls.size() == u2_urls.size());
+	for (std::size_t i = 0; i < u_urls.size(); i++) {
+		REQUIRE(u_urls[i].first == u2_urls[i].first);
+	}
+	for (const auto& [url, origin] : u.get_urls()) {
+		(void)origin;
 		REQUIRE(u.get_tags(url) == u2.get_tags(url));
+	}
+
+}
+
+TEST_CASE("URL reader updates feed origin when writing data",
+	"[FileUrlReader]")
+{
+	const auto testDataPath = "data/test-urls.txt"_path;
+	test_helpers::TempFile urlsFile;
+
+	test_helpers::copy_file(testDataPath, urlsFile.get_path());
+
+	GIVEN("A URL reader with some loaded feeds") {
+		FileUrlReader u(urlsFile.get_path());
+		u.reload();
+
+		SECTION("line numbers take comments into account") {
+			const auto urls = u.get_urls();
+			REQUIRE(urls[0].second.file_origin->line_number == 1);
+			REQUIRE(urls[1].second.file_origin->line_number == 2);
+			REQUIRE(urls[2].second.file_origin->line_number == 4);
+		}
+
+		WHEN("Feed URLs are written to file") {
+			u.write_config();
+
+			THEN("Line numbers in feed origin data are updated to account for removed comments") {
+				const auto urls = u.get_urls();
+				REQUIRE(urls[0].second.file_origin->line_number == 1);
+				REQUIRE(urls[1].second.file_origin->line_number == 2);
+				REQUIRE(urls[2].second.file_origin->line_number == 3);
+			}
+		}
 	}
 }
 
@@ -121,7 +173,7 @@ TEST_CASE("Preserves URLs as-is", "[FileUrlReader][issue926]")
 	u.reload();
 
 	REQUIRE(u.get_urls().size() == 1);
-	REQUIRE(u.get_urls()[0] ==
+	REQUIRE(u.get_urls()[0].first ==
 		R"_(exec:curl --silent https://feeds.metaebene.me/raumzeit/m4a  | sed 's#\(</guid>\|</id>\)#-M4A&#')_");
 }
 

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -132,7 +132,8 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 
 	REQUIRE(urlcfg.get_urls().size() == testUrls.size());
 
-	for (const auto& url : urlcfg.get_urls()) {
+	for (const auto& [url, origin] : urlcfg.get_urls()) {
+		(void)origin;
 		INFO("url = " << url);
 
 		const auto entry = testUrls.find(url);
@@ -164,7 +165,8 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 
 	REQUIRE(urlcfg.get_urls().size() == combinedUrls.size());
 
-	for (const auto& url : urlcfg.get_urls()) {
+	for (const auto& [url, origin] : urlcfg.get_urls()) {
+		(void)origin;
 		INFO("url = " << url);
 
 		const auto entry = combinedUrls.find(url);
@@ -199,7 +201,8 @@ TEST_CASE("import() turns URLs that start with a pipe symbol (\"|\") "
 
 	REQUIRE(urlcfg.get_urls().size() == opmlUrls.size());
 
-	for (const auto& url : urlcfg.get_urls()) {
+	for (const auto& [url, origin] : urlcfg.get_urls()) {
+		(void)origin;
 		INFO("url = " << url);
 
 		const auto entry = opmlUrls.find(url);
@@ -235,7 +238,8 @@ TEST_CASE("import() turns \"filtercmd\" attribute into a `filter:` URL "
 
 	REQUIRE(urlcfg.get_urls().size() == opmlUrls.size());
 
-	for (const auto& url : urlcfg.get_urls()) {
+	for (const auto& [url, origin] : urlcfg.get_urls()) {
+		(void)origin;
 		INFO("url = " << url);
 
 		const auto entry = opmlUrls.find(url);
@@ -268,7 +272,8 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 
 	REQUIRE(urlcfg.get_urls().size() == testUrls.size());
 
-	for (const auto& url : urlcfg.get_urls()) {
+	for (const auto& [url, origin] : urlcfg.get_urls()) {
+		(void)origin;
 		INFO("url = " << url);
 
 		const auto entry = testUrls.find(url);
@@ -294,7 +299,8 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 
 	REQUIRE(urlcfg.get_urls().size() == combinedUrls.size());
 
-	for (const auto& url : urlcfg.get_urls()) {
+	for (const auto& [url, origin] : urlcfg.get_urls()) {
+		(void)origin;
 		INFO("url = " << url);
 
 		const auto entry = combinedUrls.find(url);
@@ -317,7 +323,7 @@ TEST_CASE("import() tags from category attribute", "[Opml]")
 	const std::vector<std::string> tags{"tag one", "tag_two", "tag/three"};
 	const auto& urls = urlcfg.get_urls();
 	REQUIRE(urls.size() == 1);
-	REQUIRE(urlcfg.get_tags(urls[0]) == tags);
+	REQUIRE(urlcfg.get_tags(urls[0].first) == tags);
 }
 
 TEST_CASE("import() returns an error when the <opml> root element is missing", "[Opml]")

--- a/test/opmlurlreader.cpp
+++ b/test/opmlurlreader.cpp
@@ -52,7 +52,8 @@ TEST_CASE("OpmlUrlReader::reload() reads URLs and tags from an OPML file",
 
 	REQUIRE(reader.get_urls().size() == expected.size());
 
-	for (const auto& url : reader.get_urls()) {
+	for (const auto& [url, origin] : reader.get_urls()) {
+		(void)origin;
 		INFO("url = " << url);
 
 		const auto e = expected.find(url);
@@ -113,7 +114,8 @@ TEST_CASE("OpmlUrlReader::reload() loads URLs from multiple sources",
 
 	REQUIRE(reader.get_urls().size() == expected.size());
 
-	for (const auto& url : reader.get_urls()) {
+	for (const auto& [url, origin] : reader.get_urls()) {
+		(void)origin;
 		INFO("url = " << url);
 
 		const auto e = expected.find(url);
@@ -178,7 +180,8 @@ TEST_CASE("OpmlUrlReader::reload() skips things that can't be parsed",
 
 	REQUIRE(reader.get_urls().size() == expected.size());
 
-	for (const auto& url : reader.get_urls()) {
+	for (const auto& [url, origin] : reader.get_urls()) {
+		(void)origin;
 		INFO("url = " << url);
 
 		const auto e = expected.find(url);

--- a/test/remoteapiurlreader.cpp
+++ b/test/remoteapiurlreader.cpp
@@ -95,9 +95,12 @@ TEST_CASE("RemoteApiUrlReader reload includes query urls and urls from the Remot
 				REQUIRE(loaded_urls.size() == 3);
 
 				const std::string query_feed = R"(query:Unread Articles:unread = "yes")";
-				REQUIRE(loaded_urls[0] == query_feed);
-				REQUIRE(loaded_urls[1] == feed1);
-				REQUIRE(loaded_urls[2] == feed2);
+				REQUIRE(loaded_urls[0].first == query_feed);
+				REQUIRE(loaded_urls[0].second.file_origin->line_number == 2);
+				REQUIRE(loaded_urls[1].first == feed1);
+				REQUIRE(loaded_urls[1].second.file_origin == std::nullopt);
+				REQUIRE(loaded_urls[2].first == feed2);
+				REQUIRE(loaded_urls[2].second.file_origin == std::nullopt);
 
 				REQUIRE(url_reader.get_tags(query_feed).size() == 2);
 				REQUIRE(url_reader.get_tags(feed1).size() == 2);


### PR DESCRIPTION
Implements part of https://github.com/newsboat/newsboat/issues/1262 (that issue mentions "automagically" adding parameters based on the configured editor. I rather stay away from that, the maintenance of an editor list, and the potential issues with a symlinked editor. ~~Instead, I've added a separate operation with an argument~~)
Resolves https://github.com/newsboat/newsboat/issues/3338
Resolves https://github.com/akrennmair/newsbeuter/issues/258

Rendered docs: 
<img width="999" height="273" alt="image" src="https://github.com/user-attachments/assets/5f8442dd-899f-42b9-b4cb-55ec0432c16b" />

---

~~I've only added support for this operation to the feedlist.
It might make sense to extend this behavior to the articlelist as well, but I'm not sure what would be the best feed to jump to for query feeds and search result feeds (might make sense to jump to the feed of the selected article)~~

The added tracking of `urls` source line for feeds still feels a bit brittle. For example, it would have been easy to miss the following scenarios:
- updating line numbers when writing to the `urls` file
- taking over the `FeedOrigin` data when internalizing a feed after reload

If there are ideas for making this less error prone, I'm all ears.