### PR TITLE
docs: fix mandoc sp warnings in lock file locations section

### DIFF
--- a/doc/chapter-files.asciidoc
+++ b/doc/chapter-files.asciidoc
@@ -26,17 +26,15 @@ and Podboat remove these files when you quit the program, so there is no need
 to copy them anywhere — just be aware of them in case you write scripts that
 work with _cache.db_ or _queue_. By default, lock files are located as follows:
 
-|===
-||dotdir|XDG
+Newsboat::
 
-|Newsboat
-|_~/.newsboat/cache.db.lock_
-|_$XDG_DATA_HOME/newsboat/cache.db.lock_
+* dotdir: _~/.newsboat/cache.db.lock_
+* XDG: _$XDG_DATA_HOME/newsboat/cache.db.lock_
 
-|Podboat
-|_~/.newsboat/pb-lock.pid_
-|_$XDG_DATA_HOME/newsboat/.lock_
-|===
+Podboat::
+
+* dotdir: _~/.newsboat/pb-lock.pid_
+* XDG: _$XDG_DATA_HOME/newsboat/.lock_
 
 Newsboat places the lock file next to the cache file, so if you specify
 <<cache-file,cache-file>> setting or pass `--cache-file` command-line argument,


### PR DESCRIPTION
Fixes #2225

## Problem

`mandoc -W unsupp doc/newsboat.1` reported nine `UNSUPP: ignoring macro in table: sp` warnings for the lock file location table in `doc/chapter-files.asciidoc` (see maintainer reproduction in the issue).

Asciidoctor's manpage backend emits `.sp` inside grid table cells; mandoc does not support that troff macro inside tables.

## Solution

Replace the three-column grid table with labeled lists (`Newsboat::` / `Podboat::` with bullet items for dotdir and XDG paths). Content is unchanged; only the AsciiDoc structure differs.

## Verification

```sh
make doc/newsboat.1
mandoc -W unsupp doc/newsboat.1 2>&1 | grep -c sp
```

Before (master): 367 `sp` warnings  
After this branch: 358 `sp` warnings (the nine from the lock file table are gone)

Lock file paths still appear in the manpage without table `.sp` macros around lines ~4504–4520.

Made with [Cursor](https://cursor.com)