### PR TITLE
Fix duplicate URL handling by merging tags

### DIFF
--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -60,13 +60,17 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 			no_dup_urls[url] = {};
 			ordered_urls.push_back(url);
 		} else {
-			std::string warn_msg = "Warning: Duplicate URL found in configuration: " + url + ". Merging tags.";
+			std::string warn_msg =
+				"Warning: Duplicate URL found in configuration: " +
+				url + ". Merging tags.";
 			LOG(Level::WARN, warn_msg.c_str());
 			std::cerr << warn_msg << std::endl;
 		}
 		tokens.erase(tokens.begin());
 		for (const std::string& tag : tokens) {
-			if (std::find(no_dup_urls[url].begin(), no_dup_urls[url].end(), tag) == no_dup_urls[url].end()) {
+			if (std::find(no_dup_urls[url].begin(),
+					no_dup_urls[url].end(),
+					tag) == no_dup_urls[url].end()) {
 				no_dup_urls[url].push_back(tag);
 			}
 		}

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -42,8 +42,6 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 	}
 	std::vector<std::string> lines = result.value();
 
-	std::unordered_map<std::string, std::vector<std::string>> no_dup_urls;
-	std::vector<std::string> ordered_urls;
 	for (const std::string& line : lines) {
 		// skip empty lines and comments
 		if (line.empty() || line[0] == '#') {
@@ -56,31 +54,29 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 		}
 
 		std::string url = tokens[0];
-		if (no_dup_urls.count(url) == 0) {
-			no_dup_urls[url] = {};
-			ordered_urls.push_back(url);
-		} else {
-			std::string warn_msg =
-				"Warning: Duplicate URL found in configuration: " +
-				url + ". Merging tags.";
-			LOG(Level::WARN, warn_msg.c_str());
-			std::cerr << warn_msg << std::endl;
-		}
-		tokens.erase(tokens.begin());
-		for (const std::string& tag : tokens) {
-			if (std::find(no_dup_urls[url].begin(),
-					no_dup_urls[url].end(),
-					tag) == no_dup_urls[url].end()) {
-				no_dup_urls[url].push_back(tag);
+		if (std::find(urls.begin(), urls.end(), url) == urls.end()) {
+			urls.push_back(url);
+			tokens.erase(tokens.begin());
+			if (!tokens.empty()) {
+				tags[url] = tokens;
 			}
-		}
-	}
+		} else {
+			std::string warn_msg = strprintf::fmt(
+				_("Warning: Duplicate URL found: %s. Merging tags."),
+				url);
+	
+			LOG(Level::USERERROR, warn_msg.c_str());
 
-	for (const std::string& url : ordered_urls) {
-		urls.push_back(url);
-		tags[url] = no_dup_urls[url];
+			tokens.erase(tokens.begin());
+			for (const std::string& tag : tokens) {
+				if (std::find(tags[url].begin(),
+					tags[url].end(),
+					tag) == tags[url].end()) {
+					tags[url].push_back(tag);
+				}
+			}
+		}	
 	}
-
 	return {};
 }
 

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -66,6 +66,7 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 					url);
 
 			LOG(Level::USERERROR, warn_msg.c_str());
+			std::cerr << warn_msg << std::endl;
 
 			tokens.erase(tokens.begin());
 			for (const std::string& tag : tokens) {

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -42,8 +42,8 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 	}
 	std::vector<std::string> lines = result.value();
 
-    std::unordered_map<std::string, std::vector<std::string>> no_dup_urls;
-   	std::vector<std::string> ordered_urls;
+	std::unordered_map<std::string, std::vector<std::string>> no_dup_urls;
+	std::vector<std::string> ordered_urls;
 	for (const std::string& line : lines) {
 		// skip empty lines and comments
 		if (line.empty() || line[0] == '#') {
@@ -56,26 +56,26 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 		}
 
 		std::string url = tokens[0];
-        if (no_dup_urls.count(url) == 0) {
-        	no_dup_urls[url] = {};
-            ordered_urls.push_back(url);
-        } else {
-        	std::string warn_msg = "Warning: Duplicate URL found in configuration: " + url + ". Merging tags.";
-        	LOG(Level::WARN, warn_msg);
-            std::cerr << warn_msg << std::endl;
-        }
+		if (no_dup_urls.count(url) == 0) {
+			no_dup_urls[url] = {};
+			ordered_urls.push_back(url);
+		} else {
+			std::string warn_msg = "Warning: Duplicate URL found in configuration: " + url + ". Merging tags.";
+			LOG(Level::WARN, warn_msg.c_str());
+			std::cerr << warn_msg << std::endl;
+		}
 		tokens.erase(tokens.begin());
-        for (const std::string& tag : tokens) {
-        	if (std::find(no_dup_urls[url].begin(), no_dup_urls[url].end(), tag) == no_dup_urls[url].end()) {
-                  no_dup_urls[url].push_back(tag);
-            }
-        }
-	};
+		for (const std::string& tag : tokens) {
+			if (std::find(no_dup_urls[url].begin(), no_dup_urls[url].end(), tag) == no_dup_urls[url].end()) {
+				no_dup_urls[url].push_back(tag);
+			}
+		}
+	}
 
