### PR TITLE
fix(i18n): drop "RSS" from --url-file help text

### DIFF
--- a/contrib/completions/newsboat.fish
+++ b/contrib/completions/newsboat.fish
@@ -2,7 +2,7 @@ complete -c newsboat -s e -l export-to-opml -d "export OPML feed to stdout"
 complete -c newsboat -l export-to-opml2 -d "export OPML 2.0 feed including tags to stdout"
 complete -c newsboat -s r -l refresh-on-start -d "refresh feeds on start"
 complete -c newsboat -s i -l import-from-opml -d "import OPML file" -r
-complete -c newsboat -s u -l url-file -d "read RSS feed URLs from file" -r
+complete -c newsboat -s u -l url-file -d "read feed URLs from file" -r
 complete -c newsboat -s c -l cache-file -d "use specified file as cache file" -r
 complete -c newsboat -s C -l config-file -d "use specified file as config file" -r
 complete -c newsboat -l queue-file -d "use specified file as podcast queue file" -r

--- a/doc/chapter-firststeps.asciidoc
+++ b/doc/chapter-firststeps.asciidoc
@@ -11,7 +11,7 @@ usage: ./newsboat [-i <file>|-e] [-u <urlfile>] [-c <cachefile>] [-x <command> .
     -e, --export-to-opml            export OPML feed to stdout
     -r, --refresh-on-start          refresh feeds on start
     -i, --import-from-opml=<file>   import OPML file
-    -u, --url-file=<urlfile>        read RSS feed URLs from <urlfile>
+    -u, --url-file=<urlfile>        read feed URLs from <urlfile>
     -c, --cache-file=<cachefile>    use <cachefile> as cache file
     -C, --config-file=<configfile>  read configuration from <configfile>
     -X, --vacuum                    compact the cache

--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -54,7 +54,7 @@ void print_usage(const std::string& argv0, const ConfigPaths& configpaths)
 			'u',
 			"url-file",
 			_s("<file>"),
-			_s("read RSS feed URLs from <file>")
+			_s("read feed URLs from <file>")
 		},
 		{
 			'c',

--- a/po/ca.po
+++ b/po/ca.po
@@ -51,7 +51,7 @@ msgstr "importar arxiu OPML"
 
 #: newsboat.cpp:57
 #, fuzzy
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "llegir fonts URLs de fonts RSS desde <arxiu url>"
 
 #: newsboat.cpp:63

--- a/po/de.po
+++ b/po/de.po
@@ -50,7 +50,7 @@ msgid "import OPML file"
 msgstr "OPML-Datei importieren"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "RSS-Feed-URLs aus <datei> lesen"
 
 #: newsboat.cpp:63

--- a/po/es.po
+++ b/po/es.po
@@ -50,7 +50,7 @@ msgid "import OPML file"
 msgstr "importar archivo OPML"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "leer las URL de fuentes RSS desde <archivo>"
 
 #: newsboat.cpp:63

--- a/po/fr.po
+++ b/po/fr.po
@@ -56,7 +56,7 @@ msgstr "importer un fichier OPML"
 
 #: newsboat.cpp:57
 #, fuzzy
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "lire les liens des fils RSS depuis le fichier <fichier_url>"
 
 #: newsboat.cpp:63

--- a/po/hu.po
+++ b/po/hu.po
@@ -52,7 +52,7 @@ msgstr "OPML fájl importálása"
 
 #: newsboat.cpp:57
 #, fuzzy
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "RSS források URL-jeinek olvasása <urlfile>-ból"
 
 #: newsboat.cpp:63

--- a/po/it.po
+++ b/po/it.po
@@ -51,7 +51,7 @@ msgid "import OPML file"
 msgstr "importa file OPML"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "leggi gli URL dei feed RSS da <file>"
 
 #: newsboat.cpp:63

--- a/po/ja.po
+++ b/po/ja.po
@@ -50,7 +50,7 @@ msgstr "OPMLファイルの指定"
 
 #: newsboat.cpp:57
 #, fuzzy
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "URLファイルの指定"
 
 #: newsboat.cpp:63

--- a/po/nb.po
+++ b/po/nb.po
@@ -52,7 +52,7 @@ msgstr "importer OPML-fil"
 
 #: newsboat.cpp:57
 #, fuzzy
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "les RSS-strømmer fra <URL-fil>"
 
 #: newsboat.cpp:63

--- a/po/newsboat.pot
+++ b/po/newsboat.pot
@@ -50,7 +50,7 @@ msgid "import OPML file"
 msgstr ""
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr ""
 
 #: newsboat.cpp:63

--- a/po/nl.po
+++ b/po/nl.po
@@ -52,7 +52,7 @@ msgid "import OPML file"
 msgstr "importeer vanuit OPML-bestand"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "lees RSS-feed URLs uit <bestand>"
 
 #: newsboat.cpp:63

--- a/po/pl.po
+++ b/po/pl.po
@@ -52,7 +52,7 @@ msgid "import OPML file"
 msgstr "zaimportuj plik OPML"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "wczytaj adresy URL kanałów z <pliku>"
 
 #: newsboat.cpp:63

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -55,7 +55,7 @@ msgstr "importar arquivo OPML"
 
 #: newsboat.cpp:57
 #, fuzzy
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "ler URLs de fontes RSS de <arquivourl>"
 
 #: newsboat.cpp:63

--- a/po/ru.po
+++ b/po/ru.po
@@ -54,7 +54,7 @@ msgid "import OPML file"
 msgstr "импортировать файл OPML"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "загрузить список ссылок на ленты RSS из <файла>"
 
 #: newsboat.cpp:63

--- a/po/sk.po
+++ b/po/sk.po
@@ -50,7 +50,7 @@ msgstr "import OPML súboru"
 
 #: newsboat.cpp:57
 #, fuzzy
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "načítať URL adresy RSS kanálov z <urlfile>"
 
 #: newsboat.cpp:63

--- a/po/sv.po
+++ b/po/sv.po
@@ -52,7 +52,7 @@ msgid "import OPML file"
 msgstr "importera OPML-fil"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "läs in URL:er till RSS-flöden från <fil>"
 
 #: newsboat.cpp:63

--- a/po/tr.po
+++ b/po/tr.po
@@ -51,7 +51,7 @@ msgid "import OPML file"
 msgstr "OPML dosyası içe aktar"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "<dosya>'dan RSS beslemesi URL'lerini oku"
 
 #: newsboat.cpp:63

--- a/po/uk.po
+++ b/po/uk.po
@@ -53,7 +53,7 @@ msgid "import OPML file"
 msgstr "імпортувати файл OPML"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "читати посилання на RSS теми з <файлу>"
 
 #: newsboat.cpp:63

--- a/po/zh.po
+++ b/po/zh.po
@@ -49,7 +49,7 @@ msgid "import OPML file"
 msgstr "导入 OPML 文件"
 
 #: newsboat.cpp:57
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "从<超链文件>里读取 RSS 种子列表"
 
 #: newsboat.cpp:63

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -51,7 +51,7 @@ msgstr "匯入OPML檔案"
 
 #: newsboat.cpp:57
 #, fuzzy
-msgid "read RSS feed URLs from <file>"
+msgid "read feed URLs from <file>"
 msgstr "從<網址檔案>讀取RSS來源的網址"
 
 #: newsboat.cpp:63


### PR DESCRIPTION
Fixes #3160

Newsboat supports Atom and other non-RSS formats; the `--url-file` / `-u` help text should not say "RSS feed URLs".

## Changes

- `newsboat.cpp`: `_s("read feed URLs from <file>")`
- `doc/chapter-firststeps.asciidoc`: matching usage line
- `contrib/completions/newsboat.fish`: completion description
- `po/newsboat.pot` and all `po/*.po`: updated msgid (existing translations kept)

## Note

Other strings that mention "RSS feed URLs" (e.g. the "no URLs configured" error in `controller.cpp`) are unchanged; this PR only addresses the `--url-file` option wording from the issue.

Made with [Cursor](https://cursor.com)