### PR TITLE
fix 3323 segfault

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -26,7 +26,6 @@ inline void Cache::run_sql_impl(const std::string& query,
 	bool do_throw)
 {
 	LOG(Level::DEBUG, "running query: %s", query);
-	std::lock_guard<std::recursive_mutex> lock(mtx);
 	const int rc = sqlite3_exec(
 			db, query.c_str(), callback, callback_argument, nullptr);
 	if (rc != SQLITE_OK) {
@@ -478,10 +477,10 @@ void Cache::update_lastmodified(const std::string& feedurl,
 		return;
 	}
 
+	std::lock_guard<std::recursive_mutex> lock(mtx);
 	run_sql(prepare_query("INSERT OR IGNORE INTO rss_feed (rssurl, url, title) VALUES ('%q', '', '')",
 			feedurl));
 
-	std::lock_guard<std::recursive_mutex> lock(mtx);
 	std::string query = "UPDATE rss_feed SET ";
 	if (t > 0) {
 		query.append(prepare_query("lastmodified = '%d'", t));

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -26,6 +26,7 @@ inline void Cache::run_sql_impl(const std::string& query,
 	bool do_throw)
 {
 	LOG(Level::DEBUG, "running query: %s", query);
+	std::lock_guard<std::recursive_mutex> lock(mtx);
 	const int rc = sqlite3_exec(
 			db, query.c_str(), callback, callback_argument, nullptr);
 	if (rc != SQLITE_OK) {

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -2,6 +2,8 @@
 
 #include <memory>
 #include <sstream>
+#include <thread>
+#include <vector>
 
 #include "3rd-party/catch.hpp"
 #include "configcontainer.h"
@@ -151,6 +153,45 @@ TEST_CASE("Last-Modified and ETag values are also stored in DB if feed was not y
 
 	REQUIRE(output_lastmodified == lastmodified);
 	REQUIRE(output_etag == etag);
+}
+
+TEST_CASE("Last-Modified and ETag values can be updated from multiple threads",
+	"[Cache]")
+{
+	ConfigContainer cfg;
+	auto rsscache = Cache::in_memory(cfg);
+
+	constexpr unsigned int thread_count = 8;
+	constexpr unsigned int update_count = 100;
+	std::vector<std::thread> threads;
+
+	for (unsigned int i = 0; i < thread_count; ++i) {
+		threads.emplace_back([&, i]() {
+			const std::string feedurl =
+				"http://example.com/feed-" + std::to_string(i) + ".xml";
+			const std::string etag = "etag-" + std::to_string(i);
+
+			for (unsigned int j = 0; j < update_count; ++j) {
+				rsscache->update_lastmodified(feedurl, j + 1, etag);
+			}
+		});
+	}
+
+	for (auto& thread : threads) {
+		thread.join();
+	}
+
+	for (unsigned int i = 0; i < thread_count; ++i) {
+		const std::string feedurl =
+			"http://example.com/feed-" + std::to_string(i) + ".xml";
+		time_t lastmodified{};
+		std::string etag;
+
+		rsscache->fetch_lastmodified(feedurl, lastmodified, etag);
+
+		REQUIRE(lastmodified == update_count);
+		REQUIRE(etag == "etag-" + std::to_string(i));
+	}
 }
 
 TEST_CASE("mark_all_read marks all items in the feed read", "[Cache]")


### PR DESCRIPTION
Fix https://github.com/newsboat/newsboat/issues/3323 . I think.

Before the fix I can segfault newsboat sometimes. I don't have a perfect repro, but it would crash often. With the fix, so far, I see no crashes.
The core dump when it crashed was:

```
(lldb) bt
* thread #8, stop reason = ESR_EC_DABORT_EL0 (fault address: 0x2f2f3a7370747468)
    frame #0: 0x000000019141f0e4 libsqlite3.dylib`sqlite3DbMallocRawNNTyped + 52
    frame #1: 0x00000001913aff04 libsqlite3.dylib`exprDup + 168
    frame #2: 0x00000001913b00e8 libsqlite3.dylib`exprDup + 652
    frame #3: 0x0000000191451c8c libsqlite3.dylib`sqlite3ExprCodeRunJustOnce + 172
    frame #4: 0x0000000191457888 libsqlite3.dylib`sqlite3ExprCodeFactorable + 148
    frame #5: 0x00000001913bb7d0 libsqlite3.dylib`sqlite3Insert + 5592
    frame #6: 0x00000001913789b0 libsqlite3.dylib`yy_reduce + 6844
    frame #7: 0x0000000191375e90 libsqlite3.dylib`sqlite3RunParser + 796
    frame #8: 0x000000019137534c libsqlite3.dylib`sqlite3Prepare + 588
    frame #9: 0x0000000191374f78 libsqlite3.dylib`sqlite3LockAndPrepare + 224
    frame #10: 0x0000000191374c78 libsqlite3.dylib`sqlite3_exec + 1764
  * frame #11: 0x00000001005d4628 newsboat`newsboat::Cache::run_sql_impl(this=0x0000000102ca6030, query="INSERT OR IGNORE INTO rss_feed (rssurl, url, title) VALUES ('https://www.theverge.com/rss/index.xml', '', '')", callback=0x0000000000000000, callback_argument=0x0000000000000000, do_throw=true) at cache.cpp:29:17
    frame #12: 0x00000001005d458c newsboat`newsboat::Cache::run_sql(this=0x0000000102ca6030, query="INSERT OR IGNORE INTO rss_feed (rssurl, url, title) VALUES ('https://www.theverge.com/rss/index.xml', '', '')", callback=0x0000000000000000, callback_argument=0x0000000000000000) at cache.cpp:44:2
    frame #13: 0x00000001005d6a84 newsboat`newsboat::Cache::update_lastmodified(this=0x0000000102ca6030, feedurl="https://www.theverge.com/rss/index.xml", t=0, etag="W/\"bcc2a74b6105f429c07e96cc3e2f0791\"") at cache.cpp:480:2
    frame #14: 0x00000001006e4128 newsboat`newsboat::FeedRetriever::download_http(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)::$_0::operator()(this=0x000000016fc9a1b0) const at feedretriever.cpp:237:8
    frame #15: 0x00000001006e2ddc newsboat`newsboat::FeedRetriever::download_http(this=0x000000016fc9ab90, uri="https://www.theverge.com/rss/index.xml") at feedretriever.cpp:245:4
    frame #16: 0x00000001006e14ec newsboat`newsboat::FeedRetriever::retrieve(this=0x000000016fc9ab90, uri="https://www.theverge.com/rss/index.xml") at feedretriever.cpp:69:10
    frame #17: 0x00000001007dbf44 newsboat`newsboat::Reloader::reload(this=0x0000000cb90c8000, pos=9, easyhandle=0x000000016fc9adf8, show_progress=true, unattended=false) at reloader.cpp:110:44
    frame #18: 0x00000001007e8548 newsboat`newsboat::Reloader::reload_indexes_impl(std::__1::vector<unsigned int, std::__1::allocator<unsigned int>>, bool)::$_0::operator()(this=0x0000000cb8c16148, start=6, end=7) const at reloader.cpp:268:4
    frame #24: 0x00000001007dd388 newsboat`std::__1::function<void (unsigned int, unsigned int)>::operator()(this=0x0000000cb8c4cc08, __arg=6, __arg=7) const at function.h:772:10
    frame #25: 0x00000001007e3084 newsboat`newsboat::Reloader::partition_reload_to_threads(std::__1::function<void (unsigned int, unsigned int)>, unsigned int)::$_0::operator()(this=0x0000000cb8c4cc08) const at reloader.cpp:180:5
    frame #28: 0x00000001007e2acc newsboat`void* std::__1::__thread_proxy[abi:nqe210106]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, newsboat::Reloader::partition_reload_to_threads(std::__1::function<void (unsigned int, unsigned int)>, unsigned int)::$_0>>(__vp=0x0000000cb8c4cc00) at thread.h:168:3
    frame #29: 0x0000000189471c58 libsystem_pthread.dylib`_pthread_start + 136
(lldb)
```
