### PR TITLE
Handle all input in Podboat itself

### DIFF
--- a/include/event.h
+++ b/include/event.h
@@ -1,0 +1,16 @@
+#ifndef NEWSBOAT_EVENT_H_
+#define NEWSBOAT_EVENT_H_
+
+#include <optional>
+#include <string>
+
+namespace newsboat {
+
+struct Event {
+	std::string name{};
+	std::optional<std::string> printableCharacter;
+};
+
+} // namespace newsboat
+
+#endif /* NEWSBOAT_EVENT_H_ */

--- a/include/stflpp.h
+++ b/include/stflpp.h
@@ -7,6 +7,8 @@ extern "C" {
 
 #include <string>
 
+#include "event.h"
+
 namespace newsboat {
 
 class Stfl {
@@ -26,6 +28,10 @@ public:
 		Form& operator=(Form&&) = delete;
 
 		std::string run(int timeout);
+		void draw_form();
+		void recalculate_widget_dimensions();
+
+		Event wait_for_event(int timeout);
 
 		std::string get(const std::string& name);
 		void set(const std::string& name, const std::string& value);
@@ -41,6 +47,10 @@ public:
 			const std::string& text);
 
 	private:
+		std::string convert(std::wstring input);
+		std::string key_to_string(wint_t wch);
+		std::string function_key_to_string(wint_t wch);
+
 		stfl_form* f;
 		stfl_ipool* ipool;
 	};

--- a/src/formaction.cpp
+++ b/src/formaction.cpp
@@ -120,7 +120,7 @@ void FormAction::set_status(const std::string& text)
 
 void FormAction::draw_form()
 {
-	f.run(-1);
+	f.draw_form();
 }
 
 std::string FormAction::draw_form_wait_for_event(unsigned int timeout)
@@ -130,7 +130,7 @@ std::string FormAction::draw_form_wait_for_event(unsigned int timeout)
 
 void FormAction::recalculate_widget_dimensions()
 {
-	f.run(-3);
+	f.recalculate_widget_dimensions();
 }
 
 void FormAction::start_cmdline(std::string default_value)

--- a/src/pbview.cpp
+++ b/src/pbview.cpp
@@ -50,7 +50,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 	bool quit = false;
 
 	// Make sure curses is initialized
-	dllist_form.run(-3);
+	dllist_form.recalculate_widget_dimensions();
 	// Hide cursor using curses
 	curs_set(0);
 
@@ -85,7 +85,7 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			const std::string line_format =
 				ctrl.get_cfgcont()->get_configvalue("podlist-format");
 
-			dllist_form.run(-3); // compute all widget dimensions
+			dllist_form.recalculate_widget_dimensions(); // compute all widget dimensions
 
 			auto render_line = [this, line_format](std::uint32_t line,
 			std::uint32_t width) -> StflRichText {
@@ -105,7 +105,8 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			msg_line_dllist_form.set_text(ctrl.downloads()[idx].status_msg());
 		}
 
-		const auto event = dllist_form.run(500);
+		dllist_form.draw_form();
+		const auto event = dllist_form.wait_for_event(500);
 
 		if (auto_download) {
 			if (ctrl.get_maxdownloads() >
@@ -114,16 +115,16 @@ void PbView::run(bool auto_download, bool wrap_scroll)
 			}
 		}
 
-		if (event.empty() || event == "TIMEOUT") {
+		if (event.name.empty() || event.name == "TIMEOUT") {
 			continue;
 		}
 
-		if (event == "RESIZE") {
+		if (event.name == "RESIZE") {
 			handle_resize();
 			continue;
 		}
 
-		const auto key_combination = KeyCombination::from_bindkey(event);
+		const auto key_combination = KeyCombination::from_bindkey(event.name);
 		if (key_combination == KeyCombination("ESC") && !key_sequence.empty()) {
 			key_sequence.clear();
 		} else {
@@ -303,7 +304,7 @@ void PbView::handle_resize()
 {
 	std::vector<std::reference_wrapper<newsboat::Stfl::Form>> forms = {dllist_form, help_form};
 	for (const auto& form : forms) {
-		form.get().run(-3);
+		form.get().recalculate_widget_dimensions();
 	}
 	update_view = true;
 }
@@ -354,17 +355,18 @@ void PbView::run_help()
 
 	std::vector<KeyCombination> key_sequence;
 	do {
-		const auto event = help_form.run(0);
-		if (event.empty()) {
+		help_form.draw_form();
+		const auto event = help_form.wait_for_event(0);
+		if (event.name.empty() || event.name == "TIMEOUT") {
 			continue;
 		}
 
-		if (event == "RESIZE") {
+		if (event.name == "RESIZE") {
 			handle_resize();
 			continue;
 		}
 
-		const auto key_combination = KeyCombination::from_bindkey(event);
+		const auto key_combination = KeyCombination::from_bindkey(event.name);
 		if (key_combination == KeyCombination("ESC") && !key_sequence.empty()) {
 			key_sequence.clear();
 		} else {

--- a/src/stflpp.cpp
+++ b/src/stflpp.cpp
@@ -3,6 +3,7 @@
 #include <cerrno>
 #include <langinfo.h>
 #include <mutex>
+#include <ncurses.h>
 
 #include "exception.h"
 #include "logger.h"
@@ -51,6 +52,85 @@ std::string Stfl::Form::run(int timeout)
 		return "";
 	}
 }
+
+void Stfl::Form::draw_form()
+{
+	run(-1);
+}
+
+void Stfl::Form::recalculate_widget_dimensions()
+{
+	run(-3);
+}
+
+std::string Stfl::Form::convert(std::wstring input)
+{
+	const auto output = stfl_ipool_fromwc(ipool, input.c_str());
+	return output == nullptr ? "" : std::string{output};
+}
+
+std::string Stfl::Form::key_to_string(wint_t wch)
+{
+	switch (wch) {
+	case '\r':
+	case '\n':
+		return "ENTER";
+	case ' ':
+		return "SPACE";
+	case '\t':
+		return "TAB";
+	case 27:
+		return "ESC";
+	case 127:
+		return "BACKSPACE";
+	}
+	if (wch < 32) {
+		return keyname(wch);
+	} else {
+		std::wstring key{static_cast<wchar_t>(wch)};
+		return convert(key);
+	}
+}
+
+std::string Stfl::Form::function_key_to_string(wint_t wch)
+{
+	if (wch >= KEY_F(0) && wch <= KEY_F(63)) {
+		return strprintf::fmt("F%u", wch - KEY_F0);
+	}
+	const std::string name = keyname(wch);
+	if (name.substr(0, 4) == "KEY_") {
+		// Drop "KEY_" prefix from name
+		return name.substr(4);
+	} else {
+		return name;
+	}
+}
+
+Event Stfl::Form::wait_for_event(int timeout)
+{
+	wtimeout(stdscr, timeout == 0 ? -1 : timeout);
+
+	wint_t wch{};
+	const auto rc = wget_wch(stdscr, &wch);
+	LOG(Level::DEBUG, "wait_for_event: wget_wch: rc: %d, wch: %u", rc, wch);
+	Event event;
+	if (rc == ERR) {
+		event = {"TIMEOUT", std::nullopt};
+	} else if (rc == KEY_CODE_YES) {
+		event = {function_key_to_string(wch), std::nullopt};
+	} else {
+		std::optional<std::string> printableCharacter{};
+		if (iswprint(wch)) {
+			std::wstring key{static_cast<wchar_t>(wch)};
+			printableCharacter = convert(key);
+		}
+		event = {key_to_string(wch), printableCharacter};
+	}
+	LOG(Level::DEBUG, "wait_for_event: event: %s (printable character: %s)", event.name,
+		event.printableCharacter.has_value() ? "yes" : "no");
+	return event;
+}
+
 
 std::string Stfl::Form::get(const std::string& name)
 {

--- a/stfl/dllist.stfl
+++ b/stfl/dllist.stfl
@@ -6,13 +6,6 @@ vbox
   @info#style_colon_normal[hint-separator]:
   @info#style_desc_normal[hint-description]:
   @title#style_normal[title]:
-  @bind_up[bind_up]:
-  @bind_down[bind_down]:
-  @bind_page_up[bind_page_up]:
-  @bind_page_down[bind_page_down]:
-  @bind_home[bind_home]:
-  @bind_end[bind_end]:
-  @on_TAB:"TAB"
   label#title[title]
     text[head]:"Queue"
     .expand:h


### PR DESCRIPTION
I've taken the implementation from https://github.com/newsboat/newsboat/pull/3389 and made some small changes:
- Moved the `wait_for_event` and input key parsing from `FormAction` into `Stfl::Form` as Podboat does not use `FormAction`
- Added support for `timeout == 0` which is used in Podboat to wait forever (handling in stfl: [base.c line 532](https://github.com/newsboat/stfl/blob/bbb2404580e845df2556560112c8aefa27494d66/base.c#L532))

I intend to merge this directly as the changes were already reviewed in the linked PR.
The only reason the other PR is not yet merged is because of encoding issues around the new `LineEdit` implementation, but Podboat does not contain a text input field.