### PR TITLE
Point users to reload operation when trying to open empty feed

### DIFF
--- a/include/feedlistformaction.h
+++ b/include/feedlistformaction.h
@@ -19,7 +19,6 @@ class FeedListFormAction : public ListFormAction {
 public:
 	FeedListFormAction(View&,
 		std::string formstr,
-		Cache* cc,
 		FilterContainer& f,
 		ConfigContainer* cfg,
 		RegexManager& r);
@@ -107,8 +106,6 @@ private:
 	FilterContainer& filter_container;
 
 	std::optional<FeedSortStrategy> old_sort_strategy;
-
-	Cache* cache;
 };
 
 } // namespace newsboat

--- a/include/view.h
+++ b/include/view.h
@@ -9,6 +9,7 @@
 
 #include "formaction.h"
 #include "links.h"
+#include "rssitem.h"
 #include "statusline.h"
 #include "filepath.h"
 
@@ -78,7 +79,7 @@ public:
 	void push_help();
 	void push_urlview(const Links& links,
 		std::shared_ptr<RssFeed>& feed);
-	void push_searchresult(std::shared_ptr<RssFeed> feed,
+	void push_searchresult(std::vector<std::shared_ptr<RssItem>> items,
 		const std::string& phrase = "");
 	void view_dialogs();
 

--- a/src/feedlistformaction.cpp
+++ b/src/feedlistformaction.cpp
@@ -26,7 +26,6 @@ namespace newsboat {
 
 FeedListFormAction::FeedListFormAction(View& vv,
 	std::string formstr,
-	Cache* cc,
 	FilterContainer& f,
 	ConfigContainer* cfg,
 	RegexManager& r)
@@ -37,7 +36,6 @@ FeedListFormAction::FeedListFormAction(View& vv,
 	, set_filterpos(false)
 	, rxman(r)
 	, filter_container(f)
-	, cache(cc)
 {
 	valid_cmds.push_back("tag");
 	valid_cmds.push_back("goto");
@@ -1008,11 +1006,10 @@ void FeedListFormAction::op_start_search()
 		"`%s'",
 		searchphrase);
 	if (searchphrase.length() > 0) {
-		auto message_lifetime = v.get_statusline().show_message_until_finished(
-				_("Searching..."));
 		searchhistory.add_line(searchphrase);
 		std::vector<std::shared_ptr<RssItem>> items;
 		try {
+			auto message_lifetime = v.get_statusline().show_message_until_finished(_("Searching..."));
 			const auto utf8searchphrase = utils::locale_to_utf8(searchphrase);
 			items = v.get_ctrl().search_for_items(
 					utf8searchphrase, nullptr);
@@ -1023,15 +1020,8 @@ void FeedListFormAction::op_start_search()
 					e.what()));
 			return;
 		}
-		message_lifetime.reset();
-		if (!items.empty()) {
-			std::shared_ptr<RssFeed> search_dummy_feed(new RssFeed(cache, ""));
-			search_dummy_feed->set_search_feed(true);
-			search_dummy_feed->add_items(items);
-			v.push_searchresult(search_dummy_feed, searchphrase);
-		} else {
-			v.get_statusline().show_error(_("No results."));
-		}
+
+		v.push_searchresult(std::move(items), searchphrase);
 	}
 }
 

--- a/src/itemlistformaction.cpp
+++ b/src/itemlistformaction.cpp
@@ -990,15 +990,7 @@ void ItemListFormAction::qna_start_search()
 		return;
 	}
 
-	if (items.empty()) {
-		v.get_statusline().show_error(_("No results."));
-		return;
-	}
-
-	std::shared_ptr<RssFeed> search_dummy_feed(new RssFeed(rsscache, ""));
-	search_dummy_feed->set_search_feed(true);
-	search_dummy_feed->add_items(items);
-	v.push_searchresult(search_dummy_feed, searchphrase);
+	v.push_searchresult(std::move(items), searchphrase);
 }
 
 void ItemListFormAction::do_update_visible_items()

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -145,8 +145,8 @@ int View::run()
 {
 	bool have_macroprefix = false;
 
-	feedlist_form = std::make_shared<FeedListFormAction>(
-			*this, feedlist_str, rsscache, filters, cfg, rxman);
+	feedlist_form = std::make_shared<FeedListFormAction>(*this, feedlist_str, filters, cfg,
+			rxman);
 	apply_colors(feedlist_form);
 	formaction_stack.push_back(feedlist_form);
 	current_formaction = formaction_stack_size() - 1;
@@ -474,28 +474,32 @@ void View::set_tags(const std::vector<std::string>& t)
 	tags = t;
 }
 
-void View::push_searchresult(std::shared_ptr<RssFeed> feed,
+void View::push_searchresult(std::vector<std::shared_ptr<RssItem>> items,
 	const std::string& phrase)
 {
-	assert(feed != nullptr);
 	LOG(Level::DEBUG, "View::push_searchresult: pushing search result");
-	if (feed->total_item_count() > 0) {
-		if (this->get_current_formaction()->id() != Dialog::SearchResultsList) {
-			auto searchresult = std::make_shared<SearchResultsListFormAction>(
-					*this, itemlist_str, rsscache, filters, cfg, rxman);
-			apply_colors(searchresult);
-			searchresult->set_parent_formaction(get_current_formaction());
-			searchresult->add_to_history(feed, phrase);
-			searchresult->init();
-			formaction_stack.push_back(searchresult);
-			current_formaction = formaction_stack_size() - 1;
-		} else {
-			auto searchresult = std::static_pointer_cast<SearchResultsListFormAction>
-				(this->get_current_formaction());
-			searchresult->add_to_history(feed, phrase);
-		}
+	if (items.empty()) {
+		status_line.show_error(_("No results."));
+		return;
+	}
+
+	std::shared_ptr<RssFeed> feed(new RssFeed(rsscache, ""));
+	feed->set_search_feed(true);
+	feed->add_items(items);
+
+	if (this->get_current_formaction()->id() != Dialog::SearchResultsList) {
+		auto searchresult = std::make_shared<SearchResultsListFormAction>(
+				*this, itemlist_str, rsscache, filters, cfg, rxman);
+		apply_colors(searchresult);
+		searchresult->set_parent_formaction(get_current_formaction());
+		searchresult->add_to_history(feed, phrase);
+		searchresult->init();
+		formaction_stack.push_back(searchresult);
+		current_formaction = formaction_stack_size() - 1;
 	} else {
-		status_line.show_error(_("Error: feed contains no items!"));
+		auto searchresult = std::static_pointer_cast<SearchResultsListFormAction>
+			(this->get_current_formaction());
+		searchresult->add_to_history(feed, phrase);
 	}
 }
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -525,7 +525,11 @@ std::shared_ptr<ItemListFormAction> View::push_itemlist(
 		current_formaction = formaction_stack_size() - 1;
 		return itemlist;
 	} else {
-		status_line.show_error(_("Error: feed contains no items!"));
+		if (feed->is_query_feed()) {
+			status_line.show_error(_("Error: feed contains no items!"));
+		} else {
+			status_line.show_error(_("Error: feed contains no items! You can try reloading the feed"));
+		}
 		return nullptr;
 	}
 }


### PR DESCRIPTION
Just a quick idea after a recent question on our IRC channel where it turned out a new Newsboat user didn't realize they had to reload a feed to pull in new items.
Not sure about the exact message, I'm open to other suggestions.

Somewhat related: https://github.com/newsboat/newsboat/issues/1493