### PR TITLE
docker: separate C++ compiler install from fixed dependencies for better layer caching

### DIFF
--- a/docker/ubuntu_18.04-build-tools.dockerfile
+++ b/docker/ubuntu_18.04-build-tools.dockerfile
@@ -66,11 +66,12 @@ ENV PATH=/home/builder/.cargo/bin:$PATH
 RUN apt-get update \
     && apt-get upgrade --assume-yes
 
-ARG cxx_package=g++-8
-
+# Fixed dependencies only -- nothing here depends on a build-arg, so this layer's
+# cache survives a `cxx_package`/`cc`/`cxx` override (the C++ compiler itself is
+# installed separately, after Rust, below).
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
-        build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
+        build-essential libsqlite3-dev libcurl4-openssl-dev libssl-dev \
         libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
         asciidoctor wget \
     && apt-get autoremove \
@@ -107,6 +108,21 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
         --default-host x86_64-unknown-linux-gnu \
         --default-toolchain $rust_version \
     && chmod a+w $HOME/.cargo
+
+# C++ compiler last, and in its own layer -- this is the one thing a caller
+# commonly overrides (e.g. --build-arg cxx_package=clang-7), so isolating it
+# here means that override only busts this one small layer, not the much
+# larger fixed-dependencies layer above.
+USER root
+
+ARG cxx_package=g++-8
+
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends $cxx_package \
+    && apt-get autoremove \
+    && apt-get clean
+
+USER builder
 
 ARG cc=gcc-8
 ARG cxx=g++-8

--- a/docker/ubuntu_20.04-build-tools.dockerfile
+++ b/docker/ubuntu_20.04-build-tools.dockerfile
@@ -66,11 +66,12 @@ ENV PATH=/home/builder/.cargo/bin:$PATH
 RUN apt-get update \
     && apt-get upgrade --assume-yes
 
-ARG cxx_package=g++-9
-
+# Fixed dependencies only -- nothing here depends on a build-arg, so this layer's
+# cache survives a `cxx_package`/`cc`/`cxx` override (the C++ compiler itself is
+# installed separately, after Rust, below).
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
-        build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
+        build-essential libsqlite3-dev libcurl4-openssl-dev libssl-dev \
         libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
         pkg-config zlib1g-dev asciidoctor wget \
     && apt-get autoremove \
@@ -107,6 +108,21 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
         --default-host x86_64-unknown-linux-gnu \
         --default-toolchain $rust_version \
     && chmod a+w $HOME/.cargo
+
+# C++ compiler last, and in its own layer -- this is the one thing a caller
+# commonly overrides (e.g. --build-arg cxx_package=clang-10), so isolating it
+# here means that override only busts this one small layer, not the much
+# larger fixed-dependencies layer above.
+USER root
+
+ARG cxx_package=g++-9
+
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends $cxx_package \
+    && apt-get autoremove \
+    && apt-get clean
+
+USER builder
 
 ARG cc=gcc-9
 ARG cxx=g++-9

--- a/docker/ubuntu_24.04-build-tools.dockerfile
+++ b/docker/ubuntu_24.04-build-tools.dockerfile
@@ -67,11 +67,12 @@ RUN apt-get update \
     && apt-get upgrade --assume-yes \
     && apt install --assume-yes --no-install-recommends ca-certificates wget gnupg2
 
-ARG cxx_package=g++-14
-
+# Fixed dependencies only -- nothing here depends on a build-arg, so this layer's
+# cache survives a `cxx_package`/`cc`/`cxx` override (the C++ compiler itself is
+# installed separately, after Rust, below).
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
-        build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
+        build-essential libsqlite3-dev libcurl4-openssl-dev libssl-dev \
         libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
         pkg-config zlib1g-dev asciidoctor \
     && apt-get autoremove \
@@ -109,6 +110,21 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
         --default-host x86_64-unknown-linux-gnu \
         --default-toolchain $rust_version \
     && chmod a+w $HOME/.cargo
+
+# C++ compiler last, and in its own layer -- this is the one thing a caller
+# commonly overrides (e.g. --build-arg cxx_package=clang-16), so isolating it
+# here means that override only busts this one small layer, not the much
+# larger fixed-dependencies layer above.
+USER root
+
+ARG cxx_package=g++-14
+
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends $cxx_package \
+    && apt-get autoremove \
+    && apt-get clean
+
+USER builder
 
 ARG cc=gcc-14
 ARG cxx=g++-14

