### PR TITLE
Fix snap build by upgrade to core26

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -64,7 +64,7 @@ parts:
       - libxml2-16
       - librtmp1
       - locales-all
-      - libcurl4
+      - libcurl4t64
       - libstfl0
       - kitty-terminfo
       - ncurses-base

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: newsboat
 version: git
-base: core20
+base: core26
 summary: An RSS/Atom feed reader for text terminals
 description: |
   Newsboat is an RSS/Atom feed reader for the text console. It's an actively
@@ -53,7 +53,7 @@ parts:
       - gettext
       - g++
     stage-packages:
-      - libxml2
+      - libxml2-16
       - librtmp1
       - locales-all
       - libcurl4

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,10 +1,18 @@
 name: newsboat
+title: Newsboat
+license: MIT
 version: git
 base: core26
 summary: An RSS/Atom feed reader for text terminals
 description: |
   Newsboat is an RSS/Atom feed reader for the text console. It's an actively
   maintained fork of Newsbeuter.
+website: https://newsboat.org
+contact:
+  - https://github.com/newsboat/newsboat/issues
+  - newsboat@googlegroups.com
+issues: https://github.com/newsboat/newsboat/issues
+source-code: https://github.com/newsboat/newsboat
 grade: stable
 confinement: strict
 


### PR DESCRIPTION
Fixes #3391.

I already built new Snaps with these changes and they're being uploaded to the Snap Store as I'm writing this.