### PR TITLE
Fix missing handling of tags by OpmlUrlReader

### DIFF
--- a/src/opmlurlreader.cpp
+++ b/src/opmlurlreader.cpp
@@ -1,6 +1,7 @@
 #include "opmlurlreader.h"
 
 #include <cstring>
+#include <sstream>
 
 #include "logger.h"
 #include "utils.h"
@@ -82,6 +83,19 @@ void OpmlUrlReader::handle_node(xmlNode* node, const std::string& tag)
 				xmlFree(rsstext);
 			}
 
+			// Add tags
+			char* category = (char*)xmlGetProp(node, (const xmlChar*)"category");
+			if (category) {
+				std::string token;
+				std::istringstream ss = std::istringstream(category);
+				while (std::getline(ss, token, ',')) {
+					if (std::find(tmptags.begin(), tmptags.end(), token) == tmptags.end()) {
+						tmptags.push_back(token);
+					}
+				}
+				xmlFree(category);
+			}
+
 			if (tag.length() > 0) {
 				tmptags.push_back(tag);
 			}
@@ -108,8 +122,10 @@ void OpmlUrlReader::rec_find_rss_outlines(xmlNode* node, std::string tag)
 				handle_node(node, tag);
 				xmlFree(type);
 			} else {
-				char* text = (char*)xmlGetProp(
-						node, (const xmlChar*)"title");
+				char* text = (char*)xmlGetProp(node, (const xmlChar*)"text");
+				if (!text) {
+					text = (char*)xmlGetProp(node, (const xmlChar*)"title");
+				}
 				if (text) {
 					if (newtag.length() > 0) {
 						newtag.append("/");

--- a/test/data/example.opml
+++ b/test/data/example.opml
@@ -9,7 +9,7 @@
         <outline type="rss" title="Distrowatch mirror" xmlUrl="https://example.com/mirrors/distrowatch.rss" />
         <outline xmlUrl="https://example.com/feed.atom" type="rss" title="example.com website (Atom feed)" />
         <outline title="example.com website (RSS 0.9 feed)" type="rss" xmlUrl="https://example.com/feed.rss09" />
-        <outline title="Blogs">
+        <outline text="Blogs" title="should be ignored">
             <outline xmlUrl="https://blogs.example.com/~john/posts.rss" title="John's musings" type="rss" />
             <outline title="friends">
                 <outline xmlUrl="https://blogs.example.com/~mike/.rss" title="Notes by Mike" type="rss" />

--- a/test/data/example2.opml
+++ b/test/data/example2.opml
@@ -8,12 +8,12 @@
         <outline type="rss" xmlUrl="https://one.example.com/file.xml" title="To rule them all" />
         <outline type="rss" title="Another file" xmlUrl="https://to.example.com/elves/tidings.rss" />
         <outline title="Rant boards">
-            <outline title="humans">
+            <outline text="humans">
                 <outline xmlUrl="https://third.example.com/~of/internet.rss" title="Really?" type="rss" />
             </outline>
             <outline xmlUrl="https://four.example.com/~john/posts.rss" title="and another" type="rss" />
         </outline>
-        <outline xmlUrl="https://example.com/five.atom" type="rss" title="another title" />
+        <outline xmlUrl="https://example.com/five.atom" type="rss" text="another title" />
         <outline title="eloquent">
             <outline title="freddie rite about fings" xmlUrl="https://freddie.example.com/ritin/index.pl?format=rss" type="rss" />
         </outline>

--- a/test/opmlurlreader.cpp
+++ b/test/opmlurlreader.cpp
@@ -28,10 +28,14 @@ TEST_CASE("OPML URL reader gets the path to input file from \"opml-url\" "
 TEST_CASE("OpmlUrlReader::reload() reads URLs and tags from an OPML file",
 	"[OpmlUrlReader]")
 {
+	const auto cwd = utils::getcwd();
+
 	ConfigContainer cfg;
 	cfg.set_configvalue(
 		"opml-url",
-		"file://" + utils::getcwd().to_locale_string() + "/data/example.opml");
+		"file://" + cwd.to_locale_string() + "/data/example.opml"
+		+ " "
+		+ "file://" + cwd.to_locale_string() + "/data/category.opml");
 
 	OpmlUrlReader reader(cfg, Filepath());
 
@@ -48,6 +52,7 @@ TEST_CASE("OpmlUrlReader::reload() reads URLs and tags from an OPML file",
 		{"https://blogs.example.com/~john/posts.rss", {"~John's musings", "Blogs"}},
 		{"https://fred.example.com/writing/index.php?type=rss", {"~Fred on everything", "eloquent"}},
 		{"https://blogs.example.com/~mike/.rss", {"~Notes by Mike", "Blogs/friends"}},
+		{"http://feeds.bbci.co.uk/news/business/rss.xml?edition=int", {"tag one", "tag_two", "tag/three"}},
 	};
 
 	REQUIRE(reader.get_urls().size() == expected.size());


### PR DESCRIPTION
Adds missing handling of `category` properties, and `text` from outer outlines

<sub>Probably worth taking a look at #292 sometime soon</sub>