### PR TITLE
FreshRSS API: Use nlohmann json instead of json-c

### DIFF
--- a/src/freshrssapi.cpp
+++ b/src/freshrssapi.cpp
@@ -1,7 +1,7 @@
 #include "freshrssapi.h"
 
+#include <cinttypes>
 #include <curl/curl.h>
-#include <json.h>
 #include <time.h>
 #include <vector>
 #include <thread>
@@ -110,71 +110,66 @@ std::vector<TaggedFeedUrl> FreshRssApi::get_subscribed_urls()
 		"FreshRssApi::get_subscribed_urls: document = %s",
 		result);
 
-	json_object* reply = json_tokener_parse(result.c_str());
-	if (reply == nullptr) {
+	nlohmann::json reply;
+	try {
+		reply = nlohmann::json::parse(result);
+	} catch (nlohmann::json::parse_error& e) {
 		LOG(Level::ERROR,
-			"FreshRssApi::get_subscribed_urls: failed to parse "
-			"response "
-			"as JSON.");
+			"FreshRssApi::get_subscribed_urls: failed to parse response as JSON: %s",
+			e.what());
 		return urls;
 	}
 
-	json_object* subscription_obj{};
-	json_object_object_get_ex(reply, "subscriptions", &subscription_obj);
-	array_list* subscriptions = json_object_get_array(subscription_obj);
+	try {
+		const nlohmann::json& subscriptions = reply.at("subscriptions");
 
-	int len = array_list_length(subscriptions);
+		for (std::size_t i = 0; i < subscriptions.size(); i++) {
+			std::vector<std::string> tags;
+			const nlohmann::json& sub = subscriptions.at(i);
 
-	for (int i = 0; i < len; i++) {
-		std::vector<std::string> tags;
-		json_object* sub =
-			json_object_array_get_idx(subscription_obj, i);
-
-		json_object* id_str{};
-		json_object_object_get_ex(sub, "id", &id_str);
-		const char* id = json_object_get_string(id_str);
-		if (id == nullptr) {
-			LOG(Level::WARN, "Skipping a subscription without an id");
-			continue;
-		}
-
-		json_object* title_str{};
-		json_object_object_get_ex(sub, "title", &title_str);
-		const char* title = json_object_get_string(title_str);
-		if (title != nullptr) {
-			tags.push_back(std::string("~") + title);
-		} else {
-			LOG(Level::WARN, "Subscription has no title, so let's call it \"%i\"", i);
-			tags.push_back(std::string("~") + std::to_string(i));
-		}
-
-		json_object* cats_obj{};
-		json_object_object_get_ex(sub, "categories", &cats_obj);
-		array_list* cats = json_object_get_array(cats_obj);
-
-		int ncats = array_list_length(cats);
-		for (int x = 0; x < ncats; x++) {
-			json_object* cat = json_object_array_get_idx(cats_obj, x);
-			json_object* cat_name{};
-			json_object_object_get_ex(cat, "label", &cat_name);
-			const char* category = json_object_get_string(cat_name);
-			if (category == nullptr) {
-				LOG(Level::WARN, "Skipping subscription's category whose name is a null value");
+			if (!sub.contains("id") || sub.at("id").is_null()) {
+				LOG(Level::WARN, "Skipping a subscription without an id");
 				continue;
 			}
-			tags.push_back(category);
+
+			const std::string id = sub.at("id");
+
+			if (sub.contains("title") && !sub.at("title").is_null()) {
+				const std::string title = sub.at("title");
+				tags.push_back(std::string("~") + title);
+			} else {
+				LOG(Level::WARN, "Subscription has no title, so let's call it \"%zu\"", i);
+				tags.push_back(std::string("~") + std::to_string(i));
+			}
+
+			if (sub.contains("categories") && !sub.at("categories").is_null()) {
+				const nlohmann::json& categories = sub.at("categories");
+
+				for (const auto& cat : categories) {
+					if (!cat.contains("label") || cat.at("label").is_null()) {
+						LOG(Level::WARN, "Skipping subscription's category whose name is a null value");
+						continue;
+					}
+
+					const std::string category = cat.at("label");
+					tags.push_back(category);
+				}
+			}
+
+			char* escaped_id = curl_easy_escape(handle.ptr(), id.c_str(), 0);
+			auto url = strprintf::fmt("%s%s%s",
+					cfg.get_configvalue("freshrss-url"),
+					FRESHRSS_FEED_PREFIX,
+					escaped_id);
+			urls.push_back(TaggedFeedUrl(url, tags));
+			curl_free(escaped_id);
 		}
-
-		char* escaped_id = curl_easy_escape(handle.ptr(), id, 0);
-		auto url = strprintf::fmt("%s%s%s",
-				cfg.get_configvalue("freshrss-url"),
-				FRESHRSS_FEED_PREFIX,
-				escaped_id);
-		urls.push_back(TaggedFeedUrl(url, tags));
-		curl_free(escaped_id);
+	} catch (nlohmann::json::exception& e) {
+		LOG(Level::ERROR,
+			"FreshRssApi::get_subscribed_urls: failed to parse subscriptions: %s",
+			e.what());
+		return urls;
 	}
-
-	json_object_put(reply);
 
 	return urls;
 }


### PR DESCRIPTION
Part of #3408

Replace the remaining json-c usage in the FreshRSS API with nlohmann/json library.

The implementation follows the same approach as #3436, using `nlohmann::json::parse()` and handling nlohmann/json exceptions for invalid or unexpected responses. The `nlohmann::json` name is kept instead of introducing a `using` alias, matching the existing style already used elsewhere in `freshrssapi.cpp`.

Removing the json-c include also exposed an existing transitive include dependency: `freshrssapi.cpp` uses the `PRIu64` format macro in `fetch_feed()`, but did not include the header that defines it directly. Previously, this happened to be made available indirectly through the json-c headers. This change adds `<cinttypes>` explicitly, making the dependency on `PRIu64` direct and independent of json-c.
