### PR TITLE
Feature/offline mode for remote services

### DIFF
--- a/include/cache.h
+++ b/include/cache.h
@@ -79,6 +79,7 @@ public:
 	std::vector<std::string> get_read_item_guids();
 	void fetch_descriptions(RssFeed* feed);
 	std::string fetch_description(const RssItem& item);
+	std::vector<std::string> fetch_feed_urls();
 
 private:
 	SchemaVersion get_schema_version();

--- a/include/cacheapi.h
+++ b/include/cacheapi.h
@@ -1,0 +1,26 @@
+#ifndef NEWSBOAT_CACHEAPI_H_
+#define NEWSBOAT_CACHEAPI_H_
+
+#include "remoteapi.h"
+#include "cache.h"
+
+namespace newsboat {
+class CacheApi : public RemoteApi {
+public:
+	explicit CacheApi(ConfigContainer& cfg, Cache* cache);
+	~CacheApi() override = default;
+	bool authenticate() override;
+	std::vector<TaggedFeedUrl> get_subscribed_urls() override;
+	bool mark_all_read(const std::string& feedurl) override;
+	bool mark_article_read(const std::string& guid, bool read) override;
+	bool update_article_flags(const std::string& oldflags,
+		const std::string& newflags,
+		const std::string& guid) override;
+	void add_custom_headers(curl_slist**) override;
+
+private:
+	Cache* cache;
+};
+}
+
+#endif /* NEWSBOAT_CACHEAPI_H_ */

--- a/include/cacheurlreader.h
+++ b/include/cacheurlreader.h
@@ -19,7 +19,6 @@ public:
 	std::string get_source() const override;
 
 private:
-	Cache* cache;
 	FileUrlReader file_reader;
 	RemoteApi* api;
 };

--- a/include/cacheurlreader.h
+++ b/include/cacheurlreader.h
@@ -1,0 +1,29 @@
+#ifndef NEWSBOAT_CACHEURLREADER_H_
+#define NEWSBOAT_CACHEURLREADER_H_
+
+#include <memory>
+
+#include "urlreader.h"
+#include "remoteapi.h"
+#include "fileurlreader.h"
+#include "cache.h"
+#include "utils.h"
+
+namespace newsboat {
+
+class CacheUrlReader : public UrlReader {
+public:
+	CacheUrlReader(FileUrlReader file_reader, RemoteApi* api);
+	~CacheUrlReader();
+	std::optional<utils::ReadTextFileError> reload() override;
+	std::string get_source() const override;
+
+private:
+	Cache* cache;
+	FileUrlReader file_reader;
+	RemoteApi* api;
+};
+
+}
+
+#endif /* NEWSBOAT_CACHEURLREADER_H_ */

--- a/mk/newsboat.deps
+++ b/mk/newsboat.deps
@@ -1,5 +1,7 @@
 newsboat.cpp
 src/cache.cpp
+src/cacheurlreader.cpp
+src/cacheapi.cpp
 src/charencoding.cpp
 src/cliargsparser.cpp
 src/configactionhandler.cpp
@@ -66,5 +68,3 @@ src/ttrssapi.cpp
 src/urlreader.cpp
 src/urlviewformaction.cpp
 src/view.cpp
-src/cacheurlreader.cpp
-src/cacheapi.cpp

--- a/mk/newsboat.deps
+++ b/mk/newsboat.deps
@@ -66,3 +66,5 @@ src/ttrssapi.cpp
 src/urlreader.cpp
 src/urlviewformaction.cpp
 src/view.cpp
