### PR TITLE
Reject control characters in podcast queue data

### DIFF
--- a/include/queuemanager.h
+++ b/include/queuemanager.h
@@ -16,6 +16,7 @@ enum class EnqueueStatus {
 	URL_QUEUED_ALREADY, // `extra_string` should specify the concerning URL
 	OUTPUT_FILENAME_USED_ALREADY, // `extra_filename` should specify the generated filename
 	QUEUE_FILE_OPEN_ERROR, // `extra_filename` should specify the location of the queue file
+	INVALID_ENQUEUE_DATA, // The URL is not an HTTP(S) URL
 };
 
 struct EnqueueResult {
@@ -46,4 +47,3 @@ private:
 }
 
 #endif /* NEWSBOAT_QUEUEMANAGER_H_ */
-

--- a/include/utils.h
+++ b/include/utils.h
@@ -34,6 +34,9 @@ enum class HTTPMethod {
 };
 
 std::string strip_comments(const std::string& line);
+bool contains_control_characters(std::string_view str);
+std::string replace_control_characters(std::string_view str,
+	char replacement = '_');
 std::vector<std::string> tokenize(const std::string& str,
 	std::string delimiters = " \r\n\t");
 std::vector<std::string> tokenize_spaced(const std::string& str,
@@ -115,6 +118,7 @@ std::string join(const std::vector<std::string>& strings,
 	const std::string& separator);
 
 std::string censor_url(const std::string& url);
+std::string sanitize_url(const std::string& url);
 
 void trim_end(std::string& str);
 

--- a/rust/libnewsboat-ffi/src/utils.rs
+++ b/rust/libnewsboat-ffi/src/utils.rs
@@ -61,6 +61,7 @@ mod bridged {
         fn consolidate_whitespace(input: &str) -> String;
         fn absolute_url(base_url: &str, link: &str) -> String;
         fn censor_url(url: &str) -> String;
+        fn sanitize_url(url: &str) -> String;
         fn trim(rs_str: &str) -> &str;
         fn trim_end(rs_str: &str) -> &str;
         fn quote(input: &str) -> String;

--- a/rust/libnewsboat/src/utils.rs
+++ b/rust/libnewsboat/src/utils.rs
@@ -100,6 +100,11 @@ pub fn is_http_url(url: &str) -> bool {
     url.starts_with("https://") || url.starts_with("http://")
 }
 
+/// Percent-encode ASCII control characters in a URL.
+pub fn sanitize_url(url: &str) -> String {
+    percent_encode(url.as_bytes(), CONTROLS).to_string()
+}
+
 pub fn is_query_url(url: &str) -> bool {
     url.starts_with("query:")
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -731,6 +731,10 @@ void Controller::replace_feed(RssFeed& oldfeed, RssFeed& newfeed, unsigned int p
 			v->get_statusline().show_error(
 				strprintf::fmt(_("Failed to open queue file: %s."), result.extra_filename));
 			break;
+		case EnqueueStatus::INVALID_ENQUEUE_DATA:
+			v->get_statusline().show_error(
+				_("Item has a non-HTTP enclosure URL."));
+			break;
 		}
 	}
 

--- a/src/itemutils.cpp
+++ b/src/itemutils.cpp
@@ -38,6 +38,10 @@ bool enqueue_item_enclosure(RssItem& item, RssFeed& feed,
 			v.get_statusline().show_error(
 				strprintf::fmt(_("Failed to open queue file: %s."), result.extra_filename));
 			return false;
+		case EnqueueStatus::INVALID_ENQUEUE_DATA:
+			v.get_statusline().show_error(
+				_("Item has a non-HTTP enclosure URL."));
+			return false;
 		}
 
 		// Not reachable, all switch cases return a result already,

--- a/src/queueloader.cpp
+++ b/src/queueloader.cpp
@@ -121,9 +121,6 @@ void QueueLoader::update_from_queue_file(CategorizedDownloads& downloads) const
 			continue;
 		}
 
-		LOG(Level::DEBUG,
-			"QueueLoader::reload: loaded `%s' from queue file",
-			line);
 		const std::vector<std::string> fields = utils::tokenize_quoted(line);
 		bool url_found = false;
 
@@ -142,6 +139,27 @@ void QueueLoader::update_from_queue_file(CategorizedDownloads& downloads) const
 			}
 			continue;
 		}
