### PR TITLE
docs: document operation arguments for bind and macros

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -6,7 +6,7 @@ reload-all||kbd:[Shift+R]||Reload all feeds.
 mark-feed-read||kbd:[Shift+A]||Mark all articles in the currently selected feed read.
 mark-all-feeds-read||kbd:[Shift+C]||Mark articles in all feeds read.
 mark-all-above-as-read||n/a||Mark all above as read.
-save||kbd:[S]||Export the currently selected article to a plain text file, word-wrapped according to the <<text-width,`text-width`>> setting.
+save||kbd:[S]||Export the currently selected article to a plain text file, word-wrapped according to the <<text-width,`text-width`>> setting. When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, an optional argument specifies the output file path instead of opening the file browser.
 save-all||n/a||Export all articles from the currently selected feed to plain text files, word-wrapped according to the <<text-width,`text-width`>> setting.
 next-unread||kbd:[N]||Jump to the next unread article.
 prev-unread||kbd:[P]||Jump to the previous unread article.
@@ -20,12 +20,12 @@ open-all-unread-in-browser||n/a||Open all the unread URLs in the current feed.
 open-all-unread-in-browser-and-mark-read||n/a||Open all the unread URLs in the current feed and mark them as read.
 help||kbd:[?]||Run the help screen.
 toggle-source-view||kbd:[Ctrl+U]||Toggle between the HTML view and the source view in the article view.
-toggle-article-read||kbd:[Shift+N]||Toggle the read flag for the currently selected article, and clear the delete flag if set.
+toggle-article-read||kbd:[Shift+N]||Toggle the read flag for the currently selected article, and clear the delete flag if set. When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, an optional argument of `read` or `unread` sets the flag to that state instead of toggling.
 toggle-show-read-feeds||kbd:[L]||Toggle whether read feeds should be shown in the feed list.
 show-urls||kbd:[U]||Show all URLs in the article in a list (similar to urlview).
 clear-tag||kbd:[Ctrl+T]||Clear current tag.
 set-tag||kbd:[T]||Select tag.