+src/cacheurlreader.cpp
+src/cacheapi.cpp

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -107,7 +107,6 @@ static int string_vector_callback(void* myVec,
 	char** /* azColName */)
 {
 	auto vec = static_cast<std::vector<std::string>*>(myVec);
-
 	assert(argc == 1);
 	assert(argv[0] != nullptr);
 

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -101,6 +101,21 @@ static int single_string_callback(void* handler,
 	return 0;
 }
 
+static int string_vector_callback(void* myVec,
+	int argc,
+	char** argv,
+	char** /* azColName */)
+{
+	auto vec = static_cast<std::vector<std::string>*>(myVec);
+
+	assert(argc == 1);
+	assert(argv[0] != nullptr);
+
+	vec->push_back(argv[0]);
+
+	return 0;
+}
+
 static int rssfeed_callback(void* myfeed, int argc, char** argv,
 	char** /* azColName */)
 {
@@ -1206,6 +1221,16 @@ std::string Cache::fetch_description(const RssItem& item)
 
 	run_sql(query, store_description, &description);
 	return description;
+}
+
+std::vector<std::string> Cache::fetch_feed_urls()
+{
+	std::vector<std::string> urls;
+
+	std::string query = "SELECT rssurl FROM rss_feed";
+	run_sql(query, string_vector_callback, &urls);
+
+	return urls;
 }
 
 SchemaVersion Cache::get_schema_version()

--- a/src/cacheapi.cpp
+++ b/src/cacheapi.cpp
@@ -1,0 +1,51 @@
+#include "../include/cacheapi.h"
+#include "../include/feedorigin.h"
+#include "cacheapi.h"
+
+namespace newsboat {
+
+CacheApi::CacheApi(ConfigContainer& cfg, Cache* cache) : RemoteApi(cfg), cache(cache)
+{
+
+}
+
+bool CacheApi::authenticate()
+{
+	return false;
+}
+
+std::vector<TaggedFeedUrl> CacheApi::get_subscribed_urls()
+{
+
+	auto urls = cache->fetch_feed_urls();
+	std::vector<TaggedFeedUrl> url_pairs;
+
+	for (std::string url : urls) {
+		url_pairs.push_back({url, {}});
+	}
+
+	return url_pairs;
+}
+
+bool CacheApi::mark_all_read(const std::string&)
+{
+	return false;
+}
+
+
+bool CacheApi::mark_article_read(const std::string&, bool)
+{
+	return false;
+}
+
+bool CacheApi::update_article_flags(const std::string&,
+	const std::string&, const std::string&)
+{
+	return false;
+}
+
+void CacheApi::add_custom_headers(curl_slist**)
+{
+}
+
+}

--- a/src/cacheurlreader.cpp
+++ b/src/cacheurlreader.cpp
@@ -28,7 +28,7 @@ std::optional<utils::ReadTextFileError> CacheUrlReader::reload()
 		urls.push_back({url.first, FeedOrigin{std::nullopt}});
 	}
 
-    return std::nullopt;
+	return std::nullopt;
 }
 
 std::string CacheUrlReader::get_source() const

--- a/src/cacheurlreader.cpp
+++ b/src/cacheurlreader.cpp
@@ -1,0 +1,39 @@
+#include "../include/cacheurlreader.h"
+
+namespace newsboat {
+
+CacheUrlReader::CacheUrlReader(FileUrlReader file_reader,
+	RemoteApi* api) : file_reader(file_reader), api(api)
+{
+}
+
+CacheUrlReader::~CacheUrlReader() {}
+
+std::optional<utils::ReadTextFileError> CacheUrlReader::reload()
+{
+	urls.clear();
+	tags.clear();
+
+	auto file_res = file_reader.reload();
+	if (file_res.has_value()) {
+		return file_res;
+	}
+
+	auto file_urls = file_reader.get_urls();
+	auto cached_urls = api->get_subscribed_urls();
+
+	urls = file_urls;
+
+	for (auto url : cached_urls) {
+		urls.push_back({url.first, FeedOrigin{std::nullopt}});
+	}
+
+    return std::nullopt;
+}
+
+std::string CacheUrlReader::get_source() const
+{
+	return "Cache";
+}
+
+} // namespace newsboat

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -61,6 +61,8 @@
 #include "ttrssapi.h"
 #include "utils.h"
 #include "view.h"
+#include "cacheurlreader.h"
+#include "cacheapi.h"
 
 namespace newsboat {
 
@@ -371,7 +373,15 @@ int Controller::run(const CliArgsParser& args)
 	if (api) {
 		if (!api->authenticate()) {
 			std::cerr << _("Authentication failed.") << std::endl;
-			return EXIT_FAILURE;
+			std::cerr << _("Do you want to use offline mode? [y/n]") << std::endl;
+			char res;
+			std::cin >> res;
+			if (res == 'y') {
+				api = std::make_unique<CacheApi>(cfg, rsscache.get());
+				urlcfg = std::make_unique<CacheUrlReader>(FileUrlReader(configpaths.url_file()), api.get());
+			} else {
+				return EXIT_FAILURE;
+			}
 		}
 	}
 	const auto error_message = urlcfg->reload();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -378,7 +378,8 @@ int Controller::run(const CliArgsParser& args)
 			std::cin >> res;
 			if (res == 'y') {
 				api = std::make_unique<CacheApi>(cfg, rsscache.get());
-				urlcfg = std::make_unique<CacheUrlReader>(FileUrlReader(configpaths.url_file()), api.get());
+				urlcfg = std::make_unique<CacheUrlReader>(FileUrlReader(configpaths.url_file()),
+						api.get());
 			} else {
 				return EXIT_FAILURE;
 			}

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -1208,3 +1208,32 @@ TEST_CASE("Ignoring articles in search", "[Cache]")
 	REQUIRE(search_items.size() == 0 );
 	REQUIRE(no_ignore_items.size() == 1);
 }
