### PR TITLE
Fix unsupported color element reporting

### DIFF
--- a/rust/libnewsboat/src/colormanager.rs
+++ b/rust/libnewsboat/src/colormanager.rs
@@ -95,7 +95,7 @@ impl ColorManager {
                     if !DEFAULT_STYLES.contains_key(element) {
                         return Err(ActionHandlerStatus::CustomErrorMessage(fmt!(
                             &gettext("`%s' is not a valid configuration element"),
-                            action
+                            *element
                         )));
                     }
 


### PR DESCRIPTION
Looks like I made a small error when porting the error handling of `ColorManager` to Rust in https://github.com/newsboat/newsboat/pull/3418
Before this fix, the error message read "`color' is not a valid configuration element" instead of mentioning the actual specified element name.