-open-search||kbd:[/]||Open the search dialog. When a search is done in the article list, then the search operation only applies to the articles of the current feed, otherwise to all articles.
+open-search||kbd:[/]||Open the search dialog. When a search is done in the article list, then the search operation only applies to the articles of the current feed, otherwise to all articles. When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, an optional argument runs the search immediately.
 goto-url||kbd:[#]||Open the URL dialog and then open a specified URL in the browser.
 one||kbd:[1]||Open URL 1 in the browser.
 two||kbd:[2]||Open URL 2 in the browser.
@@ -50,12 +50,12 @@ enqueue||kbd:[E]||Add the podcast download URL of the current article (if any is
 edit-urls||kbd:[Shift+E]||Edit the list of subscribed URLs. If a command is specified, Newsboat will replace the placeholders and then run the command. Newsboat supports the following placeholders in the command: `%f` (path to urls file), `%L` (line number of the current feed (or feed of the currently selected article) in the urls file, or 0 if the feed URL originates outside of the urls file). If no command is specified, Newsboat will start the editor configured through the <<VISUAL,`VISUAL`>> environment variable (if unset, <<EDITOR,`EDITOR`>> is used; fallback: `vi`). When editing is finished, Newsboat will reload the URLs file. Example config: `bind E feedlist,articlelist,searchresultslist edit-urls "vim +%L %f"`
 reload-urls||kbd:[Ctrl+R]||Reload the URLs configuration file.
 redraw||kbd:[Ctrl+L]||Redraw the screen.
-cmdline||kbd:[:]||Open the command line with optional string already filled in. Example configuration: `bind c everywhere cmdline "source ~/.newsboat/config"`
-set-filter||kbd:[Shift+F]||Set a filter.
-select-filter||kbd:[F]||Select a predefined filter.
+cmdline||kbd:[:]||Open the command line. When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, an optional argument pre-fills the command line. Example configuration: `bind c everywhere cmdline "source ~/.newsboat/config"`
+set-filter||kbd:[Shift+F]||Set a filter. When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, an optional argument sets the filter expression immediately.
+select-filter||kbd:[F]||Select a predefined filter. When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, an optional argument selects the named filter instead of opening the picker.
 clear-filter||kbd:[Ctrl+F]||Clear currently set filter.
 bookmark||kbd:[Ctrl+B]||Bookmark currently selected article or URL.
-edit-flags||kbd:[Ctrl+E]||Edit the flags of the currently selected article.
+edit-flags||kbd:[Ctrl+E]||Edit the flags of the currently selected article. When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, an optional argument sets the flags to that string, replacing the current flags; when omitted, the prompt is pre-filled with the current flags.
 next-unread-feed||kbd:[Ctrl+N]||Go to the next feed with unread articles. This only works from the article list.
 prev-unread-feed||kbd:[Ctrl+P]||Go to the previous feed with unread articles. This only works from the article list.
 next-feed||kbd:[J]||Go to the next feed. This only works from the article list.
@@ -67,7 +67,7 @@ view-dialogs||kbd:[V]||View list of open dialogs.
 close-dialog||kbd:[Ctrl+X]||Close currently selected dialog.
 next-dialog||kbd:[Ctrl+V]||Go to next dialog.
 prev-dialog||kbd:[Ctrl+G]||Go to previous dialog.
-pipe-to||kbd:[| ]||Pipe article to command. The text will be word-wrapped according to the <<text-width,`text-width`>> setting.
+pipe-to||kbd:[| ]||Pipe article to command. The text will be word-wrapped according to the <<text-width,`text-width`>> setting. When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, an optional argument specifies the shell command instead of opening a prompt.
 sort||kbd:[G]||Sort feeds/articles by interactively choosing the sort method.
 rev-sort||kbd:[Shift+G]||Sort feeds/articles by interactively choosing the sort method (reversed).
 up||kbd:[UP]||Go up one item in the list.
@@ -80,6 +80,6 @@ home||kbd:[HOME]||Go to the first item in the list.
 end||kbd:[END]||Go to the last item in the list.
 macro-prefix||kbd:[,]||Initiate macro execution. The next key press selects the actual macro and runs it.
 switch-focus||kbd:[TAB]||Switch focus between widgets. This is currently only applicable to the `filebrowser` and `dirbrowser` contexts.
-goto-title||n/a||Go to item whose title contains the specified string (case-insensitive).
+goto-title||n/a||Go to item whose title contains the specified string (case-insensitive). When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, the argument is the title substring to search for; when omitted, Newsboat opens a prompt.
 prevsearchresults||kbd:[Z]||Return to previous search results (if any). This only works from `searchresultslist`.
 article-feed||n/a||Go to the feed of the currently selected article.

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1044,6 +1044,65 @@ opens the list of open dialogs. From there, the user can switch to another
 dialog by selecting the appropriate entry and pressing kbd:[Enter], or can close
 open dialogs by selecting them and pressing kbd:[Ctrl+X].
 
+=== Operation Arguments
+
+Some operations accept optional arguments. When invoked from a <<bind,`bind`>>
+binding or a <<macro,`macro`>>, arguments are appended after the operation
+name. If an argument is omitted, Newsboat usually asks interactively; in some
+cases the prompt is pre-filled with the current value (for example, the current
+flags when editing flags).
+
+Arguments that contain spaces must be quoted. Examples:
+
+  macro x toggle-article-read "read"
+  macro s edit-flags s
+
+The following operations accept arguments:
+
+toggle-article-read::
+        Optional argument `read` or `unread` sets the read flag to that state
+        instead of toggling it.
+
+edit-flags::
+        Optional argument sets the article's flags to the given string,
+        replacing the current flags. When omitted, Newsboat opens a prompt
+        pre-filled with the current flags.
+
+cmdline::
+        Optional argument pre-fills the command line.
+
+open-search::
+        Optional argument runs the search immediately instead of opening the
+        search dialog.
+
+goto-title::
+        Optional argument jumps to the first item whose title contains the
+        given string (case-insensitive).
+
+select-filter::
+        Optional argument selects the named predefined filter instead of
+        opening the filter picker.
+
+set-filter::
+        Optional argument sets the filter expression immediately instead of
+        opening a prompt.
+
+save::
+        Optional argument saves the article to the given file path instead of
+        opening the file browser.
+
+pipe-to::
+        Optional argument pipes the article to the given shell command instead
+        of opening a prompt.
+
+edit-urls::
+        Optional argument runs the given command to edit the URLs file. See
+        <<edit-urls,`edit-urls`>> for placeholder details.
+
+Arguments are only supported when the operation is invoked from a <<bind,`bind`>>
+binding or a <<macro,`macro`>>. Key bindings created with <<bind-key,`bind-key`>>
+execute the operation without arguments.
+
 === Macro Support
 
 Bindings created with <<bind-key,`bind-key`>> can only execute a single


### PR DESCRIPTION
## Summary

- Add an **Operation Arguments** section next to Macro Support explaining how optional arguments work in `bind` and `macro` bindings
- Document the main operations that accept arguments (`toggle-article-read`, `edit-flags`, `cmdline`, `open-search`, `goto-title`, `select-filter`, `set-filter`, `save`, `pipe-to`, `edit-urls`)
- Extend the corresponding entries in `doc/keycmds.dsv`

## Test plan

- [ ] `make doc` / Asciidoctor build succeeds
- [ ] Man page and HTML docs render the new section and updated operation descriptions

Fixes #1336