### PR TITLE
Introduce `list{normal,focus}_deleted` highlight groups

### DIFF
--- a/doc/chapter-configuration.asciidoc
+++ b/doc/chapter-configuration.asciidoc
@@ -357,6 +357,8 @@ Currently, the following elements are supported:
 - `listfocus`: the currently selected list item
 - `listnormal_unread`: an unread list item
 - `listfocus_unread`: the currently selected unread list item
+- `listnormal_deleted`: a deleted article-list item
+- `listfocus_deleted`: the currently selected deleted article-list item
 - `title` (_added in 2.25_): current dialog's title, which is usually at the
   top of the screen (but see <<show-title-bar,`show-title-bar`>> and
   <<swap-title-and-hints,`swap-title-and-hints`>>). If you don't specify
@@ -385,6 +387,8 @@ The default color configuration of Newsboat looks like this:
 	color listfocus           yellow  blue   bold
 	color listnormal_unread   white   black  bold
 	color listfocus_unread    yellow  blue   bold
+	color listnormal_deleted  white   black
+	color listfocus_deleted   yellow  blue   bold
 	color title               yellow  blue   bold
 	color info                yellow  blue   bold
 	color hint-key            yellow  blue   bold

--- a/rust/libnewsboat/src/colormanager.rs
+++ b/rust/libnewsboat/src/colormanager.rs
@@ -32,6 +32,14 @@ static DEFAULT_STYLES: LazyLock<HashMap<&str, TextStyle>> = LazyLock::new(|| {
             TextStyle::from("yellow", "blue", &["bold"]).unwrap(),
         ),
         (
+            "listnormal_deleted",
+            TextStyle::from("default", "default", &[]).unwrap(),
+        ),
+        (
+            "listfocus_deleted",
+            TextStyle::from("yellow", "blue", &["bold"]).unwrap(),
+        ),
+        (
             "info",
             TextStyle::from("yellow", "blue", &["bold"]).unwrap(),
         ),
@@ -112,6 +120,8 @@ impl ColorManager {
 
     fn style_fallback(element: &str) -> Option<&str> {
         match element {
+            "listnormal_deleted" => Some("listnormal"),
+            "listfocus_deleted" => Some("listfocus"),
             "title" => Some("info"),
             "hint-key" => Some("info"),
             "hint-keys-delimiter" => Some("info"),

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -1180,9 +1180,12 @@ StflRichText ItemListFormAction::item2formatted_line(const ItemPtrPosPair& item,
 	fmt.register_fmt('L', item.first->length());
 
 	const auto formattedLine = fmt.do_format(itemlist_format, width);
-	auto stflFormattedLine = item.first->unread() > 0
-		? StflRichText::from_plaintext_with_style(formattedLine, "<unread>")
-		: StflRichText::from_plaintext(formattedLine);
+	auto stflFormattedLine = StflRichText::from_plaintext(formattedLine);
+	if (item.first->deleted()) {
+		stflFormattedLine.apply_style_tag("<deleted>", 0, formattedLine.length());
+	} else if (item.first->unread()) {
+		stflFormattedLine.apply_style_tag("<unread>", 0, formattedLine.length());
+	}
 
 	const int id = rxman.article_matches(item.first.get());
 	if (id != -1) {

--- a/stfl/itemlist.stfl
+++ b/stfl/itemlist.stfl
@@ -8,6 +8,8 @@ vbox
   @title#style_normal[title]:
   @style_unread_normal[listnormal_unread]:
   @style_unread_focus[listfocus_unread]:
+  @style_deleted_normal[listnormal_deleted]:
+  @style_deleted_focus[listfocus_deleted]:
   label#title[title]
     text[head]:"Articles for '#'"
     .expand:h

--- a/test/colormanager.cpp
+++ b/test/colormanager.cpp
@@ -20,6 +20,8 @@ TEST_CASE(
 	SECTION("Each processed action adds corresponding entry to return value") {
 		c.handle_action("color", {"listnormal", "default", "default"});
 		c.handle_action("color", {"listfocus_unread", "cyan", "default", "bold", "underline"});
+		c.handle_action("color", {"listnormal_deleted", "red", "default", "dim"});
+		c.handle_action("color", {"listfocus_deleted", "red", "default", "reverse"});
 		c.handle_action("color", {"background", "red", "yellow"});
 		c.handle_action("color", {"info", "green", "white", "reverse"});
 		c.handle_action("color", {"end-of-text-marker", "color123", "default", "dim", "protect"});
@@ -30,6 +32,8 @@ TEST_CASE(
 
 		REQUIRE(styles.at("listnormal") == "");
 		REQUIRE(styles.at("listfocus_unread") == "fg=cyan,attr=bold,attr=underline");
+		REQUIRE(styles.at("listnormal_deleted") == "fg=red,attr=dim");
+		REQUIRE(styles.at("listfocus_deleted") == "fg=red,attr=reverse");
 		REQUIRE(styles.at("background") == "fg=red,bg=yellow");
 		REQUIRE(styles.at("info") == "fg=green,bg=white,attr=reverse");
 		REQUIRE(styles.at("title") == "fg=green,bg=white,attr=reverse");


### PR DESCRIPTION
Hey everybody,

I would very much like to do something about https://github.com/newsboat/newsboat/issues/1854, but I think I'll start with something a lot more modest.
Here's a patch introducing highlighting for the *deleted* items (before purging).

I set its default colours so as to not disrupt anybody's preexisting set-up, and documented them after the corresponding `list{normal,focus}_unread` entries, though with a small addendum of specifying "article-list item" instead of (implied any) item.

Thanks for this fantastic tool!