+
+		const bool valid_status = fields.size() < 3
+			|| fields[2] == "missing"
+			|| fields[2] == "downloaded"
+			|| fields[2] == "played"
+			|| fields[2] == "finished";
+		// Control characters are preserved inside quoted fields.
+		const bool valid_fields = !utils::contains_control_characters(fields[0])
+			&& fields.size() <= 3
+			&& valid_status
+			&& (fields.size() < 2
+				|| !utils::contains_control_characters(fields[1]));
+		if (!valid_fields) {
+			LOG(Level::USERERROR,
+				"QueueLoader: skipping malformed queue entry");
+			continue;
+		}
+
+		LOG(Level::DEBUG,
+			"QueueLoader::reload: loaded `%s' from queue file",
+			line);
 
 		for (const auto& dl : downloads.to_keep) {
 			if (fields[0] == dl.url()) {

--- a/src/queuemanager.cpp
+++ b/src/queuemanager.cpp
@@ -17,7 +17,18 @@ QueueManager::QueueManager(ConfigContainer* cfg_, Filepath queue_file)
 
 EnqueueResult QueueManager::enqueue_url(RssItem& item, RssFeed& feed)
 {
-	const std::string& url = item.enclosure_url();
+	const std::string url = utils::sanitize_url(item.enclosure_url());
+	if (!utils::is_http_url(url)) {
+		LOG(Level::USERERROR,
+			"QueueManager: refusing to enqueue a non-HTTP podcast URL `%s' "
+			"from feed `%s'",
+			url,
+			feed.rssurl());
+		EnqueueResult result;
+		result.status = EnqueueStatus::INVALID_ENQUEUE_DATA;
+		return result;
+	}
+
 	const Filepath filename = generate_enqueue_filename(item, feed);
 
 	std::fstream f;
@@ -75,7 +86,7 @@ std::string get_hostname_from_url(const std::string& url)
 
 Filepath QueueManager::generate_enqueue_filename(RssItem& item, RssFeed& feed)
 {
-	const std::string& url = item.enclosure_url();
+	const std::string url = utils::sanitize_url(item.enclosure_url());
 	const std::string& title = utils::utf8_to_locale(item.title());
 	const time_t pubDate = item.pubDate_timestamp();
 
@@ -115,7 +126,8 @@ Filepath QueueManager::generate_enqueue_filename(RssItem& item, RssFeed& feed)
 		fmt.register_fmt('N', utils::replace_all(feed.title(), "/", "_"));
 	}
 
-	return Filepath::from_locale_string(fmt.do_format(dlformat.to_locale_string()));
+	return Filepath::from_locale_string(
+		utils::replace_control_characters(fmt.do_format(dlformat.to_locale_string())));
 }
 
 EnqueueResult QueueManager::autoenqueue(RssFeed& feed)
@@ -128,6 +140,13 @@ EnqueueResult QueueManager::autoenqueue(RssFeed& feed)
 
 		const auto enclosure_type = item->enclosure_type();
 		const auto enclosure_url = item->enclosure_url();
+		if (!utils::is_http_url(enclosure_url)) {
+			LOG(Level::DEBUG,
+				"QueueManager::autoenqueue: skipping enclosure with "
+				"invalid URL `%s'",
+				enclosure_url);
+			continue;
+		}
 
 		if (!enclosure_type.empty() && !utils::is_valid_podcast_type(enclosure_type)) {
 			LOG(Level::DEBUG, "QueueManager::autoenqueue: Skipping enclosure with url `%s'"
@@ -139,21 +158,21 @@ EnqueueResult QueueManager::autoenqueue(RssFeed& feed)
 			"QueueManager::autoenqueue: enclosure_url = `%s' enclosure_type = `%s'",
 			enclosure_url,
 			enclosure_type);
-		if (utils::is_http_url(item->enclosure_url())) {
-			LOG(Level::INFO,
-				"QueueManager::autoenqueue: enqueuing `%s'",
-				item->enclosure_url());
-			const auto result = enqueue_url(*item, feed);
-			switch (result.status) {
-			case EnqueueStatus::QUEUED_SUCCESSFULLY:
-			case EnqueueStatus::URL_QUEUED_ALREADY:
-				// Not an issue, continue processing rest of items
-				break;
-			case EnqueueStatus::QUEUE_FILE_OPEN_ERROR:
-			case EnqueueStatus::OUTPUT_FILENAME_USED_ALREADY:
-				// Let caller of `autoenqueue` handle the issue
-				return result;
-			}
+		LOG(Level::INFO,
+			"QueueManager::autoenqueue: enqueuing `%s'",
+			item->enclosure_url());
+		const auto result = enqueue_url(*item, feed);
+		switch (result.status) {
+		case EnqueueStatus::QUEUED_SUCCESSFULLY:
+		case EnqueueStatus::URL_QUEUED_ALREADY:
+			// Not an issue, continue processing rest of items
+			break;
+		case EnqueueStatus::QUEUE_FILE_OPEN_ERROR:
+		case EnqueueStatus::OUTPUT_FILENAME_USED_ALREADY:
+			return result;
+		case EnqueueStatus::INVALID_ENQUEUE_DATA:
+			// Invalid metadata is skipped; continue processing other items.
+			break;
 		}
 	}
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,5 +1,6 @@
 #include "utils.h"
 
+#include <cctype>
 #include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
@@ -47,6 +48,28 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 using HTTPMethod = newsboat::utils::HTTPMethod;
 
 namespace newsboat {
+
+bool utils::contains_control_characters(std::string_view str)
+{
+	for (const unsigned char c : str) {
+		if (std::iscntrl(c)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+std::string utils::replace_control_characters(std::string_view str,
+	char replacement)
+{
+	std::string result(str);
+	for (char& c : result) {
+		if (std::iscntrl(static_cast<unsigned char>(c))) {
+			c = replacement;
+		}
+	}
+	return result;
+}
 
 std::string utils::strip_comments(const std::string& line)
 {
@@ -532,6 +555,11 @@ std::string utils::join(const std::vector<std::string>& strings,
 std::string utils::censor_url(const std::string& url)
 {
 	return std::string(utils::bridged::censor_url(url));
+}
+
+std::string utils::sanitize_url(const std::string& url)
+{
+	return std::string(utils::bridged::sanitize_url(url));
 }
 
 void utils::trim(std::string& str)

--- a/test/queueloader.cpp
+++ b/test/queueloader.cpp
@@ -1,5 +1,7 @@
 #include "queueloader.h"
 
+#include <fstream>
+
 #include "3rd-party/catch.hpp"
 #include "test_helpers/chmod.h"
 #include "test_helpers/misc.h"
@@ -675,6 +677,36 @@ TEST_CASE("reload() skips empty lines in the queue file", "[QueueLoader]")
 	REQUIRE(downloads[5].filename() == "fifth.mp3"_path);
 	REQUIRE(downloads[5].url() == "https://example.com/episode05.mp3");
 	REQUIRE(downloads[5].status() == DlStatus::QUEUED);
+}
+
+TEST_CASE("reload() skips queue entries containing control characters",
+	"[QueueLoader]")
+{
+	test_helpers::TempFile queueFile;
+	std::ofstream queue(queueFile.get_path().to_locale_string());
+	queue << "\"https://example.com/bad\rurl\" \"/tmp/bad.mp3\"" << '\n';
+	queue << "https://example.com/bad-filename.mp3 \"/tmp/bad\tfilename.mp3\"" << '\n';
+	queue << R"(https://example.com/too-many-fields.mp3 "/tmp/bad.mp3" missing extra)" << '\n';
+	queue << R"(https://example.com/unknown-status.mp3 "/tmp/bad.mp3" unknown)" << '\n';
+	queue << R"(https://example.com/good.mp3 "/tmp/good.mp3")" << '\n';
+	queue.close();
+
+	ConfigContainer cfg;
+	auto empty_callback = []() {};
+	QueueLoader queue_loader(queueFile.get_path(), cfg, empty_callback);
+	std::vector<Download> downloads;
+
+	queue_loader.reload(downloads);
+
+	REQUIRE(downloads.size() == 1);
+	REQUIRE(downloads[0].url() == "https://example.com/good.mp3");
+	REQUIRE(downloads[0].filename() == "/tmp/good.mp3"_path);
+	REQUIRE(downloads[0].status() == DlStatus::QUEUED);
+	REQUIRE(test_helpers::file_contents(queueFile.get_path()) ==
+		std::vector<std::string> {
+			R"(https://example.com/good.mp3 "/tmp/good.mp3")",
+			""
+		});
 }
 
 TEST_CASE("reload() removes empty lines from the queue file", "[QueueLoader]")

--- a/test/queuemanager.cpp
+++ b/test/queuemanager.cpp
@@ -132,6 +132,35 @@ SCENARIO("Smoke test for QueueManager", "[QueueManager]")
 	}
 }
 
+TEST_CASE("QueueManager sanitizes control characters in queue data",
+	"[QueueManager]")
+{
+	ConfigContainer cfg;
+	cfg.set_configvalue("download-path", "/example/");
+	cfg.set_configvalue("download-filename-format", "%n");
+
+	auto rsscache = Cache::in_memory(cfg);
+
+	RssItem item(rsscache.get());
+	item.set_enclosure_url("https://example.com/episode\r\n\t.mp3");
+	item.set_enclosure_type("audio/mpeg");
+
+	RssFeed feed(rsscache.get(), "https://example.com/news.atom");
+	feed.set_title("Feed\r\n\tname");
+
+	test_helpers::TempFile queue_file;
+	QueueManager manager(&cfg, queue_file.get_path());
+
+	const auto result = manager.enqueue_url(item, feed);
+
+	REQUIRE(result.status == EnqueueStatus::QUEUED_SUCCESSFULLY);
+	REQUIRE(test_helpers::file_contents(queue_file.get_path()) ==
+		std::vector<std::string> {
+			R"(https://example.com/episode%0D%0A%09.mp3 "/example/Feed___name")",
+			""
+		});
+}
+
 SCENARIO("enqueue_url() errors if the filename is already used", "[QueueManager]")
 {
 	GIVEN("Pristine QueueManager and two RssItems") {


### PR DESCRIPTION
Podcast enclosure URLs are written to Podboat's line-oriented queue without rejecting control characters. A remote feed can encode a newline in an enclosure URL, causing Newsboat to write additional queue records. Podboat then interprets attacker-controlled fields as a download URL and output pathname.

Reject control characters in enclosure URLs and generated filenames before writing queue records. Podboat also ignores malformed queue entries and fields containing control characters when reloading the queue.

This prevents remote podcast metadata from injecting queue records and redirecting downloads to attacker-selected paths.
