### PR TITLE
fix(build): respect system default C++ compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ CPPCHECK_JOBS?=5
 # setup on the test machine.
 NEWSBOAT_RUN_IGNORED_TESTS?=0
 
-# compiler
-CXX?=c++
+# compiler: use `c++` from PATH when Make's built-in default (g++) was not overridden
+ifeq ($(origin CXX), default)
+CXX := c++
+endif
 # Compiler for building executables meant to be run on the
 # host system during cross compilation
 CXX_FOR_BUILD?=$(CXX)


### PR DESCRIPTION
## Summary

Fixes #1473.

GNU Make predefines `CXX` to `g++`, so `CXX?=c++` in the Makefile never took effect. Users who switch their system compiler via `update-alternatives` (or similar) still saw the build use `g++`.

This change only overrides `CXX` when its origin is still Make's built-in default, and sets it to `c++` so the compiler is resolved from `PATH`. Explicit overrides via environment or command line (`make CXX=clang++`) are unchanged.

The approach was suggested in the issue discussion by @nick-cd using `$(origin CXX)`.

## Test plan

- [x] `make -p` shows `CXX := c++` with no user override
- [x] `CXX=clang++ make -p` shows `CXX = clang++` (override preserved)
- [ ] Full test suite (`TMPDIR=/dev/shm make -j5 PROFILE=1 check`) — not run locally (macOS dev env; change is Makefile-only)


Made with [Cursor](https://cursor.com)