### PR TITLE
fix: show html-renderer errors in article view status bar

### DIFF
--- a/include/itemrenderer.h
+++ b/include/itemrenderer.h
@@ -52,7 +52,8 @@ std::pair<std::string, size_t> to_stfl_list(
 	unsigned int window_width,
 	RegexManager* rxman,
 	Dialog location,
-	Links& links);
+	Links& links,
+	std::string* renderer_error = nullptr);
 
 /// \brief Returns RssItem's text source as STFL list.
 ///

--- a/include/utils.h
+++ b/include/utils.h
@@ -77,6 +77,14 @@ std::string retrieve_url(const std::string& url,
 	const HTTPMethod method = HTTPMethod::GET);
 std::string run_program(const char* argv[], const std::string& input);
 
+/// Runs a program and returns its stdout. If \a spawned is set to false, the
+/// process could not be started. Otherwise, \a exit_code contains the child's
+/// exit status.
+std::string run_program_detailed(const char* argv[],
+	const std::string& input,
+	bool& spawned,
+	int& exit_code);
+
 Filepath resolve_tilde(const Filepath&);
 Filepath resolve_relative(const Filepath&, const Filepath&);
 std::string replace_all(std::string str,

--- a/po/ca.po
+++ b/po/ca.po
@@ -383,6 +383,16 @@ msgstr "Obrint caché..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Error: l'apertura de l'arxiu de caché `%s' va fallar: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Error: no es va poder marcar la font com llegida: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -378,6 +378,16 @@ msgstr "Öffne Zwischenspeicher..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Fehler: Das Öffnen der Zwischenspeicherdatei „%s“ schlug fehl: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Fehler: Konnte Feed nicht als gelesen markieren: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -378,6 +378,16 @@ msgstr "Abriendo la caché..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Error: la apertura del archivo de caché `%s' falló: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Error: no se pudo marcar la fuente como leída: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "ERROR: Debes definir `cookie-cache` para usar NewsBlur.\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -391,6 +391,16 @@ msgstr "Ouverture du cache..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Erreur : l'ouverture du fichier de cache `%s' a échoué : %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Erreur : Le fil n'a pu être marqué comme étant lu : %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -381,6 +381,16 @@ msgstr "Cache megnyitása..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Hiba `%s' cache-file megnyitása közben: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Hiba: nem tudtam olvasottnak megjelölni: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -379,6 +379,16 @@ msgstr "Sto aprendo la cache..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Errore: apertura del file cache `%s' fallita: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Errore: impossibile contrassegnare il feed come letto: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "ERRORE: Devi impostare `cookie-cache` per usare NewsBlur.\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -373,6 +373,16 @@ msgstr "キャッシュを読み込み中…"
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr ""
 
+#: src/itemrenderer.cpp:188
+#, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr ""
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/nb.po
+++ b/po/nb.po
@@ -384,6 +384,16 @@ msgstr "Åpner mellomlager..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Feil: åpning av mellomlagerfilen `%s' feilet: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Feil: kunne ikke markere nyhetsstrømmen som lest: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -359,6 +359,16 @@ msgstr ""
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr ""
 
+#: src/itemrenderer.cpp:188
+#, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr ""
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -380,6 +380,16 @@ msgstr "Openen van de cache..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Fout: openen van het cachebestand ‘%s’ is mislukt: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Fout: feed als gelezen markeren is mislukt: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -379,6 +379,16 @@ msgstr "Otwieranie pamięci podręcznej..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Błąd: otwarcie pliku pamięci podręcznej '%s' nieudane: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Błąd: nie udało się oznaczyć kanału jako przeczytanego: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "BŁĄD: Musisz ustawić `cookie-cache` aby korzystać z NewsBlur.\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -392,6 +392,16 @@ msgstr "Abrindo o cache..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Erro: falha ao abrir o arquivo de cache '%s': %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Erro: não foi possível marcar fonte como lida: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "ERRO: Você deve definir a opção `cookie-cache` para usar o NewsBlur.\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -383,6 +383,16 @@ msgstr "Открываю кэш..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Ошибка: попытка открыть файл кэша `%s' завершилась неудачей: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Ошибка: невозможно отметить ленту как прочитанную: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "Ошибка: для пользования NewsBlur нужно задать `cookie-cache`.\n"

--- a/po/sk.po
+++ b/po/sk.po
@@ -379,6 +379,16 @@ msgstr "Otvorenie vyrovnávacej pamäte..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Chyba: otvorenie \"cache\" súboru `%s' zlyhalo: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Chyba: nemožno označiť čítanie kanála: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -378,6 +378,16 @@ msgstr "Öppnar cache..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Fel: öppnande av cache-fil `%s' misslyckades: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Fel: kunde inte markera flöde som läst: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "FEL: Du måste sätta 'cookie-cache' för att använda NewsBlur.\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -378,6 +378,16 @@ msgstr "Önbellek açılıyor..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Hata: '%s' önbellek dosyası açılamadı: %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Hata: Besleme okundu olarak imlenemedi: %s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "HATA: NewsBlur kullanmak için `cookie-cache`i ayarlamalısınız.\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -381,6 +381,16 @@ msgstr "Відкриваю кеш..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "Помилка: при відкритті файлу кеша `%s' виникла %s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "Помилка: не можу позначити тему: %s як прочитану"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -370,6 +370,16 @@ msgstr "打开缓存......"
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "错误：打开缓存文件`%s'失败：%s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "错误：无法将种子标记为已读：%s"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr "错误：你必须设置`cookie-cache`后才能使用 NewsBlur。\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -378,6 +378,16 @@ msgstr "打開快取中..."
 msgid "Error: opening the cache file `%s' failed: %s"
 msgstr "錯誤:打開快取檔案`%s' 失敗:%s"
 
+#: src/itemrenderer.cpp:188
+#, fuzzy, c-format
+msgid "Error: could not run html-renderer (%s)"
+msgstr "錯誤：無法將來源%s標記為已讀"
+
+#: src/itemrenderer.cpp:194
+#, c-format
+msgid "Error: html-renderer failed with exit code %d"
+msgstr ""
+
 #: src/controller.cpp:259
 msgid "ERROR: You must set `cookie-cache` to use NewsBlur.\n"
 msgstr ""

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -90,6 +90,12 @@ mod bridged {
         fn podcast_mime_to_link_type(mime_type: &str, result: &mut i64) -> bool;
 
         fn run_program(argv: &[&str], input: String) -> String;
+        fn run_program_detailed(
+            argv: &[&str],
+            input: String,
+            output: &mut String,
+            exit_code: &mut i32,
+        ) -> bool;
 
         fn translit(tocode: &str, fromcode: &str) -> String;
         fn utf8_to_locale(text: &str) -> Vec<u8>;
@@ -239,6 +245,26 @@ fn podcast_mime_to_link_type(mime_type: &str, result: &mut i64) -> bool {
 
         None => {
             // We don't assign anything to `result` because it won't be used on the other side.
+            false
+        }
+    }
+}
+
+fn run_program_detailed(
+    argv: &[&str],
+    input: String,
+    output: &mut String,
+    exit_code: &mut i32,
+) -> bool {
+    let (stdout, status) = utils::run_program_with_status(argv, input);
+    *output = stdout;
+    match status {
+        Some(code) => {
+            *exit_code = code;
+            true
+        }
+        None => {
+            *exit_code = -1;
             false
         }
     }

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -467,18 +467,22 @@ pub fn run_command(cmd: &str, param: &str) {
     }
 }
 
-pub fn run_program(cmd_with_args: &[&str], input: String) -> String {
+/// Returns captured stdout and the child exit code.
+/// `exit_code` is `None` if the process could not be spawned or its output could not be read.
+pub fn run_program_with_status(cmd_with_args: &[&str], input: String) -> (String, Option<i32>) {
     if cmd_with_args.is_empty() {
-        return String::new();
+        return (String::new(), Some(0));
     }
 
-    Command::new(cmd_with_args[0])
+    let child = match Command::new(cmd_with_args[0])
         .args(&cmd_with_args[1..])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
-        .map_err(|error| {
+    {
+        Ok(child) => child,
+        Err(error) => {
             log!(
                 Level::Debug,
                 "utils::run_program: spawning a child for \"{:?}\" \
@@ -487,32 +491,41 @@ pub fn run_program(cmd_with_args: &[&str], input: String) -> String {
                 &input,
                 error
             );
-        })
-        .and_then(|mut child| {
-            if let Some(mut stdin) = child.stdin.take() {
-                std::thread::spawn(move || {
-                    if let Err(error) = stdin.write_all(input.as_bytes()) {
-                        log!(
-                            Level::Debug,
-                            "utils::run_program: failed to write to child's stdin: {}",
-                            error
-                        );
-                    }
-                });
-            }
+            return (String::new(), None);
+        }
+    };
 
-            child
-                .wait_with_output()
-                .map_err(|error| {
-                    log!(
-                        Level::Debug,
-                        "utils::run_program: failed to read child's stdout: {}",
-                        error
-                    );
-                })
-                .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
-        })
-        .unwrap_or_else(|_| String::new())
+    let mut child = child;
+    if let Some(mut stdin) = child.stdin.take() {
+        std::thread::spawn(move || {
+            if let Err(error) = stdin.write_all(input.as_bytes()) {
+                log!(
+                    Level::Debug,
+                    "utils::run_program: failed to write to child's stdin: {}",
+                    error
+                );
+            }
+        });
+    }
+
+    match child.wait_with_output() {
+        Ok(output) => (
+            String::from_utf8_lossy(&output.stdout).into_owned(),
+            output.status.code(),
+        ),
+        Err(error) => {
+            log!(
+                Level::Debug,
+                "utils::run_program: failed to read child's stdout: {}",
+                error
+            );
+            (String::new(), None)
+        }
+    }
+}
+
+pub fn run_program(cmd_with_args: &[&str], input: String) -> String {
+    run_program_with_status(cmd_with_args, input).0
 }
 
 pub fn make_title(rs_str: &str) -> String {
@@ -1702,6 +1715,13 @@ mod tests {
             run_program(&["echo", "-n", "hello world"], String::new()),
             "hello world"
         );
+    }
+
+    #[test]
+    fn t_run_program_with_status_reports_exit_code() {
+        let (output, exit_code) = run_program_with_status(&["sh", "-c", "exit 42"], String::new());
+        assert_eq!(output, "");
+        assert_eq!(exit_code, Some(42));
     }
 
     #[test]

--- a/src/itemrenderer.cpp
+++ b/src/itemrenderer.cpp
@@ -1,8 +1,10 @@
 #include "itemrenderer.h"
 
+#include <optional>
 #include <set>
 #include <sstream>
 
+#include "config.h"
 #include "configcontainer.h"
 #include "htmlrenderer.h"
 #include "logger.h"
@@ -147,7 +149,7 @@ void prepare_enclosure(RssItem& item,
 	}
 }
 
-void render_html(
+std::optional<std::string> render_html(
 	ConfigContainer& cfg,
 	const std::string& source,
 	std::vector<std::pair<LineType, std::string>>& lines,
@@ -159,31 +161,51 @@ void render_html(
 	if (renderer == "internal"_path) {
 		HtmlRenderer rnd(raw);
 		rnd.render(source, lines, thelinks, url);
-	} else {
-		const char* argv[4];
-		argv[0] = "/bin/sh";
-		argv[1] = "-c";
-		const std::string renderer_locale_string = renderer.to_locale_string();
-		argv[2] = renderer_locale_string.c_str();
-		argv[3] = nullptr;
-		LOG(Level::DEBUG,
-			"item_renderer::render_html: source = %s",
-			source);
-		LOG(Level::DEBUG,
-			"item_renderer::render_html: html-renderer = %s",
-			argv[2]);
-
-		const std::string output = utils::run_program(argv, source);
-		std::istringstream is(output);
-		std::string line;
-		while (!is.eof()) {
-			getline(is, line);
-			if (!raw) {
-				line = StflRichText::from_plaintext(line).stfl_quoted();
-			}
-			lines.push_back(std::make_pair(LineType::softwrappable, line));
-		}
+		return std::nullopt;
 	}
+
+	const char* argv[4];
+	argv[0] = "/bin/sh";
+	argv[1] = "-c";
+	const std::string renderer_locale_string = renderer.to_locale_string();
+	argv[2] = renderer_locale_string.c_str();
+	argv[3] = nullptr;
+	LOG(Level::DEBUG,
+		"item_renderer::render_html: source = %s",
+		source);
+	LOG(Level::DEBUG,
+		"item_renderer::render_html: html-renderer = %s",
+		argv[2]);
+
+	const std::string renderer_display = cfg.get_configvalue("html-renderer");
+	bool spawned = false;
+	int exit_code = 0;
+	const std::string output = utils::run_program_detailed(
+			argv, source, spawned, exit_code);
+
+	if (!spawned) {
+		return strprintf::fmt(
+				_("Error: could not run html-renderer (%s)"),
+				renderer_display);
+	}
+
+	if (exit_code != 0) {
+		return strprintf::fmt(
+				_("Error: html-renderer failed with exit code %d"),
+				exit_code);
+	}
+
+	std::istringstream is(output);
+	std::string line;
+	while (!is.eof()) {
+		getline(is, line);
+		if (!raw) {
+			line = StflRichText::from_plaintext(line).stfl_quoted();
+		}
+		lines.push_back(std::make_pair(LineType::softwrappable, line));
+	}
+
+	return std::nullopt;
 }
 
 void item_renderer::render_plaintext(
@@ -270,7 +292,8 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 	unsigned int window_width,
 	RegexManager* rxman,
 	Dialog location,
-	Links& links)
+	Links& links,
+	std::string* renderer_error)
 {
 	std::vector<std::pair<LineType, std::string>> lines;
 	const auto item_description = item.description();
@@ -282,7 +305,10 @@ std::pair<std::string, size_t> item_renderer::to_stfl_list(
 	const auto body = utils::utf8_to_locale(item_description.text);
 
 	if (should_render_as_html(item_description.mime)) {
-		render_html(cfg, body, lines, links, baseurl, false);
+		const auto error = render_html(cfg, body, lines, links, baseurl, false);
+		if (error.has_value() && renderer_error != nullptr) {
+			*renderer_error = error.value();
+		}
 	} else {
 		render_plaintext(body, lines, OutputFormat::StflRichText);
 	}

--- a/src/itemviewformaction.cpp
+++ b/src/itemviewformaction.cpp
@@ -127,6 +127,7 @@ void ItemViewFormAction::prepare()
 				}
 			}
 
+			std::string renderer_error;
 			std::tie(formatted_text, num_lines) =
 				item_renderer::to_stfl_list(
 					// cfg can't be nullptr because that's a long-lived object
@@ -137,7 +138,11 @@ void ItemViewFormAction::prepare()
 					window_width,
 					&rxman,
 					Dialog::Article,
-					links);
+					links,
+					&renderer_error);
+			if (!renderer_error.empty()) {
+				set_status(renderer_error);
+			}
 		}
 
 		textview.stfl_replace_lines(num_lines, formatted_text);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -336,6 +336,16 @@ std::string utils::retrieve_url(const std::string& url,
 
 std::string utils::run_program(const char* argv[], const std::string& input)
 {
+	bool spawned = false;
+	int exit_code = 0;
+	return run_program_detailed(argv, input, spawned, exit_code);
+}
+
+std::string utils::run_program_detailed(const char* argv[],
+	const std::string& input,
+	bool& spawned,
+	int& exit_code)
+{
 	std::vector<rust::Str> slices;
 	for (; *argv; ++argv) {
 		slices.emplace_back(*argv);
@@ -343,7 +353,10 @@ std::string utils::run_program(const char* argv[], const std::string& input)
 
 	const auto rs_argv = rust::Slice<const rust::Str>(slices.data(), slices.size());
 
-	return std::string(utils::bridged::run_program(rs_argv, input));
+	std::string output;
+	spawned = utils::bridged::run_program_detailed(
+			rs_argv, input, output, exit_code);
+	return output;
 }
 
 Filepath utils::resolve_tilde(const Filepath& path)

--- a/test/itemrenderer.cpp
+++ b/test/itemrenderer.cpp
@@ -786,3 +786,49 @@ TEST_CASE("item_renderer::render_plaintext() splits text on newlines", "[item_re
 		}, OutputFormat::PlainText);
 	}
 }
