### PR TITLE
docs: clarify set-tag is an alias for select-tag

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -24,7 +24,8 @@ toggle-article-read||kbd:[Shift+N]||Toggle the read flag for the currently selec
 toggle-show-read-feeds||kbd:[L]||Toggle whether read feeds should be shown in the feed list.
 show-urls||kbd:[U]||Show all URLs in the article in a list (similar to urlview).
 clear-tag||kbd:[Ctrl+T]||Clear current tag.
-set-tag||kbd:[T]||Select tag.
+set-tag||kbd:[T]||Alias for <<select-tag,`select-tag`>>.
+select-tag||kbd:[T]||Select tag.
 open-search||kbd:[/]||Open the search dialog. When a search is done in the article list, then the search operation only applies to the articles of the current feed, otherwise to all articles.
 goto-url||kbd:[#]||Open the URL dialog and then open a specified URL in the browser.
 one||kbd:[1]||Open URL 1 in the browser.

--- a/po/ca.po
+++ b/po/ca.po
@@ -1465,7 +1465,11 @@ msgstr "Mostrar URLs en l'article actual"
 msgid "Clear current tag"
 msgstr "Eliminar la etiqueta actual"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Seleccionar etiqueta"
 

--- a/po/de.po
+++ b/po/de.po
@@ -1446,7 +1446,11 @@ msgstr "URLs im aktuellen Artikel zeigen"
 msgid "Clear current tag"
 msgstr "Aktuellen Tag löschen"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Tag auswählen"
 

--- a/po/es.po
+++ b/po/es.po
@@ -1440,7 +1440,11 @@ msgstr "Mostrar las URL del artículo actual"
 msgid "Clear current tag"
 msgstr "Borrar la etiqueta actual"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Seleccionar etiqueta"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -1469,7 +1469,11 @@ msgstr "Afficher les liens contenus dans l'article actuel"
 msgid "Clear current tag"
 msgstr "Retirer l'étiquette"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Appliquer une étiquette"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -1459,7 +1459,11 @@ msgstr "URL-ek az aktuális cikkben"
 msgid "Clear current tag"
 msgstr "Aktuális cimke törlése"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Cimke kijelölése"
 

--- a/po/it.po
+++ b/po/it.po
@@ -1435,7 +1435,11 @@ msgstr "Mostra gli URL nell'articolo corrente"
 msgid "Clear current tag"
 msgstr "Pulisci il tag corrente"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Seleziona tag"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -1397,7 +1397,11 @@ msgstr ""
 msgid "Clear current tag"
 msgstr ""
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr ""
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -1465,7 +1465,11 @@ msgstr "Vis artikkelens URLer"
 msgid "Clear current tag"
 msgstr "Tøm valgte etikett"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Velg etikett"
 

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -1375,7 +1375,11 @@ msgstr ""
 msgid "Clear current tag"
 msgstr ""
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -1446,7 +1446,11 @@ msgstr "URLs in huidige artikelen tonen"
 msgid "Clear current tag"
 msgstr "Huidige tag wissen"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Tag selecteren"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1445,7 +1445,11 @@ msgstr "Pokaż odnośniki w aktualnym artykule"
 msgid "Clear current tag"
 msgstr "Wyczyść aktualny tag"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Wybierz tag"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1479,7 +1479,11 @@ msgstr "Mostrar URLs no artigo atual"
 msgid "Clear current tag"
 msgstr "Limpar etiqueta atual"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Selecionar etiqueta"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -1444,7 +1444,11 @@ msgstr "Показывать ссылки в текущей заметке"
 msgid "Clear current tag"
 msgstr "Очистить текущую метку"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Выбрать метку"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -1458,7 +1458,11 @@ msgstr "Zobraziť adresy URL v aktuálnom článku"
 msgid "Clear current tag"
 msgstr "Vymazať aktuálnu značku (tag)"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Vybrať značku (tag)"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -1439,7 +1439,11 @@ msgstr "Visa URL:er i nuvarande artikel"
 msgid "Clear current tag"
 msgstr "Nollställ nuvarande tagg"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Välj tagg"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -1437,7 +1437,11 @@ msgstr "Geçerli yazıdaki URL'leri göster"
 msgid "Clear current tag"
 msgstr "Geçerli etiketi temizle"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Etiket seç"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -1444,7 +1444,11 @@ msgstr "Показати URLs в поточній статті"
 msgid "Clear current tag"
 msgstr "Очистити поточну мітку"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "Вибрати мітку"
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -1413,7 +1413,11 @@ msgstr "列出当前文章里的所有链接"
 msgid "Clear current tag"
 msgstr "清除当前标签"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "选择标签"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1438,7 +1438,11 @@ msgstr "列出當前文章裡的所有鏈結"
 msgid "Clear current tag"
 msgstr "清除當前標籤"
 
-#: src/keymap.cpp:261 src/keymap.cpp:268
+#: src/keymap.cpp:261
+msgid "Alias for select-tag"
+msgstr ""
+
+#: src/keymap.cpp:268
 msgid "Select tag"
 msgstr "選擇標籤"
 

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -258,7 +258,7 @@ static const std::vector<OpDesc> opdescs = {
 		OP_SETTAG,
 		"set-tag",
 		KeyCombination("t"),
-		translatable("Select tag"),
+		translatable("Alias for select-tag"),
 		KM_FEEDLIST
 	},
 	{


### PR DESCRIPTION
## Summary

Fixes #2713.

Implements the approach suggested by @Minoru: document `set-tag` as a legacy alias for `select-tag` without breaking existing configs.

- Help dialog: `set-tag` description is now "Alias for select-tag"
- Man page / HTML key list: updated `doc/keycmds.dsv` (adds `select-tag` entry; `set-tag` points to it)
- Translation catalog: new `msgid` in `po/newsboat.pot` and merged into locale `.po` files

`set-tag` remains functional; removal is planned for Newsboat 3.0.

## Test plan

- [x] `awk -f doc/createKeyCommandsListView.awk doc/keycmds.dsv` — verified generated key command text
- [x] `make msgmerge` — updated all `.po` files
- [ ] `make run-i18nspector` — not run locally
- [ ] Full build — not run locally


Made with [Cursor](https://cursor.com)