### PR TITLE
ci: use job-level conditional instead of path filter for no_dbg_macros

### DIFF
--- a/.github/workflows/asciidoctor.yml
+++ b/.github/workflows/asciidoctor.yml
@@ -2,16 +2,32 @@ name: Asciidoctor with warnings-as-errors
 
 on:
   push:
-    paths: &included_paths
-      - .github/workflows/**
-      - doc/**
-      - docker/**
   pull_request:
-    paths: *included_paths
 
 jobs:
+  changes:
+    name: "Detect relevant changes"
+    runs-on: ubuntu-24.04
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v7
+
+      - name: Filter paths
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - .github/workflows/**
+              - doc/**
+              - docker/**
+
   code_formatting:
     name: Asciidoctor with warnings-as-errors
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/i18nspector.yml
+++ b/.github/workflows/i18nspector.yml
@@ -2,16 +2,32 @@ name: .po files
 
 on:
   push:
-    paths: &included_paths
-      - .github/workflows/**
-      - docker/**
-      - po/*.{po,pot}'
   pull_request:
-    paths: *included_paths
 
 jobs:
+  changes:
+    name: "Detect relevant changes"
+    runs-on: ubuntu-24.04
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v7
+
+      - name: Filter paths
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - .github/workflows/**
+              - docker/**
+              - po/*.{po,pot}'
+
   code_formatting:
     name: .po files
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/no_dbg_macros.yml
+++ b/.github/workflows/no_dbg_macros.yml
@@ -2,15 +2,31 @@ name: "No dbg! macros in Rust code"
 
 on:
   push:
-    paths: &included_paths
-      - '**.rs'
-      - '.github/**'
   pull_request:
-    paths: *included_paths
 
 jobs:
+  changes:
+    name: "Detect relevant changes"
+    runs-on: ubuntu-24.04
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v7
+
+      - name: Filter paths
+        uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - '**.rs'
+              - '.github/**'
+
   check_for_dbg_macros:
     name: "No dbg! macros in Rust code"
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
Fixes the pattern described in #3399 for one workflow, as a small, reviewable first step.

GitHub Actions leaves a required check permanently "Pending" when its workflow is skipped by a trigger-level `paths:` filter — as you noted, this blocks merges even when nothing relevant changed. Per GitHub's own docs (quoted in #3399), a *job* skipped via an `if:` conditional reports "Success" instead, which satisfies required-check rules.

This PR moves the path filter for `no_dbg_macros.yml` out of the trigger (`on: push/pull_request: paths:`) and into a `changes` job using `dorny/paths-filter@v4`, gating the real job on that job's output.

**Update**: per @Minoru's comment, this now also applies the same change to `asciidoctor.yml` and `i18nspector.yml` — the only other two workflows using the same trigger-level `paths:` pattern.