### PR TITLE
FileBrowser: Move current directory to separate STFL control

### DIFF
--- a/include/filebrowserformaction.h
+++ b/include/filebrowserformaction.h
@@ -1,6 +1,7 @@
 #ifndef NEWSBOAT_FILEBROWSERFORMACTION_H_
 #define NEWSBOAT_FILEBROWSERFORMACTION_H_
 
+#include <optional>
 #include <sys/stat.h>
 #include <grp.h>
 
@@ -27,6 +28,11 @@ public:
 	void set_default_filename(const Filepath& fn)
 	{
 		default_filename = fn;
+	}
+
+	std::optional<Filepath> get_result()
+	{
+		return result;
 	}
 
 	Dialog id() const override
@@ -67,7 +73,9 @@ private:
 	std::string get_formatted_filename(const Filepath& filename, mode_t mode);
 
 	Variant variant;
+	std::optional<Filepath> result;
 
+	LineView current_directory;
 	LineView file_prompt_line;
 	Filepath default_filename;
 

--- a/include/view.h
+++ b/include/view.h
@@ -34,8 +34,7 @@ public:
 	explicit View(Controller&);
 	~View();
 	int run();
-	std::string run_modal(std::shared_ptr<FormAction> f,
-		const std::string& value = "");
+	void run_modal(std::shared_ptr<FormAction> f);
 
 	void set_feedlist(std::vector<std::shared_ptr<RssFeed>> feeds);
 	void update_visible_feeds(std::vector<std::shared_ptr<RssFeed>> feeds);

--- a/src/filebrowserformaction.cpp
+++ b/src/filebrowserformaction.cpp
@@ -27,6 +27,7 @@ FileBrowserFormAction::FileBrowserFormAction(View& vv,
 	Variant variant)
 	: FormAction(vv, formstr, cfg)
 	, variant(variant)
+	, current_directory(f, "current_directory")
 	, file_prompt_line(f, "fileprompt")
 	, files_list("files", FormAction::f, cfg->get_configvalue_as_int("scrolloff"))
 	, view(vv)
