### PR TITLE
Handle all input in Newsboat itself

### DIFF
--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -8,6 +8,7 @@
 #include "configcontainer.h"
 #include "file_system.h"
 #include "formaction.h"
+#include "lineedit.h"
 #include "listwidget.h"
 #include "stflrichtext.h"
 
@@ -47,6 +48,8 @@ public:
 	}
 	std::string title() override;
 
+	bool handle_event(const Event& event) override;
+
 protected:
 	std::string main_widget() const override
 	{
@@ -77,6 +80,7 @@ private:
 
 	LineView current_directory;
 	LineView file_prompt_line;
+	LineEdit filename_input;
 	Filepath default_filename;
 
 	ListWidget files_list;

--- a/include/filepath.h
+++ b/include/filepath.h
@@ -36,6 +36,13 @@ public:
 	/// etc.
 	static Filepath from_locale_string(const std::string&);
 
+	/// Constructs a filepath from string in utf-8 encoding.
+	///
+	/// \note This does not perform any canonicalization, i.e. it does nothing
+	/// to tilde (~), repeated path separators (path///to/file), symbolic links
+	/// etc.
+	static Filepath from_utf8_string(const std::string&);
+
 	Filepath(Filepath&&) = default;
 	Filepath& operator=(Filepath&&) = default;
 

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -102,6 +102,12 @@ public:
 	void delete_word();
 	void handle_cmdline_completion();
 
+	virtual bool handle_event(const Event& /*event*/)
+	{
+		// Not handled by default but FormActions can override if necessary
+		return false;
+	};
+
 	void handle_qna_event(const Event& event, bool inside_cmd);
 
 	void set_parent_formaction(std::shared_ptr<FormAction> fa)

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "event.h"
 #include "history.h"
 #include "keymap.h"
 #include "lineedit.h"
@@ -76,7 +77,7 @@ public:
 	void set_status(const std::string& text);
 
 	void draw_form();
-	std::string draw_form_wait_for_event(unsigned int timeout);
+	Event wait_for_event();
 	void recalculate_widget_dimensions();
 
 	virtual void handle_cmdline(const std::string& cmd);

--- a/include/formaction.h
+++ b/include/formaction.h
@@ -102,7 +102,7 @@ public:
 	void delete_word();
 	void handle_cmdline_completion();
 
-	void handle_qna_event(std::string event, bool inside_cmd);
+	void handle_qna_event(const Event& event, bool inside_cmd);
 
 	void set_parent_formaction(std::shared_ptr<FormAction> fa)
 	{

--- a/include/lineedit.h
+++ b/include/lineedit.h
@@ -23,7 +23,7 @@ public:
 	void set_position(std::uint32_t pos);
 	std::uint32_t get_position();
 
-	void handle_event(const Event& event);
+	bool handle_event(const Event& event);
 
 private:
 	void sync_to_stfl();

--- a/include/lineedit.h
+++ b/include/lineedit.h
@@ -1,6 +1,9 @@
 #ifndef NEWSBOAT_LINEEDIT_H_
 #define NEWSBOAT_LINEEDIT_H_
 
+#include "libnewsboat-ffi/src/lineedit.rs.h" // IWYU pragma: export
+
+#include "event.h"
 #include "stflpp.h"
 
 #include <cstdint>
@@ -20,7 +23,12 @@ public:
 	void set_position(std::uint32_t pos);
 	std::uint32_t get_position();
 
+	void handle_event(const Event& event);
+
 private:
+	void sync_to_stfl();
+
+	rust::Box<lineedit::bridged::LineEdit> rs_object;
 	Stfl::Form& f;
 	const std::string name;
 };

--- a/include/view.h
+++ b/include/view.h
@@ -145,7 +145,7 @@ protected:
 
 	void apply_colors(std::shared_ptr<FormAction> fa);
 
-	bool handle_qna_event(const std::string& event, std::shared_ptr<FormAction> fa);
+	bool handle_qna_event(const Event& event, std::shared_ptr<FormAction> fa);
 	void handle_resize();
 
 	Controller& ctrl;

--- a/include/view.h
+++ b/include/view.h
@@ -145,7 +145,7 @@ protected:
 
 	void apply_colors(std::shared_ptr<FormAction> fa);
 
-	bool handle_qna_event(const Event& event, std::shared_ptr<FormAction> fa);
+	bool handle_event(const Event& event, std::shared_ptr<FormAction> fa);
 	void handle_resize();
 
 	Controller& ctrl;

--- a/rust/libnewsboat-ffi/build.rs
+++ b/rust/libnewsboat-ffi/build.rs
@@ -21,6 +21,7 @@ fn main() {
     add_cxxbridge("history");
     add_cxxbridge("keycombination");
     add_cxxbridge("keymap");
+    add_cxxbridge("lineedit");
     add_cxxbridge("logger");
     add_cxxbridge("matchererror");
     add_cxxbridge("scopemeasure");

--- a/rust/libnewsboat-ffi/src/filepath.rs
+++ b/rust/libnewsboat-ffi/src/filepath.rs
@@ -19,6 +19,7 @@ mod bridged {
 
         fn create_empty() -> Box<PathBuf>;
         fn create(filepath: Vec<u8>) -> Box<PathBuf>;
+        fn create_from_utf8(filepath: &str) -> Box<PathBuf>;
         fn equals(lhs: &PathBuf, rhs: &PathBuf) -> bool;
         fn less_than(lhs: &PathBuf, rhs: &PathBuf) -> bool;
         fn into_bytes(filepath: &PathBuf) -> Vec<u8>;
@@ -41,6 +42,10 @@ fn create(filepath: Vec<u8>) -> Box<PathBuf> {
     let filepath: &OsStr = OsStrExt::from_bytes(&filepath);
     let filepath = std::path::Path::new(filepath);
     Box::new(PathBuf(filepath.to_path_buf()))
+}
+
+fn create_from_utf8(filepath: &str) -> Box<PathBuf> {
+    Box::new(PathBuf(std::path::PathBuf::from(filepath)))
 }
 
 fn equals(lhs: &PathBuf, rhs: &PathBuf) -> bool {

--- a/rust/libnewsboat-ffi/src/lib.rs
+++ b/rust/libnewsboat-ffi/src/lib.rs
@@ -19,6 +19,7 @@ pub mod history;
 pub mod human_panic;
 pub mod keycombination;
 pub mod keymap;
+pub mod lineedit;
 pub mod logger;
 pub mod matchererror;
 pub mod scopemeasure;

--- a/rust/libnewsboat-ffi/src/lineedit.rs
+++ b/rust/libnewsboat-ffi/src/lineedit.rs
@@ -15,7 +15,7 @@ mod bridged {
         fn get_cursor_location(lineedit: &LineEdit) -> usize;
         fn set_cursor_location(lineedit: &mut LineEdit, location: usize);
         fn insert_at_cursor(lineedit: &mut LineEdit, text: &str);
-        fn handle_event(lineedit: &mut LineEdit, event: &str);
+        fn handle_event(lineedit: &mut LineEdit, event: &str) -> bool;
     }
 }
 
@@ -43,6 +43,6 @@ fn insert_at_cursor(lineedit: &mut LineEdit, text: &str) {
     lineedit.0.insert_at_cursor(text);
 }
 
-fn handle_event(lineedit: &mut LineEdit, event: &str) {
-    lineedit.0.handle_event(event);
+fn handle_event(lineedit: &mut LineEdit, event: &str) -> bool {
+    lineedit.0.handle_event(event)
 }

--- a/rust/libnewsboat-ffi/src/lineedit.rs
+++ b/rust/libnewsboat-ffi/src/lineedit.rs
@@ -1,0 +1,48 @@
+use libnewsboat::lineedit;
+
+// cxx doesn't allow to share types from other crates, so we have to wrap it
+// cf. https://github.com/dtolnay/cxx/issues/496
+struct LineEdit(lineedit::LineEdit);
+
+#[cxx::bridge(namespace = "newsboat::lineedit::bridged")]
+mod bridged {
+    extern "Rust" {
+        type LineEdit;
+
+        fn create() -> Box<LineEdit>;
+        fn get_text(lineedit: &LineEdit) -> &str;
+        fn set_text(lineedit: &mut LineEdit, text: String);
+        fn get_cursor_location(lineedit: &LineEdit) -> usize;
+        fn set_cursor_location(lineedit: &mut LineEdit, location: usize);
+        fn insert_at_cursor(lineedit: &mut LineEdit, text: &str);
+        fn handle_event(lineedit: &mut LineEdit, event: &str);
+    }
+}
+
+fn create() -> Box<LineEdit> {
+    Box::new(LineEdit(lineedit::LineEdit::default()))
+}
+
+fn get_text(lineedit: &LineEdit) -> &str {
+    lineedit.0.get_text()
+}
+
+fn set_text(lineedit: &mut LineEdit, text: String) {
+    lineedit.0.set_text(text);
+}
+
+fn get_cursor_location(lineedit: &LineEdit) -> usize {
+    lineedit.0.get_cursor_location()
+}
+
+fn set_cursor_location(lineedit: &mut LineEdit, location: usize) {
+    lineedit.0.set_cursor_location(location);
+}
+
+fn insert_at_cursor(lineedit: &mut LineEdit, text: &str) {
+    lineedit.0.insert_at_cursor(text);
+}
+
+fn handle_event(lineedit: &mut LineEdit, event: &str) {
+    lineedit.0.handle_event(event);
+}

--- a/rust/libnewsboat/src/lib.rs
+++ b/rust/libnewsboat/src/lib.rs
@@ -21,6 +21,7 @@ pub mod fslock;
 pub mod history;
 pub mod keycombination;
 pub mod keymap;
+pub mod lineedit;
 pub mod links;
 pub mod matchable;
 pub mod matcher;

--- a/rust/libnewsboat/src/lineedit.rs
+++ b/rust/libnewsboat/src/lineedit.rs
@@ -1,0 +1,222 @@
+#[derive(Default)]
+pub struct LineEdit {
+    text: String,
+    // Location in unicode codepoints
+    cursor: usize,
+}
+
+impl LineEdit {
+    pub fn get_text(&self) -> &str {
+        &self.text
+    }
+
+    pub fn set_text(&mut self, text: String) {
+        self.text = text;
+        self.cursor = self.cursor.clamp(0, self.text.chars().count());
+    }
+
+    pub fn get_cursor_location(&self) -> usize {
+        self.cursor
+    }
+
+    pub fn set_cursor_location(&mut self, location: usize) {
+        self.cursor = location.clamp(0, self.text.chars().count());
+    }
+
+    pub fn insert_at_cursor(&mut self, text: &str) {
+        let chars = self.text.chars();
+        let before: String = chars.clone().take(self.cursor).collect();
+        let after: String = chars.skip(self.cursor).collect();
+        self.text = before + text + &after;
+        self.cursor += text.chars().count();
+    }
+
+    fn remove_nth_char(&mut self, index: usize) {
+        let chars = self.text.chars();
+        let before: String = chars.clone().take(index).collect();
+        let after: String = chars.skip(index + 1).collect();
+        self.text = before + &after;
+    }
+
+    pub fn handle_event(&mut self, event: &str) {
+        match event {
+            "LEFT" => {
+                if self.cursor >= 1 {
+                    self.cursor -= 1;
+                }
+            }
+            "RIGHT" => {
+                if self.cursor < self.text.chars().count() {
+                    self.cursor += 1;
+                }
+            }
+            "HOME" | "^A" => {
+                self.cursor = 0;
+            }
+            "END" | "^E" => {
+                self.cursor = self.text.chars().count();
+            }
+            "DC" => {
+                if self.cursor < self.text.chars().count() {
+                    self.remove_nth_char(self.cursor);
+                }
+            }
+            "BACKSPACE" => {
+                if self.cursor >= 1 {
+                    self.remove_nth_char(self.cursor - 1);
+                    self.cursor -= 1;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LineEdit;
+
+    #[test]
+    fn t_set_text_clamps_cursor_to_valid_location() {
+        let mut lineedit = LineEdit::default();
+        lineedit.set_text("many words make long sentence".to_owned());
+        lineedit.set_cursor_location(10);
+
+        lineedit.set_text("short".to_owned());
+        assert_eq!(lineedit.get_cursor_location(), 5);
+
+        lineedit.set_text("longer".to_owned());
+        assert_eq!(lineedit.get_cursor_location(), 5);
+
+        lineedit.set_text("ß大".to_owned());
+        assert_eq!(lineedit.get_cursor_location(), 2);
+
+        lineedit.set_text("".to_owned());
+        assert_eq!(lineedit.get_cursor_location(), 0);
+    }
+
+    #[test]
+    fn t_set_cursor_location_clamps_to_valid_location() {
+        let mut lineedit = LineEdit::default();
+
+        lineedit.set_cursor_location(10);
+        assert_eq!(lineedit.get_cursor_location(), 0);
+
+        lineedit.set_text("ß大".to_owned());
+        lineedit.set_cursor_location(10);
+        assert_eq!(lineedit.get_cursor_location(), 2);
+
+        lineedit.set_text("many words make long sentence".to_owned());
+        lineedit.set_cursor_location(10);
+        assert_eq!(lineedit.get_cursor_location(), 10);
+    }
+
+    #[test]
+    fn t_handle_event_left() {
+        let mut lineedit = LineEdit::default();
+        lineedit.set_text("abc".to_owned());
+        lineedit.set_cursor_location(2);
+
+        lineedit.handle_event("LEFT");
+        assert_eq!(lineedit.get_cursor_location(), 1);
+
+        lineedit.handle_event("LEFT");
+        assert_eq!(lineedit.get_cursor_location(), 0);
+
+        lineedit.handle_event("LEFT");
+        assert_eq!(lineedit.get_cursor_location(), 0);
+    }
+
+    #[test]
+    fn t_handle_event_right() {
+        let mut lineedit = LineEdit::default();
+        lineedit.set_text("大ßc".to_owned());
+        lineedit.set_cursor_location(1);
+
+        lineedit.handle_event("RIGHT");
+        assert_eq!(lineedit.get_cursor_location(), 2);
+
+        lineedit.handle_event("RIGHT");
+        assert_eq!(lineedit.get_cursor_location(), 3);
+
+        lineedit.handle_event("RIGHT");
+        assert_eq!(lineedit.get_cursor_location(), 3);
+    }
+
+    #[test]
+    fn t_handle_event_home_ctrl_a() {
+        for event in &["HOME", "^A"] {
+            let mut lineedit = LineEdit::default();
+            lineedit.set_text("abc".to_owned());
+            lineedit.set_cursor_location(2);
+
+            lineedit.handle_event(event);
+            assert_eq!(lineedit.get_cursor_location(), 0);
+        }
+    }
+
+    #[test]
+    fn t_handle_event_end_ctrl_e() {
+        for event in &["END", "^E"] {
+            let mut lineedit = LineEdit::default();
+            lineedit.set_text("大ßc".to_owned());
+            lineedit.set_cursor_location(1);
+
+            lineedit.handle_event(event);
+            assert_eq!(lineedit.get_cursor_location(), 3);
+        }
+    }
+
+    #[test]
+    fn t_handle_event_delete() {
+        let mut lineedit = LineEdit::default();
+        lineedit.set_text("大ßc".to_owned());
+        lineedit.set_cursor_location(1);
+
+        lineedit.handle_event("DC");
+        assert_eq!(lineedit.get_text(), "大c");
+        assert_eq!(lineedit.get_cursor_location(), 1);
+
+        lineedit.handle_event("DC");
+        assert_eq!(lineedit.get_text(), "大");
+        assert_eq!(lineedit.get_cursor_location(), 1);
+
+        lineedit.handle_event("DC");
+        assert_eq!(lineedit.get_text(), "大");
+        assert_eq!(lineedit.get_cursor_location(), 1);
+    }
+
+    #[test]
+    fn t_handle_event_backspace() {
+        let mut lineedit = LineEdit::default();
+        lineedit.set_text("大ßc".to_owned());
+        lineedit.set_cursor_location(2);
+
+        lineedit.handle_event("BACKSPACE");
+        assert_eq!(lineedit.get_text(), "大c");
+        assert_eq!(lineedit.get_cursor_location(), 1);
+
+        lineedit.handle_event("BACKSPACE");
+        assert_eq!(lineedit.get_text(), "c");
+        assert_eq!(lineedit.get_cursor_location(), 0);
+
+        lineedit.handle_event("BACKSPACE");
+        assert_eq!(lineedit.get_text(), "c");
+        assert_eq!(lineedit.get_cursor_location(), 0);
+    }
+
+    #[test]
+    fn t_insert_at_cursor() {
+        let mut lineedit = LineEdit::default();
+        lineedit.set_text("大c".to_owned());
+        lineedit.set_cursor_location(1);
+
+        lineedit.insert_at_cursor("ß");
+        assert_eq!(lineedit.get_text(), "大ßc");
+        assert_eq!(lineedit.get_cursor_location(), 2);
+
+        lineedit.insert_at_cursor("more text");
+        assert_eq!(lineedit.get_text(), "大ßmore textc");
+        assert_eq!(lineedit.get_cursor_location(), 11);
+    }
+}

--- a/rust/libnewsboat/src/lineedit.rs
+++ b/rust/libnewsboat/src/lineedit.rs
@@ -38,36 +38,43 @@ impl LineEdit {
         self.text = before + &after;
     }
 
-    pub fn handle_event(&mut self, event: &str) {
+    // Returns true if event is handled
+    pub fn handle_event(&mut self, event: &str) -> bool {
         match event {
             "LEFT" => {
                 if self.cursor >= 1 {
                     self.cursor -= 1;
                 }
+                true
             }
             "RIGHT" => {
                 if self.cursor < self.text.chars().count() {
                     self.cursor += 1;
                 }
+                true
             }
             "HOME" | "^A" => {
                 self.cursor = 0;
+                true
             }
             "END" | "^E" => {
                 self.cursor = self.text.chars().count();
+                true
             }
             "DC" => {
                 if self.cursor < self.text.chars().count() {
                     self.remove_nth_char(self.cursor);
                 }
+                true
             }
             "BACKSPACE" => {
                 if self.cursor >= 1 {
                     self.remove_nth_char(self.cursor - 1);
                     self.cursor -= 1;
                 }
+                true
             }
-            _ => {}
+            _ => false,
         }
     }
 }

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -77,7 +77,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 				}
 				break;
 				case file_system::FileType::RegularFile: {
-					filename_input.set_value(selection.name.to_locale_string());
+					filename_input.set_value(selection.name.display());
 					f.set_focus("filename");
 				}
 				break;
@@ -90,13 +90,13 @@ bool FileBrowserFormAction::process_operation(Operation op,
 				if (variant == Variant::DirectorySelection) {
 					auto fn = utils::getcwd();
 					if (!filename.empty()) {
-						fn.push(Filepath::from_locale_string(filename));
+						fn.push(Filepath::from_utf8_string(filename));
 					}
 					result = fn;
 				} else {
 					if (!filename.empty()) {
 						auto fn = utils::getcwd();
-						fn.push(Filepath::from_locale_string(filename));
+						fn.push(Filepath::from_utf8_string(filename));
 						struct stat sbuf;
 						/*
 						 * this check is very important, as people will
@@ -365,7 +365,7 @@ void FileBrowserFormAction::init()
 
 	std::string filenametext;
 	if (variant == Variant::FileSelection) {
-		filenametext = default_filename.to_locale_string();
+		filenametext = default_filename.display();
 	}
 
 	filename_input.set_value(filenametext);

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -29,9 +29,19 @@ FileBrowserFormAction::FileBrowserFormAction(View& vv,
 	, variant(variant)
 	, current_directory(f, "current_directory")
 	, file_prompt_line(f, "fileprompt")
+	, filename_input(f, "filename")
 	, files_list("files", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
 	, view(vv)
 {
+}
+
+bool FileBrowserFormAction::handle_event(const Event& event)
+{
+	const std::string focus = f.get_focus();
+	if (focus == "filename") {
+		return filename_input.handle_event(event);
+	}
+	return false;
 }
 
 bool FileBrowserFormAction::process_operation(Operation op,
@@ -67,7 +77,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 				}
 				break;
 				case file_system::FileType::RegularFile: {
-					set_value("filenametext", selection.name.to_locale_string());
+					filename_input.set_value(selection.name.to_locale_string());
 					f.set_focus("filename");
 				}
 				break;
@@ -76,7 +86,7 @@ bool FileBrowserFormAction::process_operation(Operation op,
 					break;
 				}
 			} else {
-				const std::string filename = f.get("filenametext");
+				const std::string filename = filename_input.get_value();
 				if (variant == Variant::DirectorySelection) {
 					auto fn = utils::getcwd();
 					if (!filename.empty()) {
@@ -147,16 +157,11 @@ bool FileBrowserFormAction::process_operation(Operation op,
 	case OP_SK_HOME:
 		if (f.get_focus() == "files") {
 			files_list.move_to_first();
-		} else {
-			set_value("filenametext_pos", "0");
 		}
 		break;
 	case OP_SK_END:
 		if (f.get_focus() == "files") {
 			files_list.move_to_last();
-		} else {
-			const std::size_t text_length = f.get("filenametext").length();
-			set_value("filenametext_pos", std::to_string(text_length));
 		}
 		break;
 	case OP_SK_PGUP:
@@ -185,14 +190,14 @@ bool FileBrowserFormAction::process_operation(Operation op,
 		LOG(Level::DEBUG, "view::filebrowser: quitting");
 		curs_set(0);
 		v.pop_current_formaction();
-		set_value("filenametext", "");
+		filename_input.set_value("");
 		break;
 	case OP_HARDQUIT:
 		LOG(Level::DEBUG, "view::filebrowser: hard quitting");
 		while (v.formaction_stack_size() > 0) {
 			v.pop_current_formaction();
 		}
-		set_value("filenametext", "");
+		filename_input.set_value("");
 		break;
 	default:
 		report_unhandled_operation(op);
@@ -363,14 +368,13 @@ void FileBrowserFormAction::init()
 		filenametext = default_filename.to_locale_string();
 	}
 
-	set_value("filenametext", filenametext);
+	filename_input.set_value(filenametext);
 
 	// Set position to 0 and back to ensure that the text is visible
 	draw_form();
 	// TODO: #2326 use length by graphemes
 	// See: https://github.com/newsboat/newsboat/pull/2561#discussion_r1357376071
-	set_value("filenametext_pos",
-		std::to_string(filenametext.length()));
+	filename_input.set_position(filenametext.length());
 }
 
 std::vector<KeyMapHintEntry> FileBrowserFormAction::get_keymap_hint() const

--- a/src/filepath.cpp
+++ b/src/filepath.cpp
@@ -1,4 +1,5 @@
 #include "filepath.h"
+#include "libnewsboat-ffi/src/filepath.rs.h"
 
 namespace newsboat {
 
@@ -25,6 +26,13 @@ Filepath Filepath::from_locale_string(const std::string& filepath)
 {
 	Filepath result;
 	result.rs_object = filepath::bridged::create(string_to_vec(filepath));
+	return result;
+}
+
+Filepath Filepath::from_utf8_string(const std::string& filepath)
+{
+	Filepath result;
+	result.rs_object = filepath::bridged::create_from_utf8(filepath);
 	return result;
 }
 

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cinttypes>
+#include <cwctype>
 #include <ncurses.h>
 
 #include "config.h"
@@ -625,26 +626,28 @@ void FormAction::handle_cmdline_completion()
 	last_fragment = suggestion;
 }
 
-void FormAction::handle_qna_event(std::string event, bool inside_cmd)
+void FormAction::handle_qna_event(const Event& event, bool inside_cmd)
 {
-	if (event == "ESC") {
+	if (event.name == "ESC") {
 		cancel_qna();
-	} else if (inside_cmd && event == "TAB") {
+	} else if (inside_cmd && event.name == "TAB") {
 		handle_cmdline_completion();
-	} else if (event == "UP") {
+	} else if (event.name == "UP") {
 		qna_previous_history();
-	} else if (event == "DOWN") {
+	} else if (event.name == "DOWN") {
 		qna_next_history();
-	} else if (event == "ENTER") {
+	} else if (event.name == "ENTER") {
 		finish_qna_question();
-	} else if (event == "^U") {
+	} else if (event.name == "^U") {
 		clear_line();
-	} else if (event == "^K") {
+	} else if (event.name == "^K") {
 		clear_eol();
-	} else if (event == "^G") {
+	} else if (event.name == "^G") {
 		cancel_qna();
-	} else if (event == "^W") {
+	} else if (event.name == "^W") {
 		delete_word();
+	} else {
+		qna_input.handle_event(event);
 	}
 }
 

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -123,9 +123,9 @@ void FormAction::draw_form()
 	f.draw_form();
 }
 
-std::string FormAction::draw_form_wait_for_event(unsigned int timeout)
+Event FormAction::wait_for_event()
 {
-	return f.run(timeout);
+	return f.wait_for_event(INT_MAX);
 }
 
 void FormAction::recalculate_widget_dimensions()

--- a/src/lineedit.cpp
+++ b/src/lineedit.cpp
@@ -43,14 +43,17 @@ std::uint32_t LineEdit::get_position()
 	return lineedit::bridged::get_cursor_location(*rs_object);
 }
 
-void LineEdit::handle_event(const Event& event)
+bool LineEdit::handle_event(const Event& event)
 {
+	bool handled = false;
 	if (event.printableCharacter.has_value()) {
 		lineedit::bridged::insert_at_cursor(*rs_object, event.printableCharacter.value());
+		handled = true;
 	} else {
-		lineedit::bridged::handle_event(*rs_object, event.name);
+		handled = lineedit::bridged::handle_event(*rs_object, event.name);
 	}
 	sync_to_stfl();
+	return handled;
 }
 
 void LineEdit::sync_to_stfl()

--- a/src/lineedit.cpp
+++ b/src/lineedit.cpp
@@ -1,23 +1,25 @@
 #include "lineedit.h"
 
-#include "utils.h"
+#include "libnewsboat-ffi/src/lineedit.rs.h"
 
 namespace newsboat {
 
 LineEdit::LineEdit(Stfl::Form& form, const std::string& name)
-	: f(form)
+	: rs_object(lineedit::bridged::create())
+	, f(form)
 	, name(name)
 {
 }
 
 void LineEdit::set_value(const std::string& value)
 {
-	f.set(name + "_value", value);
+	lineedit::bridged::set_text(*rs_object, value);
+	sync_to_stfl();
 }
 
 std::string LineEdit::get_value()
 {
-	return f.get(name + "_value");
+	return std::string(lineedit::bridged::get_text(*rs_object));
 }
 
 void LineEdit::show()
@@ -32,13 +34,32 @@ void LineEdit::hide()
 
 void LineEdit::set_position(std::uint32_t pos)
 {
-	f.set(name + "_value_pos", std::to_string(pos));
+	lineedit::bridged::set_cursor_location(*rs_object, pos);
+	sync_to_stfl();
 }
 
 std::uint32_t LineEdit::get_position()
 {
-	std::string pos = f.get(name + "_value_pos");
-	return utils::to_u(pos, 0);
+	return lineedit::bridged::get_cursor_location(*rs_object);
+}
+
+void LineEdit::handle_event(const Event& event)
+{
+	if (event.printableCharacter.has_value()) {
+		lineedit::bridged::insert_at_cursor(*rs_object, event.printableCharacter.value());
+	} else {
+		lineedit::bridged::handle_event(*rs_object, event.name);
+	}
+	sync_to_stfl();
+}
+
+void LineEdit::sync_to_stfl()
+{
+	const auto text = std::string(lineedit::bridged::get_text(*rs_object));
+	const auto location = lineedit::bridged::get_cursor_location(*rs_object);
+
+	f.set(name + "_value", text);
+	f.set(name + "_value_pos", std::to_string(location));
 }
 
 } // namespace newsboat

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -172,11 +172,9 @@ int View::run()
 		// first, we take the current formaction.
 		std::shared_ptr<FormAction> fa = get_current_formaction();
 
-		// we signal "oh, you will receive an operation soon"
 		fa->prepare();
-
-		// we then receive the event and ignore timeouts.
-		const std::string event = fa->draw_form_wait_for_event(INT_MAX);
+		fa->draw_form();
+		const auto event = fa->wait_for_event();
 
 		if (ctrl_c_hit) {
 			ctrl_c_hit = false;
@@ -191,28 +189,28 @@ int View::run()
 			}
 		}
 
-		if (event.empty() || event == "TIMEOUT") {
+		if (event.name.empty() || event.name == "TIMEOUT") {
 			continue;
 		}
 
-		if (event == "RESIZE") {
+		if (event.name == "RESIZE") {
 			handle_resize();
 			continue;
 		}
 
-		if (handle_qna_event(event, fa)) {
+		if (handle_qna_event(event.name, fa)) {
 			continue;
 		}
 
-		LOG(Level::DEBUG, "View::run: event = %s", event);
+		LOG(Level::DEBUG, "View::run: event = %s", event.name);
 
-		const auto key_combination = KeyCombination::from_bindkey(event);
+		const auto key_combination = KeyCombination::from_bindkey(event.name);
 		if (have_macroprefix) {
 			have_macroprefix = false;
 			status_line.show_message("");
 			LOG(Level::DEBUG,
 				"View::run: running macro `%s'",
-				event);
+				event.name);
 			run_commands(keys->get_macro(key_combination), BindingType::Macro);
 		} else {
 			if (key_combination == KeyCombination("ESC") && !key_sequence.empty()) {
@@ -265,22 +263,23 @@ void View::run_modal(std::shared_ptr<FormAction> f)
 
 		fa->prepare();
 
-		const std::string event = fa->draw_form_wait_for_event(INT_MAX);
-		LOG(Level::DEBUG, "View::run: event = %s", event);
-		if (event.empty() || event == "TIMEOUT") {
+		fa->draw_form();
+		const auto event = fa->wait_for_event();
+		LOG(Level::DEBUG, "View::run: event = %s", event.name);
+		if (event.name.empty() || event.name == "TIMEOUT") {
 			continue;
 		}
 
-		if (event == "RESIZE") {
+		if (event.name == "RESIZE") {
 			handle_resize();
 			continue;
 		}
 
-		if (handle_qna_event(event, fa)) {
+		if (handle_qna_event(event.name, fa)) {
 			continue;
 		}
 
-		const auto key_combination = KeyCombination::from_bindkey(event);
+		const auto key_combination = KeyCombination::from_bindkey(event.name);
 		if (key_combination == KeyCombination("ESC") && !key_sequence.empty()) {
 			key_sequence.clear();
 		} else {
@@ -697,19 +696,20 @@ char View::confirm(const std::string& prompt, const std::string& charset)
 	char result = 0;
 
 	do {
-		const std::string event = f->draw_form_wait_for_event(0);
-		LOG(Level::DEBUG, "View::confirm: event = %s", event);
-		if (event.empty()) {
+		f->draw_form();
+		const auto event =f->wait_for_event();
+		LOG(Level::DEBUG, "View::confirm: event = %s", event.name);
+		if (event.name.empty() || event.name == "TIMEOUT") {
 			continue;
 		}
-		if (event == "ESC" || event == "ENTER") {
+		if (event.name == "ESC" || event.name == "ENTER") {
 			result = 0;
 			LOG(Level::DEBUG,
 				"View::confirm: user pressed ESC or ENTER, we "
 				"cancel confirmation dialog");
 			break;
 		}
-		result = keys->get_key(event);
+		result = keys->get_key(event.name);
 		LOG(Level::DEBUG,
 			"View::confirm: key = %c (%u)",
 			result,

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -198,7 +198,7 @@ int View::run()
 			continue;
 		}
 
-		if (handle_qna_event(event.name, fa)) {
+		if (handle_qna_event(event, fa)) {
 			continue;
 		}
 
@@ -275,7 +275,7 @@ void View::run_modal(std::shared_ptr<FormAction> f)
 			continue;
 		}
 
-		if (handle_qna_event(event.name, fa)) {
+		if (handle_qna_event(event, fa)) {
 			continue;
 		}
 
@@ -1172,7 +1172,7 @@ void View::inside_cmdline(bool f)
 	is_inside_cmdline = f;
 }
 
-bool View::handle_qna_event(const std::string& event,
+bool View::handle_qna_event(const Event& event,
 	std::shared_ptr<FormAction> fa)
 {
 	if (is_inside_qna) {

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -198,7 +198,7 @@ int View::run()
 			continue;
 		}
 
-		if (handle_qna_event(event, fa)) {
+		if (handle_event(event, fa)) {
 			continue;
 		}
 
@@ -275,7 +275,7 @@ void View::run_modal(std::shared_ptr<FormAction> f)
 			continue;
 		}
 
-		if (handle_qna_event(event, fa)) {
+		if (handle_event(event, fa)) {
 			continue;
 		}
 
@@ -1172,16 +1172,17 @@ void View::inside_cmdline(bool f)
 	is_inside_cmdline = f;
 }
 
-bool View::handle_qna_event(const Event& event,
+bool View::handle_event(const Event& event,
 	std::shared_ptr<FormAction> fa)
 {
 	if (is_inside_qna) {
-		LOG(Level::DEBUG, "View::handle_qna_event: we're inside QNA input");
+		LOG(Level::DEBUG, "View::handle_event: we're inside QNA input");
 		fa->handle_qna_event(event, is_inside_cmdline);
 
 		return true;
+	} else {
+		return fa->handle_event(event);
 	}
-	return false;
 }
 
 void View::handle_resize()

--- a/stfl/dialogs.stfl
+++ b/stfl/dialogs.stfl
@@ -6,13 +6,6 @@ vbox
   @info#style_colon_normal[hint-separator]:
   @info#style_desc_normal[hint-description]:
   @title#style_normal[title]:
-  @bind_up[bind_up]:
-  @bind_down[bind_down]:
-  @bind_page_up[bind_page_up]:
-  @bind_page_down[bind_page_down]:
-  @bind_home[bind_home]:
-  @bind_end[bind_end]:
-  @on_TAB:"TAB"
   label#title[title]
     text[head]:"Dialogs"
     .expand:h
@@ -44,8 +37,6 @@ vbox
     input[qnainput]
       modal:1
       .expand:h
-      @bind_home:**
-      @bind_end:**
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0

--- a/stfl/empty.stfl
+++ b/stfl/empty.stfl
@@ -19,8 +19,6 @@ vbox
     input[qnainput]
       modal:1
       .expand:h
-      @bind_home:**
-      @bind_end:**
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0

--- a/stfl/feedlist.stfl
+++ b/stfl/feedlist.stfl
@@ -6,15 +6,8 @@ vbox
   @info#style_colon_normal[hint-separator]:
   @info#style_desc_normal[hint-description]:
   @title#style_normal[title]:
-  @bind_up[bind_up]:
-  @bind_down[bind_down]:
-  @bind_page_up[bind_page_up]:
-  @bind_page_down[bind_page_down]:
-  @bind_home[bind_home]:
-  @bind_end[bind_end]:
   @style_unread_normal[listnormal_unread]:
   @style_unread_focus[listfocus_unread]:
-  @on_TAB:"TAB"
   label#title[title]
     text[head]:"Your feeds"
     .expand:h
@@ -46,8 +39,6 @@ vbox
     input[qnainput]
       modal:1
       .expand:h
-      @bind_home:**
-      @bind_end:**
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0

--- a/stfl/filebrowser.stfl
+++ b/stfl/filebrowser.stfl
@@ -6,13 +6,6 @@ vbox
   @info#style_colon_normal[hint-separator]:
   @info#style_desc_normal[hint-description]:
   @title#style_normal[title]:
-  @bind_up[bind_up]:
-  @bind_down[bind_down]:
-  @bind_page_up[bind_page_up]:
-  @bind_page_down[bind_page_down]:
-  @bind_home[bind_home]:
-  @bind_end[bind_end]:
-  @on_TAB:"TAB"
   label#title[title]
     text[head]:"File Browser"
     .expand:h
@@ -58,8 +51,6 @@ vbox
     input[qnainput]
       modal:1
       .expand:h
-      @bind_home:**
-      @bind_end:**
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0

--- a/stfl/filebrowser.stfl
+++ b/stfl/filebrowser.stfl
@@ -35,8 +35,8 @@ vbox
       .expand:0
     !input[filename]
       .expand:h
-      text[filenametext]:""
-      pos[filenametext_pos]:0
+      text[filename_value]:""
+      pos[filename_value_pos]:0
   vbox
     .expand:0
     .display[showhint]:1

--- a/stfl/help.stfl
+++ b/stfl/help.stfl
@@ -6,13 +6,6 @@
   @info#style_colon_normal[hint-separator]:
   @info#style_desc_normal[hint-description]:
   @title#style_normal[title]:
-  @bind_up[bind_up]:
-  @bind_down[bind_down]:
-  @bind_page_up[bind_page_up]:
-  @bind_page_down[bind_page_down]:
-  @bind_home[bind_home]:
-  @bind_end[bind_end]:
-  @on_TAB:"TAB"
   label#title[title]
     text[head]:"Help"
     .expand:h
@@ -44,8 +37,6 @@
     input[qnainput]
       modal:1
       .expand:h
-      @bind_home:**
-      @bind_end:**
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0

--- a/stfl/itemlist.stfl
+++ b/stfl/itemlist.stfl
@@ -6,15 +6,8 @@ vbox
   @info#style_colon_normal[hint-separator]:
   @info#style_desc_normal[hint-description]:
   @title#style_normal[title]:
-  @bind_up[bind_up]:
-  @bind_down[bind_down]:
-  @bind_page_up[bind_page_up]:
-  @bind_page_down[bind_page_down]:
-  @bind_home[bind_home]:
-  @bind_end[bind_end]:
   @style_unread_normal[listnormal_unread]:
   @style_unread_focus[listfocus_unread]:
-  @on_TAB:"TAB"
   label#title[title]
     text[head]:"Articles for '#'"
     .expand:h
@@ -46,8 +39,6 @@ vbox
     input[qnainput]
       modal:1
       .expand:h
-      @bind_home:**
-      @bind_end:**
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0

--- a/stfl/itemview.stfl
+++ b/stfl/itemview.stfl
@@ -6,13 +6,6 @@
   @info#style_colon_normal[hint-separator]:
   @info#style_desc_normal[hint-description]:
   @title#style_normal[title]:
-  @bind_up[bind_up]:
-  @bind_down[bind_down]:
-  @bind_page_up[bind_page_up]:
-  @bind_page_down[bind_page_down]:
-  @bind_home[bind_home]:
-  @bind_end[bind_end]:
-  @on_TAB:"TAB"
   label#title[title]
     text[head]:"Article '#'"
     .expand:h
@@ -49,8 +42,6 @@
     input[qnainput]
       modal:1
       .expand:h
-      @bind_home:**
-      @bind_end:**
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0

--- a/stfl/selecttag.stfl
+++ b/stfl/selecttag.stfl
@@ -6,13 +6,6 @@ vbox
   @info#style_colon_normal[hint-separator]:
   @info#style_desc_normal[hint-description]:
   @title#style_normal[title]:
-  @bind_up[bind_up]:
-  @bind_down[bind_down]:
-  @bind_page_up[bind_page_up]:
-  @bind_page_down[bind_page_down]:
-  @bind_home[bind_home]:
-  @bind_end[bind_end]:
-  @on_TAB:"TAB"
   label#title[title]
     text[head]:""
     .expand:h
@@ -44,8 +37,6 @@ vbox
     input[qnainput]
       modal:1
       .expand:h
-      @bind_home:**
-      @bind_end:**
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0

--- a/stfl/urlview.stfl
+++ b/stfl/urlview.stfl
@@ -6,13 +6,6 @@ vbox
   @info#style_colon_normal[hint-separator]:
   @info#style_desc_normal[hint-description]:
   @title#style_normal[title]:
-  @bind_up[bind_up]:
-  @bind_down[bind_down]:
-  @bind_page_up[bind_page_up]:
-  @bind_page_down[bind_page_down]:
-  @bind_home[bind_home]:
-  @bind_end[bind_end]:
-  @on_TAB:"TAB"
   label#title[title]
     text[head]:""
     .expand:h
@@ -44,8 +37,6 @@ vbox
     input[qnainput]
       modal:1
       .expand:h
-      @bind_home:**
-      @bind_end:**
       text[qna_value]:""
       pos[qna_value_pos]:0
       .display[show_qna_input]:0


### PR DESCRIPTION
This is another step in getting rid of our STFL dependency (https://github.com/newsboat/newsboat/issues/232)
It is quite a big change so I definitely want to postpone merging until after the upcoming release (and I'm planning to test this for a while on my regular Newsboat setup)

Follow up work  which I prefer doing in a separate PR:
- ~~Handle input directly in Podboat as well without depending on STFL for input~~ -> https://github.com/newsboat/newsboat/pull/3420
- Move input handling from `FormAction::handle_qna_event` to `LineEdit` (at least the ones which are purely text based and do not require `History` access)

Some relevant parts of STFL which we no longer depend on after this PR:
- waiting for input: https://github.com/newsboat/stfl/blob/bbb2404580e845df2556560112c8aefa27494d66/base.c#L532-L537 -> implemented in our `FormAction`
- translating input to event string: https://github.com/newsboat/stfl/blob/bbb2404580e845df2556560112c8aefa27494d66/binding.c#L30-L84 -> implemented in our `FormAction`
- single-line input processing: https://github.com/newsboat/stfl/blob/bbb2404580e845df2556560112c8aefa27494d66/widgets/wt_input.c#L114-L175 -> Implemented on Rust side in `lineedit.rs` (`handle_event`, `insert_at_cursor`) and C++ side in `lineedit.cpp` (`LineEdit::handle_event`)