### PR TITLE
Initialize LC_TIME locale from environment

### DIFF
--- a/newsboat.cpp
+++ b/newsboat.cpp
@@ -250,6 +250,7 @@ int main(int argc, char* argv[])
 
 	setlocale(LC_CTYPE, "");
 	setlocale(LC_MESSAGES, "");
+	setlocale(LC_TIME, "");
 
 	textdomain(PACKAGE);
 	bindtextdomain(PACKAGE, LOCALEDIR);

--- a/podboat.cpp
+++ b/podboat.cpp
@@ -20,6 +20,7 @@ int main(int argc, char* argv[])
 
 	setlocale(LC_CTYPE, "");
 	setlocale(LC_MESSAGES, "");
+	setlocale(LC_TIME, "");
 
 	textdomain(PACKAGE);
 	bindtextdomain(PACKAGE, LOCALEDIR);


### PR DESCRIPTION
By default, C locale is used, so locale-dependent strftime specifiers like %b and %D produce English strings instead of localized ones.

Fixes #3341.