### PR TITLE
docs: fix typos in format strings and macro section

### DIFF
--- a/doc/chapter-format-strings.asciidoc
+++ b/doc/chapter-format-strings.asciidoc
@@ -91,10 +91,10 @@ Identifier:Meaning
 [[podlist-format-i]]<<podlist-format-i,+i+>>:Download index
 [[podlist-format-d]]<<podlist-format-d,+d+>>:Currently downloaded size in megabytes, displays one digit of precision
 [[podlist-format-t]]<<podlist-format-t,+t+>>:Total download size in megabytes, displays one digit of precision
-[[podlist-format-p]]<<podlist-format-p,+p+>>:Downloaded precentage, displays one digit of precision
+[[podlist-format-p]]<<podlist-format-p,+p+>>:Downloaded percentage, displays one digit of precision
 [[podlist-format-k]]<<podlist-format-k,+k+>>:Download speed, displays two digit of precision, always in KB/s (does not include the "KB/s" text)
 [[podlist-format-K]]<<podlist-format-K,+K+>>:Download speed, displays two digit of precision, human readable (automatically switches between KB/s, MB/s, and GB/s)
-[[podlist-format-S]]<<podlist-format-S,+S+>>:Status of download, displays one of the folowing; "queued", "downloading", "ready", "canceled", "deleted", "missing", "played", "finished" or "failed"
+[[podlist-format-S]]<<podlist-format-S,+S+>>:Status of download; displays one of "queued", "downloading", "ready", "cancelled", "deleted", "missing", "played", "finished", "failed", or "rename failed"
 [[podlist-format-u]]<<podlist-format-u,+u+>>:Url of the download
 [[podlist-format-F]]<<podlist-format-F,+F+>>:Absolute filename of the download from the root directory (e.g. ~/downloads/podcast.mp3 -> /home/name/downloads/podcast.mp3)
 [[podlist-format-b]]<<podlist-format-b,+b+>>:Basename of the download (e.g. /home/name/downloads/podcast.mp3 -> podcast.mp3)

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -1047,7 +1047,7 @@ open dialogs by selecting them and pressing kbd:[Ctrl+X].
 === Macro Support
 
 Bindings created with <<bind-key,`bind-key`>> can only execute a single
-operation, like <<open,`open`>> or <<quit,`quit`>>. Macros where introduced to
+operation, like <<open,`open`>> or <<quit,`quit`>>. Macros were introduced to
 allow running multiple operations. However, we now have the <<bind,`bind`>>
 command which is more flexible and also allows running multiple operations. To
 read more about the <<bind,`bind`>> command, see <<_key_bindings,Key Bindings>>.


### PR DESCRIPTION
Small documentation cleanup (no issue filed).

- `chapter-format-strings.asciidoc`: fix "precentage" → "percentage", "folowing" → removed; align Podboat status spellings with `Download::status_text()` (`cancelled`, `rename failed`)
- `newsboat.asciidoc`: "Macros where introduced" → "Macros were introduced"

Made with [Cursor](https://cursor.com)