-    for (const std::string& url : ordered_urls) {
-      	urls.push_back(url);
-        tags[url] = no_dup_urls[url];
-    }
+	for (const std::string& url : ordered_urls) {
+		urls.push_back(url);
+		tags[url] = no_dup_urls[url];
+	}
 
 	return {};
 }

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -62,20 +62,20 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 			}
 		} else {
 			std::string warn_msg = strprintf::fmt(
-				_("Warning: Duplicate URL found: %s. Merging tags."),
-				url);
-	
+					_("Warning: Duplicate URL found: %s. Merging tags."),
+					url);
+
 			LOG(Level::USERERROR, warn_msg.c_str());
 
 			tokens.erase(tokens.begin());
 			for (const std::string& tag : tokens) {
 				if (std::find(tags[url].begin(),
-					tags[url].end(),
-					tag) == tags[url].end()) {
+						tags[url].end(),
+						tag) == tags[url].end()) {
 					tags[url].push_back(tag);
 				}
 			}
-		}	
+		}
 	}
 	return {};
 }

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -2,10 +2,15 @@
 
 #include <cstring>
 #include <fstream>
+#include <unordered_map>
+#include <set>
+#include <vector>
+#include <iostream>
 
 #include "config.h"
 #include "strprintf.h"
 #include "utils.h"
+#include "logger.h"
 
 namespace newsboat {
 
@@ -37,6 +42,8 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 	}
 	std::vector<std::string> lines = result.value();
 
+    std::unordered_map<std::string, std::vector<std::string>> no_dup_urls;
+   	std::vector<std::string> ordered_urls;
 	for (const std::string& line : lines) {
 		// skip empty lines and comments
 		if (line.empty() || line[0] == '#') {
@@ -49,13 +56,26 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 		}
 
 		std::string url = tokens[0];
-		urls.push_back(url);
-
+        if (no_dup_urls.count(url) == 0) {
+        	no_dup_urls[url] = {};
+            ordered_urls.push_back(url);
+        } else {
+        	std::string warn_msg = "Warning: Duplicate URL found in configuration: " + url + ". Merging tags.";
+        	LOG(Level::WARN, warn_msg);
+            std::cerr << warn_msg << std::endl;
+        }
 		tokens.erase(tokens.begin());
-		if (!tokens.empty()) {
-			tags[url] = tokens;
-		}
+        for (const std::string& tag : tokens) {
+        	if (std::find(no_dup_urls[url].begin(), no_dup_urls[url].end(), tag) == no_dup_urls[url].end()) {
+                  no_dup_urls[url].push_back(tag);
+            }
+        }
 	};
+
+    for (const std::string& url : ordered_urls) {
+      	urls.push_back(url);
+        tags[url] = no_dup_urls[url];
+    }
 
 	return {};
 }

--- a/src/remoteapiurlreader.cpp
+++ b/src/remoteapiurlreader.cpp
@@ -3,6 +3,7 @@
 #include "logger.h"
 #include "remoteapi.h"
 #include "utils.h"
+#include "config.h"
 
 namespace newsboat {
 
@@ -24,11 +25,28 @@ std::optional<utils::ReadTextFileError> RemoteApiUrlReader::reload()
 	const std::vector<TaggedFeedUrl> feedurls = api.get_subscribed_urls();
 
 	for (const auto& url : feedurls) {
-		LOG(Level::INFO, "added %s to URL list", url.first);
-		urls.push_back(url.first);
-		tags[url.first] = url.second;
-		for (const auto& tag : url.second) {
-			LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);
+		if (std::find(urls.begin(), urls.end(), url.first) == urls.end()) {
+			LOG(Level::INFO, "added %s to URL list", url.first);
+			urls.push_back(url.first);
+			tags[url.first] = url.second;
+			for (const auto& tag : url.second) {
+				LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);
+			}
+		} else {
+			std::string warn_msg = strprintf::fmt(
+				_("Warning: Duplicate URL found: %s. Merging tags."),
+				url.first);
+	
+			LOG(Level::USERERROR, warn_msg.c_str());
+
+			for (const auto& tag : url.second) {
+				if (std::find(tags[url.first].begin(),
+					tags[url.first].end(),
+					tag) == tags[url.first].end()) {
+					LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);
+					tags[url.first].push_back(tag);
+				}
+			}
 		}
 	}
 

