### PR TITLE
Reject special URLs from online OPML

### DIFF
--- a/src/opmlurlreader.cpp
+++ b/src/opmlurlreader.cpp
@@ -68,6 +68,16 @@ void OpmlUrlReader::handle_node(xmlNode* node, const std::string& tag)
 			(char*)xmlGetProp(node, (const xmlChar*)"xmlUrl");
 		if (rssurl && strlen(rssurl) > 0) {
 			std::string theurl(rssurl);
+			xmlFree(rssurl);
+
+			if (!utils::is_http_url(theurl)) {
+				LOG(Level::USERERROR,
+					"OpmlUrlReader: skipping non-HTTP(S) URL from "
+					"remote OPML: %s",
+					theurl);
+				return;
+			}
+
 			urls.push_back({theurl, FeedOrigin{}});
 
 			std::vector<std::string> tmptags;
@@ -103,8 +113,7 @@ void OpmlUrlReader::handle_node(xmlNode* node, const std::string& tag)
 			if (tmptags.size() > 0) {
 				tags[theurl] = tmptags;
 			}
-		}
-		if (rssurl) {
+		} else if (rssurl) {
 			xmlFree(rssurl);
 		}
 	}


### PR DESCRIPTION
Online OPML subscription mode accepts xmlUrl attributes without validating their scheme. A server controlling the configured opml-url can return exec: or filter: entries, which are later passed to a shell during feed refresh. This allows command execution as the Newsboat user without modifying the local urls file.

Reject non-HTTP(S) xmlUrl values in OpmlUrlReader and report them as user-visible errors. This keeps exec: and filter: available in explicitly local configuration while preventing remote OPML from activating them.

This is a follow-up to #3400. That PR fixes manual --import-from-opml conversions of Liferea pipe URLs and filtercmd; this change covers the separate online OPML subscription path and does not duplicate those changes.
