### PR TITLE
docs: document binding edit-flags with a fixed flag

### DIFF
--- a/doc/keycmds.dsv
+++ b/doc/keycmds.dsv
@@ -55,7 +55,7 @@ set-filter||kbd:[Shift+F]||Set a filter.
 select-filter||kbd:[F]||Select a predefined filter.
 clear-filter||kbd:[Ctrl+F]||Clear currently set filter.
 bookmark||kbd:[Ctrl+B]||Bookmark currently selected article or URL.
-edit-flags||kbd:[Ctrl+E]||Edit the flags of the currently selected article.
+edit-flags||kbd:[Ctrl+E]||Edit the flags of the currently selected article. When invoked from a <<bind,`bind`>> binding or <<macro,`macro`>>, an optional argument sets the flags to that string, replacing the current flags.
 next-unread-feed||kbd:[Ctrl+N]||Go to the next feed with unread articles. This only works from the article list.
 prev-unread-feed||kbd:[Ctrl+P]||Go to the previous feed with unread articles. This only works from the article list.
 next-feed||kbd:[J]||Go to the next feed. This only works from the article list.

--- a/doc/newsboat.asciidoc
+++ b/doc/newsboat.asciidoc
@@ -946,6 +946,17 @@ articles via the filter language.
 If an article contains one or more flags, it is marked with an "!" in the
 article list. In the article view, all flags (if available) are listed.
 
+To apply a fixed set of flags from a <<bind,`bind`>> binding or <<macro,`macro`>>
+without opening the flag editor, pass the flags as an argument to
+<<edit-flags,`edit-flags`>>. For example, to star articles in Tiny Tiny RSS with
+<<ttrss-flag-star,`ttrss-flag-star`>> set to `"s"`:
+
+    bind s articlelist edit-flags s
+
+This replaces the article's flags with exactly `s`; it does not toggle flags on
+and off. Use the interactive editor (kbd:[Ctrl+E]) if you need to add or remove
+individual flags.
+
 === Commandline Commands
 
 Newsboat comes with a `-x` option that indicates that commands added as arguments


### PR DESCRIPTION
Fixes #632

Documents how to apply a predefined flag (e.g. Tiny Tiny RSS star via `ttrss-flag-star "s"`) using:

```
bind s articlelist edit-flags s
```

Also clarifies that the argument **replaces** the article's flags rather than toggling them, since true toggle behavior would require a separate feature.

Made with [Cursor](https://cursor.com)