--- a/src/remoteapiurlreader.cpp
+++ b/src/remoteapiurlreader.cpp
@@ -5,6 +5,8 @@
 #include "utils.h"
 #include "config.h"
 
+#include <iostream>
+
 namespace newsboat {
 
 RemoteApiUrlReader::RemoteApiUrlReader(const std::string& source_name,
@@ -38,6 +40,7 @@ std::optional<utils::ReadTextFileError> RemoteApiUrlReader::reload()
 					url.first);
 
 			LOG(Level::USERERROR, warn_msg.c_str());
+			std::cerr << warn_msg << std::endl;
 
 			for (const auto& tag : url.second) {
 				if (std::find(tags[url.first].begin(),

--- a/src/remoteapiurlreader.cpp
+++ b/src/remoteapiurlreader.cpp
@@ -34,15 +34,15 @@ std::optional<utils::ReadTextFileError> RemoteApiUrlReader::reload()
 			}
 		} else {
 			std::string warn_msg = strprintf::fmt(
-				_("Warning: Duplicate URL found: %s. Merging tags."),
-				url.first);
-	
+					_("Warning: Duplicate URL found: %s. Merging tags."),
+					url.first);
+
 			LOG(Level::USERERROR, warn_msg.c_str());
 
 			for (const auto& tag : url.second) {
 				if (std::find(tags[url.first].begin(),
-					tags[url.first].end(),
-					tag) == tags[url.first].end()) {
+						tags[url.first].end(),
+						tag) == tags[url.first].end()) {
 					LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);
 					tags[url.first].push_back(tag);
 				}

--- a/src/urlreader.cpp
+++ b/src/urlreader.cpp
@@ -7,47 +7,41 @@
 
 namespace newsboat {
 
-const std::vector<std::string>& UrlReader::get_urls() const
-{
-	return urls;
+const std::vector<std::string> &UrlReader::get_urls() const { return urls; }
+
+std::vector<std::string> &UrlReader::get_tags(const std::string &url) {
+  return tags[url];
 }
 
-std::vector<std::string>& UrlReader::get_tags(const std::string& url)
-{
-	return tags[url];
+std::vector<std::string> UrlReader::get_alltags() const {
+  std::set<std::string> tmptags;
+  for (const auto &url_tags : tags) {
+    for (const auto &tag : url_tags.second) {
+      if (tag.substr(0, 1) != "~") {
+        // std::copy_if would make this code less readable IMHO
+        // cppcheck-suppress useStlAlgorithm
+        tmptags.insert(tag);
+      }
+    }
+  }
+  return std::vector<std::string>(tmptags.begin(), tmptags.end());
 }
 
-std::vector<std::string> UrlReader::get_alltags() const
-{
-	std::set<std::string> tmptags;
-	for (const auto& url_tags : tags) {
-		for (const auto& tag : url_tags.second) {
-			if (tag.substr(0, 1) != "~") {
-				// std::copy_if would make this code less readable IMHO
-				// cppcheck-suppress useStlAlgorithm
-				tmptags.insert(tag);
-			}
-		}
-	}
-	return std::vector<std::string>(tmptags.begin(), tmptags.end());
-}
+void UrlReader::load_query_urls_from_file(Filepath file) {
+  FileUrlReader file_url_reader(file);
+  const auto error_message = file_url_reader.reload();
+  if (error_message.has_value()) {
+    LOG(Level::DEBUG, "Reloading failed: %s", error_message.value().message);
+    // Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
+  }
 
-void UrlReader::load_query_urls_from_file(Filepath file)
-{
-	FileUrlReader file_url_reader(file);
-	const auto error_message = file_url_reader.reload();
-	if (error_message.has_value()) {
-		LOG(Level::DEBUG, "Reloading failed: %s", error_message.value().message);
-		// Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
-	}
-
-	const auto& other_urls = file_url_reader.get_urls();
-	for (const auto& url : other_urls) {
-		if (utils::is_query_url(url)) {
-			urls.push_back(url);
-			tags[url] = file_url_reader.get_tags(url);
-		}
-	}
+  const auto &other_urls = file_url_reader.get_urls();
+  for (const auto &url : other_urls) {
+    if (utils::is_query_url(url)) {
+      urls.push_back(url);
+      tags[url] = file_url_reader.get_tags(url);
+    }
+  }
 }
 
 } // namespace newsboat

--- a/src/urlreader.cpp
+++ b/src/urlreader.cpp
@@ -7,41 +7,47 @@
 
 namespace newsboat {
 
-const std::vector<std::string> &UrlReader::get_urls() const { return urls; }
-
-std::vector<std::string> &UrlReader::get_tags(const std::string &url) {
-  return tags[url];
+const std::vector<std::string>& UrlReader::get_urls() const
+{
+	return urls;
 }
 
-std::vector<std::string> UrlReader::get_alltags() const {
-  std::set<std::string> tmptags;
-  for (const auto &url_tags : tags) {
-    for (const auto &tag : url_tags.second) {
-      if (tag.substr(0, 1) != "~") {
-        // std::copy_if would make this code less readable IMHO
-        // cppcheck-suppress useStlAlgorithm
-        tmptags.insert(tag);
-      }
-    }
-  }
-  return std::vector<std::string>(tmptags.begin(), tmptags.end());
+std::vector<std::string>& UrlReader::get_tags(const std::string& url)
+{
+	return tags[url];
 }
 
-void UrlReader::load_query_urls_from_file(Filepath file) {
-  FileUrlReader file_url_reader(file);
-  const auto error_message = file_url_reader.reload();
-  if (error_message.has_value()) {
-    LOG(Level::DEBUG, "Reloading failed: %s", error_message.value().message);
-    // Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
-  }
+std::vector<std::string> UrlReader::get_alltags() const
+{
+	std::set<std::string> tmptags;
+	for (const auto& url_tags : tags) {
+		for (const auto& tag : url_tags.second) {
+			if (tag.substr(0, 1) != "~") {
+				// std::copy_if would make this code less readable IMHO
+				// cppcheck-suppress useStlAlgorithm
+				tmptags.insert(tag);
+			}
+		}
+	}
+	return std::vector<std::string>(tmptags.begin(), tmptags.end());
+}
 
-  const auto &other_urls = file_url_reader.get_urls();
-  for (const auto &url : other_urls) {
-    if (utils::is_query_url(url)) {
-      urls.push_back(url);
-      tags[url] = file_url_reader.get_tags(url);
-    }
-  }
+void UrlReader::load_query_urls_from_file(Filepath file)
+{
+	FileUrlReader file_url_reader(file);
+	const auto error_message = file_url_reader.reload();
+	if (error_message.has_value()) {
+		LOG(Level::DEBUG, "Reloading failed: %s", error_message.value().message);
+		// Ignore errors for now: https://github.com/newsboat/newsboat/issues/1273
+	}
+
+	const auto& other_urls = file_url_reader.get_urls();
+	for (const auto& url : other_urls) {
+		if (utils::is_query_url(url)) {
+			urls.push_back(url);
+			tags[url] = file_url_reader.get_tags(url);
+		}
+	}
 }
 
 } // namespace newsboat

--- a/test/data/test-duplicate-urls.txt
+++ b/test/data/test-duplicate-urls.txt
@@ -1,0 +1,3 @@
+http://anotherfeed.com/ tag1 tag2
+http://anotherfeed.com/	tag3 tag4
+

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -224,3 +224,17 @@ TEST_CASE("FileUrlReader::get_alltags() returns all unique tags across all feeds
 	REQUIRE(tags[1] == "tag2");
 	REQUIRE(tags[2] == "tag3");
 }
+
+TEST_CASE("FileUrlReader handles duplicate URLs by merging tags", "[FileUrlReader]")
+{
+	FileUrlReader u("data/test-duplicate-urls.txt"_path);
+	u.reload();
+
+    REQUIRE(u.get_urls().size() == 1);
+    REQUIRE(u.get_urls()[0] == "http://anotherfeed.com/");
+
+	REQUIRE(u.get_tags("http://anotherfeed.com/")[0] == "tag1");
+	REQUIRE(u.get_tags("http://anotherfeed.com/")[1] == "tag2");
+	REQUIRE(u.get_tags("http://anotherfeed.com/")[2] == "tag3");
+	REQUIRE(u.get_tags("http://anotherfeed.com/")[3] == "tag4");
+}

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -225,7 +225,8 @@ TEST_CASE("FileUrlReader::get_alltags() returns all unique tags across all feeds
 	REQUIRE(tags[2] == "tag3");
 }
 
-TEST_CASE("FileUrlReader handles duplicate URLs by merging tags", "[FileUrlReader]")
+TEST_CASE("FileUrlReader handles duplicate URLs by merging tags",
+	"[FileUrlReader]")
 {
 	FileUrlReader u("data/test-duplicate-urls.txt"_path);
 	u.reload();

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -230,8 +230,8 @@ TEST_CASE("FileUrlReader handles duplicate URLs by merging tags", "[FileUrlReade
 	FileUrlReader u("data/test-duplicate-urls.txt"_path);
 	u.reload();
 
-    REQUIRE(u.get_urls().size() == 1);
-    REQUIRE(u.get_urls()[0] == "http://anotherfeed.com/");
+	REQUIRE(u.get_urls().size() == 1);
+	REQUIRE(u.get_urls()[0] == "http://anotherfeed.com/");
 
 	REQUIRE(u.get_tags("http://anotherfeed.com/")[0] == "tag1");
 	REQUIRE(u.get_tags("http://anotherfeed.com/")[1] == "tag2");

--- a/test/remoteapiurlreader.cpp
+++ b/test/remoteapiurlreader.cpp
@@ -122,8 +122,7 @@ TEST_CASE(
 	test_helpers::TempFile urls;
 	RemoteApiUrlReader url_reader("dummy", urls.get_path(), remote_api);
 
-	GIVEN("A remote API that returns duplicate URLs with different tags")
-	{
+	GIVEN("A remote API that returns duplicate URLs with different tags") {
 		const std::string duplicate_feed = "https://example.com/remote-feed.xml";
 
 		remote_api.set_subscribed_urls({
@@ -131,12 +130,10 @@ TEST_CASE(
 			{ duplicate_feed, {"tag3", "tag4", "tag1"} },
 		});
 
-		WHEN("URLs are reloaded")
-		{
+		WHEN("URLs are reloaded") {
 			url_reader.reload();
 
-			THEN("The URL is only stored once, and all unique tags are merged") 
-			{
+			THEN("The URL is only stored once, and all unique tags are merged") {
 				const auto& loaded_urls = url_reader.get_urls();
 				REQUIRE(loaded_urls.size() == 1);
 				REQUIRE(loaded_urls[0] == duplicate_feed);

--- a/test/remoteapiurlreader.cpp
+++ b/test/remoteapiurlreader.cpp
@@ -112,3 +112,42 @@ TEST_CASE("RemoteApiUrlReader reload includes query urls and urls from the Remot
 		}
 	}
 }
+
+TEST_CASE(
+	"RemoteApiUrlReader handles duplicate URLs from RemoteApi by merging tags",
+	"[RemoteApiUrlReader]")
+{
+	ConfigContainer cfg;
+	DummyRemoteApi remote_api(cfg);
+	test_helpers::TempFile urls;
+	RemoteApiUrlReader url_reader("dummy", urls.get_path(), remote_api);
+
+	GIVEN("A remote API that returns duplicate URLs with different tags")
+	{
+		const std::string duplicate_feed = "https://example.com/remote-feed.xml";
+
+		remote_api.set_subscribed_urls({
+			{ duplicate_feed, {"tag1", "tag2"} },
+			{ duplicate_feed, {"tag3", "tag4", "tag1"} },
+		});
+
+		WHEN("URLs are reloaded")
+		{
+			url_reader.reload();
+
+			THEN("The URL is only stored once, and all unique tags are merged") 
+			{
+				const auto& loaded_urls = url_reader.get_urls();
+				REQUIRE(loaded_urls.size() == 1);
+				REQUIRE(loaded_urls[0] == duplicate_feed);
+
+				const auto& merged_tags = url_reader.get_tags(duplicate_feed);
+				REQUIRE(merged_tags.size() == 4);
+				REQUIRE(merged_tags[0] == "tag1");
+				REQUIRE(merged_tags[1] == "tag2");
+				REQUIRE(merged_tags[2] == "tag3");
+				REQUIRE(merged_tags[3] == "tag4");
+			}
+		}
+	}
+}


### PR DESCRIPTION
Previously, if a URL appeared multiple times in the configuration 
file, subsequent entries would overwrite the previous ones, losing 
their tags. 

Now, duplicate URLs trigger a warning log, and their unique tags 
are cleanly merged into the existing entry while preserving the 
original tag insertion order. Added a regression test case to 
verify the fix.