### PR TITLE
docs: add stable links to development documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,13 @@ documentation can be found in `doc/` and related issues can be found under the
 [issue tracker](https://github.com/newsboat/newsboat/labels/docs). New features
 that are added should also be documented.
 
+Published manuals are versioned at `https://newsboat.org/releases/<version>/docs/`.
+For links that should always describe the current development tree (for example
+in tldr-pages or other external projects), use the files on `master` instead:
+
+- <https://github.com/newsboat/newsboat/blob/master/doc/newsboat.asciidoc>
+- <https://github.com/newsboat/newsboat/blob/master/doc/faq.asciidoc>
+
 
 ## Translations
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,12 @@ There are numerous ways:
 Support
 -------
 
-* Check out our
-  [documentation](https://newsboat.org/releases/2.43/docs/newsboat.html) and
-  [FAQ](https://newsboat.org/releases/2.43/docs/faq.html)
+* Check out our documentation:
+  ** [Latest release (2.43)](https://newsboat.org/releases/2.43/docs/newsboat.html)
+     and [FAQ](https://newsboat.org/releases/2.43/docs/faq.html)
+  ** [Development version (tracks
+     `master`)](https://github.com/newsboat/newsboat/tree/master/doc) — use this
+     link when you need docs that always match the current repository
 * Report security vulnerabilities to security@newsboat.org. Please encrypt your emails to
   [OpenPGP key 4ED6CD61932B9EBE](https://newsboat.org/newsboat.pgp) if you can.
 * Report bugs and ask questions on


### PR DESCRIPTION
## Summary

Adds repository-based documentation links that track `master`, so external projects (e.g. tldr-pages) and contributors can reference docs without updating URLs on every release.

- README Support section: release docs + development docs under `doc/` on GitHub
- CONTRIBUTING: guidance on when to use versioned `newsboat.org` URLs vs. stable `master` links

Fixes #3215

## Test plan

- [x] Markdown/asciidoc only; no build impact

Made with [Cursor](https://cursor.com)