### PR TITLE
UrlReader: Combine `urls` and `tags` into single storage

### DIFF
--- a/include/feedhqapi.h
+++ b/include/feedhqapi.h
@@ -21,7 +21,6 @@ public:
 		const std::string& guid) override;
 
 private:
-	std::vector<std::string> get_tags(xmlNode* node);
 	std::string get_new_token();
 	std::string retrieve_auth();
 	std::string post_content(const std::string& url,

--- a/include/freshrssapi.h
+++ b/include/freshrssapi.h
@@ -28,7 +28,6 @@ public:
 	rsspp::Feed fetch_feed(const std::string& id, CurlHandle& cached_handle);
 
 private:
-	std::vector<std::string> get_tags(xmlNode* node);
 	std::string get_new_token();
 	bool refresh_token();
 	std::string retrieve_auth();

--- a/include/inoreaderapi.h
+++ b/include/inoreaderapi.h
@@ -21,7 +21,6 @@ public:
 		const std::string& guid);
 
 private:
-	std::vector<std::string> get_tags(xmlNode* node);
 	std::string retrieve_auth();
 	std::string post_content(const std::string& url,
 		const std::string& postdata);

--- a/include/oldreaderapi.h
+++ b/include/oldreaderapi.h
@@ -21,7 +21,6 @@ public:
 		const std::string& guid) override;
 
 private:
-	std::vector<std::string> get_tags(xmlNode* node);
 	std::string get_new_token();
 	std::string retrieve_auth();
 	std::string post_content(const std::string& url,

--- a/include/urlreader.h
+++ b/include/urlreader.h
@@ -1,7 +1,6 @@
 #ifndef NEWSBOAT_URLREADER_H_
 #define NEWSBOAT_URLREADER_H_
 
-#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -15,6 +14,12 @@ namespace newsboat {
 /// \brief Base class for classes that supply Newsboat with feed URLs.
 class UrlReader {
 public:
+	struct FeedUrl {
+		std::string url;
+		FeedOrigin origin;
+		std::vector<std::string> tags;
+	};
+
 	UrlReader() = default;
 	virtual ~UrlReader() = default;
 
@@ -32,7 +37,7 @@ public:
 	virtual std::string get_source() const = 0;
 
 	/// \brief A list of feed URLs with their origin
-	const std::vector<std::pair<std::string, FeedOrigin>>& get_urls() const;
+	const std::vector<UrlReader::FeedUrl>& get_urls() const;
 
 	/// \brief Tags of feed that has url `url`.
 	std::vector<std::string>& get_tags(const std::string& url);
@@ -43,8 +48,7 @@ public:
 protected:
 	void load_query_urls_from_file(Filepath file);
 
-	std::vector<std::pair<std::string, FeedOrigin>> urls;
-	std::map<std::string, std::vector<std::string>> tags;
+	std::vector<FeedUrl> feed_urls;
 };
 
 } // namespace newsboat

--- a/include/urlreader.h
+++ b/include/urlreader.h
@@ -36,11 +36,12 @@ public:
 	/// Tiny RSS").
 	virtual std::string get_source() const = 0;
 
-	/// \brief A list of feed URLs with their origin
+	/// \brief A list of feed URLs with their origin and tags
 	const std::vector<UrlReader::FeedUrl>& get_urls() const;
 
-	/// \brief Tags of feed that has url `url`.
-	std::vector<std::string>& get_tags(const std::string& url);
+	/// \brief Get entry of feed that has url `url`
+	/// (or nullptr if it does not exist)
+	FeedUrl* get_entry(const std::string& url);
 
 	/// \brief List of all extant tags.
 	std::vector<std::string> get_alltags() const;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -453,16 +453,16 @@ int Controller::run(const CliArgsParser& args)
 	std::cout.flush();
 
 	unsigned int i = 0;
