### PR TITLE
docs: explain Podboat download states

### DIFF
--- a/doc/chapter-format-strings.asciidoc
+++ b/doc/chapter-format-strings.asciidoc
@@ -94,7 +94,7 @@ Identifier:Meaning
 [[podlist-format-p]]<<podlist-format-p,+p+>>:Downloaded precentage, displays one digit of precision
 [[podlist-format-k]]<<podlist-format-k,+k+>>:Download speed, displays two digit of precision, always in KB/s (does not include the "KB/s" text)
 [[podlist-format-K]]<<podlist-format-K,+K+>>:Download speed, displays two digit of precision, human readable (automatically switches between KB/s, MB/s, and GB/s)
-[[podlist-format-S]]<<podlist-format-S,+S+>>:Status of download, displays one of the folowing; "queued", "downloading", "ready", "canceled", "deleted", "missing", "played", "finished" or "failed"
+[[podlist-format-S]]<<podlist-format-S,+S+>>:Status of download (see <<_download_states,Download States>>); displays one of "queued", "downloading", "ready", "cancelled", "deleted", "missing", "played", "finished", "failed", or "rename failed"
 [[podlist-format-u]]<<podlist-format-u,+u+>>:Url of the download
 [[podlist-format-F]]<<podlist-format-F,+F+>>:Absolute filename of the download from the root directory (e.g. ~/downloads/podcast.mp3 -> /home/name/downloads/podcast.mp3)
 [[podlist-format-b]]<<podlist-format-b,+b+>>:Basename of the download (e.g. /home/name/downloads/podcast.mp3 -> podcast.mp3)

--- a/doc/chapter-podboat.asciidoc
+++ b/doc/chapter-podboat.asciidoc
@@ -9,6 +9,61 @@ to a directory on the local filesystem. Podboat comes with the Newsboat
 package, and features a look and feel very close to the one of Newsboat. It
 also shares the same configuration file.
 
+=== Download States
+
+The <<podlist-format-S,`%S`>> field in <<pb-podlist-format,`podlist-format`>> shows
+the status of each queue entry. The values below match what Podboat displays and
+what is stored in the queue file (when applicable):
+
+*queued*::
+        Default when an entry is added to the queue; waiting to be downloaded.
+
+*downloading*::
+        Download in progress. Can be reached from most other states via
+        <<pb-download,`pb-download`>>.
+
+*ready*::
+        Download finished successfully; the file can be played. Stored in the
+        queue file as `downloaded`. If the target file already exists on disk
+        when the queue is loaded, Podboat may set this state instead of
+        *queued*.
+
+*played*::
+        Set after <<pb-play,`pb-play`>> runs the <<player,`player`>> command and
+        returns, regardless of whether playback completed or the player exited
+        with an error. Stored in the queue file as `played`. There is no
+        built-in way to revert to *ready* except re-downloading or editing the
+        queue file manually.
+
+*finished*::
+        Set manually with <<pb-mark-as-finished,`pb-mark-as-finished`>> (only from
+        *played*). Marks that you are done with the entry. Stored in the queue
+        file as `finished`. <<pb-purge,`pb-purge`>> removes *finished* entries from
+        the queue.
+
+*failed*::
+        Download failed, or a partial file was found on disk without a complete
+        download.
+
+*cancelled*::
+        User cancelled an in-progress download with <<pb-cancel,`pb-cancel`>>.
+
+*deleted*::
+        User marked the entry for removal with <<pb-delete,`pb-delete`>>. Removed
+        from the queue on exit or by <<pb-purge,`pb-purge`>>.
+
+*missing*::
+        The expected file is not on disk. Stored in the queue file as `missing`.
+
+*rename failed*::
+        Download completed but renaming the partial file to the final filename
+        failed.
+
+*ready* vs *played* vs *finished*::
+        *ready* means the file is on disk and can be played. *played* means the
+        player was started at least once. *finished* is an explicit mark that
+        you are done with the entry (for example after fully listening to it).
+
 Podcasts that have been downloaded but haven't been played yet remain in the
 queue but are marked as downloaded. You can remove them by purging them from
 the queue with the kbd:[Shift+P] key. After you've played a file and close Podboat, it

--- a/doc/chapter-podcasts.asciidoc
+++ b/doc/chapter-podcasts.asciidoc
@@ -11,6 +11,5 @@ it also recognizes and handles the Yahoo Media RSS extensions.
 
 Remote APIs don't always list those "enclosures", so podcasts might be missing
 from Newsboat. Such APIs are marked
-<<#_newsboat_as_a_client_for_newsreading_services,in the relevant section of our
-docs>>. If a note is missing but you still don't see enclosures in Newsboat,
+<<_newsboat_as_a_client_for_newsreading_services,Newsboat as a client for newsreading services>>. If a note is missing but you still don't see enclosures in Newsboat,
 please file an issue and we'll get to the bottom of it!


### PR DESCRIPTION
Fixes #875

Partially addresses #910 (one additional cross-link).

## Changes

- Add **Download States** section to `doc/chapter-podboat.asciidoc` describing each `%S` status, queue-file markers, and the difference between *ready*, *played*, and *finished*
- Link `podlist-format` `%S` identifier to the new section; align listed values with `Download::status_text()` (`cancelled`, `rename failed`)
- Replace vague "relevant section" wording in `doc/chapter-podcasts.asciidoc` with a direct xref to the remote-API section

## Verification

```sh
make doc/newsboat.1 doc/podboat.1
```

Asciidoctor completes without errors.

Made with [Cursor](https://cursor.com)