--- a/docker/ubuntu_25.04-build-tools.dockerfile
+++ b/docker/ubuntu_25.04-build-tools.dockerfile
@@ -67,11 +67,12 @@ RUN apt-get update \
     && apt-get upgrade --assume-yes \
     && apt install --assume-yes --no-install-recommends ca-certificates wget gnupg2
 
-ARG cxx_package=g++-15
-
+# Fixed dependencies only -- nothing here depends on a build-arg, so this layer's
+# cache survives a `cxx_package`/`cc`/`cxx` override (the C++ compiler itself is
+# installed separately, after Rust, below).
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
-        build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
+        build-essential libsqlite3-dev libcurl4-openssl-dev libssl-dev \
         libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
         pkg-config zlib1g-dev asciidoctor \
     && apt-get autoremove \
@@ -109,6 +110,21 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
         --default-host x86_64-unknown-linux-gnu \
         --default-toolchain $rust_version \
     && chmod a+w $HOME/.cargo
+
+# C++ compiler last, and in its own layer -- this is the one thing a caller
+# commonly overrides (e.g. --build-arg cxx_package=clang-16), so isolating it
+# here means that override only busts this one small layer, not the much
+# larger fixed-dependencies layer above.
+USER root
+
+ARG cxx_package=g++-15
+
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends $cxx_package \
+    && apt-get autoremove \
+    && apt-get clean
+
+USER builder
 
 ARG cc=gcc-15
 ARG cxx=g++-15

--- a/docker/ubuntu_26.04-build-tools.dockerfile
+++ b/docker/ubuntu_26.04-build-tools.dockerfile
@@ -67,11 +67,12 @@ RUN apt-get update \
     && apt-get upgrade --assume-yes \
     && apt install --assume-yes --no-install-recommends ca-certificates wget gnupg2
 
-ARG cxx_package=g++-16
-
+# Fixed dependencies only -- nothing here depends on a build-arg, so this layer's
+# cache survives a `cxx_package`/`cc`/`cxx` override (the C++ compiler itself is
+# installed separately, after Rust, below).
 RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends \
-        build-essential $cxx_package libsqlite3-dev libcurl4-openssl-dev libssl-dev \
+        build-essential libsqlite3-dev libcurl4-openssl-dev libssl-dev \
         libxml2-dev libstfl-dev libjson-c-dev libncursesw5-dev gettext git \
         pkg-config zlib1g-dev asciidoctor \
     && apt-get autoremove \
@@ -109,6 +110,21 @@ RUN wget -O $HOME/rustup.sh --secure-protocol=TLSv1_2 https://sh.rustup.rs \
         --default-host x86_64-unknown-linux-gnu \
         --default-toolchain $rust_version \
     && chmod a+w $HOME/.cargo
+
+# C++ compiler last, and in its own layer -- this is the one thing a caller
+# commonly overrides (e.g. --build-arg cxx_package=clang-16), so isolating it
+# here means that override only busts this one small layer, not the much
+# larger fixed-dependencies layer above.
+USER root
+
+ARG cxx_package=g++-16
+
+RUN apt-get update \
+    && apt-get install --assume-yes --no-install-recommends $cxx_package \
+    && apt-get autoremove \
+    && apt-get clean
+
+USER builder
 
 ARG cc=gcc-16
 ARG cxx=g++-16


### PR DESCRIPTION
## Summary
Closes #3365.

Each `*-build-tools.dockerfile` installed the C++ compiler package (`$cxx_package`) in the same `apt-get install` layer as ~15 fixed dependencies (libsqlite3-dev, libcurl4-openssl-dev, etc.). Since `cxx_package` is commonly overridden — every file's own header documents a "build with non-default compiler" example — overriding it busted that entire combined layer, forcing a reinstall of everything else too.

Split into a separate, later layer, following the order suggested in the issue: fixed dependencies → test user → Rust → C++ compiler (installed last since it's the one thing callers actually override).

## Verification
Built all 5 variants successfully with default args. Then rebuilt 24.04 with `--build-arg cxx_package=clang-16 --build-arg cc=clang-16 --build-arg cxx=clang++-16` and confirmed the improvement directly in the build output — every layer up to and including the fixed-dependencies install stayed `CACHED`; only the new, small compiler-install layer rebuilt (18s):
```
#7 [3/8] RUN ... build-essential libsqlite3-dev ... asciidoctor ...
#7 CACHED
...
#11 [8/8] RUN apt-get install ... clang-16 ...
#11 DONE 18.1s
```

## Test plan
- [x] All 5 dockerfiles build successfully with default args
- [x] Compiler-override cache behaviour verified directly (above), not just reasoned about
- [x] No functional change to the resulting image — same packages installed, same final `CC`/`CXX` env vars