-	for (const auto& [url, origin] : urlcfg->get_urls()) {
+	for (const auto& feed_url : urlcfg->get_urls()) {
 		try {
 			bool ignore_disp =
 				(cfg.get_configvalue("ignore-mode") ==
 					"display");
 			std::shared_ptr<RssFeed> feed =
 				rsscache->internalize_rssfeed(
-					url, ignore_disp ? &ign : nullptr);
-			feed->set_origin(origin);
-			feed->set_tags(urlcfg->get_tags(url));
+					feed_url.url, ignore_disp ? &ign : nullptr);
+			feed->set_origin(feed_url.origin);
+			feed->set_tags(feed_url.tags);
 			feed->set_order(i);
 			feedcontainer.add_feed(feed);
 		} catch (const DbException& e) {
@@ -472,9 +472,8 @@ int Controller::run(const CliArgsParser& args)
 			return EXIT_FAILURE;
 		} catch (const std::string& str) {
 			std::cerr << strprintf::fmt(
-					_("Error while loading feed '%s': "
-						"%s"),
-					url,
+					_("Error while loading feed '%s': %s"),
+					feed_url.url,
 					str)
 				<< std::endl;
 			return EXIT_FAILURE;
@@ -829,11 +828,11 @@ void Controller::reload_urls_file()
 	std::vector<std::shared_ptr<RssFeed>> new_feeds;
 	unsigned int i = 0;
 
-	for (const auto& [url, origin] : urlcfg->get_urls()) {
-		const auto feed = feedcontainer.get_feed_by_url(url);
+	for (const auto& feed_url : urlcfg->get_urls()) {
+		const auto feed = feedcontainer.get_feed_by_url(feed_url.url);
 		if (feed) {
-			feed->set_origin(origin);
-			feed->set_tags(urlcfg->get_tags(url));
+			feed->set_origin(feed_url.origin);
+			feed->set_tags(urlcfg->get_tags(feed_url.url));
 			feed->set_order(i);
 			new_feeds.push_back(feed);
 		} else {
@@ -842,10 +841,10 @@ void Controller::reload_urls_file()
 					(cfg.get_configvalue("ignore-mode") ==
 						"display");
 				std::shared_ptr<RssFeed> new_feed =
-					rsscache->internalize_rssfeed(url,
+					rsscache->internalize_rssfeed(feed_url.url,
 						ignore_disp ? &ign : nullptr);
-				new_feed->set_origin(origin);
-				new_feed->set_tags(urlcfg->get_tags(url));
+				new_feed->set_origin(feed_url.origin);
+				new_feed->set_tags(feed_url.tags);
 				new_feed->set_order(i);
 				new_feeds.push_back(new_feed);
 			} catch (const DbException& e) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -710,7 +710,10 @@ void Controller::replace_feed(RssFeed& oldfeed, RssFeed& newfeed, unsigned int p
 	LOG(Level::DEBUG,
 		"Controller::replace_feed: after internalize_rssfeed");
 
-	feed->set_tags(urlcfg->get_tags(oldfeed.rssurl()));
+	auto* feed_url = urlcfg->get_entry(oldfeed.rssurl());
+	if (feed_url != nullptr) {
+		feed->set_tags(feed_url->tags);
+	}
 	feed->set_order(oldfeed.get_order());
 	feedcontainer.replace_feed(pos, feed);
 
@@ -832,7 +835,7 @@ void Controller::reload_urls_file()
 		const auto feed = feedcontainer.get_feed_by_url(feed_url.url);
 		if (feed) {
 			feed->set_origin(feed_url.origin);
-			feed->set_tags(urlcfg->get_tags(feed_url.url));
+			feed->set_tags(feed_url.tags);
 			feed->set_order(i);
 			new_feeds.push_back(feed);
 		} else {

--- a/src/feedhqurlreader.cpp
+++ b/src/feedhqurlreader.cpp
@@ -27,38 +27,25 @@ FeedHqUrlReader::~FeedHqUrlReader() {}
 #define SHARED_ITEMS_URL \
 	"http://feedhq.org/reader/atom/user/-/state/com.google/broadcast"
 
-#define ADD_URL(url, caption)                 \
-	do {                                  \
-		tmptags.clear();              \
-		urls.push_back({(url), FeedOrigin{}});        \
-		tmptags.push_back((caption)); \
-		tags[(url)] = tmptags;        \
-	} while (0)
-
 std::optional<utils::ReadTextFileError> FeedHqUrlReader::reload()
 {
-	urls.clear();
-	tags.clear();
+	feed_urls.clear();
 
 	if (cfg->get_configvalue_as_bool("feedhq-show-special-feeds")) {
-		std::vector<std::string> tmptags;
-		ADD_URL(BROADCAST_FRIENDS_URL,
-			std::string("~") + _("People you follow"));
-		ADD_URL(STARRED_ITEMS_URL,
-			std::string("~") + _("Starred items"));
-		ADD_URL(SHARED_ITEMS_URL, std::string("~") + _("Shared items"));
+		feed_urls.emplace_back(FeedUrl{BROADCAST_FRIENDS_URL, FeedOrigin{}, {std::string("~") + _("People you follow")}});
+		feed_urls.emplace_back(FeedUrl{STARRED_ITEMS_URL, FeedOrigin{}, {std::string("~") + _("Starred items")}});
+		feed_urls.emplace_back(FeedUrl{SHARED_ITEMS_URL, FeedOrigin{}, {std::string("~") + _("Shared items")}});
 	}
 
 	load_query_urls_from_file(file);
 
-	std::vector<TaggedFeedUrl> feedurls = api->get_subscribed_urls();
-	for (const auto& tagged : feedurls) {
+	std::vector<TaggedFeedUrl> subscribed_urls = api->get_subscribed_urls();
+	for (const auto& tagged : subscribed_urls) {
 		std::string url = tagged.first;
 		std::vector<std::string> url_tags = tagged.second;
 
 		LOG(Level::DEBUG, "added %s to URL list", url);
-		urls.push_back({url, FeedOrigin{}});
-		tags[tagged.first] = url_tags;
+		feed_urls.emplace_back(FeedUrl{url, FeedOrigin{}, url_tags});
 		for (const auto& tag : url_tags) {
 			LOG(Level::DEBUG, "%s: added tag %s", url, tag);
 		}

--- a/src/fileurlreader.cpp
+++ b/src/fileurlreader.cpp
@@ -2,8 +2,6 @@
 
 #include <cstring>
 #include <fstream>
-#include <unordered_map>
-#include <set>
 #include <vector>
 #include <iostream>
 
@@ -28,14 +26,12 @@ std::string FileUrlReader::get_source() const
 void FileUrlReader::add_url(const std::string& url,
 	const std::vector<std::string>& url_tags)
 {
-	urls.push_back({url, FeedOrigin{}});
-	tags[url] = url_tags;
+	feed_urls.emplace_back(FeedUrl{url, FeedOrigin{}, url_tags});
 }
 
 std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 {
-	urls.clear();
-	tags.clear();
+	feed_urls.clear();
 
 	auto result = utils::read_text_file(filename);
 	if (!result) {
@@ -57,17 +53,15 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 			continue;
 		}
 
-		std::string url = tokens[0];
-		auto it = std::find_if(urls.begin(), urls.end(),
-		[&url](const std::pair<std::string, FeedOrigin>& u) {
-			return u.first == url;
+		const std::string url = tokens[0];
+		tokens.erase(tokens.begin());
+
+		auto it = std::find_if(feed_urls.begin(), feed_urls.end(),
+		[&url](const FeedUrl& u) {
+			return u.url == url;
 		});
-		if (it == urls.end()) {
-			urls.push_back({url, FeedOrigin{FileOrigin{line_number}}});
-			tokens.erase(tokens.begin());
-			if (!tokens.empty()) {
-				tags[url] = tokens;
-			}
+		if (it == feed_urls.end()) {
+			feed_urls.emplace_back(FeedUrl{url, FeedOrigin{FileOrigin{line_number}}, tokens});
 		} else {
 			std::string warn_msg = strprintf::fmt(
 					_("Warning: Duplicate URL found: %s. Merging tags."),
@@ -76,12 +70,9 @@ std::optional<utils::ReadTextFileError> FileUrlReader::reload()
 			LOG(Level::USERERROR, warn_msg.c_str());
 			std::cerr << warn_msg << std::endl;
 
-			tokens.erase(tokens.begin());
 			for (const std::string& tag : tokens) {
-				if (std::find(tags[url].begin(),
-						tags[url].end(),
-						tag) == tags[url].end()) {
-					tags[url].push_back(tag);
+				if (std::find(it->tags.begin(), it->tags.end(), tag) == it->tags.end()) {
+					it->tags.push_back(tag);
 				}
 			}
 		}
@@ -102,19 +93,17 @@ std::optional<std::string> FileUrlReader::write_config()
 	}
 
 	std::size_t line_number = 0;
-	for (auto& [url, origin] : urls) {
+	for (auto& feed_url : feed_urls) {
 		line_number++;
-		f << utils::quote_if_necessary(url);
-		if (tags[url].size() > 0) {
-			for (const auto& tag : tags[url]) {
-				f << " \"" << tag << "\"";
-			}
+		f << utils::quote_if_necessary(feed_url.url);
+		for (const auto& tag : feed_url.tags) {
+			f << " \"" << tag << "\"";
 		}
 		f << std::endl;
 
 		// Update origin as writing to urls file might remove comments and empty lines,
 		// resulting in URLs ending up at different line numbers
-		origin = FeedOrigin{FileOrigin{line_number}};
+		feed_url.origin = FeedOrigin{FileOrigin{line_number}};
 	}
 
 	return {};

--- a/src/freshrssurlreader.cpp
+++ b/src/freshrssurlreader.cpp
@@ -21,16 +21,12 @@ FreshRssUrlReader::~FreshRssUrlReader() {}
 
 std::optional<utils::ReadTextFileError> FreshRssUrlReader::reload()
 {
-	urls.clear();
-	tags.clear();
+	feed_urls.clear();
 
 	if (cfg->get_configvalue_as_bool("freshrss-show-special-feeds")) {
-		std::vector<std::string> tmptags;
 		const std::string star_url = cfg->get_configvalue("freshrss-url") +
 			"/reader/api/0/stream/contents/user/-/state/com.google/starred";
-		urls.push_back({star_url, FeedOrigin{}});
-		tmptags.push_back(std::string("~") + _("Starred items"));
-		tags[star_url] = tmptags;
+		feed_urls.emplace_back(FeedUrl{star_url, FeedOrigin{}, {std::string("~") + _("Starred items")}});
 	}
 
 	load_query_urls_from_file(file);
@@ -41,8 +37,7 @@ std::optional<utils::ReadTextFileError> FreshRssUrlReader::reload()
 		std::vector<std::string> url_tags = tagged.second;
 
 		LOG(Level::DEBUG, "added %s to URL list", url);
-		urls.push_back({url, FeedOrigin{}});
-		tags[tagged.first] = url_tags;
+		feed_urls.emplace_back(FeedUrl{url, FeedOrigin{}, url_tags});
 		for (const auto& tag : url_tags) {
 			LOG(Level::DEBUG, "%s: added tag %s", url, tag);
 		}

--- a/src/inoreaderurlreader.cpp
+++ b/src/inoreaderurlreader.cpp
@@ -29,37 +29,23 @@ InoreaderUrlReader::~InoreaderUrlReader() {}
 	"http://inoreader.com/reader/atom/user/-/state/com.google/" \
 	"saved-web-pages"
 
-#define ADD_URL(url, caption)                 \
-	do {                                  \
-		tmptags.clear();              \
-		urls.push_back({(url), FeedOrigin{}});        \
-		tmptags.push_back((caption)); \
-		tags[(url)] = tmptags;        \
-	} while (0)
-
 std::optional<utils::ReadTextFileError> InoreaderUrlReader::reload()
 {
-	urls.clear();
-	tags.clear();
+	feed_urls.clear();
 
 	if (cfg->get_configvalue_as_bool("inoreader-show-special-feeds")) {
-		std::vector<std::string> tmptags;
-		ADD_URL(STARRED_ITEMS_URL,
-			std::string("~") + _("Starred items"));
-		ADD_URL(BROADCAST_ITEMS_URL,
-			std::string("~") + _("Broadcast items"));
-		ADD_URL(LIKED_ITEMS_URL, std::string("~") + _("Liked items"));
-		ADD_URL(SAVED_WEB_PAGES_ITEMS_URL,
-			std::string("~") + _("Saved web pages"));
+		feed_urls.emplace_back(FeedUrl{STARRED_ITEMS_URL, FeedOrigin{}, {std::string("~") + _("Starred items")}});
+		feed_urls.emplace_back(FeedUrl{BROADCAST_ITEMS_URL, FeedOrigin{}, {std::string("~") + _("Broadcast items")}});
+		feed_urls.emplace_back(FeedUrl{LIKED_ITEMS_URL, FeedOrigin{}, {std::string("~") + _("Liked items")}});
+		feed_urls.emplace_back(FeedUrl{SAVED_WEB_PAGES_ITEMS_URL, FeedOrigin{}, {std::string("~") + _("Saved web pages")}});
 	}
 
 	load_query_urls_from_file(file);
 
-	std::vector<TaggedFeedUrl> feedurls = api->get_subscribed_urls();
-	for (const auto& url : feedurls) {
+	std::vector<TaggedFeedUrl> subscribed_urls = api->get_subscribed_urls();
+	for (const auto& url : subscribed_urls) {
 		LOG(Level::DEBUG, "added %s to URL list", url.first);
-		urls.push_back({url.first, FeedOrigin{}});
-		tags[url.first] = url.second;
+		feed_urls.push_back(FeedUrl{url.first, FeedOrigin{}, url.second});
 		for (const auto& tag : url.second) {
 			LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);
 		}

--- a/src/minifluxurlreader.cpp
+++ b/src/minifluxurlreader.cpp
@@ -21,26 +21,19 @@ MinifluxUrlReader::~MinifluxUrlReader() {}
 
 std::optional<utils::ReadTextFileError> MinifluxUrlReader::reload()
 {
-	urls.clear();
-	tags.clear();
+	feed_urls.clear();
 
 	if (cfg->get_configvalue_as_bool("miniflux-show-special-feeds")) {
-		std::vector<std::string> tmptags;
-		const std::string star_url = "starred";
-		urls.push_back({star_url, FeedOrigin{}});
-		std::string star_tag = std::string("~") + _("Starred items");
-		tmptags.push_back(star_tag);
-		tags[star_url] = tmptags;
+		feed_urls.emplace_back(FeedUrl{"starred", FeedOrigin{}, {std::string("~") + _("Starred items")}});
 	}
 
 	load_query_urls_from_file(file);
 
-	const std::vector<TaggedFeedUrl> feedurls = api->get_subscribed_urls();
+	const std::vector<TaggedFeedUrl> subscribed_urls = api->get_subscribed_urls();
 
-	for (const auto& url : feedurls) {
+	for (const auto& url : subscribed_urls) {
 		LOG(Level::INFO, "added %s to URL list", url.first);
-		urls.push_back({url.first, FeedOrigin{}});
-		tags[url.first] = url.second;
+		feed_urls.emplace_back(FeedUrl{url.first, FeedOrigin{}, url.second});
 		for (const auto& tag : url.second) {
 			LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);
 		}

--- a/src/oldreaderurlreader.cpp
+++ b/src/oldreaderurlreader.cpp
@@ -28,26 +28,14 @@ OldReaderUrlReader::~OldReaderUrlReader() {}
 	"https://theoldreader.com/reader/atom/user/-/state/com.google/" \
 	"broadcast"
 
-#define ADD_URL(url, caption)                 \
-	do {                                  \
-		tmptags.clear();              \
-		urls.push_back({(url), FeedOrigin{}});        \
-		tmptags.push_back((caption)); \
-		tags[(url)] = tmptags;        \
-	} while (0)
-
 std::optional<utils::ReadTextFileError> OldReaderUrlReader::reload()
 {
-	urls.clear();
-	tags.clear();
+	feed_urls.clear();
 
 	if (cfg->get_configvalue_as_bool("oldreader-show-special-feeds")) {
-		std::vector<std::string> tmptags;
-		ADD_URL(BROADCAST_FRIENDS_URL,
-			std::string("~") + _("People you follow"));
-		ADD_URL(STARRED_ITEMS_URL,
-			std::string("~") + _("Starred items"));
-		ADD_URL(SHARED_ITEMS_URL, std::string("~") + _("Shared items"));
+		feed_urls.emplace_back(FeedUrl{BROADCAST_FRIENDS_URL, FeedOrigin{}, {std::string("~") + _("People you follow")}});
+		feed_urls.emplace_back(FeedUrl{STARRED_ITEMS_URL, FeedOrigin{}, {std::string("~") + _("Starred items")}});
+		feed_urls.emplace_back(FeedUrl{SHARED_ITEMS_URL, FeedOrigin{}, {std::string("~") + _("Shared items")}});
 	}
 
 	load_query_urls_from_file(file);
@@ -55,8 +43,7 @@ std::optional<utils::ReadTextFileError> OldReaderUrlReader::reload()
 	std::vector<TaggedFeedUrl> feedurls = api->get_subscribed_urls();
 	for (const auto& url : feedurls) {
 		LOG(Level::DEBUG, "added %s to URL list", url.first);
-		urls.push_back({url.first, FeedOrigin{}});
-		tags[url.first] = url.second;
+		feed_urls.emplace_back(FeedUrl{url.first, FeedOrigin{}, url.second});
 		for (const auto& tag : url.second) {
 			LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);
 		}

--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -187,7 +187,7 @@ void rec_find_rss_outlines(
 					ss = std::istringstream(category);
 				}
 
-				auto& urltags = urlcfg.get_tags(quoted_url);
+				auto& urltags = urlcfg.get_entry(quoted_url)->tags;
 				while (std::getline(ss, token, ',')) {
 					if (std::find(urltags.begin(), urltags.end(), token) == urltags.end()) {
 						urltags.push_back(token);

--- a/src/opml.cpp
+++ b/src/opml.cpp
@@ -146,8 +146,8 @@ void rec_find_rss_outlines(
 					static_cast<uint64_t>(urlcfg.get_urls().size()));
 
 				auto& urls = urlcfg.get_urls();
-				const auto is_same_url = [&quoted_url](auto& url) {
-					return url.first == quoted_url;
+				const auto is_same_url = [&quoted_url](auto& feed_url) {
+					return feed_url.url == quoted_url;
 				};
 				if (std::find_if(urls.begin(), urls.end(), is_same_url) == urls.end()) {
 					LOG(Level::DEBUG, "opml::import: added url = %s", quoted_url);

--- a/src/opmlurlreader.cpp
+++ b/src/opmlurlreader.cpp
@@ -15,8 +15,7 @@ OpmlUrlReader::OpmlUrlReader(ConfigContainer& c, const Filepath& url_file)
 
 std::optional<utils::ReadTextFileError> OpmlUrlReader::reload()
 {
-	urls.clear();
-	tags.clear();
+	feed_urls.clear();
 
 	std::vector<std::string> opml_urls =
 		utils::tokenize_quoted(this->get_source(), " ");
@@ -68,7 +67,6 @@ void OpmlUrlReader::handle_node(xmlNode* node, const std::string& tag)
 			(char*)xmlGetProp(node, (const xmlChar*)"xmlUrl");
 		if (rssurl && strlen(rssurl) > 0) {
 			std::string theurl(rssurl);
-			urls.push_back({theurl, FeedOrigin{}});
 
 			std::vector<std::string> tmptags;
 
@@ -99,10 +97,7 @@ void OpmlUrlReader::handle_node(xmlNode* node, const std::string& tag)
 			if (tag.length() > 0) {
 				tmptags.push_back(tag);
 			}
-
-			if (tmptags.size() > 0) {
-				tags[theurl] = tmptags;
-			}
+			feed_urls.emplace_back(FeedUrl{theurl, FeedOrigin{}, tmptags});
 		}
 		if (rssurl) {
 			xmlFree(rssurl);

--- a/src/remoteapiurlreader.cpp
+++ b/src/remoteapiurlreader.cpp
@@ -19,22 +19,20 @@ RemoteApiUrlReader::RemoteApiUrlReader(const std::string& source_name,
 
 std::optional<utils::ReadTextFileError> RemoteApiUrlReader::reload()
 {
-	urls.clear();
-	tags.clear();
+	feed_urls.clear();
 
 	load_query_urls_from_file(file);
 
-	const std::vector<TaggedFeedUrl> feedurls = api.get_subscribed_urls();
+	const std::vector<TaggedFeedUrl> subsribed_urls = api.get_subscribed_urls();
 
-	for (const auto& url : feedurls) {
-		auto it = std::find_if(urls.begin(), urls.end(),
-		[&url](const std::pair<std::string, FeedOrigin>& u) {
-			return u.first == url.first;
+	for (const auto& url : subsribed_urls) {
+		auto it = std::find_if(feed_urls.begin(), feed_urls.end(),
+		[&url](const FeedUrl& u) {
+			return u.url == url.first;
 		});
-		if (it == urls.end()) {
+		if (it == feed_urls.end()) {
 			LOG(Level::INFO, "added %s to URL list", url.first);
-			urls.push_back({url.first, FeedOrigin{}});
-			tags[url.first] = url.second;
+			feed_urls.emplace_back(FeedUrl{url.first, FeedOrigin{}, url.second});
 			for (const auto& tag : url.second) {
 				LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);
 			}
@@ -47,11 +45,9 @@ std::optional<utils::ReadTextFileError> RemoteApiUrlReader::reload()
 			std::cerr << warn_msg << std::endl;
 
 			for (const auto& tag : url.second) {
-				if (std::find(tags[url.first].begin(),
-						tags[url.first].end(),
-						tag) == tags[url.first].end()) {
+				if (std::find(it->tags.begin(), it->tags.end(), tag) == it->tags.end()) {
 					LOG(Level::DEBUG, "%s: added tag %s", url.first, tag);
-					tags[url.first].push_back(tag);
+					it->tags.push_back(tag);
 				}
 			}
 		}

--- a/src/urlreader.cpp
+++ b/src/urlreader.cpp
@@ -7,21 +7,32 @@
 
 namespace newsboat {
 
-const std::vector<std::pair<std::string, FeedOrigin>>& UrlReader::get_urls() const
+const std::vector<UrlReader::FeedUrl>& UrlReader::get_urls() const
 {
-	return urls;
+	return feed_urls;
 }
 
 std::vector<std::string>& UrlReader::get_tags(const std::string& url)
 {
-	return tags[url];
+	// TODO: Get rid of dummy return value by changing UrlReader interface
+	static std::vector<std::string> dummy{};
+
+	auto it = std::find_if(feed_urls.begin(),
+	feed_urls.end(), [&url](const FeedUrl& feed_url) {
+		return feed_url.url == url;
+	});
+	if (it != feed_urls.end()) {
+		return it->tags;
+	} else {
+		return dummy;
+	}
 }
 
 std::vector<std::string> UrlReader::get_alltags() const
 {
 	std::set<std::string> tmptags;
-	for (const auto& url_tags : tags) {
-		for (const auto& tag : url_tags.second) {
+	for (const auto& feed : feed_urls) {
+		for (const auto& tag : feed.tags) {
 			if (tag.substr(0, 1) != "~") {
 				// std::copy_if would make this code less readable IMHO
 				// cppcheck-suppress useStlAlgorithm
@@ -42,10 +53,9 @@ void UrlReader::load_query_urls_from_file(Filepath file)
 	}
 
 	const auto& other_urls = file_url_reader.get_urls();
-	for (const auto& [url, origin] : other_urls) {
-		if (utils::is_query_url(url)) {
-			urls.push_back({url, origin});
-			tags[url] = file_url_reader.get_tags(url);
+	for (const auto& feed_url : other_urls) {
+		if (utils::is_query_url(feed_url.url)) {
+			feed_urls.push_back(feed_url);
 		}
 	}
 }

--- a/src/urlreader.cpp
+++ b/src/urlreader.cpp
@@ -12,19 +12,16 @@ const std::vector<UrlReader::FeedUrl>& UrlReader::get_urls() const
 	return feed_urls;
 }
 
-std::vector<std::string>& UrlReader::get_tags(const std::string& url)
+UrlReader::FeedUrl* UrlReader::get_entry(const std::string& url)
 {
-	// TODO: Get rid of dummy return value by changing UrlReader interface
-	static std::vector<std::string> dummy{};
-
 	auto it = std::find_if(feed_urls.begin(),
 	feed_urls.end(), [&url](const FeedUrl& feed_url) {
 		return feed_url.url == url;
 	});
 	if (it != feed_urls.end()) {
-		return it->tags;
+		return &*it;
 	} else {
-		return dummy;
+		return nullptr;
 	}
 }
 

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -27,9 +27,9 @@ TEST_CASE("URL reader extracts all URLs from the file", "[FileUrlReader]")
 	u.reload();
 
 	REQUIRE(u.get_urls().size() == 3);
-	REQUIRE(u.get_urls()[0].first == "http://test1.url.cc/feed.xml");
-	REQUIRE(u.get_urls()[1].first == "http://anotherfeed.com/");
-	REQUIRE(u.get_urls()[2].first == "http://onemorefeed.at/feed/");
+	REQUIRE(u.get_urls()[0].url == "http://test1.url.cc/feed.xml");
+	REQUIRE(u.get_urls()[1].url == "http://anotherfeed.com/");
+	REQUIRE(u.get_urls()[2].url == "http://onemorefeed.at/feed/");
 }
 
 TEST_CASE("URL reader stores origin for each feed", "[FileUrlReader]")
@@ -39,9 +39,9 @@ TEST_CASE("URL reader stores origin for each feed", "[FileUrlReader]")
 	u.reload();
 
 	REQUIRE(u.get_urls().size() == 3);
-	REQUIRE(u.get_urls()[0].second.file_origin->line_number == 1);
-	REQUIRE(u.get_urls()[1].second.file_origin->line_number == 2);
-	REQUIRE(u.get_urls()[2].second.file_origin->line_number == 4);
+	REQUIRE(u.get_urls()[0].origin.file_origin->line_number == 1);
+	REQUIRE(u.get_urls()[1].origin.file_origin->line_number == 2);
+	REQUIRE(u.get_urls()[2].origin.file_origin->line_number == 4);
 }
 
 TEST_CASE("URL reader extracts feeds' tags", "[FileUrlReader]")
@@ -100,11 +100,10 @@ TEST_CASE("URL reader writes files that it can understand later",
 	auto u2_urls = u2.get_urls();
 	REQUIRE(u_urls.size() == u2_urls.size());
 	for (std::size_t i = 0; i < u_urls.size(); i++) {
-		REQUIRE(u_urls[i].first == u2_urls[i].first);
+		REQUIRE(u_urls[i].url == u2_urls[i].url);
 	}
-	for (const auto& [url, origin] : u.get_urls()) {
-		(void)origin;
-		REQUIRE(u.get_tags(url) == u2.get_tags(url));
+	for (const auto& feed_url : u.get_urls()) {
+		REQUIRE(u.get_tags(feed_url.url) == u2.get_tags(feed_url.url));
 	}
 
 }
@@ -123,9 +122,9 @@ TEST_CASE("URL reader updates feed origin when writing data",
 
 		SECTION("line numbers take comments into account") {
 			const auto urls = u.get_urls();
-			REQUIRE(urls[0].second.file_origin->line_number == 1);
-			REQUIRE(urls[1].second.file_origin->line_number == 2);
-			REQUIRE(urls[2].second.file_origin->line_number == 4);
+			REQUIRE(urls[0].origin.file_origin->line_number == 1);
+			REQUIRE(urls[1].origin.file_origin->line_number == 2);
+			REQUIRE(urls[2].origin.file_origin->line_number == 4);
 		}
 
 		WHEN("Feed URLs are written to file") {
@@ -133,9 +132,9 @@ TEST_CASE("URL reader updates feed origin when writing data",
 
 			THEN("Line numbers in feed origin data are updated to account for removed comments") {
 				const auto urls = u.get_urls();
-				REQUIRE(urls[0].second.file_origin->line_number == 1);
-				REQUIRE(urls[1].second.file_origin->line_number == 2);
-				REQUIRE(urls[2].second.file_origin->line_number == 3);
+				REQUIRE(urls[0].origin.file_origin->line_number == 1);
+				REQUIRE(urls[1].origin.file_origin->line_number == 2);
+				REQUIRE(urls[2].origin.file_origin->line_number == 3);
 			}
 		}
 	}
@@ -173,7 +172,7 @@ TEST_CASE("Preserves URLs as-is", "[FileUrlReader][issue926]")
 	u.reload();
 
 	REQUIRE(u.get_urls().size() == 1);
-	REQUIRE(u.get_urls()[0].first ==
+	REQUIRE(u.get_urls()[0].url ==
 		R"_(exec:curl --silent https://feeds.metaebene.me/raumzeit/m4a  | sed 's#\(</guid>\|</id>\)#-M4A&#')_");
 }
 
@@ -284,7 +283,7 @@ TEST_CASE("FileUrlReader handles duplicate URLs by merging tags",
 	u.reload();
 
 	REQUIRE(u.get_urls().size() == 1);
-	REQUIRE(u.get_urls()[0].first == "http://anotherfeed.com/");
+	REQUIRE(u.get_urls()[0].url == "http://anotherfeed.com/");
 
 	REQUIRE(u.get_tags("http://anotherfeed.com/")[0] == "tag1");
 	REQUIRE(u.get_tags("http://anotherfeed.com/")[1] == "tag2");

--- a/test/fileurlreader.cpp
+++ b/test/fileurlreader.cpp
@@ -49,17 +49,17 @@ TEST_CASE("URL reader extracts feeds' tags", "[FileUrlReader]")
 	FileUrlReader u("data/test-urls.txt"_path);
 	u.reload();
 
-	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml").size() == 3);
-	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml")[0] == "~title");
-	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml")[1] == "tag1");
-	REQUIRE(u.get_tags("http://test1.url.cc/feed.xml")[2] == "tag2");
+	REQUIRE(u.get_entry("http://test1.url.cc/feed.xml")->tags.size() == 3);
+	REQUIRE(u.get_entry("http://test1.url.cc/feed.xml")->tags[0] == "~title");
+	REQUIRE(u.get_entry("http://test1.url.cc/feed.xml")->tags[1] == "tag1");
+	REQUIRE(u.get_entry("http://test1.url.cc/feed.xml")->tags[2] == "tag2");
 
-	REQUIRE(u.get_tags("http://anotherfeed.com/").size() == 0);
+	REQUIRE(u.get_entry("http://anotherfeed.com/")->tags.size() == 0);
 
-	REQUIRE(u.get_tags("http://onemorefeed.at/feed/").size() == 3);
-	REQUIRE(u.get_tags("http://onemorefeed.at/feed/")[0] == "tag1");
-	REQUIRE(u.get_tags("http://onemorefeed.at/feed/")[1] == "~another title");
-	REQUIRE(u.get_tags("http://onemorefeed.at/feed/")[2] == "tag3");
+	REQUIRE(u.get_entry("http://onemorefeed.at/feed/")->tags.size() == 3);
+	REQUIRE(u.get_entry("http://onemorefeed.at/feed/")->tags[0] == "tag1");
+	REQUIRE(u.get_entry("http://onemorefeed.at/feed/")->tags[1] == "~another title");
+	REQUIRE(u.get_entry("http://onemorefeed.at/feed/")->tags[2] == "tag3");
 }
 
 TEST_CASE("URL reader keeps track of unique tags", "[FileUrlReader]")
@@ -103,7 +103,7 @@ TEST_CASE("URL reader writes files that it can understand later",
 		REQUIRE(u_urls[i].url == u2_urls[i].url);
 	}
 	for (const auto& feed_url : u.get_urls()) {
-		REQUIRE(u.get_tags(feed_url.url) == u2.get_tags(feed_url.url));
+		REQUIRE(u.get_entry(feed_url.url)->tags == u2.get_entry(feed_url.url)->tags);
 	}
 
 }
@@ -285,8 +285,10 @@ TEST_CASE("FileUrlReader handles duplicate URLs by merging tags",
 	REQUIRE(u.get_urls().size() == 1);
 	REQUIRE(u.get_urls()[0].url == "http://anotherfeed.com/");
 
-	REQUIRE(u.get_tags("http://anotherfeed.com/")[0] == "tag1");
-	REQUIRE(u.get_tags("http://anotherfeed.com/")[1] == "tag2");
-	REQUIRE(u.get_tags("http://anotherfeed.com/")[2] == "tag3");
-	REQUIRE(u.get_tags("http://anotherfeed.com/")[3] == "tag4");
+	auto& tags = u.get_entry("http://anotherfeed.com/")->tags;
+	REQUIRE(tags.size() == 4);
+	REQUIRE(tags[0] == "tag1");
+	REQUIRE(tags[1] == "tag2");
+	REQUIRE(tags[2] == "tag3");
+	REQUIRE(tags[3] == "tag4");
 }

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -138,7 +138,7 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 		const auto entry = testUrls.find(feed_url.url);
 		REQUIRE(entry != testUrls.cend());
 
-		const auto tags = urlcfg.get_tags(feed_url.url);
+		const auto& tags = urlcfg.get_entry(feed_url.url)->tags;
 		REQUIRE(tags == entry->second);
 	}
 
@@ -170,7 +170,7 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 		const auto entry = combinedUrls.find(feed_url.url);
 		REQUIRE(entry != testUrls.cend());
 
-		const auto tags = urlcfg.get_tags(feed_url.url);
+		const auto& tags = urlcfg.get_entry(feed_url.url)->tags;
 		REQUIRE(tags == entry->second);
 	}
 }
@@ -205,7 +205,7 @@ TEST_CASE("import() turns URLs that start with a pipe symbol (\"|\") "
 		const auto entry = opmlUrls.find(feed_url.url);
 		REQUIRE(entry != opmlUrls.cend());
 
-		const auto tags = urlcfg.get_tags(feed_url.url);
+		const auto& tags = urlcfg.get_entry(feed_url.url)->tags;
 		REQUIRE(tags == entry->second);
 	}
 }
@@ -241,7 +241,7 @@ TEST_CASE("import() turns \"filtercmd\" attribute into a `filter:` URL "
 		const auto entry = opmlUrls.find(feed_url.url);
 		REQUIRE(entry != opmlUrls.cend());
 
-		const auto tags = urlcfg.get_tags(feed_url.url);
+		const auto& tags = urlcfg.get_entry(feed_url.url)->tags;
 		REQUIRE(tags == entry->second);
 	}
 }
@@ -274,7 +274,7 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 		const auto entry = testUrls.find(feed_url.url);
 		REQUIRE(entry != testUrls.cend());
 
-		const auto tags = urlcfg.get_tags(feed_url.url);
+		const auto& tags = urlcfg.get_entry(feed_url.url)->tags;
 		REQUIRE(tags == entry->second);
 	}
 
@@ -300,7 +300,7 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 		const auto entry = combinedUrls.find(feed_url.url);
 		REQUIRE(entry != testUrls.cend());
 
-		const auto tags = urlcfg.get_tags(feed_url.url);
+		const auto& tags = urlcfg.get_entry(feed_url.url)->tags;
 		REQUIRE(tags == entry->second);
 	}
 }
@@ -317,7 +317,7 @@ TEST_CASE("import() tags from category attribute", "[Opml]")
 	const std::vector<std::string> tags{"tag one", "tag_two", "tag/three"};
 	const auto& urls = urlcfg.get_urls();
 	REQUIRE(urls.size() == 1);
-	REQUIRE(urlcfg.get_tags(urls[0].url) == tags);
+	REQUIRE(urlcfg.get_entry(urls[0].url)->tags == tags);
 }
 
 TEST_CASE("import() returns an error when the <opml> root element is missing", "[Opml]")

--- a/test/opml.cpp
+++ b/test/opml.cpp
@@ -132,14 +132,13 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 
 	REQUIRE(urlcfg.get_urls().size() == testUrls.size());
 
-	for (const auto& [url, origin] : urlcfg.get_urls()) {
-		(void)origin;
-		INFO("url = " << url);
+	for (const auto& feed_url : urlcfg.get_urls()) {
+		INFO("url = " << feed_url.url);
 
-		const auto entry = testUrls.find(url);
+		const auto entry = testUrls.find(feed_url.url);
 		REQUIRE(entry != testUrls.cend());
 
-		const auto tags = urlcfg.get_tags(url);
+		const auto tags = urlcfg.get_tags(feed_url.url);
 		REQUIRE(tags == entry->second);
 	}
 
@@ -165,14 +164,13 @@ TEST_CASE("import() populates UrlReader with URLs from the OPML file", "[Opml]")
 
 	REQUIRE(urlcfg.get_urls().size() == combinedUrls.size());
 
-	for (const auto& [url, origin] : urlcfg.get_urls()) {
-		(void)origin;
-		INFO("url = " << url);
+	for (const auto& feed_url : urlcfg.get_urls()) {
+		INFO("url = " << feed_url.url);
 
-		const auto entry = combinedUrls.find(url);
+		const auto entry = combinedUrls.find(feed_url.url);
 		REQUIRE(entry != testUrls.cend());
 
-		const auto tags = urlcfg.get_tags(url);
+		const auto tags = urlcfg.get_tags(feed_url.url);
 		REQUIRE(tags == entry->second);
 	}
 }
@@ -201,14 +199,13 @@ TEST_CASE("import() turns URLs that start with a pipe symbol (\"|\") "
 
 	REQUIRE(urlcfg.get_urls().size() == opmlUrls.size());
 
-	for (const auto& [url, origin] : urlcfg.get_urls()) {
-		(void)origin;
-		INFO("url = " << url);
+	for (const auto& feed_url : urlcfg.get_urls()) {
+		INFO("url = " << feed_url.url);
 
-		const auto entry = opmlUrls.find(url);
+		const auto entry = opmlUrls.find(feed_url.url);
 		REQUIRE(entry != opmlUrls.cend());
 
-		const auto tags = urlcfg.get_tags(url);
+		const auto tags = urlcfg.get_tags(feed_url.url);
 		REQUIRE(tags == entry->second);
 	}
 }
@@ -238,14 +235,13 @@ TEST_CASE("import() turns \"filtercmd\" attribute into a `filter:` URL "
 
 	REQUIRE(urlcfg.get_urls().size() == opmlUrls.size());
 
-	for (const auto& [url, origin] : urlcfg.get_urls()) {
-		(void)origin;
-		INFO("url = " << url);
+	for (const auto& feed_url : urlcfg.get_urls()) {
+		INFO("url = " << feed_url.url);
 
-		const auto entry = opmlUrls.find(url);
+		const auto entry = opmlUrls.find(feed_url.url);
 		REQUIRE(entry != opmlUrls.cend());
 
-		const auto tags = urlcfg.get_tags(url);
+		const auto tags = urlcfg.get_tags(feed_url.url);
 		REQUIRE(tags == entry->second);
 	}
 }
@@ -272,14 +268,13 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 
 	REQUIRE(urlcfg.get_urls().size() == testUrls.size());
 
-	for (const auto& [url, origin] : urlcfg.get_urls()) {
-		(void)origin;
-		INFO("url = " << url);
+	for (const auto& feed_url : urlcfg.get_urls()) {
+		INFO("url = " << feed_url.url);
 
-		const auto entry = testUrls.find(url);
+		const auto entry = testUrls.find(feed_url.url);
 		REQUIRE(entry != testUrls.cend());
 
-		const auto tags = urlcfg.get_tags(url);
+		const auto tags = urlcfg.get_tags(feed_url.url);
 		REQUIRE(tags == entry->second);
 	}
 
@@ -299,14 +294,13 @@ TEST_CASE("import() skips URLs that are already present in UrlReader",
 
 	REQUIRE(urlcfg.get_urls().size() == combinedUrls.size());
 
-	for (const auto& [url, origin] : urlcfg.get_urls()) {
-		(void)origin;
-		INFO("url = " << url);
+	for (const auto& feed_url : urlcfg.get_urls()) {
+		INFO("url = " << feed_url.url);
 
-		const auto entry = combinedUrls.find(url);
+		const auto entry = combinedUrls.find(feed_url.url);
 		REQUIRE(entry != testUrls.cend());
 
-		const auto tags = urlcfg.get_tags(url);
+		const auto tags = urlcfg.get_tags(feed_url.url);
 		REQUIRE(tags == entry->second);
 	}
 }
@@ -323,7 +317,7 @@ TEST_CASE("import() tags from category attribute", "[Opml]")
 	const std::vector<std::string> tags{"tag one", "tag_two", "tag/three"};
 	const auto& urls = urlcfg.get_urls();
 	REQUIRE(urls.size() == 1);
-	REQUIRE(urlcfg.get_tags(urls[0].first) == tags);
+	REQUIRE(urlcfg.get_tags(urls[0].url) == tags);
 }
 
 TEST_CASE("import() returns an error when the <opml> root element is missing", "[Opml]")

--- a/test/opmlurlreader.cpp
+++ b/test/opmlurlreader.cpp
@@ -63,7 +63,7 @@ TEST_CASE("OpmlUrlReader::reload() reads URLs and tags from an OPML file",
 		const auto e = expected.find(feed_url.url);
 		REQUIRE(e != expected.cend());
 
-		const auto tags = reader.get_tags(feed_url.url);
+		const auto& tags = reader.get_entry(feed_url.url)->tags;
 		REQUIRE(tags == e->second);
 	}
 
@@ -124,7 +124,7 @@ TEST_CASE("OpmlUrlReader::reload() loads URLs from multiple sources",
 		const auto e = expected.find(feed_url.url);
 		REQUIRE(e != expected.cend());
 
-		const auto tags = reader.get_tags(feed_url.url);
+		const auto& tags = reader.get_entry(feed_url.url)->tags;
 		REQUIRE(tags == e->second);
 	}
 
@@ -189,7 +189,7 @@ TEST_CASE("OpmlUrlReader::reload() skips things that can't be parsed",
 		const auto e = expected.find(feed_url.url);
 		REQUIRE(e != expected.cend());
 
-		const auto tags = reader.get_tags(feed_url.url);
+		const auto& tags = reader.get_entry(feed_url.url)->tags;
 		REQUIRE(tags == e->second);
 	}
 

--- a/test/opmlurlreader.cpp
+++ b/test/opmlurlreader.cpp
@@ -57,14 +57,13 @@ TEST_CASE("OpmlUrlReader::reload() reads URLs and tags from an OPML file",
 
 	REQUIRE(reader.get_urls().size() == expected.size());
 
-	for (const auto& [url, origin] : reader.get_urls()) {
-		(void)origin;
-		INFO("url = " << url);
+	for (const auto& feed_url : reader.get_urls()) {
+		INFO("url = " << feed_url.url);
 
-		const auto e = expected.find(url);
+		const auto e = expected.find(feed_url.url);
 		REQUIRE(e != expected.cend());
 
-		const auto tags = reader.get_tags(url);
+		const auto tags = reader.get_tags(feed_url.url);
 		REQUIRE(tags == e->second);
 	}
 
@@ -119,14 +118,13 @@ TEST_CASE("OpmlUrlReader::reload() loads URLs from multiple sources",
 
 	REQUIRE(reader.get_urls().size() == expected.size());
 
-	for (const auto& [url, origin] : reader.get_urls()) {
-		(void)origin;
-		INFO("url = " << url);
+	for (const auto& feed_url : reader.get_urls()) {
+		INFO("url = " << feed_url.url);
 
-		const auto e = expected.find(url);
+		const auto e = expected.find(feed_url.url);
 		REQUIRE(e != expected.cend());
 
-		const auto tags = reader.get_tags(url);
+		const auto tags = reader.get_tags(feed_url.url);
 		REQUIRE(tags == e->second);
 	}
 
@@ -185,14 +183,13 @@ TEST_CASE("OpmlUrlReader::reload() skips things that can't be parsed",
 
 	REQUIRE(reader.get_urls().size() == expected.size());
 
-	for (const auto& [url, origin] : reader.get_urls()) {
-		(void)origin;
-		INFO("url = " << url);
+	for (const auto& feed_url : reader.get_urls()) {
+		INFO("url = " << feed_url.url);
 
-		const auto e = expected.find(url);
+		const auto e = expected.find(feed_url.url);
 		REQUIRE(e != expected.cend());
 
-		const auto tags = reader.get_tags(url);
+		const auto tags = reader.get_tags(feed_url.url);
 		REQUIRE(tags == e->second);
 	}
 

--- a/test/remoteapiurlreader.cpp
+++ b/test/remoteapiurlreader.cpp
@@ -102,9 +102,9 @@ TEST_CASE("RemoteApiUrlReader reload includes query urls and urls from the Remot
 				REQUIRE(loaded_urls[2].url == feed2);
 				REQUIRE(loaded_urls[2].origin.file_origin == std::nullopt);
 
-				REQUIRE(url_reader.get_tags(query_feed).size() == 2);
-				REQUIRE(url_reader.get_tags(feed1).size() == 2);
-				REQUIRE(url_reader.get_tags(feed2).size() == 0);
+				REQUIRE(url_reader.get_entry(query_feed)->tags.size() == 2);
+				REQUIRE(url_reader.get_entry(feed1)->tags.size() == 2);
+				REQUIRE(url_reader.get_entry(feed2)->tags.size() == 0);
 			}
 
 			THEN("Alltags includes tags from both sources but excludes title rename tags") {
@@ -141,7 +141,7 @@ TEST_CASE(
 				REQUIRE(loaded_urls.size() == 1);
 				REQUIRE(loaded_urls[0].url == duplicate_feed);
 
-				const auto& merged_tags = url_reader.get_tags(duplicate_feed);
+				const auto& merged_tags = url_reader.get_entry(duplicate_feed)->tags;
 				REQUIRE(merged_tags.size() == 4);
 				REQUIRE(merged_tags[0] == "tag1");
 				REQUIRE(merged_tags[1] == "tag2");

--- a/test/remoteapiurlreader.cpp
+++ b/test/remoteapiurlreader.cpp
@@ -95,12 +95,12 @@ TEST_CASE("RemoteApiUrlReader reload includes query urls and urls from the Remot
 				REQUIRE(loaded_urls.size() == 3);
 
 				const std::string query_feed = R"(query:Unread Articles:unread = "yes")";
-				REQUIRE(loaded_urls[0].first == query_feed);
-				REQUIRE(loaded_urls[0].second.file_origin->line_number == 2);
-				REQUIRE(loaded_urls[1].first == feed1);
-				REQUIRE(loaded_urls[1].second.file_origin == std::nullopt);
-				REQUIRE(loaded_urls[2].first == feed2);
-				REQUIRE(loaded_urls[2].second.file_origin == std::nullopt);
+				REQUIRE(loaded_urls[0].url == query_feed);
+				REQUIRE(loaded_urls[0].origin.file_origin->line_number == 2);
+				REQUIRE(loaded_urls[1].url == feed1);
+				REQUIRE(loaded_urls[1].origin.file_origin == std::nullopt);
+				REQUIRE(loaded_urls[2].url == feed2);
+				REQUIRE(loaded_urls[2].origin.file_origin == std::nullopt);
 
 				REQUIRE(url_reader.get_tags(query_feed).size() == 2);
 				REQUIRE(url_reader.get_tags(feed1).size() == 2);
@@ -139,7 +139,7 @@ TEST_CASE(
 			THEN("The URL is only stored once, and all unique tags are merged") {
 				const auto& loaded_urls = url_reader.get_urls();
 				REQUIRE(loaded_urls.size() == 1);
-				REQUIRE(loaded_urls[0].first == duplicate_feed);
+				REQUIRE(loaded_urls[0].url == duplicate_feed);
 
 				const auto& merged_tags = url_reader.get_tags(duplicate_feed);
 				REQUIRE(merged_tags.size() == 4);


### PR DESCRIPTION
Avoid urls/tags lists getting out of sync.
Preparation for https://github.com/newsboat/newsboat/issues/3345.