### PR TITLE
CI: use `make --shuffle` in "extra checks" jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,23 +34,6 @@ jobs:
               cxx=g++-14
               rust_version=1.92.0
 
-          - name: GCC 16, more warnings and checks (Ubuntu 26.04)
-            image: newsboat/ci-26.04-gcc16:latest
-            dockerfile: docker/ubuntu_26.04-build-tools.dockerfile
-            build_args: |
-              cxx_package=g++-16
-              cc=gcc-16
-              cxx=g++-16
-            cxxflags: &extra_warnings_and_checks_env "-D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-all -Wstack-protector -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3"
-          - name: Clang 22, more warnings and checks (Ubuntu 26.04)
-            image: newsboat/ci-26.04-clang22:latest
-            dockerfile: docker/ubuntu_26.04-build-tools.dockerfile
-            build_args: |
-              cxx_package=clang-22
-              cc=clang-22
-              cxx=clang++-22
-            cxxflags: *extra_warnings_and_checks_env
-
           - name: Rust stable, GCC 13 (Ubuntu 24.04)
             image: newsboat/ci-24.04-gcc13:latest
             dockerfile: docker/ubuntu_24.04-build-tools.dockerfile
@@ -216,4 +199,133 @@ jobs:
               'mkdir fakeroot && \
               make DESTDIR=fakeroot install && \
               make DESTDIR=fakeroot uninstall && \
+              test $(find fakeroot -type f -print | wc -l) -eq 0'
+
+  linux_extra_checks:
+    strategy:
+      matrix:
+        include:
+          - name: GCC 16, more warnings and checks (Ubuntu 26.04)
+            image: newsboat/ci-26.04-gcc16:latest
+            dockerfile: docker/ubuntu_26.04-build-tools.dockerfile
+            build_args: |
+              cxx_package=g++-16
+              cc=gcc-16
+              cxx=g++-16
+          - name: Clang 22, more warnings and checks (Ubuntu 26.04)
+            image: newsboat/ci-26.04-clang22:latest
+            dockerfile: docker/ubuntu_26.04-build-tools.dockerfile
+            build_args: |
+              cxx_package=clang-22
+              cc=clang-22
+              cxx=clang++-22
+
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-24.04
+    env:
+      CXXFLAGS: -D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -fstack-protector-all -Wstack-protector -D_FORTIFY_SOURCE=2 -Wnull-dereference -Wdouble-promotion -O3
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@v4
+
+      # We need to pass UID and GID into `docker buildx build`, but the action
+      # doesn't support assigning build args from shell commands. This step is
+      # a workaround: it sets environment variables which are then referenced
+      # in the Docker build args
+      - name: Set UID and GID environment variables
+        run: |
+          echo "UID=$(id -u)" >> $GITHUB_ENV
+          echo "GID=$(id -g)" >> $GITHUB_ENV
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v7
+        with:
+          file: ${{ matrix.dockerfile }}
+          build-args: |
+            UID=${{ env.UID }}
+            GID=${{ env.GID }}
+            ${{ matrix.build_args }}
+
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+
+          push: false
+          load: true
+
+          tags: ${{ matrix.image }}
+
+      - name: Pre-create ~/.cargo subdirs
+        run: |
+          mkdir --parents ~/.cargo/git
+          mkdir --parents ~/.cargo/registry
+
+      - name: Cache ~/.cargo
+        uses: actions/cache@v5
+        id: cargo_cache
+        with:
+          key: cargo-${{ hashFiles('Cargo.lock', '**/Cargo.toml') }}
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+
+      - name: Build
+        run: |
+          docker run \
+            --rm \
+            --tty \
+            --mount type=bind,source=$HOME/.cargo/git,target=/home/builder/.cargo/git \
+            --mount type=bind,source=$HOME/.cargo/registry,target=/home/builder/.cargo/registry \
+            --mount type=bind,source=$(pwd),target=/home/builder/src \
+            --env RUSTFLAGS='-D warnings' \
+            --env CXXFLAGS \
+            ${{ matrix.image }} \
+            make --shuffle -j$(nproc) --keep-going all test
+
+      - name: Test
+        run: |
+          docker run \
+            --rm \
+            --tty \
+            --mount type=bind,source=$HOME/.cargo/git,target=/home/builder/.cargo/git \
+            --mount type=bind,source=$HOME/.cargo/registry,target=/home/builder/.cargo/registry \
+            --mount type=bind,source=$(pwd),target=/home/builder/src \
+            --env RUSTFLAGS='-D warnings' \
+            --env RUST_TEST_THREADS=$(nproc) \
+            --env RUST_BACKTRACE=1 \
+            --env CXXFLAGS \
+            ${{ matrix.image }} \
+            make --shuffle -j$(nproc) NEWSBOAT_RUN_IGNORED_TESTS=1 ci-check
+
+      - name: Run Clippy
+        run: |
+          docker run \
+            --rm \
+            --tty \
+            --mount type=bind,source=$HOME/.cargo/git,target=/home/builder/.cargo/git \
+            --mount type=bind,source=$HOME/.cargo/registry,target=/home/builder/.cargo/registry \
+            --mount type=bind,source=$(pwd),target=/home/builder/src \
+            --env RUSTFLAGS='-D warnings' \
+            --env CXXFLAGS \
+            ${{ matrix.image }} \
+            cargo clippy --all-targets --all-features -- -D warnings -A unknown-lints
+
+      - name: Fake install
+        run: |
+          docker run \
+            --rm \
+            --tty \
+            --mount type=bind,source=$HOME/.cargo/git,target=/home/builder/.cargo/git \
+            --mount type=bind,source=$HOME/.cargo/registry,target=/home/builder/.cargo/registry \
+            --mount type=bind,source=$(pwd),target=/home/builder/src \
+            --env RUSTFLAGS='-D warnings' \
+            --env CXXFLAGS \
+            ${{ matrix.image }} \
+            sh -c \
+              'mkdir fakeroot && \
+              make --shuffle DESTDIR=fakeroot install && \
+              make --shuffle DESTDIR=fakeroot uninstall && \
               test $(find fakeroot -type f -print | wc -l) -eq 0'


### PR DESCRIPTION
GNU Make builds targets in deterministic order; parallelism muddles it somewhat, but not that much. `make --shuffle` explicitly enables non-deterministic building, so targets are made in random order where dependencies allow for that. This mode should help uncover missing dependencies between targets because such targets will sometimes fail to build.