### PR TITLE
docs: clarify NewsBlur starring is unsupported

### DIFF
--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -344,7 +344,12 @@ you can configure in Newsboat regarding NewsBlur.
 
 NewsBlur's folders are converted into Newsboat tags. You can select and
 filter feeds by tags; see <<_tagging>> and <<_filter_language>> for details.
-NewsBlur's starring/saving feature is currently unsupported by Newsboat.
+
+Starred/saved articles (NewsBlur's "saved" items) are *not* supported by
+Newsboat: you cannot sync NewsBlur stars into Newsboat, and there is no
+`newsblur-flag-star` setting. Other services such as <<_freshrss,FreshRSS>> and
+<<_miniflux,Miniflux>> document how to map flags to starring when the feature is
+available.
 
 === FeedHQ
 


### PR DESCRIPTION
Fixes #2270

The NewsBlur section already noted that starring/saving is unsupported, but it was easy to miss compared to other services that document `*-flag-star` settings in detail.

This change states the limitation explicitly and points readers to FreshRSS/Miniflux sections where starring *is* supported.

Made with [Cursor](https://cursor.com)