+
+
+TEST_CASE("fetch_feed_urls returns feeds correctly", "[Cache]")
+{
+	auto cfg = std::make_unique<ConfigContainer>();
+	auto rsscache = Cache::in_memory(*cfg);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(*cfg, *rsscache, easyHandle);
+	test_helpers::TempFile dbfile;
+
+
+	auto feedurl1 = "file://data/rss20_1.xml";
+	auto feedurl2 = "file://data/atom10_1.xml";
+
+	RssParser parser1(feedurl1, *rsscache, *cfg, nullptr);
+	RssParser parser2(feedurl2, *rsscache, *cfg, nullptr);
+
+	auto feed1 = parser1.parse(feed_retriever.retrieve(feedurl1));
+	auto feed2 = parser2.parse(feed_retriever.retrieve(feedurl2));
+
+	rsscache->externalize_rssfeed(*feed1, false);
+	rsscache->externalize_rssfeed(*feed2, false);
+
+	auto feeds = rsscache->fetch_feed_urls();
+
+	REQUIRE(feeds.size() == 2);
+	REQUIRE(feeds[1] == feedurl1);
+	REQUIRE(feeds[0] == feedurl2);
+}

--- a/test/cacheapi.cpp
+++ b/test/cacheapi.cpp
@@ -1,0 +1,31 @@
+#include "cacheapi.h"
+
+#include "3rd-party/catch.hpp"
+#include "configcontainer.h"
+#include "curlhandle.h"
+#include "feedretriever.h"
+#include "rssfeed.h"
+#include "rssparser.h"
+#include "test_helpers/tempfile.h"
+
+using namespace newsboat;
+
+TEST_CASE("get_subscribed_urls gets all cached feeds", "[CacheApi]")
+{
+	auto cfg = std::make_unique<ConfigContainer>();
+	auto rsscache = Cache::in_memory(*cfg);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(*cfg, *rsscache, easyHandle);
+	test_helpers::TempFile dbfile;
+
+	auto feedurl = "file://data/rss.xml";
+	RssParser parser(feedurl, *rsscache, *cfg, nullptr);
+	auto feed = parser.parse(feed_retriever.retrieve(feedurl));
+	rsscache->externalize_rssfeed(*feed, false);
+
+	CacheApi api(*cfg, rsscache.get());
+	auto feeds = api.get_subscribed_urls();
+
+	REQUIRE(feeds.size() == 1);
+	REQUIRE(feeds[0].first == feedurl);
+}

--- a/test/cacheurlreader.cpp
+++ b/test/cacheurlreader.cpp
@@ -1,0 +1,44 @@
+#include "cacheurlreader.h"
+
+#include "3rd-party/catch.hpp"
+#include "configcontainer.h"
+#include "curlhandle.h"
+#include "feedretriever.h"
+#include "rssfeed.h"
+#include "rssparser.h"
+#include "fileurlreader.h"
+#include "cacheapi.h"
+#include "test_helpers/tempfile.h"
+
+using namespace newsboat;
+
+TEST_CASE("reload gets urls in both cache and file", "[CacheUrlReader]")
+{
+	auto cfg = std::make_unique<ConfigContainer>();
+	auto rsscache = Cache::in_memory(*cfg);
+	CurlHandle easyHandle;
+	FeedRetriever feed_retriever(*cfg, *rsscache, easyHandle);
+	test_helpers::TempFile dbfile;
+
+	auto feedurl = "file://data/rss.xml";
+	RssParser parser1(feedurl, *rsscache, *cfg, nullptr);
+	auto feed = parser1.parse(feed_retriever.retrieve(feedurl));
+	rsscache->externalize_rssfeed(*feed, false);
+
+	CacheApi api = CacheApi(*cfg, rsscache.get());
+
+	const auto url = "data/test-urls.txt"_path;
+	FileUrlReader file_reader(url);
+
+	CacheUrlReader url_reader(file_reader, &api);
+	url_reader.reload();
+
+	auto feeds = url_reader.get_urls();
+
+	REQUIRE(feeds.size() == 4);
+
+	REQUIRE(feeds[0].first == "http://test1.url.cc/feed.xml");
+	REQUIRE(feeds[1].first == "http://anotherfeed.com/");
+	REQUIRE(feeds[2].first == "http://onemorefeed.at/feed/");
+	REQUIRE(feeds[3].first == "file://data/rss.xml");
+}


### PR DESCRIPTION
This PR adds offline mode by loading urls from cache when a remote service is down.
I tryed to follow [this](https://github.com/newsboat/newsboat/issues/2675#issuecomment-5006520506) as much as I can and I made tests for everything I added.

### Here is a breakdown of what I did:
- I first needed a way to fetch feed urls so I added `fetch_feed_urls` in `Cache`.
- This method was then used my `CacheApi` to return the urls and other methods in this class I left empty I still dont know if I should make the throw an error or what.
- Then `CacheUrlReader` uses `CacheApi` and the already existing `FileUrlReader` to combine both cache and file urls into one vector when reloading.
- In `Controller` if we ever get that a server is down we ask the user if they want to switch to offline mode or not by a [y/n] cin if no we EXIT_FAILURE of yes we use our new api and url reader

I hope this is good and gets reviewed!!

closes #221