@@ -41,8 +42,8 @@ bool FileBrowserFormAction::process_operation(Operation op,
 	case OP_OPEN: {
 		/*
 		 * whenever "ENTER" is hit, we need to distinguish two different cases:
-		 *   - focus on files list => add name of current entry to path and, in
-		 *     case of directory, enter the directory
+		 *   - focus on files list => in case of directory, enter directory.
+		 *     Otherwise, overwrite filename field with name of entry
 		 *   - focus on filename field => exit dialog and return filename
 		 */
 		LOG(Level::DEBUG, "FileBrowserFormAction: 'opening' item");
@@ -62,27 +63,11 @@ bool FileBrowserFormAction::process_operation(Operation op,
 					auto fn = utils::getcwd();
 					update_title(fn);
 
-					switch (variant) {
-					case Variant::FileSelection: {
-						const auto fnstr = Filepath::from_locale_string(f.get("filenametext")).file_name();
-						if (fnstr) {
-							fn.push(*fnstr);
-						}
-						set_value("filenametext", fn.to_locale_string());
-						break;
-					}
-					case Variant::DirectorySelection: {
-						const auto fn_with_trailing_slash = fn.join(Filepath{});
-						set_value("filenametext", fn_with_trailing_slash.to_locale_string());
-						break;
-					}
-					}
 					do_redraw = true;
 				}
 				break;
 				case file_system::FileType::RegularFile: {
-					const auto filename = utils::getcwd().join(selection.name);
-					set_value("filenametext", filename.to_locale_string());
+					set_value("filenametext", selection.name.to_locale_string());
 					f.set_focus("filename");
 				}
 				break;
@@ -91,29 +76,40 @@ bool FileBrowserFormAction::process_operation(Operation op,
 					break;
 				}
 			} else {
-				bool do_pop = true;
-				if (variant == Variant::FileSelection) {
-					std::string fn = f.get("filenametext");
-					struct stat sbuf;
-					/*
-					 * this check is very important, as people will
-					 * kill us if they accidentaly overwrote their
-					 * files with no further warning...
-					 */
-					if (::stat(fn.c_str(), &sbuf) != -1) {
-						f.set_focus("files");
-						if (v.confirm(
-								strprintf::fmt(
-									_("Do you really want to overwrite `%s' "
-										"(y:Yes n:No)? "),
-									fn),
-								_("yn")) == *_("n")) {
-							do_pop = false;
+				const std::string filename = f.get("filenametext");
+				if (variant == Variant::DirectorySelection) {
+					auto fn = utils::getcwd();
+					if (!filename.empty()) {
+						fn.push(Filepath::from_locale_string(filename));
+					}
+					result = fn;
+				} else {
+					if (!filename.empty()) {
+						auto fn = utils::getcwd();
+						fn.push(Filepath::from_locale_string(filename));
+						struct stat sbuf;
+						/*
+						 * this check is very important, as people will
+						 * kill us if they accidentaly overwrote their
+						 * files with no further warning...
+						 */
+						if (::stat(fn.to_locale_string().c_str(), &sbuf) != -1) {
+							f.set_focus("files");
+							if (v.confirm(
+									strprintf::fmt(
+										_("Do you really want to overwrite `%s' "
+											"(y:Yes n:No)? "),
+										fn),
+									_("yn")) == *_("y")) {
+								result = fn;
+							}
+							f.set_focus("filename");
+						} else {
+							result = fn;
 						}
-						f.set_focus("filenametext");
 					}
 				}
-				if (do_pop) {
+				if (result.has_value()) {
 					curs_set(0);
 					v.pop_current_formaction();
 				}
@@ -300,6 +296,7 @@ void FileBrowserFormAction::prepare()
 	 */
 	if (do_redraw) {
 		update_title(utils::getcwd());
+		current_directory.set_text(strprintf::fmt("(%s) ", utils::getcwd().to_locale_string()));
 
 		id_at_position.clear();
 		lines.clear();
@@ -347,7 +344,7 @@ void FileBrowserFormAction::init()
 
 	switch (variant) {
 	case Variant::FileSelection:
-		file_prompt_line.set_text(_("File: "));
+		file_prompt_line.set_text(_("Filename: "));
 		break;
 	case Variant::DirectorySelection:
 		file_prompt_line.set_text(_("Directory: "));
@@ -361,14 +358,9 @@ void FileBrowserFormAction::init()
 	const int status = ::chdir(save_path.to_locale_string().c_str());
 	LOG(Level::DEBUG, "view::filebrowser: chdir(%s) = %i", save_path, status);
 
-	std::string filenametext{};
-	switch (variant) {
-	case Variant::FileSelection:
+	std::string filenametext;
+	if (variant == Variant::FileSelection) {
 		filenametext = default_filename.to_locale_string();
-		break;
-	case Variant::DirectorySelection:
-		filenametext = save_path.to_locale_string();
-		break;
 	}
 
 	set_value("filenametext", filenametext);
@@ -383,8 +375,10 @@ void FileBrowserFormAction::init()
 
 std::vector<KeyMapHintEntry> FileBrowserFormAction::get_keymap_hint() const
 {
-	static const std::vector<KeyMapHintEntry> hints = {{OP_QUIT, _("Cancel")},
-		{OP_OPEN, _("Save")}
+	static const std::vector<KeyMapHintEntry> hints = {
+		{OP_QUIT, _("Cancel")},
+		{OP_OPEN, _("Save")},
+		{OP_SWITCH_FOCUS, _("Switch focus")},
 	};
 	return hints;
 }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -243,8 +243,7 @@ int View::run()
 	return EXIT_SUCCESS;
 }
 
-std::string View::run_modal(std::shared_ptr<FormAction> f,
-	const std::string& value)
+void View::run_modal(std::shared_ptr<FormAction> f)
 {
 	// Modal dialogs should not allow changing to a different dialog (except by
 	// closing the modal dialog)
@@ -324,12 +323,6 @@ std::string View::run_modal(std::shared_ptr<FormAction> f,
 				}
 			}
 		}
-	}
-
-	if (value.empty()) {
-		return "";
-	} else {
-		return f->get_value(value);
 	}
 }
 
@@ -649,11 +642,8 @@ std::optional<Filepath> View::run_filebrowser(const Filepath& default_filename)
 	apply_colors(filebrowser);
 	filebrowser->set_default_filename(default_filename);
 	filebrowser->set_parent_formaction(get_current_formaction());
-	const std::string res = run_modal(filebrowser, "filenametext");
-	if (res.empty()) {
-		return std::nullopt;
-	}
-	return Filepath::from_locale_string(res);
+	run_modal(filebrowser);
+	return filebrowser->get_result();
 }
 
 std::optional<Filepath> View::run_dirbrowser()
@@ -662,11 +652,8 @@ std::optional<Filepath> View::run_dirbrowser()
 			*this, filebrowser_str, cfg, FileBrowserFormAction::Variant::DirectorySelection);
 	apply_colors(dirbrowser);
 	dirbrowser->set_parent_formaction(get_current_formaction());
-	std::string res = run_modal(dirbrowser, "filenametext");
-	if (res.empty()) {
-		return std::nullopt;
-	}
-	return Filepath::from_locale_string(res);
+	run_modal(dirbrowser);
+	return dirbrowser->get_result();
 }
 
 std::string View::select_tag(const std::string& current_tag)
@@ -682,7 +669,7 @@ std::string View::select_tag(const std::string& current_tag)
 	selecttag->set_parent_formaction(get_current_formaction());
 	selecttag->set_tags(tags);
 	selecttag->set_selected_value(current_tag);
-	run_modal(selecttag, "");
+	run_modal(selecttag);
 	return selecttag->get_selected_value();
 }
 
@@ -694,7 +681,7 @@ std::string View::select_filter(const std::vector<FilterNameExprPair>& filters)
 	apply_colors(selecttag);
 	selecttag->set_parent_formaction(get_current_formaction());
 	selecttag->set_filters(filters);
-	run_modal(selecttag, "");
+	run_modal(selecttag);
 	return selecttag->get_selected_value();
 }
 

--- a/stfl/filebrowser.stfl
+++ b/stfl/filebrowser.stfl
@@ -30,6 +30,9 @@ vbox
     label
       .expand:0
       text[fileprompt]:""
+    label
+      text[current_directory]:""
+      .expand:0
     !input[filename]
       .expand:h
       text[filenametext]:""


### PR DESCRIPTION
Preparation for https://github.com/newsboat/newsboat/pull/3389 (to allow only editing the filename and thus avoiding editing of unsupported bytes/characters in existing directory names)

I expect this change will also make it easier to get rid of the changing of current working directory (which in turn would resolve - https://github.com/newsboat/newsboat/issues/1688)

<img width="917" height="613" alt="image" src="https://github.com/user-attachments/assets/4e7c553e-3705-4f47-93b5-0bcb7d4c3b3e" />