+
+TEST_CASE("item_renderer::to_stfl_list() reports html-renderer failures",
+	"[item_renderer]")
+{
+	test_helpers::TzEnvVar tzEnv;
+	tzEnv.set("UTC");
+
+	ConfigContainer cfg;
+	RegexManager rxman;
+	cfg.set_configvalue("text-width", "80");
+
+	auto rsscache = Cache::in_memory(cfg);
+
+	std::shared_ptr<RssItem> item;
+	std::shared_ptr<RssFeed> feed;
+	std::tie(item, feed) = create_test_item(rsscache.get());
+	item->set_description("<p>Hello, world!</p>", "text/html");
+
+	SECTION("non-zero exit code") {
+		cfg.set_configvalue("html-renderer", "exit 42");
+
+		Links links;
+		std::string renderer_error;
+		item_renderer::to_stfl_list(cfg,
+			*item,
+			80,
+			80,
+			&rxman,
+			Dialog::Article,
+			links,
+			&renderer_error);
+
+		REQUIRE(renderer_error.find("exit code 42") != std::string::npos);
+	}
+
+	SECTION("spawn failure") {
+		cfg.set_configvalue("html-renderer", "exit 0");
+		const char* argv[2];
+		argv[0] = "/nonexistent-shell-for-newsboat-test";
+		argv[1] = nullptr;
+		bool spawned = false;
+		int exit_code = 0;
+		utils::run_program_detailed(argv, "", spawned, exit_code);
+		REQUIRE_FALSE(spawned);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #280.

When an external `html-renderer` fails (cannot spawn `/bin/sh` or the renderer exits with a non-zero status), Newsboat now reports the error in the article view status bar instead of silently showing an empty description.

## Changes

- Add `utils::run_program_detailed()` / `run_program_with_status()` to capture spawn failures and exit codes
- `render_html()` returns an optional error message for external renderers
- `item_renderer::to_stfl_list()` accepts an optional `renderer_error` out-parameter
- `ItemViewFormAction::prepare()` calls `set_status()` when rendering fails

## Test plan

- [x] `cargo test -p libnewsboat t_run_program_with_status_reports_exit_code`
- [x] Added Catch2 test for non-zero renderer exit code (`html-renderer "exit 42"`)
- [x] `cargo build -p libnewsboat-ffi` (CXX bridge compiles)
- [ ] Full `make check` — not run locally (missing asciidoctor/doc build deps on macOS); CI should cover Linux/FreeBSD matrix


Made with [Cursor](https://cursor.com)